### PR TITLE
Add a pseudo-random number generator to CTS

### DIFF
--- a/docs/helper_index.txt
+++ b/docs/helper_index.txt
@@ -62,6 +62,7 @@ Whenever a new generally-useful helper is added, it should be indexed here.
 - {@link webgpu/util/create_elements}:
     Helpers for creating web elements like HTMLCanvasElement, OffscreenCanvas, etc.
 - {@link webgpu/util/shader}: Helpers for creating fragment shader based on intended output values, plainType, and componentCount.
+- {@link webgpu/util/prng}: Seed-able deterministic pseudo random number generator. Replacement for Math.random().
 - {@link webgpu/util/texture/base}: General texture-related helpers.
 - {@link webgpu/util/texture/data_generation}: Helper for generating dummy texture data.
 - {@link webgpu/util/texture/layout}: Helpers for working with linear image data

--- a/src/unittests/prng.spec.ts
+++ b/src/unittests/prng.spec.ts
@@ -1,0 +1,74 @@
+export const description = `
+Unittests for the pseudo random number generator
+`;
+
+import { makeTestGroup } from '../common/framework/test_group.js';
+import { fullU32Range } from '../webgpu/util/math.js';
+import { PRNG } from '../webgpu/util/prng.js';
+
+import { UnitTest } from './unit_test.js';
+
+export const g = makeTestGroup(UnitTest);
+
+// There exist more formal tests for the quality of random number generators
+// that are out of the scope for testing here (and are checked against the
+// original C implementation).
+// These tests are just intended to be smoke tests for implementation.
+
+// Test against the reference u32 values from the original C implementation
+// https://github.com/MersenneTwister-Lab/TinyMT/blob/master/tinymt/check32.out.txt
+g.test('check').fn(t => {
+  const p = new PRNG(1);
+  // prettier-ignore
+  const expected = [
+    2545341989, 981918433,  3715302833, 2387538352, 3591001365,
+    3820442102, 2114400566, 2196103051, 2783359912, 764534509,
+    643179475,  1822416315, 881558334,  4207026366, 3690273640,
+    3240535687, 2921447122, 3984931427, 4092394160, 44209675,
+    2188315343, 2908663843, 1834519336, 3774670961, 3019990707,
+    4065554902, 1239765502, 4035716197, 3412127188, 552822483,
+    161364450,  353727785,  140085994,  149132008,  2547770827,
+    4064042525, 4078297538, 2057335507, 622384752,  2041665899,
+    2193913817, 1080849512, 33160901,  662956935,   642999063,
+    3384709977, 1723175122, 3866752252, 521822317,  2292524454,
+  ];
+  expected.forEach((_, i) => {
+    const val = p.randomU32();
+    t.expect(
+      val === expected[i],
+      `PRNG(1) failed produced the ${i}th expected item, ${val} instead of ${expected[i]})`
+    );
+  });
+});
+
+// Prove that generator is deterministic for at least 1000 values with different
+// seeds.
+g.test('deterministic_random').fn(t => {
+  fullU32Range().forEach(seed => {
+    const lhs = new PRNG(seed);
+    const rhs = new PRNG(seed);
+    for (let i = 0; i < 1000; i++) {
+      const lhs_val = lhs.random();
+      const rhs_val = rhs.random();
+      t.expect(
+        lhs_val === rhs_val,
+        `For seed ${seed}, the ${i}th item, PRNG was non-deterministic (${lhs_val} vs ${rhs_val})`
+      );
+    }
+  });
+});
+
+g.test('deterministic_randomU32').fn(t => {
+  fullU32Range().forEach(seed => {
+    const lhs = new PRNG(seed);
+    const rhs = new PRNG(seed);
+    for (let i = 0; i < 1000; i++) {
+      const lhs_val = lhs.randomU32();
+      const rhs_val = rhs.randomU32();
+      t.expect(
+        lhs_val === rhs_val,
+        `For seed ${seed}, the ${i}th item, PRNG was non-deterministic (${lhs_val} vs ${rhs_val})`
+      );
+    }
+  });
+});

--- a/src/webgpu/util/prng.ts
+++ b/src/webgpu/util/prng.ts
@@ -1,0 +1,125 @@
+import { assert } from '../../common/util/util.js';
+
+import { kValue } from './constants.js';
+
+/**
+ * Seed-able deterministic pseudo random generator for the WebGPU CTS
+ *
+ * This generator requires setting a seed value and the sequence of values
+ * generated is deterministic based on the seed.
+ *
+ * This generator is intended to be a replacement for Math.random().
+ *
+ * This generator is not cryptographically secure, though nothing in the CTS
+ * should be needing cryptographic security.
+ *
+ * The current implementation is based on TinyMT
+ * (https://github.com/MersenneTwister-Lab/TinyMT), which is a version of
+ * Mersenne Twister that has reduced the internal state size at the cost of
+ * shortening the period length of the generated sequence. The period is still
+ * 2^127 - 1 entries long, so should be sufficient for use in the CTS, but it is
+ * less costly to create multiple instances of the class.
+ */
+export class PRNG {
+  // Storing variables for temper() as members, so they don't need to be
+  // reallocated per call to temper()
+  private readonly t_vars: Uint32Array;
+
+  // Storing variables for next() as members, so they don't need to be
+  // reallocated per call to next()
+  private readonly n_vars: Uint32Array;
+
+  // Generator internal state
+  private readonly state: Uint32Array;
+
+  // Default tuning parameters for TinyMT.
+  // These are tested to not generate an all zero initial state.
+  private static readonly kMat1: number = 0x8f7011ee;
+  private static readonly kMat2: number = 0xfc78ff1f;
+  private static readonly kTMat: number = 0x3793fdff;
+
+  // TinyMT algorithm internal magic numbers
+  private static readonly kMask = 0x7fffffff;
+  private static readonly kMinLoop = 8;
+  private static readonly kPreLoop = 8;
+  private static readonly kSH0 = 1;
+  private static readonly kSH1 = 10;
+  private static readonly kSH8 = 8;
+
+  // u32.max + 1, used to scale the u32 value from temper() to [0, 1).
+  private static readonly kRandomDivisor = 4294967296.0;
+
+  /**
+   * constructor
+   *
+   * @param seed value used to initialize random number sequence. Results are
+   *             guaranteed to be deterministic based on this.
+   *             This value must be in the range of unsigned 32-bit integers.
+   *             Non-integers will be rounded.
+   */
+  constructor(seed: number) {
+    assert(seed >= 0 && seed <= kValue.u32.max, 'seed to PRNG needs to a u32');
+
+    this.t_vars = new Uint32Array(2);
+    this.n_vars = new Uint32Array(2);
+
+    this.state = new Uint32Array([Math.round(seed), PRNG.kMat1, PRNG.kMat2, PRNG.kTMat]);
+    for (let i = 1; i < PRNG.kMinLoop; i++) {
+      this.state[i & 3] ^=
+        i + Math.imul(1812433253, this.state[(i - 1) & 3] ^ (this.state[(i - 1) & 3] >>> 30));
+    }
+
+    // Check that the initial state isn't all 0s, since the algorithm assumes
+    // that this never occurs
+    assert(
+      (this.state[0] & PRNG.kMask) !== 0 ||
+        this.state[1] !== 0 ||
+        this.state[2] !== 0 ||
+        this.state[2] !== 0,
+      'Initialization of PRNG unexpectedly generated all 0s initial state, this means the tuning parameters are bad'
+    );
+
+    for (let i = 0; i < PRNG.kPreLoop; i++) {
+      this.next();
+    }
+  }
+
+  /** Advances the internal state to the next values */
+  private next() {
+    this.n_vars[0] = (this.state[0] & PRNG.kMask) ^ this.state[1] ^ this.state[2];
+    this.n_vars[1] = this.state[3];
+    this.n_vars[0] ^= this.n_vars[0] << PRNG.kSH0;
+    this.n_vars[1] ^= (this.n_vars[1] >>> PRNG.kSH0) ^ this.n_vars[0];
+    this.state[0] = this.state[1];
+    this.state[1] = this.state[2];
+    this.state[2] = this.n_vars[0] ^ (this.n_vars[1] << PRNG.kSH1);
+    this.state[3] = this.n_vars[1];
+    if ((this.n_vars[1] & 1) !== 0) {
+      this.state[1] ^= PRNG.kMat1;
+      this.state[2] ^= PRNG.kMat2;
+    }
+  }
+
+  /** @returns a 32-bit unsigned integer based on the current state */
+  private temper(): number {
+    this.t_vars[0] = this.state[3];
+    this.t_vars[1] = this.state[0] + (this.state[2] >>> PRNG.kSH8);
+    this.t_vars[0] ^= this.t_vars[1];
+    if ((this.t_vars[1] & 1) !== 0) {
+      this.t_vars[0] ^= PRNG.kTMat;
+    }
+    return this.t_vars[0];
+  }
+
+  /** @returns a value on the range of [0, 1)  and advances the state */
+  public random(): number {
+    this.next();
+    return this.temper() / PRNG.kRandomDivisor;
+  }
+
+  /** @returns a 32-bit unsigned integer value and advances the state */
+  public randomU32(): number {
+    this.next();
+    return this.temper();
+  }
+}


### PR DESCRIPTION
This adds a utility class, PRNG, that provides a seed-able deterministic random number generator, to assist generating
large sets of test cases without having to encode each one into a source file.

It is based off of TinyMT
(https://github.com/MersenneTwister-Lab/TinyMT), a small state version of Mersenne Twister.

Fixes #2881

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
