### PR TITLE
Shader execution tests for f16 built-in min, max

### DIFF
--- a/src/unittests/floating_point.spec.ts
+++ b/src/unittests/floating_point.spec.ts
@@ -3959,119 +3959,169 @@ g.test('ldexpInterval_f32')
     );
   });
 
-g.test('maxInterval_f32')
-  .paramsSubcasesOnly<ScalarPairToIntervalCase>(
-    // prettier-ignore
-    [
-      // 32-bit normals
-      { input: [0, 0], expected: 0 },
-      { input: [1, 0], expected: 1 },
-      { input: [0, 1], expected: 1 },
-      { input: [-1, 0], expected: 0 },
-      { input: [0, -1], expected: 0 },
-      { input: [1, 1], expected: 1 },
-      { input: [1, -1], expected: 1 },
-      { input: [-1, 1], expected: 1 },
-      { input: [-1, -1], expected: -1 },
+// prettier-ignore
+const kMaxInterval64BitsCases = {
+  f32: [
+    // 0.1 rounded to f32 0x3DCCCCCC or 0x3DCCCCCD, -0.1 rounded to f32 0xBDCCCCCD or 0xBDCCCCCC
+    { input: [0.1, 0], expected: [kMinusOneULPFunctions['f32'](reinterpretU32AsF32(0x3dcccccd)), reinterpretU32AsF32(0x3dcccccd)] },  // ~0.1
+    { input: [0, 0.1], expected: [kMinusOneULPFunctions['f32'](reinterpretU32AsF32(0x3dcccccd)), reinterpretU32AsF32(0x3dcccccd)] },  // ~0.1
+    { input: [0.1, 0.1], expected: [kMinusOneULPFunctions['f32'](reinterpretU32AsF32(0x3dcccccd)), reinterpretU32AsF32(0x3dcccccd)] },  // ~0.1
+    { input: [0.1, -0.1], expected: [kMinusOneULPFunctions['f32'](reinterpretU32AsF32(0x3dcccccd)), reinterpretU32AsF32(0x3dcccccd)] },  // ~0.1
+    { input: [-0.1, 0.1], expected: [kMinusOneULPFunctions['f32'](reinterpretU32AsF32(0x3dcccccd)), reinterpretU32AsF32(0x3dcccccd)] },  // ~0.1
+    { input: [-0.1, -0.1], expected: [reinterpretU32AsF32(0xbdcccccd), kPlusOneULPFunctions['f32'](reinterpretU32AsF32(0xbdcccccd))] },  // ~-0.1
+  ] as ScalarPairToIntervalCase[],
+  f16: [
+    // 0.1 rounded to f16 0x2E66 or 0x2E67, -0.1 rounded to f16 0xAE67 or 0xAE66
+    { input: [0.1, 0], expected: [reinterpretU16AsF16(0x2e66), kPlusOneULPFunctions['f16'](reinterpretU16AsF16(0x2e66))] },  // ~0.1
+    { input: [0, 0.1], expected: [reinterpretU16AsF16(0x2e66), kPlusOneULPFunctions['f16'](reinterpretU16AsF16(0x2e66))] },  // ~0.1
+    { input: [0.1, 0.1], expected: [reinterpretU16AsF16(0x2e66), kPlusOneULPFunctions['f16'](reinterpretU16AsF16(0x2e66))] },  // ~0.1
+    { input: [0.1, -0.1], expected: [reinterpretU16AsF16(0x2e66), kPlusOneULPFunctions['f16'](reinterpretU16AsF16(0x2e66))] },  // ~0.1
+    { input: [-0.1, 0.1], expected: [reinterpretU16AsF16(0x2e66), kPlusOneULPFunctions['f16'](reinterpretU16AsF16(0x2e66))] },  // ~0.1
+    { input: [-0.1, -0.1], expected: [reinterpretU16AsF16(0xae67), kPlusOneULPFunctions['f16'](reinterpretU16AsF16(0xae67))] },  // ~-0.1
+  ] as ScalarPairToIntervalCase[],
+} as const;
 
-      // 64-bit normals
-      { input: [0.1, 0], expected: [kMinusOneULPFunctions['f32'](reinterpretU32AsF32(0x3dcccccd)), reinterpretU32AsF32(0x3dcccccd)] },  // ~0.1
-      { input: [0, 0.1], expected: [kMinusOneULPFunctions['f32'](reinterpretU32AsF32(0x3dcccccd)), reinterpretU32AsF32(0x3dcccccd)] },  // ~0.1
-      { input: [-0.1, 0], expected: 0 },
-      { input: [0, -0.1], expected: 0 },
-      { input: [0.1, 0.1], expected: [kMinusOneULPFunctions['f32'](reinterpretU32AsF32(0x3dcccccd)), reinterpretU32AsF32(0x3dcccccd)] },  // ~0.1
-      { input: [0.1, -0.1], expected: [kMinusOneULPFunctions['f32'](reinterpretU32AsF32(0x3dcccccd)), reinterpretU32AsF32(0x3dcccccd)] },  // ~0.1
-      { input: [-0.1, 0.1], expected: [kMinusOneULPFunctions['f32'](reinterpretU32AsF32(0x3dcccccd)), reinterpretU32AsF32(0x3dcccccd)] },  // ~0.1
-      { input: [-0.1, -0.1], expected: [reinterpretU32AsF32(0xbdcccccd), kPlusOneULPFunctions['f32'](reinterpretU32AsF32(0xbdcccccd))] },  // ~-0.1
+g.test('maxInterval')
+  .params(u =>
+    u
+      .combine('trait', ['f32', 'f16'] as const)
+      .beginSubcases()
+      .expandWithParams<ScalarPairToIntervalCase>(p => {
+        const trait = FP[p.trait];
+        const constants = trait.constants();
+        // prettier-ignore
+        return [
+          // Representable normals
+          { input: [0, 0], expected: 0 },
+          { input: [1, 0], expected: 1 },
+          { input: [0, 1], expected: 1 },
+          { input: [-1, 0], expected: 0 },
+          { input: [0, -1], expected: 0 },
+          { input: [1, 1], expected: 1 },
+          { input: [1, -1], expected: 1 },
+          { input: [-1, 1], expected: 1 },
+          { input: [-1, -1], expected: -1 },
 
-      // 32-bit subnormals
-      { input: [kValue.f32.subnormal.positive.max, 0], expected: [0, kValue.f32.subnormal.positive.max] },
-      { input: [0, kValue.f32.subnormal.positive.max], expected: [0, kValue.f32.subnormal.positive.max] },
-      { input: [kValue.f32.subnormal.positive.min, 0], expected: [0, kValue.f32.subnormal.positive.min] },
-      { input: [0, kValue.f32.subnormal.positive.min], expected: [0, kValue.f32.subnormal.positive.min] },
-      { input: [kValue.f32.subnormal.negative.max, 0], expected: [kValue.f32.subnormal.negative.max, 0] },
-      { input: [0, kValue.f32.subnormal.negative.max], expected: [kValue.f32.subnormal.negative.max, 0] },
-      { input: [kValue.f32.subnormal.negative.min, 0], expected: [kValue.f32.subnormal.negative.min, 0] },
-      { input: [0, kValue.f32.subnormal.negative.min], expected: [kValue.f32.subnormal.negative.min, 0] },
-      { input: [1, kValue.f32.subnormal.positive.max], expected: 1 },
-      { input: [kValue.f32.subnormal.negative.min, kValue.f32.subnormal.positive.max], expected: [kValue.f32.subnormal.negative.min, kValue.f32.subnormal.positive.max] },
+          // 64-bit normals that not exactly representable
+          { input: [-0.1, 0], expected: 0 },
+          { input: [0, -0.1], expected: 0 },
+          ...kMaxInterval64BitsCases[p.trait],
 
-      // Infinities
-      { input: [0, kValue.f32.infinity.positive], expected: kAnyBounds },
-      { input: [kValue.f32.infinity.positive, 0], expected: kAnyBounds },
-      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.positive], expected: kAnyBounds },
-      { input: [0, kValue.f32.infinity.negative], expected: kAnyBounds },
-      { input: [kValue.f32.infinity.negative, 0], expected: kAnyBounds },
-      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.negative], expected: kAnyBounds },
-      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], expected: kAnyBounds },
-      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.negative], expected: kAnyBounds },
-    ]
+          // Representable subnormals
+          { input: [constants.positive.subnormal.max, 0], expected: [0, constants.positive.subnormal.max] },
+          { input: [0, constants.positive.subnormal.max], expected: [0, constants.positive.subnormal.max] },
+          { input: [constants.positive.subnormal.min, 0], expected: [0, constants.positive.subnormal.min] },
+          { input: [0, constants.positive.subnormal.min], expected: [0, constants.positive.subnormal.min] },
+          { input: [constants.negative.subnormal.max, 0], expected: [constants.negative.subnormal.max, 0] },
+          { input: [0, constants.negative.subnormal.max], expected: [constants.negative.subnormal.max, 0] },
+          { input: [constants.negative.subnormal.min, 0], expected: [constants.negative.subnormal.min, 0] },
+          { input: [0, constants.negative.subnormal.min], expected: [constants.negative.subnormal.min, 0] },
+          { input: [1, constants.positive.subnormal.max], expected: 1 },
+          { input: [constants.negative.subnormal.min, constants.positive.subnormal.max], expected: [constants.negative.subnormal.min, constants.positive.subnormal.max] },
+
+          // Infinities
+          { input: [0, constants.positive.infinity], expected: kAnyBounds },
+          { input: [constants.positive.infinity, 0], expected: kAnyBounds },
+          { input: [constants.positive.infinity, constants.positive.infinity], expected: kAnyBounds },
+          { input: [0, constants.negative.infinity], expected: kAnyBounds },
+          { input: [constants.negative.infinity, 0], expected: kAnyBounds },
+          { input: [constants.negative.infinity, constants.negative.infinity], expected: kAnyBounds },
+          { input: [constants.negative.infinity, constants.positive.infinity], expected: kAnyBounds },
+          { input: [constants.positive.infinity, constants.negative.infinity], expected: kAnyBounds },
+        ];
+      })
   )
   .fn(t => {
+    const trait = FP[t.params.trait];
     const [x, y] = t.params.input;
-    const expected = FP.f32.toInterval(t.params.expected);
-    const got = FP.f32.maxInterval(x, y);
+    const expected = trait.toInterval(t.params.expected);
+    const got = trait.maxInterval(x, y);
     t.expect(
       objectEquals(expected, got),
-      `f32.maxInterval(${x}, ${y}) returned ${got}. Expected ${expected}`
+      `${t.params.trait}.maxInterval(${x}, ${y}) returned ${got}. Expected ${expected}`
     );
   });
 
-g.test('minInterval_f32')
-  .paramsSubcasesOnly<ScalarPairToIntervalCase>(
-    // prettier-ignore
-    [
-      // 32-bit normals
-      { input: [0, 0], expected: 0 },
-      { input: [1, 0], expected: 0 },
-      { input: [0, 1], expected: 0 },
-      { input: [-1, 0], expected: -1 },
-      { input: [0, -1], expected: -1 },
-      { input: [1, 1], expected: 1 },
-      { input: [1, -1], expected: -1 },
-      { input: [-1, 1], expected: -1 },
-      { input: [-1, -1], expected: -1 },
+// prettier-ignore
+const kMinInterval64BitsCases = {
+  f32: [
+    // 0.1 rounded to f32 0x3DCCCCCC or 0x3DCCCCCD, -0.1 rounded to f32 0xBDCCCCCD or 0xBDCCCCCC
+    { input: [-0.1, 0], expected: [reinterpretU32AsF32(0xbdcccccd), kPlusOneULPFunctions['f32'](reinterpretU32AsF32(0xbdcccccd))] },  // ~-0.1
+    { input: [0, -0.1], expected: [reinterpretU32AsF32(0xbdcccccd), kPlusOneULPFunctions['f32'](reinterpretU32AsF32(0xbdcccccd))] },  // ~-0.1
+    { input: [0.1, 0.1], expected: [kMinusOneULPFunctions['f32'](reinterpretU32AsF32(0x3dcccccd)), reinterpretU32AsF32(0x3dcccccd)] },  // ~0.1
+    { input: [0.1, -0.1], expected: [reinterpretU32AsF32(0xbdcccccd), kPlusOneULPFunctions['f32'](reinterpretU32AsF32(0xbdcccccd))] },  // ~-0.1
+    { input: [-0.1, 0.1], expected: [reinterpretU32AsF32(0xbdcccccd), kPlusOneULPFunctions['f32'](reinterpretU32AsF32(0xbdcccccd))] },  // ~-0.1
+    { input: [-0.1, -0.1], expected: [reinterpretU32AsF32(0xbdcccccd), kPlusOneULPFunctions['f32'](reinterpretU32AsF32(0xbdcccccd))] },  // ~-0.1
+  ] as ScalarPairToIntervalCase[],
+  f16: [
+    // 0.1 rounded to f16 0x2E66 or 0x2E67, -0.1 rounded to f16 0xAE67 or 0xAE66
+    { input: [-0.1, 0], expected: [reinterpretU16AsF16(0xae67), kPlusOneULPFunctions['f16'](reinterpretU16AsF16(0xae67))] },  // ~-0.1
+    { input: [0, -0.1], expected: [reinterpretU16AsF16(0xae67), kPlusOneULPFunctions['f16'](reinterpretU16AsF16(0xae67))] },  // ~-0.1
+    { input: [0.1, 0.1], expected: [reinterpretU16AsF16(0x2e66), kPlusOneULPFunctions['f16'](reinterpretU16AsF16(0x2e66))] },  // ~0.1
+    { input: [0.1, -0.1], expected: [reinterpretU16AsF16(0xae67), kPlusOneULPFunctions['f16'](reinterpretU16AsF16(0xae67))] },  // ~-0.1
+    { input: [-0.1, 0.1], expected: [reinterpretU16AsF16(0xae67), kPlusOneULPFunctions['f16'](reinterpretU16AsF16(0xae67))] },  // ~-0.1
+    { input: [-0.1, -0.1], expected: [reinterpretU16AsF16(0xae67), kPlusOneULPFunctions['f16'](reinterpretU16AsF16(0xae67))] },  // ~-0.1
+  ] as ScalarPairToIntervalCase[],
+} as const;
 
-      // 64-bit normals
-      { input: [0.1, 0], expected: 0 },
-      { input: [0, 0.1], expected: 0 },
-      { input: [-0.1, 0], expected: [reinterpretU32AsF32(0xbdcccccd), kPlusOneULPFunctions['f32'](reinterpretU32AsF32(0xbdcccccd))] },  // ~-0.1
-      { input: [0, -0.1], expected: [reinterpretU32AsF32(0xbdcccccd), kPlusOneULPFunctions['f32'](reinterpretU32AsF32(0xbdcccccd))] },  // ~-0.1
-      { input: [0.1, 0.1], expected: [kMinusOneULPFunctions['f32'](reinterpretU32AsF32(0x3dcccccd)), reinterpretU32AsF32(0x3dcccccd)] },  // ~0.1
-      { input: [0.1, -0.1], expected: [reinterpretU32AsF32(0xbdcccccd), kPlusOneULPFunctions['f32'](reinterpretU32AsF32(0xbdcccccd))] },  // ~-0.1
-      { input: [-0.1, 0.1], expected: [reinterpretU32AsF32(0xbdcccccd), kPlusOneULPFunctions['f32'](reinterpretU32AsF32(0xbdcccccd))] },  // ~-0.1
-      { input: [-0.1, -0.1], expected: [reinterpretU32AsF32(0xbdcccccd), kPlusOneULPFunctions['f32'](reinterpretU32AsF32(0xbdcccccd))] },  // ~-0.1
+g.test('minInterval')
+  .params(u =>
+    u
+      .combine('trait', ['f32', 'f16'] as const)
+      .beginSubcases()
+      .expandWithParams<ScalarPairToIntervalCase>(p => {
+        const trait = FP[p.trait];
+        const constants = trait.constants();
+        // prettier-ignore
+        return [
+          // Representable normals
+          { input: [0, 0], expected: 0 },
+          { input: [1, 0], expected: 0 },
+          { input: [0, 1], expected: 0 },
+          { input: [-1, 0], expected: -1 },
+          { input: [0, -1], expected: -1 },
+          { input: [1, 1], expected: 1 },
+          { input: [1, -1], expected: -1 },
+          { input: [-1, 1], expected: -1 },
+          { input: [-1, -1], expected: -1 },
 
-      // 32-bit subnormals
-      { input: [kValue.f32.subnormal.positive.max, 0], expected: [0, kValue.f32.subnormal.positive.max] },
-      { input: [0, kValue.f32.subnormal.positive.max], expected: [0, kValue.f32.subnormal.positive.max] },
-      { input: [kValue.f32.subnormal.positive.min, 0], expected: [0, kValue.f32.subnormal.positive.min] },
-      { input: [0, kValue.f32.subnormal.positive.min], expected: [0, kValue.f32.subnormal.positive.min] },
-      { input: [kValue.f32.subnormal.negative.max, 0], expected: [kValue.f32.subnormal.negative.max, 0] },
-      { input: [0, kValue.f32.subnormal.negative.max], expected: [kValue.f32.subnormal.negative.max, 0] },
-      { input: [kValue.f32.subnormal.negative.min, 0], expected: [kValue.f32.subnormal.negative.min, 0] },
-      { input: [0, kValue.f32.subnormal.negative.min], expected: [kValue.f32.subnormal.negative.min, 0] },
-      { input: [-1, kValue.f32.subnormal.positive.max], expected: -1 },
-      { input: [kValue.f32.subnormal.negative.min, kValue.f32.subnormal.positive.max], expected: [kValue.f32.subnormal.negative.min, kValue.f32.subnormal.positive.max] },
+          // 64-bit normals that not exactly representable
+          { input: [0.1, 0], expected: 0 },
+          { input: [0, 0.1], expected: 0 },
+          ...kMinInterval64BitsCases[p.trait],
 
-      // Infinities
-      { input: [0, kValue.f32.infinity.positive], expected: kAnyBounds },
-      { input: [kValue.f32.infinity.positive, 0], expected: kAnyBounds },
-      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.positive], expected: kAnyBounds },
-      { input: [0, kValue.f32.infinity.negative], expected: kAnyBounds },
-      { input: [kValue.f32.infinity.negative, 0], expected: kAnyBounds },
-      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.negative], expected: kAnyBounds },
-      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], expected: kAnyBounds },
-      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.negative], expected: kAnyBounds },
-    ]
+          // Representable subnormals
+          { input: [constants.positive.subnormal.max, 0], expected: [0, constants.positive.subnormal.max] },
+          { input: [0, constants.positive.subnormal.max], expected: [0, constants.positive.subnormal.max] },
+          { input: [constants.positive.subnormal.min, 0], expected: [0, constants.positive.subnormal.min] },
+          { input: [0, constants.positive.subnormal.min], expected: [0, constants.positive.subnormal.min] },
+          { input: [constants.negative.subnormal.max, 0], expected: [constants.negative.subnormal.max, 0] },
+          { input: [0, constants.negative.subnormal.max], expected: [constants.negative.subnormal.max, 0] },
+          { input: [constants.negative.subnormal.min, 0], expected: [constants.negative.subnormal.min, 0] },
+          { input: [0, constants.negative.subnormal.min], expected: [constants.negative.subnormal.min, 0] },
+          { input: [-1, constants.positive.subnormal.max], expected: -1 },
+          { input: [constants.negative.subnormal.min, constants.positive.subnormal.max], expected: [constants.negative.subnormal.min, constants.positive.subnormal.max] },
+
+          // Infinities
+          { input: [0, constants.positive.infinity], expected: kAnyBounds },
+          { input: [constants.positive.infinity, 0], expected: kAnyBounds },
+          { input: [constants.positive.infinity, constants.positive.infinity], expected: kAnyBounds },
+          { input: [0, constants.negative.infinity], expected: kAnyBounds },
+          { input: [constants.negative.infinity, 0], expected: kAnyBounds },
+          { input: [constants.negative.infinity, constants.negative.infinity], expected: kAnyBounds },
+          { input: [constants.negative.infinity, constants.positive.infinity], expected: kAnyBounds },
+          { input: [constants.positive.infinity, constants.negative.infinity], expected: kAnyBounds },
+        ];
+      })
   )
   .fn(t => {
+    const trait = FP[t.params.trait];
     const [x, y] = t.params.input;
-    const expected = FP.f32.toInterval(t.params.expected);
-    const got = FP.f32.minInterval(x, y);
+    const expected = trait.toInterval(t.params.expected);
+    const got = trait.minInterval(x, y);
     t.expect(
       objectEquals(expected, got),
-      `f32.minInterval(${x}, ${y}) returned ${got}. Expected ${expected}`
+      `${t.params.trait}.minInterval(${x}, ${y}) returned ${got}. Expected ${expected}`
     );
   });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/max.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/max.spec.ts
@@ -18,9 +18,9 @@ Component-wise when T is a vector.
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
-import { i32, TypeF32, TypeI32, TypeU32, u32 } from '../../../../../util/conversion.js';
+import { i32, TypeF32, TypeF16, TypeI32, TypeU32, u32 } from '../../../../../util/conversion.js';
 import { FP } from '../../../../../util/floating_point.js';
-import { fullF32Range } from '../../../../../util/math.js';
+import { fullF32Range, fullF16Range } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
 import { allInputSources, Case, run } from '../../expression.js';
 
@@ -49,6 +49,14 @@ export const d = makeCaseCache('max', {
       fullF32Range(),
       'unfiltered',
       FP.f32.maxInterval
+    );
+  },
+  f16: () => {
+    return FP.f16.generateScalarPairToIntervalCases(
+      fullF16Range(),
+      fullF16Range(),
+      'unfiltered',
+      FP.f16.maxInterval
     );
   },
 });
@@ -120,4 +128,10 @@ g.test('f16')
   .params(u =>
     u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
-  .unimplemented();
+  .beforeAllSubcases(t => {
+    t.selectDeviceOrSkipTestCase({ requiredFeatures: ['shader-f16'] });
+  })
+  .fn(async t => {
+    const cases = await d.get('f16');
+    await run(t, builtin('max'), [TypeF16, TypeF16], TypeF16, t.params, cases);
+  });

--- a/src/webgpu/shader/execution/expression/call/builtin/min.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/min.spec.ts
@@ -17,9 +17,9 @@ Component-wise when T is a vector.
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
-import { i32, TypeF32, TypeI32, TypeU32, u32 } from '../../../../../util/conversion.js';
+import { i32, TypeF32, TypeF16, TypeI32, TypeU32, u32 } from '../../../../../util/conversion.js';
 import { FP } from '../../../../../util/floating_point.js';
-import { fullF32Range } from '../../../../../util/math.js';
+import { fullF32Range, fullF16Range } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
 import { allInputSources, Case, run } from '../../expression.js';
 
@@ -34,6 +34,14 @@ export const d = makeCaseCache('min', {
       fullF32Range(),
       'unfiltered',
       FP.f32.minInterval
+    );
+  },
+  f16: () => {
+    return FP.f16.generateScalarPairToIntervalCases(
+      fullF16Range(),
+      fullF16Range(),
+      'unfiltered',
+      FP.f16.minInterval
     );
   },
 });
@@ -119,4 +127,10 @@ g.test('f16')
   .params(u =>
     u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
-  .unimplemented();
+  .beforeAllSubcases(t => {
+    t.selectDeviceOrSkipTestCase({ requiredFeatures: ['shader-f16'] });
+  })
+  .fn(async t => {
+    const cases = await d.get('f16');
+    await run(t, builtin('min'), [TypeF16, TypeF16], TypeF16, t.params, cases);
+  });

--- a/src/webgpu/util/floating_point.ts
+++ b/src/webgpu/util/floating_point.ts
@@ -4972,8 +4972,8 @@ class F16Traits extends FPTraits {
   public readonly lengthInterval = this.unimplementedLength.bind(this);
   public readonly logInterval = this.unimplementedScalarToInterval.bind(this);
   public readonly log2Interval = this.unimplementedScalarToInterval.bind(this);
-  public readonly maxInterval = this.unimplementedScalarPairToInterval.bind(this);
-  public readonly minInterval = this.unimplementedScalarPairToInterval.bind(this);
+  public readonly maxInterval = this.maxIntervalImpl.bind(this);
+  public readonly minInterval = this.minIntervalImpl.bind(this);
   public readonly mixImpreciseInterval = this.unimplementedScalarTripleToInterval.bind(this);
   public readonly mixPreciseInterval = this.unimplementedScalarTripleToInterval.bind(this);
   public readonly mixIntervals = [this.mixImpreciseInterval, this.mixPreciseInterval];


### PR DESCRIPTION
This PR add execution tests for f16 built-in min and max.

Issue: #1248

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
