### PR TITLE
Compat: Make compat tests skip in non-compat mode

### DIFF
--- a/src/compat/api/validation/encoding/cmds/copyTextureToBuffer.spec.ts
+++ b/src/compat/api/validation/encoding/cmds/copyTextureToBuffer.spec.ts
@@ -3,14 +3,14 @@ Tests limitations of copyTextureToBuffer in compat mode.
 `;
 
 import { makeTestGroup } from '../../../../../common/internal/test_group.js';
-import { ValidationTest } from '../../../../../webgpu/api/validation/validation_test.js';
 import {
   kCompressedTextureFormats,
   kTextureFormatInfo,
 } from '../../../../../webgpu/format_info.js';
 import { align } from '../../../../../webgpu/util/math.js';
+import { CompatibilityTest } from '../../../../compatibility_test.js';
 
-export const g = makeTestGroup(ValidationTest);
+export const g = makeTestGroup(CompatibilityTest);
 
 g.test('compressed')
   .desc(`Tests that you can not call copyTextureToBuffer with compressed textures in compat mode.`)

--- a/src/compat/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.ts
+++ b/src/compat/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.ts
@@ -4,8 +4,8 @@ Tests limitations of bind group usage in a pipeline in compat mode.
 
 import { makeTestGroup } from '../../../../../common/internal/test_group.js';
 import { keysOf } from '../../../../../common/util/data_tables.js';
-import { ValidationTest } from '../../../../../webgpu/api/validation/validation_test.js';
 import { kRenderEncodeTypes } from '../../../../../webgpu/util/command_buffer_maker.js';
+import { CompatibilityTest } from '../../../../compatibility_test.js';
 
 const kTextureTypes = ['regular', 'storage'];
 type TextureType = typeof kTextureTypes[number];
@@ -193,24 +193,24 @@ function createAndBindTwoBindGroupsWithDifferentViewsOfSameTexture(
 const kBindCaseNames = keysOf(kBindCases);
 
 const kDrawUseCases: {
-  [key: string]: (t: ValidationTest, encoder: GPURenderCommandsMixin) => void;
+  [key: string]: (t: CompatibilityTest, encoder: GPURenderCommandsMixin) => void;
 } = {
-  draw: (t: ValidationTest, encoder: GPURenderCommandsMixin) => {
+  draw: (t: CompatibilityTest, encoder: GPURenderCommandsMixin) => {
     encoder.draw(3);
   },
-  drawIndexed: (t: ValidationTest, encoder: GPURenderCommandsMixin) => {
+  drawIndexed: (t: CompatibilityTest, encoder: GPURenderCommandsMixin) => {
     const indexBuffer = t.makeBufferWithContents(new Uint16Array([0, 1, 2]), GPUBufferUsage.INDEX);
     encoder.setIndexBuffer(indexBuffer, 'uint16');
     encoder.drawIndexed(3);
   },
-  drawIndirect(t: ValidationTest, encoder: GPURenderCommandsMixin) {
+  drawIndirect(t: CompatibilityTest, encoder: GPURenderCommandsMixin) {
     const indirectBuffer = t.makeBufferWithContents(
       new Uint32Array([3, 1, 0, 0]),
       GPUBufferUsage.INDIRECT
     );
     encoder.drawIndirect(indirectBuffer, 0);
   },
-  drawIndexedIndirect(t: ValidationTest, encoder: GPURenderCommandsMixin) {
+  drawIndexedIndirect(t: CompatibilityTest, encoder: GPURenderCommandsMixin) {
     const indexBuffer = t.makeBufferWithContents(new Uint16Array([0, 1, 2]), GPUBufferUsage.INDEX);
     encoder.setIndexBuffer(indexBuffer, 'uint16');
     const indirectBuffer = t.makeBufferWithContents(
@@ -223,12 +223,12 @@ const kDrawUseCases: {
 const kDrawCaseNames = keysOf(kDrawUseCases);
 
 const kDispatchUseCases: {
-  [key: string]: (t: ValidationTest, encoder: GPUComputePassEncoder) => void;
+  [key: string]: (t: CompatibilityTest, encoder: GPUComputePassEncoder) => void;
 } = {
-  dispatchWorkgroups(t: ValidationTest, encoder: GPUComputePassEncoder) {
+  dispatchWorkgroups(t: CompatibilityTest, encoder: GPUComputePassEncoder) {
     encoder.dispatchWorkgroups(1);
   },
-  dispatchWorkgroupsIndirect(t: ValidationTest, encoder: GPUComputePassEncoder) {
+  dispatchWorkgroupsIndirect(t: CompatibilityTest, encoder: GPUComputePassEncoder) {
     const indirectBuffer = t.makeBufferWithContents(
       new Uint32Array([1, 1, 1]),
       GPUBufferUsage.INDIRECT
@@ -239,7 +239,7 @@ const kDispatchUseCases: {
 const kDispatchCaseNames = keysOf(kDispatchUseCases);
 
 function createResourcesForRenderPassTest(
-  t: ValidationTest,
+  t: CompatibilityTest,
   textureType: TextureType,
   bindConfig: BindConfig
 ) {
@@ -270,7 +270,7 @@ function createResourcesForRenderPassTest(
 }
 
 function createResourcesForComputePassTest(
-  t: ValidationTest,
+  t: CompatibilityTest,
   textureType: TextureType,
   bindConfig: BindConfig
 ) {
@@ -295,7 +295,7 @@ function createResourcesForComputePassTest(
   return { texture, pipeline };
 }
 
-export const g = makeTestGroup(ValidationTest);
+export const g = makeTestGroup(CompatibilityTest);
 
 g.test('twoDifferentTextureViews,render_pass,used')
   .desc(

--- a/src/compat/api/validation/render_pipeline/fragment_state.spec.ts
+++ b/src/compat/api/validation/render_pipeline/fragment_state.spec.ts
@@ -4,9 +4,9 @@ Tests that you can not create a render pipeline with different per target blend 
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { keysOf } from '../../../../common/util/data_tables.js';
-import { ValidationTest } from '../../../../webgpu/api/validation/validation_test.js';
+import { CompatibilityTest } from '../../../compatibility_test.js';
 
-export const g = makeTestGroup(ValidationTest);
+export const g = makeTestGroup(CompatibilityTest);
 
 type ThreeColorTargets = [GPUColorTargetState, GPUColorTargetState | null, GPUColorTargetState];
 

--- a/src/compat/api/validation/render_pipeline/shader_module.spec.ts
+++ b/src/compat/api/validation/render_pipeline/shader_module.spec.ts
@@ -3,9 +3,9 @@ Tests limitations of createRenderPipeline related to shader modules in compat mo
 `;
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
-import { ValidationTest } from '../../../../webgpu/api/validation/validation_test.js';
+import { CompatibilityTest } from '../../../compatibility_test.js';
 
-export const g = makeTestGroup(ValidationTest);
+export const g = makeTestGroup(CompatibilityTest);
 
 g.test('sample_mask')
   .desc(

--- a/src/compat/api/validation/texture/createTexture.spec.ts
+++ b/src/compat/api/validation/texture/createTexture.spec.ts
@@ -3,9 +3,9 @@ Tests that you can not use bgra8unorm-srgb in compat mode.
 `;
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
-import { ValidationTest } from '../../../../webgpu/api/validation/validation_test.js';
+import { CompatibilityTest } from '../../../compatibility_test.js';
 
-export const g = makeTestGroup(ValidationTest);
+export const g = makeTestGroup(CompatibilityTest);
 
 g.test('unsupportedTextureFormats')
   .desc(`Tests that you can not create a bgra8unorm-srgb texture in compat mode.`)

--- a/src/compat/api/validation/texture/cubeArray.spec.ts
+++ b/src/compat/api/validation/texture/cubeArray.spec.ts
@@ -3,9 +3,9 @@ Tests that you can not create cube array views in compat mode.
 `;
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
-import { ValidationTest } from '../../../../webgpu/api/validation/validation_test.js';
+import { CompatibilityTest } from '../../../compatibility_test.js';
 
-export const g = makeTestGroup(ValidationTest);
+export const g = makeTestGroup(CompatibilityTest);
 g.test('cube_array')
   .desc('Test you cannot create a cube array texture view.')
   .params(u => u.combine('dimension', ['cube', 'cube-array'] as const))

--- a/src/compat/compatibility_test.ts
+++ b/src/compat/compatibility_test.ts
@@ -1,0 +1,10 @@
+import { ValidationTest } from '../webgpu/api/validation/validation_test.js';
+
+export class CompatibilityTest extends ValidationTest {
+  async init() {
+    await super.init();
+    if (!this.isCompatibility) {
+      this.skip('compatibility tests do not work on non-compatibility mode');
+    }
+  }
+}


### PR DESCRIPTION
This should make it easier to run webgpu: and compat: tests together as the
compat tests will not have to be manually excluded (for example via expectations.txt)
when run in non-compat

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
