### PR TITLE
wgsl: f16 built-in execution test for select

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/select.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/select.spec.ts
@@ -17,9 +17,11 @@ import {
   TypeVec,
   TypeBool,
   TypeF32,
+  TypeF16,
   TypeI32,
   TypeU32,
   f32,
+  f16,
   i32,
   u32,
   False,
@@ -39,7 +41,7 @@ function makeBool(n: number) {
   return bool((n & 1) === 1);
 }
 
-type scalarKind = 'b' | 'f' | 'i' | 'u';
+type scalarKind = 'b' | 'f' | 'h' | 'i' | 'u';
 
 const dataType = {
   b: {
@@ -49,6 +51,10 @@ const dataType = {
   f: {
     type: TypeF32,
     constructor: f32,
+  },
+  h: {
+    type: TypeF16,
+    constructor: f16,
   },
   i: {
     type: TypeI32,
@@ -66,9 +72,14 @@ g.test('scalar')
   .params(u =>
     u
       .combine('inputSource', allInputSources)
-      .combine('component', ['b', 'f', 'i', 'u'] as const)
+      .combine('component', ['b', 'f', 'h', 'i', 'u'] as const)
       .combine('overload', ['scalar', 'vec2', 'vec3', 'vec4'] as const)
   )
+  .beforeAllSubcases(t => {
+    if (t.params.component === 'h') {
+      t.selectDeviceOrSkipTestCase({ requiredFeatures: ['shader-f16'] });
+    }
+  })
   .fn(async t => {
     const componentType = dataType[t.params.component as scalarKind].type;
     const cons = dataType[t.params.component as scalarKind].constructor;
@@ -136,9 +147,14 @@ g.test('vector')
   .params(u =>
     u
       .combine('inputSource', allInputSources)
-      .combine('component', ['b', 'f', 'i', 'u'] as const)
+      .combine('component', ['b', 'f', 'h', 'i', 'u'] as const)
       .combine('overload', ['vec2', 'vec3', 'vec4'] as const)
   )
+  .beforeAllSubcases(t => {
+    if (t.params.component === 'h') {
+      t.selectDeviceOrSkipTestCase({ requiredFeatures: ['shader-f16'] });
+    }
+  })
   .fn(async t => {
     const componentType = dataType[t.params.component as scalarKind].type;
     const cons = dataType[t.params.component as scalarKind].constructor;


### PR DESCRIPTION
This PR add execution test for f16 built-in `select`.

Issue: #1248

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
