### PR TITLE
Give a visual indication for skipped tests

### DIFF
--- a/src/common/runtime/standalone.ts
+++ b/src/common/runtime/standalone.ts
@@ -321,6 +321,9 @@ function makeSubtreeHTML(n: TestSubtree, parentLevel: TestQueryLevel): Visualize
       if (subtreeResult.fail > 0) {
         status += 'fail';
       }
+      if (subtreeResult.skip === subtreeResult.total) {
+        status += 'skip';
+      }
       div.setAttribute('data-status', status);
       if (autoCloseOnPass.checked && status === 'pass') {
         div.firstElementChild!.removeAttribute('open');

--- a/standalone/index.html
+++ b/standalone/index.html
@@ -42,7 +42,7 @@
         --testcase-data-status-fail-bg-color: #fdd;
         --testcase-data-status-warn-bg-color: #ffb;
         --testcase-data-status-pass-bg-color: #cfc;
-        --testcase-data-status-skip-bg-color: #eee;
+        --testcase-data-status-skip-bg-color: #aaf;
 
         --testcase-logs-bg-color: #white;
         --testcase-log-odd-bg-color: #fff;
@@ -74,7 +74,7 @@
           --testcase-data-status-fail-bg-color: #400;
           --testcase-data-status-warn-bg-color: #660;
           --testcase-data-status-pass-bg-color: #040;
-          --testcase-data-status-skip-bg-color: #444;
+          --testcase-data-status-skip-bg-color: #446;
 
           --testcase-logs-bg-color: #black;
           --testcase-log-odd-bg-color: #000;
@@ -288,8 +288,14 @@
       .subtree[data-status='pass'] {
         background: linear-gradient(90deg, var(--testcase-data-status-pass-bg-color), var(--testcase-data-status-pass-bg-color) 16px, var(--bg-color) 16px);
       }
+      .subtree[data-status='skip'] {
+        background: linear-gradient(90deg, var(--testcase-data-status-skip-bg-color), var(--testcase-data-status-skip-bg-color) 16px, var(--bg-color) 16px);
+      }
       .subtree[data-status='pass']::before {
         content: "✔"
+      }
+      .subtree[data-status='skip']::before {
+        content: "○"
       }
       .subtree[data-status='passfail']::before {
         content: "✔/⛔"


### PR DESCRIPTION
As it is, skipped tests, at a glance, show no or a very subtle indication that they've been run. Effectively I click run and don't notice anything has happened. With this change, I see the progress.

before:
<img width="420" alt="Screenshot 2023-07-25 at 15 26 40" src="https://github.com/gpuweb/cts/assets/234804/b25cf9cf-8b79-4688-b7b0-d3d00e5358e3">



after:
<img width="418" alt="Screenshot 2023-07-25 at 15 27 25" src="https://github.com/gpuweb/cts/assets/234804/486f842f-5b7f-4aac-bc83-7c2aaf2e340a">



<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
