### PR TITLE
Update floating point framework based on spec changes

### DIFF
--- a/src/unittests/floating_point.spec.ts
+++ b/src/unittests/floating_point.spec.ts
@@ -19,14 +19,14 @@ import { UnitTest } from './unit_test.js';
 
 export const g = makeTestGroup(UnitTest);
 
-/** Bounds indicating an expectation of an indeterminate value */
-const kIndeterminateBounds: IntervalBounds = [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY];
+/** Bounds indicating an expectation of unbounded error */
+const kUnboundedBounds: IntervalBounds = [Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY];
 
-/** Interval from kIndeterminateBounds */
-const kIndeterminateInterval = {
-  f32: FP.f32.toParam(kIndeterminateBounds),
-  f16: FP.f16.toParam(kIndeterminateBounds),
-  abstract: FP.abstract.toParam(kIndeterminateBounds),
+/** Interval from kUnboundedBounds */
+const kUnboundedInterval = {
+  f32: FP.f32.toParam(kUnboundedBounds),
+  f16: FP.f16.toParam(kUnboundedBounds),
+  abstract: FP.abstract.toParam(kUnboundedBounds),
 };
 
 /** @returns a number N * ULP greater than the provided number */
@@ -140,7 +140,7 @@ g.test('constructor')
           // Infinities
           { input: [0, constants.positive.infinity], expected: [0, Number.POSITIVE_INFINITY] },
           { input: [constants.negative.infinity, 0], expected: [Number.NEGATIVE_INFINITY, 0] },
-          { input: [constants.negative.infinity, constants.positive.infinity], expected: kIndeterminateBounds },
+          { input: [constants.negative.infinity, constants.positive.infinity], expected: kUnboundedBounds },
         ];
 
         // Note: Out of range values are limited to infinities for abstract float, due to abstract
@@ -447,7 +447,7 @@ g.test('spanIntervals')
           { intervals: [[2, 5], [0, 1]], expected: [0, 5] },
           { intervals: [[0, 2], [1, 5]], expected: [0, 5] },
           { intervals: [[0, 5], [1, 2]], expected: [0, 5] },
-          { intervals: [[constants.negative.infinity, 0], [0, constants.positive.infinity]], expected: kIndeterminateBounds },
+          { intervals: [[constants.negative.infinity, 0], [0, constants.positive.infinity]], expected: kUnboundedBounds },
 
           // Multiple Intervals
           { intervals: [[0, 1], [2, 3], [4, 5]], expected: [0, 5] },
@@ -683,8 +683,8 @@ g.test('toVector')
           { input: [1, [2], trait.toParam([3])], expected: [1, 2, 3] },
           { input: [1, trait.toParam([2]), [3], 4], expected: [1, 2, 3, 4] },
           {
-            input: [1, [2], [2, 3], kIndeterminateInterval[p.trait]],
-            expected: [1, 2, [2, 3], kIndeterminateBounds],
+            input: [1, [2], [2, 3], kUnboundedInterval[p.trait]],
+            expected: [1, 2, [2, 3], kUnboundedBounds],
           },
         ];
       })
@@ -1839,20 +1839,20 @@ g.test('absoluteErrorInterval')
         // prettier-ignore
         return [
           // Edge Cases
-          // 1. Interval around infinity would be kIndeterminateBounds
-          { value: constants.positive.infinity, error: 0, expected: kIndeterminateBounds },
-          { value: constants.positive.infinity, error: largeErr, expected: kIndeterminateBounds },
-          { value: constants.positive.infinity, error: 1, expected: kIndeterminateBounds },
-          { value: constants.negative.infinity, error: 0, expected: kIndeterminateBounds },
-          { value: constants.negative.infinity, error: largeErr, expected: kIndeterminateBounds },
-          { value: constants.negative.infinity, error: 1, expected: kIndeterminateBounds },
+          // 1. Interval around infinity would be kUnboundedBounds
+          { value: constants.positive.infinity, error: 0, expected: kUnboundedBounds },
+          { value: constants.positive.infinity, error: largeErr, expected: kUnboundedBounds },
+          { value: constants.positive.infinity, error: 1, expected: kUnboundedBounds },
+          { value: constants.negative.infinity, error: 0, expected: kUnboundedBounds },
+          { value: constants.negative.infinity, error: largeErr, expected: kUnboundedBounds },
+          { value: constants.negative.infinity, error: 1, expected: kUnboundedBounds },
           // 2. Interval around largest finite positive/negative
           { value: constants.positive.max, error: 0, expected: constants.positive.max },
-          { value: constants.positive.max, error: largeErr, expected: kIndeterminateBounds},
-          { value: constants.positive.max, error: constants.positive.max, expected: kIndeterminateBounds},
+          { value: constants.positive.max, error: largeErr, expected: kUnboundedBounds},
+          { value: constants.positive.max, error: constants.positive.max, expected: kUnboundedBounds},
           { value: constants.negative.min, error: 0, expected: constants.negative.min },
-          { value: constants.negative.min, error: largeErr, expected: kIndeterminateBounds},
-          { value: constants.negative.min, error: constants.positive.max, expected: kIndeterminateBounds},
+          { value: constants.negative.min, error: largeErr, expected: kUnboundedBounds},
+          { value: constants.negative.min, error: constants.positive.max, expected: kUnboundedBounds},
           // 3. Interval around small but normal center, center should not get flushed.
           { value: constants.positive.min, error: 0, expected: constants.positive.min },
           { value: constants.positive.min, error: smallErr, expected: [constants.positive.min - smallErr, constants.positive.min + smallErr]},
@@ -2014,8 +2014,8 @@ g.test('correctlyRoundedInterval')
         // prettier-ignore
         return [
           // Edge Cases
-          { value: constants.positive.infinity, expected: kIndeterminateBounds },
-          { value: constants.negative.infinity, expected: kIndeterminateBounds },
+          { value: constants.positive.infinity, expected: kUnboundedBounds },
+          { value: constants.negative.infinity, expected: kUnboundedBounds },
           { value: constants.positive.max, expected: constants.positive.max },
           { value: constants.negative.min, expected: constants.negative.min },
           { value: constants.positive.min, expected: constants.positive.min },
@@ -2078,21 +2078,21 @@ g.test('ulpInterval')
         // prettier-ignore
         return [
           // Edge Cases
-          { value: constants.positive.infinity, num_ulp: 0, expected: kIndeterminateBounds },
-          { value: constants.positive.infinity, num_ulp: 1, expected: kIndeterminateBounds },
-          { value: constants.positive.infinity, num_ulp: ULPValue, expected: kIndeterminateBounds },
-          { value: constants.negative.infinity, num_ulp: 0, expected: kIndeterminateBounds },
-          { value: constants.negative.infinity, num_ulp: 1, expected: kIndeterminateBounds },
-          { value: constants.negative.infinity, num_ulp: ULPValue, expected: kIndeterminateBounds },
+          { value: constants.positive.infinity, num_ulp: 0, expected: kUnboundedBounds },
+          { value: constants.positive.infinity, num_ulp: 1, expected: kUnboundedBounds },
+          { value: constants.positive.infinity, num_ulp: ULPValue, expected: kUnboundedBounds },
+          { value: constants.negative.infinity, num_ulp: 0, expected: kUnboundedBounds },
+          { value: constants.negative.infinity, num_ulp: 1, expected: kUnboundedBounds },
+          { value: constants.negative.infinity, num_ulp: ULPValue, expected: kUnboundedBounds },
           { value: constants.positive.max, num_ulp: 0, expected: constants.positive.max },
-          { value: constants.positive.max, num_ulp: 1, expected: kIndeterminateBounds },
-          { value: constants.positive.max, num_ulp: ULPValue, expected: kIndeterminateBounds },
+          { value: constants.positive.max, num_ulp: 1, expected: kUnboundedBounds },
+          { value: constants.positive.max, num_ulp: ULPValue, expected: kUnboundedBounds },
           { value: constants.positive.min, num_ulp: 0, expected: constants.positive.min },
           { value: constants.positive.min, num_ulp: 1, expected: [0, plusOneULP(constants.positive.min)] },
           { value: constants.positive.min, num_ulp: ULPValue, expected: [0, plusNULP(constants.positive.min, ULPValue)] },
           { value: constants.negative.min, num_ulp: 0, expected: constants.negative.min },
-          { value: constants.negative.min, num_ulp: 1, expected: kIndeterminateBounds },
-          { value: constants.negative.min, num_ulp: ULPValue, expected: kIndeterminateBounds },
+          { value: constants.negative.min, num_ulp: 1, expected: kUnboundedBounds },
+          { value: constants.negative.min, num_ulp: ULPValue, expected: kUnboundedBounds },
           { value: constants.negative.max, num_ulp: 0, expected: constants.negative.max },
           { value: constants.negative.max, num_ulp: 1, expected: [minusOneULP(constants.negative.max), 0] },
           { value: constants.negative.max, num_ulp: ULPValue, expected: [minusNULP(constants.negative.max, ULPValue), 0] },
@@ -2181,8 +2181,8 @@ g.test('absInterval')
           ...kAbsIntervalCases.map(t => {return {input: t.input, expected: t.expected[p.trait]} as ScalarToIntervalCase}),
 
           // Edge cases
-          { input: constants.positive.infinity, expected: kIndeterminateBounds },
-          { input: constants.negative.infinity, expected: kIndeterminateBounds },
+          { input: constants.positive.infinity, expected: kUnboundedBounds },
+          { input: constants.negative.infinity, expected: kUnboundedBounds },
           { input: constants.positive.max, expected: constants.positive.max },
           { input: constants.positive.min, expected: constants.positive.min },
           { input: constants.negative.min, expected: constants.positive.max },
@@ -2251,17 +2251,17 @@ g.test('acosInterval')
         const constants = trait.constants();
         // prettier-ignore
         return [
-          // The acceptance interval @ x = -1 and 1 is kIndeterminateBounds, because
+          // The acceptance interval @ x = -1 and 1 is kUnboundedBounds, because
           // sqrt(1 - x*x) = sqrt(0), and sqrt is defined in terms of inverseqrt
-          // The acceptance interval @ x = 0 is kIndeterminateBounds, because atan2 is not
+          // The acceptance interval @ x = 0 is kUnboundedBounds, because atan2 is not
           // well-defined/implemented at 0.
-          { input: constants.negative.infinity, expected: kIndeterminateBounds },
-          { input: constants.negative.min, expected: kIndeterminateBounds },
-          { input: -1, expected: kIndeterminateBounds },
-          { input: 0, expected: kIndeterminateBounds },
-          { input: 1, expected: kIndeterminateBounds },
-          { input: constants.positive.max, expected: kIndeterminateBounds },
-          { input: constants.positive.infinity, expected: kIndeterminateBounds },
+          { input: constants.negative.infinity, expected: kUnboundedBounds },
+          { input: constants.negative.min, expected: kUnboundedBounds },
+          { input: -1, expected: kUnboundedBounds },
+          { input: 0, expected: kUnboundedBounds },
+          { input: 1, expected: kUnboundedBounds },
+          { input: constants.positive.max, expected: kUnboundedBounds },
+          { input: constants.positive.infinity, expected: kUnboundedBounds },
 
           // Cases that bounded by absolute error and inherited from atan2(sqrt(1-x*x), x). Note that
           // even x is very close to 1.0 and the expected result is close to 0.0, the expected
@@ -2288,15 +2288,15 @@ g.test('acoshAlternativeInterval_f32')
       // Some of these are hard coded, since the error intervals are difficult
       // to express in a closed human-readable form due to the inherited nature
       // of the errors.
-      { input: kValue.f32.infinity.negative, expected: kIndeterminateBounds },
-      { input: kValue.f32.negative.min, expected: kIndeterminateBounds },
-      { input: -1, expected: kIndeterminateBounds },
-      { input: 0, expected: kIndeterminateBounds },
-      { input: 1, expected: kIndeterminateBounds },  // 1/0 occurs in inverseSqrt in this formulation
+      { input: kValue.f32.infinity.negative, expected: kUnboundedBounds },
+      { input: kValue.f32.negative.min, expected: kUnboundedBounds },
+      { input: -1, expected: kUnboundedBounds },
+      { input: 0, expected: kUnboundedBounds },
+      { input: 1, expected: kUnboundedBounds },  // 1/0 occurs in inverseSqrt in this formulation
       { input: 1.1, expected: [reinterpretU64AsF64(0x3fdc_6368_8000_0000n), reinterpretU64AsF64(0x3fdc_636f_2000_0000n)] },  // ~0.443..., differs from the primary in the later digits
       { input: 10, expected: [reinterpretU64AsF64(0x4007_f21e_4000_0000n), reinterpretU64AsF64(0x4007_f21f_6000_0000n)] },  // ~2.993...
-      { input: kValue.f32.positive.max, expected: kIndeterminateBounds },
-      { input: kValue.f32.infinity.positive, expected: kIndeterminateBounds },
+      { input: kValue.f32.positive.max, expected: kUnboundedBounds },
+      { input: kValue.f32.infinity.positive, expected: kUnboundedBounds },
     ]
   )
   .fn(t => {
@@ -2315,15 +2315,15 @@ g.test('acoshPrimaryInterval_f32')
       // Some of these are hard coded, since the error intervals are difficult
       // to express in a closed human-readable form due to the inherited nature
       // of the errors.
-      { input: kValue.f32.infinity.negative, expected: kIndeterminateBounds },
-      { input: kValue.f32.negative.min, expected: kIndeterminateBounds },
-      { input: -1, expected: kIndeterminateBounds },
-      { input: 0, expected: kIndeterminateBounds },
-      { input: 1, expected: kIndeterminateBounds },  // 1/0 occurs in inverseSqrt in this formulation
+      { input: kValue.f32.infinity.negative, expected: kUnboundedBounds },
+      { input: kValue.f32.negative.min, expected: kUnboundedBounds },
+      { input: -1, expected: kUnboundedBounds },
+      { input: 0, expected: kUnboundedBounds },
+      { input: 1, expected: kUnboundedBounds },  // 1/0 occurs in inverseSqrt in this formulation
       { input: 1.1, expected: [reinterpretU64AsF64(0x3fdc_6368_2000_0000n), reinterpretU64AsF64(0x3fdc_636f_8000_0000n)] }, // ~0.443..., differs from the alternative in the later digits
       { input: 10, expected: [reinterpretU64AsF64(0x4007_f21e_4000_0000n), reinterpretU64AsF64(0x4007_f21f_6000_0000n)] },  // ~2.993...
-      { input: kValue.f32.positive.max, expected: kIndeterminateBounds },
-      { input: kValue.f32.infinity.positive, expected: kIndeterminateBounds },
+      { input: kValue.f32.positive.max, expected: kUnboundedBounds },
+      { input: kValue.f32.infinity.positive, expected: kUnboundedBounds },
     ]
   )
   .fn(t => {
@@ -2360,20 +2360,20 @@ g.test('asinInterval')
         const abs_error = p.trait === 'f32' ? 6.77e-5 : 3.91e-3;
         // prettier-ignore
         return [
-          // The acceptance interval @ x = -1 and 1 is kIndeterminateBounds, because
+          // The acceptance interval @ x = -1 and 1 is kUnboundedBounds, because
           // sqrt(1 - x*x) = sqrt(0), and sqrt is defined in terms of inversqrt.
-          // The acceptance interval @ x = 0 is kIndeterminateBounds, because atan2 is not
+          // The acceptance interval @ x = 0 is kUnboundedBounds, because atan2 is not
           // well-defined/implemented at 0.
-          { input: constants.negative.infinity, expected: kIndeterminateBounds },
-          { input: constants.negative.min, expected: kIndeterminateBounds },
-          { input: -1, expected: kIndeterminateBounds },
-          // Subnormal input may get flushed to 0, and result in kIndeterminateBounds.
-          { input: constants.negative.subnormal.min, expected: kIndeterminateBounds },
-          { input: 0, expected: kIndeterminateBounds },
-          { input: constants.positive.subnormal.max, expected: kIndeterminateBounds },
-          { input: 1, expected: kIndeterminateBounds },
-          { input: constants.positive.max, expected: kIndeterminateBounds },
-          { input: constants.positive.infinity, expected: kIndeterminateBounds },
+          { input: constants.negative.infinity, expected: kUnboundedBounds },
+          { input: constants.negative.min, expected: kUnboundedBounds },
+          { input: -1, expected: kUnboundedBounds },
+          // Subnormal input may get flushed to 0, and result in kUnboundedBounds.
+          { input: constants.negative.subnormal.min, expected: kUnboundedBounds },
+          { input: 0, expected: kUnboundedBounds },
+          { input: constants.positive.subnormal.max, expected: kUnboundedBounds },
+          { input: 1, expected: kUnboundedBounds },
+          { input: constants.positive.max, expected: kUnboundedBounds },
+          { input: constants.positive.infinity, expected: kUnboundedBounds },
 
           // When input near 0, the expected result is bounded by absolute error rather than ULP
           // error. Away from 0 the atan2 inherited error should be larger.
@@ -2402,13 +2402,13 @@ g.test('asinhInterval_f32')
       // Some of these are hard coded, since the error intervals are difficult
       // to express in a closed human-readable form due to the inherited nature
       // of the errors.
-      { input: kValue.f32.infinity.negative, expected: kIndeterminateBounds },
-      { input: kValue.f32.negative.min, expected: kIndeterminateBounds },
+      { input: kValue.f32.infinity.negative, expected: kUnboundedBounds },
+      { input: kValue.f32.negative.min, expected: kUnboundedBounds },
       { input: -1, expected: [reinterpretU64AsF64(0xbfec_343a_8000_0000n), reinterpretU64AsF64(0xbfec_3432_8000_0000n)] },  // ~-0.88137...
       { input: 0, expected: [reinterpretU64AsF64(0xbeaa_0000_2000_0000n), reinterpretU64AsF64(0x3eb1_ffff_d000_0000n)] },  // ~0
       { input: 1, expected: [reinterpretU64AsF64(0x3fec_3435_4000_0000n), reinterpretU64AsF64(0x3fec_3437_8000_0000n)] },  // ~0.88137...
-      { input: kValue.f32.positive.max, expected: kIndeterminateBounds },
-      { input: kValue.f32.infinity.positive, expected: kIndeterminateBounds },
+      { input: kValue.f32.positive.max, expected: kUnboundedBounds },
+      { input: kValue.f32.infinity.positive, expected: kUnboundedBounds },
     ]
   )
   .fn(t => {
@@ -2472,8 +2472,8 @@ g.test('atanInterval')
           { input: 0, expected: 0 },
           ...kAtanIntervalCases[p.trait],
 
-          { input: constants.negative.infinity, expected: kIndeterminateBounds },
-          { input: constants.positive.infinity, expected: kIndeterminateBounds },
+          { input: constants.negative.infinity, expected: kUnboundedBounds },
+          { input: constants.positive.infinity, expected: kUnboundedBounds },
         ];
       })
   )
@@ -2501,15 +2501,15 @@ g.test('atanhInterval_f32')
     [
       // Some of these are hard coded, since the error intervals are difficult
       // to express in a closed human-readable form due to the inherited nature of the errors.
-      { input: kValue.f32.infinity.negative, expected: kIndeterminateBounds },
-      { input: kValue.f32.negative.min, expected: kIndeterminateBounds },
-      { input: -1, expected: kIndeterminateBounds },
+      { input: kValue.f32.infinity.negative, expected: kUnboundedBounds },
+      { input: kValue.f32.negative.min, expected: kUnboundedBounds },
+      { input: -1, expected: kUnboundedBounds },
       { input: -0.1, expected: [reinterpretU64AsF64(0xbfb9_af9a_6000_0000n), reinterpretU64AsF64(0xbfb9_af8c_c000_0000n)] },  // ~-0.1003...
       { input: 0, expected: [reinterpretU64AsF64(0xbe96_0000_2000_0000n), reinterpretU64AsF64(0x3e98_0000_0000_0000n)] },  // ~0
       { input: 0.1, expected: [reinterpretU64AsF64(0x3fb9_af8b_8000_0000n), reinterpretU64AsF64(0x3fb9_af9b_0000_0000n)] },  // ~0.1003...
-      { input: 1, expected: kIndeterminateBounds },
-      { input: kValue.f32.positive.max, expected: kIndeterminateBounds },
-      { input: kValue.f32.infinity.positive, expected: kIndeterminateBounds },
+      { input: 1, expected: kUnboundedBounds },
+      { input: kValue.f32.positive.max, expected: kUnboundedBounds },
+      { input: kValue.f32.infinity.positive, expected: kUnboundedBounds },
     ]
   )
   .fn(t => {
@@ -2557,8 +2557,8 @@ g.test('ceilInterval')
         { input: -1.9, expected: -1 },
 
         // Edge cases
-        { input: constants.positive.infinity, expected: kIndeterminateBounds },
-        { input: constants.negative.infinity, expected: kIndeterminateBounds },
+        { input: constants.positive.infinity, expected: kUnboundedBounds },
+        { input: constants.negative.infinity, expected: kUnboundedBounds },
         { input: constants.positive.max, expected: constants.positive.max },
         { input: constants.positive.min, expected: 1 },
         { input: constants.negative.min, expected: constants.negative.min },
@@ -2623,13 +2623,13 @@ g.test('cosInterval')
           // substantially different, so instead of getting 0 you get a value on the
           // order of 10^-8 away from 0, thus difficult to express in a
           // human-readable manner.
-          { input: constants.negative.infinity, expected: kIndeterminateBounds },
-          { input: constants.negative.min, expected: kIndeterminateBounds },
+          { input: constants.negative.infinity, expected: kUnboundedBounds },
+          { input: constants.negative.min, expected: kUnboundedBounds },
           { input: constants.negative.pi.whole, expected: [-1, kPlusOneULPFunctions[p.trait](-1)] },
           { input: 0, expected: [1, 1] },
           { input: constants.positive.pi.whole, expected: [-1, kPlusOneULPFunctions[p.trait](-1)] },
-          { input: constants.positive.max, expected: kIndeterminateBounds },
-          { input: constants.positive.infinity, expected: kIndeterminateBounds },
+          { input: constants.positive.max, expected: kUnboundedBounds },
+          { input: constants.positive.infinity, expected: kUnboundedBounds },
 
           ...(kCosIntervalThirdPiCases[p.trait] as ScalarToIntervalCase[]),
         ];
@@ -2659,13 +2659,13 @@ g.test('coshInterval_f32')
       // Some of these are hard coded, since the error intervals are difficult
       // to express in a closed human-readable form due to the inherited nature
       // of the errors.
-      { input: kValue.f32.infinity.negative, expected: kIndeterminateBounds },
-      { input: kValue.f32.negative.min, expected: kIndeterminateBounds },
+      { input: kValue.f32.infinity.negative, expected: kUnboundedBounds },
+      { input: kValue.f32.negative.min, expected: kUnboundedBounds },
       { input: -1, expected: [ reinterpretU32AsF32(0x3fc583a4), reinterpretU32AsF32(0x3fc583b1)] },  // ~1.1543...
       { input: 0, expected: [reinterpretU32AsF32(0x3f7ffffd), reinterpretU32AsF32(0x3f800002)] },  // ~1
       { input: 1, expected: [ reinterpretU32AsF32(0x3fc583a4), reinterpretU32AsF32(0x3fc583b1)] },  // ~1.1543...
-      { input: kValue.f32.positive.max, expected: kIndeterminateBounds },
-      { input: kValue.f32.infinity.positive, expected: kIndeterminateBounds },
+      { input: kValue.f32.positive.max, expected: kUnboundedBounds },
+      { input: kValue.f32.infinity.positive, expected: kUnboundedBounds },
     ]
   )
   .fn(t => {
@@ -2682,8 +2682,8 @@ g.test('degreesInterval_f32')
   .paramsSubcasesOnly<ScalarToIntervalCase>(
     // prettier-ignore
     [
-      { input: kValue.f32.infinity.negative, expected: kIndeterminateBounds },
-      { input: kValue.f32.negative.min, expected: kIndeterminateBounds },
+      { input: kValue.f32.infinity.negative, expected: kUnboundedBounds },
+      { input: kValue.f32.negative.min, expected: kUnboundedBounds },
       { input: kValue.f32.negative.pi.whole, expected: [kMinusOneULPFunctions['f32'](-180), kPlusOneULPFunctions['f32'](-180)] },
       { input: kValue.f32.negative.pi.three_quarters, expected: [kMinusOneULPFunctions['f32'](-135), kPlusOneULPFunctions['f32'](-135)] },
       { input: kValue.f32.negative.pi.half, expected: [kMinusOneULPFunctions['f32'](-90), kPlusOneULPFunctions['f32'](-90)] },
@@ -2697,8 +2697,8 @@ g.test('degreesInterval_f32')
       { input: kValue.f32.positive.pi.half, expected: [kMinusOneULPFunctions['f32'](90), kPlusOneULPFunctions['f32'](90)] },
       { input: kValue.f32.positive.pi.three_quarters, expected: [kMinusOneULPFunctions['f32'](135), kPlusOneULPFunctions['f32'](135)] },
       { input: kValue.f32.positive.pi.whole, expected: [kMinusOneULPFunctions['f32'](180), kPlusOneULPFunctions['f32'](180)] },
-      { input: kValue.f32.positive.max, expected: kIndeterminateBounds },
-      { input: kValue.f32.infinity.positive, expected: kIndeterminateBounds },
+      { input: kValue.f32.positive.max, expected: kUnboundedBounds },
+      { input: kValue.f32.infinity.positive, expected: kUnboundedBounds },
     ]
   )
   .fn(t => {
@@ -2714,10 +2714,10 @@ g.test('expInterval_f32')
   .paramsSubcasesOnly<ScalarToIntervalCase>(
     // prettier-ignore
     [
-      { input: kValue.f32.infinity.negative, expected: kIndeterminateBounds },
+      { input: kValue.f32.infinity.negative, expected: kUnboundedBounds },
       { input: 0, expected: 1 },
       { input: 1, expected: [kValue.f32.positive.e, kPlusOneULPFunctions['f32'](kValue.f32.positive.e)] },
-      { input: 89, expected: kIndeterminateBounds },
+      { input: 89, expected: kUnboundedBounds },
     ]
   )
   .fn(t => {
@@ -2740,10 +2740,10 @@ g.test('exp2Interval_f32')
   .paramsSubcasesOnly<ScalarToIntervalCase>(
     // prettier-ignore
     [
-      { input: kValue.f32.infinity.negative, expected: kIndeterminateBounds },
+      { input: kValue.f32.infinity.negative, expected: kUnboundedBounds },
       { input: 0, expected: 1 },
       { input: 1, expected: 2 },
-      { input: 128, expected: kIndeterminateBounds },
+      { input: 128, expected: kUnboundedBounds },
     ]
   )
   .fn(t => {
@@ -2798,8 +2798,8 @@ g.test('floorInterval')
           { input: -1.9, expected: -2 },
 
           // Edge cases
-          { input: constants.positive.infinity, expected: kIndeterminateBounds },
-          { input: constants.negative.infinity, expected: kIndeterminateBounds },
+          { input: constants.positive.infinity, expected: kUnboundedBounds },
+          { input: constants.negative.infinity, expected: kUnboundedBounds },
           { input: constants.positive.max, expected: constants.positive.max },
           { input: constants.positive.min, expected: 0 },
           { input: constants.negative.min, expected: constants.negative.min },
@@ -2839,8 +2839,8 @@ g.test('fractInterval_f32')
       { input: -1.1, expected: [reinterpretU64AsF64(0x3fec_cccc_c000_0000n), reinterpretU64AsF64(0x3fec_cccd_0000_0000n), ] }, // ~0.9
 
       // Edge cases
-      { input: kValue.f32.infinity.positive, expected: kIndeterminateBounds },
-      { input: kValue.f32.infinity.negative, expected: kIndeterminateBounds },
+      { input: kValue.f32.infinity.positive, expected: kUnboundedBounds },
+      { input: kValue.f32.infinity.negative, expected: kUnboundedBounds },
       { input: kValue.f32.positive.max, expected: 0 },
       { input: kValue.f32.positive.min, expected: [kValue.f32.positive.min, kValue.f32.positive.min] },
       { input: kValue.f32.negative.min, expected: 0 },
@@ -2904,9 +2904,9 @@ g.test('inverseSqrtInterval')
           ...kInverseSqrtIntervalCases[p.trait],
 
           // Out of definition domain
-          { input: -1, expected: kIndeterminateBounds },
-          { input: 0, expected: kIndeterminateBounds },
-          { input: constants.positive.infinity, expected: kIndeterminateBounds },
+          { input: -1, expected: kUnboundedBounds },
+          { input: 0, expected: kUnboundedBounds },
+          { input: constants.positive.infinity, expected: kUnboundedBounds },
         ];
       })
   )
@@ -2935,8 +2935,8 @@ g.test('lengthIntervalScalar_f32')
       // to express in a closed human-readable form due to the inherited nature
       // of the errors.
       //
-      // length(0) = kIndeterminateBounds, because length uses sqrt, which is defined as 1/inversesqrt
-      {input: 0, expected: kIndeterminateBounds },
+      // length(0) = kUnboundedBounds, because length uses sqrt, which is defined as 1/inversesqrt
+      {input: 0, expected: kUnboundedBounds },
       {input: 1.0, expected: [reinterpretU64AsF64(0x3fef_ffff_7000_0000n), reinterpretU64AsF64(0x3ff0_0000_9000_0000n)] },  // ~1
       {input: -1.0, expected: [reinterpretU64AsF64(0x3fef_ffff_7000_0000n), reinterpretU64AsF64(0x3ff0_0000_9000_0000n)] },  // ~1
       {input: 0.1, expected: [reinterpretU64AsF64(0x3fb9_9998_9000_0000n), reinterpretU64AsF64(0x3fb9_999a_7000_0000n)] },  // ~0.1
@@ -2945,18 +2945,18 @@ g.test('lengthIntervalScalar_f32')
       {input: -10.0, expected: [reinterpretU64AsF64(0x4023_ffff_7000_0000n), reinterpretU64AsF64(0x4024_0000_b000_0000n)] },  // ~10
 
       // Subnormal Cases
-      { input: kValue.f32.subnormal.negative.min, expected: kIndeterminateBounds },
-      { input: kValue.f32.subnormal.negative.max, expected: kIndeterminateBounds },
-      { input: kValue.f32.subnormal.positive.min, expected: kIndeterminateBounds },
-      { input: kValue.f32.subnormal.positive.max, expected: kIndeterminateBounds },
+      { input: kValue.f32.subnormal.negative.min, expected: kUnboundedBounds },
+      { input: kValue.f32.subnormal.negative.max, expected: kUnboundedBounds },
+      { input: kValue.f32.subnormal.positive.min, expected: kUnboundedBounds },
+      { input: kValue.f32.subnormal.positive.max, expected: kUnboundedBounds },
 
       // Edge cases
-      { input: kValue.f32.infinity.positive, expected: kIndeterminateBounds },
-      { input: kValue.f32.infinity.negative, expected: kIndeterminateBounds },
-      { input: kValue.f32.negative.min, expected: kIndeterminateBounds },
-      { input: kValue.f32.negative.max, expected: kIndeterminateBounds },
-      { input: kValue.f32.positive.min, expected: kIndeterminateBounds },
-      { input: kValue.f32.positive.max, expected: kIndeterminateBounds },
+      { input: kValue.f32.infinity.positive, expected: kUnboundedBounds },
+      { input: kValue.f32.infinity.negative, expected: kUnboundedBounds },
+      { input: kValue.f32.negative.min, expected: kUnboundedBounds },
+      { input: kValue.f32.negative.max, expected: kUnboundedBounds },
+      { input: kValue.f32.positive.min, expected: kUnboundedBounds },
+      { input: kValue.f32.positive.max, expected: kUnboundedBounds },
     ]
   )
   .fn(t => {
@@ -2996,8 +2996,8 @@ g.test('logInterval')
       .expandWithParams<ScalarToIntervalCase>(p => {
         // prettier-ignore
         return [
-          { input: -1, expected: kIndeterminateBounds },
-          { input: 0, expected: kIndeterminateBounds },
+          { input: -1, expected: kUnboundedBounds },
+          { input: 0, expected: kUnboundedBounds },
           { input: 1, expected: 0 },
           ...kLogIntervalCases[p.trait],
         ];
@@ -3045,8 +3045,8 @@ g.test('log2Interval')
       .expandWithParams<ScalarToIntervalCase>(p => {
         // prettier-ignore
         return [
-          { input: -1, expected: kIndeterminateBounds },
-          { input: 0, expected: kIndeterminateBounds },
+          { input: -1, expected: kUnboundedBounds },
+          { input: 0, expected: kUnboundedBounds },
           { input: 1, expected: 0 },
           { input: 2, expected: 1 },
           { input: 16, expected: 4 },
@@ -3087,8 +3087,8 @@ g.test('negationInterval_f32')
       { input: -1.9, expected: [kMinusOneULPFunctions['f32'](reinterpretU32AsF32(0x3ff33334)), reinterpretU32AsF32(0x3ff33334)] },  // ~1.9
 
       // Edge cases
-      { input: kValue.f32.infinity.positive, expected: kIndeterminateBounds },
-      { input: kValue.f32.infinity.negative, expected: kIndeterminateBounds },
+      { input: kValue.f32.infinity.positive, expected: kUnboundedBounds },
+      { input: kValue.f32.infinity.negative, expected: kUnboundedBounds },
       { input: kValue.f32.positive.max, expected: kValue.f32.negative.min },
       { input: kValue.f32.positive.min, expected: kValue.f32.negative.max },
       { input: kValue.f32.negative.min, expected: kValue.f32.positive.max },
@@ -3114,8 +3114,8 @@ g.test('quantizeToF16Interval_f32')
   .paramsSubcasesOnly<ScalarToIntervalCase>(
     // prettier-ignore
     [
-      { input: kValue.f32.infinity.negative, expected: kIndeterminateBounds },
-      { input: kValue.f32.negative.min, expected: kIndeterminateBounds },
+      { input: kValue.f32.infinity.negative, expected: kUnboundedBounds },
+      { input: kValue.f32.negative.min, expected: kUnboundedBounds },
       { input: kValue.f16.negative.min, expected: kValue.f16.negative.min },
       { input: -1, expected: -1 },
       { input: -0.1, expected: [reinterpretU32AsF32(0xbdcce000), reinterpretU32AsF32(0xbdccc000)] },  // ~-0.1
@@ -3131,8 +3131,8 @@ g.test('quantizeToF16Interval_f32')
       { input: 0.1, expected: [reinterpretU32AsF32(0x3dccc000), reinterpretU32AsF32(0x3dcce000)] },  // ~0.1
       { input: 1, expected: 1 },
       { input: kValue.f16.positive.max, expected: kValue.f16.positive.max },
-      { input: kValue.f32.positive.max, expected: kIndeterminateBounds },
-      { input: kValue.f32.infinity.positive, expected: kIndeterminateBounds },
+      { input: kValue.f32.positive.max, expected: kUnboundedBounds },
+      { input: kValue.f32.infinity.positive, expected: kUnboundedBounds },
     ]
   )
   .fn(t => {
@@ -3149,7 +3149,7 @@ g.test('radiansInterval_f32')
   .paramsSubcasesOnly<ScalarToIntervalCase>(
     // prettier-ignore
     [
-      { input: kValue.f32.infinity.negative, expected: kIndeterminateBounds },
+      { input: kValue.f32.infinity.negative, expected: kUnboundedBounds },
       { input: -180, expected: [kMinusOneULPFunctions['f32'](kValue.f32.negative.pi.whole), kPlusOneULPFunctions['f32'](kValue.f32.negative.pi.whole)] },
       { input: -135, expected: [kMinusOneULPFunctions['f32'](kValue.f32.negative.pi.three_quarters), kPlusOneULPFunctions['f32'](kValue.f32.negative.pi.three_quarters)] },
       { input: -90, expected: [kMinusOneULPFunctions['f32'](kValue.f32.negative.pi.half), kPlusOneULPFunctions['f32'](kValue.f32.negative.pi.half)] },
@@ -3163,7 +3163,7 @@ g.test('radiansInterval_f32')
       { input: 90, expected: [kMinusOneULPFunctions['f32'](kValue.f32.positive.pi.half), kPlusOneULPFunctions['f32'](kValue.f32.positive.pi.half)] },
       { input: 135, expected: [kMinusOneULPFunctions['f32'](kValue.f32.positive.pi.three_quarters), kPlusOneULPFunctions['f32'](kValue.f32.positive.pi.three_quarters)] },
       { input: 180, expected: [kMinusOneULPFunctions['f32'](kValue.f32.positive.pi.whole), kPlusOneULPFunctions['f32'](kValue.f32.positive.pi.whole)] },
-      { input: kValue.f32.infinity.positive, expected: kIndeterminateBounds },
+      { input: kValue.f32.infinity.positive, expected: kUnboundedBounds },
     ]
   )
   .fn(t => {
@@ -3215,8 +3215,8 @@ g.test('roundInterval')
       { input: -1.9, expected: -2 },
 
       // Edge cases
-      { input: constants.positive.infinity, expected: kIndeterminateBounds },
-      { input: constants.negative.infinity, expected: kIndeterminateBounds },
+      { input: constants.positive.infinity, expected: kUnboundedBounds },
+      { input: constants.negative.infinity, expected: kUnboundedBounds },
       { input: constants.positive.max, expected: constants.positive.max },
       { input: constants.positive.min, expected: 0 },
       { input: constants.negative.min, expected: constants.negative.min },
@@ -3266,8 +3266,8 @@ g.test('saturateInterval_f32')
       { input: kValue.f32.subnormal.negative.max, expected: [kValue.f32.subnormal.negative.max, 0.0] },
 
       // Infinities
-      { input: kValue.f32.infinity.positive, expected: kIndeterminateBounds },
-      { input: kValue.f32.infinity.negative, expected: kIndeterminateBounds },
+      { input: kValue.f32.infinity.positive, expected: kUnboundedBounds },
+      { input: kValue.f32.infinity.negative, expected: kUnboundedBounds },
     ]
   )
   .fn(t => {
@@ -3283,7 +3283,7 @@ g.test('signInterval_f32')
   .paramsSubcasesOnly<ScalarToIntervalCase>(
     // prettier-ignore
     [
-      { input: kValue.f32.infinity.negative, expected: kIndeterminateBounds },
+      { input: kValue.f32.infinity.negative, expected: kUnboundedBounds },
       { input: kValue.f32.negative.min, expected: -1 },
       { input: -10, expected: -1 },
       { input: -1, expected: -1 },
@@ -3299,7 +3299,7 @@ g.test('signInterval_f32')
       { input: 1, expected: 1 },
       { input: 10, expected: 1 },
       { input: kValue.f32.positive.max, expected: 1 },
-      { input: kValue.f32.infinity.positive, expected: kIndeterminateBounds },
+      { input: kValue.f32.infinity.positive, expected: kUnboundedBounds },
     ]
   )
   .fn(t => {
@@ -3326,13 +3326,13 @@ g.test('sinInterval')
           // substantially different, so instead of getting 0 you get a value on the
           // order of 10^-8 away from it, thus difficult to express in a
           // human-readable manner.
-          { input: constants.negative.infinity, expected: kIndeterminateBounds },
-          { input: constants.negative.min, expected: kIndeterminateBounds },
+          { input: constants.negative.infinity, expected: kUnboundedBounds },
+          { input: constants.negative.min, expected: kUnboundedBounds },
           { input: constants.negative.pi.half, expected: [-1, kPlusOneULPFunctions[p.trait](-1)] },
           { input: 0, expected: 0 },
           { input: constants.positive.pi.half, expected: [kMinusOneULPFunctions[p.trait](1), 1] },
-          { input: constants.positive.max, expected: kIndeterminateBounds },
-          { input: constants.positive.infinity, expected: kIndeterminateBounds },
+          { input: constants.positive.max, expected: kUnboundedBounds },
+          { input: constants.positive.infinity, expected: kUnboundedBounds },
         ];
       })
   )
@@ -3360,13 +3360,13 @@ g.test('sinhInterval_f32')
       // Some of these are hard coded, since the error intervals are difficult
       // to express in a closed human-readable form due to the inherited nature
       // of the errors.
-      { input: kValue.f32.infinity.negative, expected: kIndeterminateBounds },
-      { input: kValue.f32.negative.min, expected: kIndeterminateBounds },
+      { input: kValue.f32.infinity.negative, expected: kUnboundedBounds },
+      { input: kValue.f32.negative.min, expected: kUnboundedBounds },
       { input: -1, expected: [ reinterpretU32AsF32(0xbf966d05), reinterpretU32AsF32(0xbf966cf8)] },  // ~-1.175...
       { input: 0, expected: [reinterpretU32AsF32(0xb4600000), reinterpretU32AsF32(0x34600000)] },  // ~0
       { input: 1, expected: [ reinterpretU32AsF32(0x3f966cf8), reinterpretU32AsF32(0x3f966d05)] },  // ~1.175...
-      { input: kValue.f32.positive.max, expected: kIndeterminateBounds },
-      { input: kValue.f32.infinity.positive, expected: kIndeterminateBounds },
+      { input: kValue.f32.positive.max, expected: kUnboundedBounds },
+      { input: kValue.f32.infinity.positive, expected: kUnboundedBounds },
     ]
   )
   .fn(t => {
@@ -3443,9 +3443,9 @@ g.test('sqrtInterval')
           ...kSqrtIntervalCases[p.trait],
 
           // Cases out of definition domain
-          { input: -1, expected: kIndeterminateBounds },
-          { input: 0, expected: kIndeterminateBounds },
-          { input: constants.positive.infinity, expected: kIndeterminateBounds },
+          { input: -1, expected: kUnboundedBounds },
+          { input: 0, expected: kUnboundedBounds },
+          { input: constants.positive.infinity, expected: kUnboundedBounds },
         ];
       })
   )
@@ -3489,15 +3489,15 @@ g.test('tanInterval_f32')
       //
       // The examples here have been manually traced to confirm the expectation
       // values are correct.
-      { input: kValue.f32.infinity.negative, expected: kIndeterminateBounds },
-      { input: kValue.f32.negative.min, expected: kIndeterminateBounds },
+      { input: kValue.f32.infinity.negative, expected: kUnboundedBounds },
+      { input: kValue.f32.negative.min, expected: kUnboundedBounds },
       { input: kValue.f32.negative.pi.whole, expected: [reinterpretU64AsF64(0xbf40_02bc_9000_0000n), reinterpretU64AsF64(0x3f40_0144_f000_0000n)] },  // ~0.0
-      { input: kValue.f32.negative.pi.half, expected: kIndeterminateBounds },
+      { input: kValue.f32.negative.pi.half, expected: kUnboundedBounds },
       { input: 0, expected: [reinterpretU64AsF64(0xbf40_0200_b000_0000n), reinterpretU64AsF64(0x3f40_0200_b000_0000n)] },  // ~0.0
-      { input: kValue.f32.positive.pi.half, expected: kIndeterminateBounds },
+      { input: kValue.f32.positive.pi.half, expected: kUnboundedBounds },
       { input: kValue.f32.positive.pi.whole, expected: [reinterpretU64AsF64(0xbf40_0144_f000_0000n), reinterpretU64AsF64(0x3f40_02bc_9000_0000n)] },  // ~0.0
-      { input: kValue.f32.positive.max, expected: kIndeterminateBounds },
-      { input: kValue.f32.infinity.positive, expected: kIndeterminateBounds },
+      { input: kValue.f32.positive.max, expected: kUnboundedBounds },
+      { input: kValue.f32.infinity.positive, expected: kUnboundedBounds },
     ]
   )
   .fn(t => {
@@ -3516,13 +3516,13 @@ g.test('tanhInterval_f32')
       // Some of these are hard coded, since the error intervals are difficult
       // to express in a closed human-readable form due to the inherited nature
       // of the errors.
-      { input: kValue.f32.infinity.negative, expected: kIndeterminateBounds },
-      { input: kValue.f32.negative.min, expected: kIndeterminateBounds },
+      { input: kValue.f32.infinity.negative, expected: kUnboundedBounds },
+      { input: kValue.f32.negative.min, expected: kUnboundedBounds },
       { input: -1, expected: [reinterpretU64AsF64(0xbfe8_5efd_1000_0000n), reinterpretU64AsF64(0xbfe8_5ef8_9000_0000n)] },  // ~-0.7615...
       { input: 0, expected: [reinterpretU64AsF64(0xbe8c_0000_b000_0000n), reinterpretU64AsF64(0x3e8c_0000_b000_0000n)] },  // ~0
       { input: 1, expected: [reinterpretU64AsF64(0x3fe8_5ef8_9000_0000n), reinterpretU64AsF64(0x3fe8_5efd_1000_0000n)] },  // ~0.7615...
-      { input: kValue.f32.positive.max, expected: kIndeterminateBounds },
-      { input: kValue.f32.infinity.positive, expected: kIndeterminateBounds },
+      { input: kValue.f32.positive.max, expected: kUnboundedBounds },
+      { input: kValue.f32.infinity.positive, expected: kUnboundedBounds },
     ]
   )
   .fn(t => {
@@ -3551,8 +3551,8 @@ g.test('truncInterval_f32')
       { input: -1.9, expected: -1 },
 
       // Edge cases
-      { input: kValue.f32.infinity.positive, expected: kIndeterminateBounds },
-      { input: kValue.f32.infinity.negative, expected: kIndeterminateBounds },
+      { input: kValue.f32.infinity.positive, expected: kUnboundedBounds },
+      { input: kValue.f32.infinity.negative, expected: kUnboundedBounds },
       { input: kValue.f32.positive.max, expected: kValue.f32.positive.max },
       { input: kValue.f32.positive.min, expected: 0 },
       { input: kValue.f32.negative.min, expected: kValue.f32.negative.min },
@@ -3652,14 +3652,14 @@ g.test('additionInterval')
           { input: [0, constants.negative.subnormal.min], expected: [constants.negative.subnormal.min, 0] },
 
           // Infinities
-          { input: [0, constants.positive.infinity], expected: kIndeterminateBounds },
-          { input: [constants.positive.infinity, 0], expected: kIndeterminateBounds },
-          { input: [constants.positive.infinity, constants.positive.infinity], expected: kIndeterminateBounds },
-          { input: [0, constants.negative.infinity], expected: kIndeterminateBounds },
-          { input: [constants.negative.infinity, 0], expected: kIndeterminateBounds },
-          { input: [constants.negative.infinity, constants.negative.infinity], expected: kIndeterminateBounds },
-          { input: [constants.negative.infinity, constants.positive.infinity], expected: kIndeterminateBounds },
-          { input: [constants.positive.infinity, constants.negative.infinity], expected: kIndeterminateBounds },
+          { input: [0, constants.positive.infinity], expected: kUnboundedBounds },
+          { input: [constants.positive.infinity, 0], expected: kUnboundedBounds },
+          { input: [constants.positive.infinity, constants.positive.infinity], expected: kUnboundedBounds },
+          { input: [0, constants.negative.infinity], expected: kUnboundedBounds },
+          { input: [constants.negative.infinity, 0], expected: kUnboundedBounds },
+          { input: [constants.negative.infinity, constants.negative.infinity], expected: kUnboundedBounds },
+          { input: [constants.negative.infinity, constants.positive.infinity], expected: kUnboundedBounds },
+          { input: [constants.positive.infinity, constants.negative.infinity], expected: kUnboundedBounds },
         ];
       })
   )
@@ -3766,33 +3766,33 @@ g.test('atan2Interval')
 
           // Cases that y out of bound.
           // positive y, positive x
-          { input: [Number.POSITIVE_INFINITY, 1], expected: kIndeterminateBounds },
+          { input: [Number.POSITIVE_INFINITY, 1], expected: kUnboundedBounds },
           // positive y, negative x
-          { input: [Number.POSITIVE_INFINITY, -1], expected: kIndeterminateBounds },
+          { input: [Number.POSITIVE_INFINITY, -1], expected: kUnboundedBounds },
           // negative y, negative x
-          { input: [Number.NEGATIVE_INFINITY, -1], expected: kIndeterminateBounds },
+          { input: [Number.NEGATIVE_INFINITY, -1], expected: kUnboundedBounds },
           // negative y, positive x
-          { input: [Number.NEGATIVE_INFINITY, 1], expected: kIndeterminateBounds },
+          { input: [Number.NEGATIVE_INFINITY, 1], expected: kUnboundedBounds },
 
           // Discontinuity @ origin (0,0)
-          { input: [0, 0], expected: kIndeterminateBounds },
-          { input: [0, constants.positive.subnormal.max], expected: kIndeterminateBounds },
-          { input: [0, constants.negative.subnormal.min], expected: kIndeterminateBounds },
-          { input: [0, constants.positive.min], expected: kIndeterminateBounds },
-          { input: [0, constants.negative.max], expected: kIndeterminateBounds },
-          { input: [0, constants.positive.max], expected: kIndeterminateBounds },
-          { input: [0, constants.negative.min], expected: kIndeterminateBounds },
-          { input: [0, constants.positive.infinity], expected: kIndeterminateBounds },
-          { input: [0, constants.negative.infinity], expected: kIndeterminateBounds },
-          { input: [0, 1], expected: kIndeterminateBounds },
-          { input: [constants.positive.subnormal.max, 1], expected: kIndeterminateBounds },
-          { input: [constants.negative.subnormal.min, 1], expected: kIndeterminateBounds },
+          { input: [0, 0], expected: kUnboundedBounds },
+          { input: [0, constants.positive.subnormal.max], expected: kUnboundedBounds },
+          { input: [0, constants.negative.subnormal.min], expected: kUnboundedBounds },
+          { input: [0, constants.positive.min], expected: kUnboundedBounds },
+          { input: [0, constants.negative.max], expected: kUnboundedBounds },
+          { input: [0, constants.positive.max], expected: kUnboundedBounds },
+          { input: [0, constants.negative.min], expected: kUnboundedBounds },
+          { input: [0, constants.positive.infinity], expected: kUnboundedBounds },
+          { input: [0, constants.negative.infinity], expected: kUnboundedBounds },
+          { input: [0, 1], expected: kUnboundedBounds },
+          { input: [constants.positive.subnormal.max, 1], expected: kUnboundedBounds },
+          { input: [constants.negative.subnormal.min, 1], expected: kUnboundedBounds },
 
-          // Very large |x| values should cause kIndeterminateBounds to be returned, due to the restrictions on division
-          { input: [1, constants.positive.max], expected: kIndeterminateBounds },
-          { input: [1, constants.positive.nearest_max], expected: kIndeterminateBounds },
-          { input: [1, constants.negative.min], expected: kIndeterminateBounds },
-          { input: [1, constants.negative.nearest_min], expected: kIndeterminateBounds },
+          // Very large |x| values should cause kUnboundedBounds to be returned, due to the restrictions on division
+          { input: [1, constants.positive.max], expected: kUnboundedBounds },
+          { input: [1, constants.positive.nearest_max], expected: kUnboundedBounds },
+          { input: [1, constants.negative.min], expected: kUnboundedBounds },
+          { input: [1, constants.negative.nearest_min], expected: kUnboundedBounds },
         ];
       })
   )
@@ -3815,15 +3815,15 @@ g.test('distanceIntervalScalar_f32')
       // to express in a closed human-readable  form due to the inherited nature
       // of the errors.
       //
-      // distance(x, y), where x - y = 0 has an acceptance interval of kIndeterminateBounds,
-      // because distance(x, y) = length(x - y), and length(0) = kIndeterminateBounds
-      { input: [0, 0], expected: kIndeterminateBounds },
+      // distance(x, y), where x - y = 0 has an acceptance interval of kUnboundedBounds,
+      // because distance(x, y) = length(x - y), and length(0) = kUnboundedBounds
+      { input: [0, 0], expected: kUnboundedBounds },
       { input: [1.0, 0], expected: [reinterpretU64AsF64(0x3fef_ffff_7000_0000n), reinterpretU64AsF64(0x3ff0_0000_9000_0000n)] },  // ~1
       { input: [0.0, 1.0], expected: [reinterpretU64AsF64(0x3fef_ffff_7000_0000n), reinterpretU64AsF64(0x3ff0_0000_9000_0000n)] },  // ~1
-      { input: [1.0, 1.0], expected: kIndeterminateBounds },
+      { input: [1.0, 1.0], expected: kUnboundedBounds },
       { input: [-0.0, -1.0], expected: [reinterpretU64AsF64(0x3fef_ffff_7000_0000n), reinterpretU64AsF64(0x3ff0_0000_9000_0000n)] },  // ~1
       { input: [0.0, -1.0], expected: [reinterpretU64AsF64(0x3fef_ffff_7000_0000n), reinterpretU64AsF64(0x3ff0_0000_9000_0000n)] },  // ~1
-      { input: [-1.0, -1.0], expected: kIndeterminateBounds },
+      { input: [-1.0, -1.0], expected: kUnboundedBounds },
       { input: [0.1, 0], expected: [reinterpretU64AsF64(0x3fb9_9998_9000_0000n), reinterpretU64AsF64(0x3fb9_999a_7000_0000n)] },  // ~0.1
       { input: [0, 0.1], expected: [reinterpretU64AsF64(0x3fb9_9998_9000_0000n), reinterpretU64AsF64(0x3fb9_999a_7000_0000n)] },  // ~0.1
       { input: [-0.1, 0], expected: [reinterpretU64AsF64(0x3fb9_9998_9000_0000n), reinterpretU64AsF64(0x3fb9_999a_7000_0000n)] },  // ~0.1
@@ -3834,18 +3834,18 @@ g.test('distanceIntervalScalar_f32')
       { input: [0, -10.0], expected: [reinterpretU64AsF64(0x4023_ffff_7000_0000n), reinterpretU64AsF64(0x4024_0000_b000_0000n)] },  // ~10
 
       // Subnormal Cases
-      { input: [kValue.f32.subnormal.negative.min, 0], expected: kIndeterminateBounds },
-      { input: [kValue.f32.subnormal.negative.max, 0], expected: kIndeterminateBounds },
-      { input: [kValue.f32.subnormal.positive.min, 0], expected: kIndeterminateBounds },
-      { input: [kValue.f32.subnormal.positive.max, 0], expected: kIndeterminateBounds },
+      { input: [kValue.f32.subnormal.negative.min, 0], expected: kUnboundedBounds },
+      { input: [kValue.f32.subnormal.negative.max, 0], expected: kUnboundedBounds },
+      { input: [kValue.f32.subnormal.positive.min, 0], expected: kUnboundedBounds },
+      { input: [kValue.f32.subnormal.positive.max, 0], expected: kUnboundedBounds },
 
       // Edge cases
-      { input: [kValue.f32.infinity.positive, 0], expected: kIndeterminateBounds },
-      { input: [kValue.f32.infinity.negative, 0], expected: kIndeterminateBounds },
-      { input: [kValue.f32.negative.min, 0], expected: kIndeterminateBounds },
-      { input: [kValue.f32.negative.max, 0], expected: kIndeterminateBounds },
-      { input: [kValue.f32.positive.min, 0], expected: kIndeterminateBounds },
-      { input: [kValue.f32.positive.max, 0], expected: kIndeterminateBounds },
+      { input: [kValue.f32.infinity.positive, 0], expected: kUnboundedBounds },
+      { input: [kValue.f32.infinity.negative, 0], expected: kUnboundedBounds },
+      { input: [kValue.f32.negative.min, 0], expected: kUnboundedBounds },
+      { input: [kValue.f32.negative.max, 0], expected: kUnboundedBounds },
+      { input: [kValue.f32.positive.min, 0], expected: kUnboundedBounds },
+      { input: [kValue.f32.positive.max, 0], expected: kUnboundedBounds },
     ]
   )
   .fn(t => {
@@ -3929,15 +3929,15 @@ g.test('divisionInterval')
           ...kDivisionInterval64BitsNormalCases[p.trait],
 
           // Denominator out of range
-          { input: [1, constants.positive.infinity], expected: kIndeterminateBounds },
-          { input: [1, constants.negative.infinity], expected: kIndeterminateBounds },
-          { input: [constants.negative.infinity, constants.negative.infinity], expected: kIndeterminateBounds },
-          { input: [constants.negative.infinity, constants.positive.infinity], expected: kIndeterminateBounds },
-          { input: [constants.positive.infinity, constants.negative.infinity], expected: kIndeterminateBounds },
-          { input: [1, constants.positive.max], expected: kIndeterminateBounds },
-          { input: [1, constants.negative.min], expected: kIndeterminateBounds },
-          { input: [1, 0], expected: kIndeterminateBounds },
-          { input: [1, constants.positive.subnormal.max], expected: kIndeterminateBounds },
+          { input: [1, constants.positive.infinity], expected: kUnboundedBounds },
+          { input: [1, constants.negative.infinity], expected: kUnboundedBounds },
+          { input: [constants.negative.infinity, constants.negative.infinity], expected: kUnboundedBounds },
+          { input: [constants.negative.infinity, constants.positive.infinity], expected: kUnboundedBounds },
+          { input: [constants.positive.infinity, constants.negative.infinity], expected: kUnboundedBounds },
+          { input: [1, constants.positive.max], expected: kUnboundedBounds },
+          { input: [1, constants.negative.min], expected: kUnboundedBounds },
+          { input: [1, 0], expected: kUnboundedBounds },
+          { input: [1, constants.positive.subnormal.max], expected: kUnboundedBounds },
         ];
       })
   )
@@ -3989,12 +3989,12 @@ g.test('ldexpInterval_f32')
       { input: [-1.9999998807907104, 127], expected: kValue.f32.negative.min },
 
       // Out of Bounds
-      { input: [1, 128], expected: kIndeterminateBounds },
-      { input: [-1, 128], expected: kIndeterminateBounds },
-      { input: [100, 126], expected: kIndeterminateBounds },
-      { input: [-100, 126], expected: kIndeterminateBounds },
-      { input: [kValue.f32.positive.max, kValue.i32.positive.max], expected: kIndeterminateBounds },
-      { input: [kValue.f32.negative.min, kValue.i32.positive.max], expected: kIndeterminateBounds },
+      { input: [1, 128], expected: kUnboundedBounds },
+      { input: [-1, 128], expected: kUnboundedBounds },
+      { input: [100, 126], expected: kUnboundedBounds },
+      { input: [-100, 126], expected: kUnboundedBounds },
+      { input: [kValue.f32.positive.max, kValue.i32.positive.max], expected: kUnboundedBounds },
+      { input: [kValue.f32.negative.min, kValue.i32.positive.max], expected: kUnboundedBounds },
     ]
   )
   .fn(t => {
@@ -4068,14 +4068,14 @@ g.test('maxInterval')
           { input: [constants.negative.subnormal.min, constants.positive.subnormal.max], expected: [constants.negative.subnormal.min, constants.positive.subnormal.max] },
 
           // Infinities
-          { input: [0, constants.positive.infinity], expected: kIndeterminateBounds },
-          { input: [constants.positive.infinity, 0], expected: kIndeterminateBounds },
-          { input: [constants.positive.infinity, constants.positive.infinity], expected: kIndeterminateBounds },
-          { input: [0, constants.negative.infinity], expected: kIndeterminateBounds },
-          { input: [constants.negative.infinity, 0], expected: kIndeterminateBounds },
-          { input: [constants.negative.infinity, constants.negative.infinity], expected: kIndeterminateBounds },
-          { input: [constants.negative.infinity, constants.positive.infinity], expected: kIndeterminateBounds },
-          { input: [constants.positive.infinity, constants.negative.infinity], expected: kIndeterminateBounds },
+          { input: [0, constants.positive.infinity], expected: kUnboundedBounds },
+          { input: [constants.positive.infinity, 0], expected: kUnboundedBounds },
+          { input: [constants.positive.infinity, constants.positive.infinity], expected: kUnboundedBounds },
+          { input: [0, constants.negative.infinity], expected: kUnboundedBounds },
+          { input: [constants.negative.infinity, 0], expected: kUnboundedBounds },
+          { input: [constants.negative.infinity, constants.negative.infinity], expected: kUnboundedBounds },
+          { input: [constants.negative.infinity, constants.positive.infinity], expected: kUnboundedBounds },
+          { input: [constants.positive.infinity, constants.negative.infinity], expected: kUnboundedBounds },
         ];
       })
   )
@@ -4151,14 +4151,14 @@ g.test('minInterval')
           { input: [constants.negative.subnormal.min, constants.positive.subnormal.max], expected: [constants.negative.subnormal.min, constants.positive.subnormal.max] },
 
           // Infinities
-          { input: [0, constants.positive.infinity], expected: kIndeterminateBounds },
-          { input: [constants.positive.infinity, 0], expected: kIndeterminateBounds },
-          { input: [constants.positive.infinity, constants.positive.infinity], expected: kIndeterminateBounds },
-          { input: [0, constants.negative.infinity], expected: kIndeterminateBounds },
-          { input: [constants.negative.infinity, 0], expected: kIndeterminateBounds },
-          { input: [constants.negative.infinity, constants.negative.infinity], expected: kIndeterminateBounds },
-          { input: [constants.negative.infinity, constants.positive.infinity], expected: kIndeterminateBounds },
-          { input: [constants.positive.infinity, constants.negative.infinity], expected: kIndeterminateBounds },
+          { input: [0, constants.positive.infinity], expected: kUnboundedBounds },
+          { input: [constants.positive.infinity, 0], expected: kUnboundedBounds },
+          { input: [constants.positive.infinity, constants.positive.infinity], expected: kUnboundedBounds },
+          { input: [0, constants.negative.infinity], expected: kUnboundedBounds },
+          { input: [constants.negative.infinity, 0], expected: kUnboundedBounds },
+          { input: [constants.negative.infinity, constants.negative.infinity], expected: kUnboundedBounds },
+          { input: [constants.negative.infinity, constants.positive.infinity], expected: kUnboundedBounds },
+          { input: [constants.positive.infinity, constants.negative.infinity], expected: kUnboundedBounds },
         ];
       })
   )
@@ -4254,22 +4254,22 @@ g.test('multiplicationInterval')
           ...kMultiplicationInterval64BitsNormalCases[p.trait],
 
           // Infinities
-          { input: [0, constants.positive.infinity], expected: kIndeterminateBounds },
-          { input: [1, constants.positive.infinity], expected: kIndeterminateBounds },
-          { input: [-1, constants.positive.infinity], expected: kIndeterminateBounds },
-          { input: [constants.positive.infinity, constants.positive.infinity], expected: kIndeterminateBounds },
-          { input: [0, constants.negative.infinity], expected: kIndeterminateBounds },
-          { input: [1, constants.negative.infinity], expected: kIndeterminateBounds },
-          { input: [-1, constants.negative.infinity], expected: kIndeterminateBounds },
-          { input: [constants.negative.infinity, constants.negative.infinity], expected: kIndeterminateBounds },
-          { input: [constants.positive.infinity, constants.negative.infinity], expected: kIndeterminateBounds },
-          { input: [constants.negative.infinity, constants.positive.infinity], expected: kIndeterminateBounds },
+          { input: [0, constants.positive.infinity], expected: kUnboundedBounds },
+          { input: [1, constants.positive.infinity], expected: kUnboundedBounds },
+          { input: [-1, constants.positive.infinity], expected: kUnboundedBounds },
+          { input: [constants.positive.infinity, constants.positive.infinity], expected: kUnboundedBounds },
+          { input: [0, constants.negative.infinity], expected: kUnboundedBounds },
+          { input: [1, constants.negative.infinity], expected: kUnboundedBounds },
+          { input: [-1, constants.negative.infinity], expected: kUnboundedBounds },
+          { input: [constants.negative.infinity, constants.negative.infinity], expected: kUnboundedBounds },
+          { input: [constants.positive.infinity, constants.negative.infinity], expected: kUnboundedBounds },
+          { input: [constants.negative.infinity, constants.positive.infinity], expected: kUnboundedBounds },
 
           // Edges
-          { input: [constants.positive.max, constants.positive.max], expected: kIndeterminateBounds },
-          { input: [constants.negative.min, constants.negative.min], expected: kIndeterminateBounds },
-          { input: [constants.positive.max, constants.negative.min], expected: kIndeterminateBounds },
-          { input: [constants.negative.min, constants.positive.max], expected: kIndeterminateBounds },
+          { input: [constants.positive.max, constants.positive.max], expected: kUnboundedBounds },
+          { input: [constants.negative.min, constants.negative.min], expected: kUnboundedBounds },
+          { input: [constants.positive.max, constants.negative.min], expected: kUnboundedBounds },
+          { input: [constants.negative.min, constants.positive.max], expected: kUnboundedBounds },
         ];
       })
   )
@@ -4291,20 +4291,20 @@ g.test('powInterval_f32')
       // Some of these are hard coded, since the error intervals are difficult
       // to express in a closed human-readable form due to the inherited nature
       // of the errors.
-      { input: [-1, 0], expected: kIndeterminateBounds },
-      { input: [0, 0], expected: kIndeterminateBounds },
+      { input: [-1, 0], expected: kUnboundedBounds },
+      { input: [0, 0], expected: kUnboundedBounds },
       { input: [1, 0], expected: [kMinusNULPFunctions['f32'](1, 3), reinterpretU64AsF64(0x3ff0_0000_3000_0000n)] },  // ~1
       { input: [2, 0], expected: [kMinusNULPFunctions['f32'](1, 3), reinterpretU64AsF64(0x3ff0_0000_3000_0000n)] },  // ~1
       { input: [kValue.f32.positive.max, 0], expected: [kMinusNULPFunctions['f32'](1, 3), reinterpretU64AsF64(0x3ff0_0000_3000_0000n)] },  // ~1
-      { input: [0, 1], expected: kIndeterminateBounds },
+      { input: [0, 1], expected: kUnboundedBounds },
       { input: [1, 1], expected: [reinterpretU64AsF64(0x3fef_fffe_dfff_fe00n), reinterpretU64AsF64(0x3ff0_0000_c000_0200n)] },  // ~1
       { input: [1, 100], expected: [reinterpretU64AsF64(0x3fef_ffba_3fff_3800n), reinterpretU64AsF64(0x3ff0_0023_2000_c800n)] },  // ~1
-      { input: [1, kValue.f32.positive.max], expected: kIndeterminateBounds },
+      { input: [1, kValue.f32.positive.max], expected: kUnboundedBounds },
       { input: [2, 1], expected: [reinterpretU64AsF64(0x3fff_fffe_a000_0200n), reinterpretU64AsF64(0x4000_0001_0000_0200n)] },  // ~2
       { input: [2, 2], expected: [reinterpretU64AsF64(0x400f_fffd_a000_0400n), reinterpretU64AsF64(0x4010_0001_a000_0400n)] },  // ~4
       { input: [10, 10], expected: [reinterpretU64AsF64(0x4202_a04f_51f7_7000n), reinterpretU64AsF64(0x4202_a070_ee08_e000n)] },  // ~10000000000
       { input: [10, 1], expected: [reinterpretU64AsF64(0x4023_fffe_0b65_8b00n), reinterpretU64AsF64(0x4024_0002_149a_7c00n)] },  // ~10
-      { input: [kValue.f32.positive.max, 1], expected: kIndeterminateBounds },
+      { input: [kValue.f32.positive.max, 1], expected: kUnboundedBounds },
     ]
   )
   .fn(t => {
@@ -4346,15 +4346,15 @@ g.test('remainderInterval_f32')
       { input: [-1, -0.1], expected: [reinterpretU32AsF32(0xbdccccd8), reinterpretU32AsF32(0x34000000)] }, // ~[-0.1, 0]
 
       // Denominator out of range
-      { input: [1, kValue.f32.infinity.positive], expected: kIndeterminateBounds },
-      { input: [1, kValue.f32.infinity.negative], expected: kIndeterminateBounds },
-      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.negative], expected: kIndeterminateBounds },
-      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], expected: kIndeterminateBounds },
-      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.negative], expected: kIndeterminateBounds },
-      { input: [1, kValue.f32.positive.max], expected: kIndeterminateBounds },
-      { input: [1, kValue.f32.negative.min], expected: kIndeterminateBounds },
-      { input: [1, 0], expected: kIndeterminateBounds },
-      { input: [1, kValue.f32.subnormal.positive.max], expected: kIndeterminateBounds },
+      { input: [1, kValue.f32.infinity.positive], expected: kUnboundedBounds },
+      { input: [1, kValue.f32.infinity.negative], expected: kUnboundedBounds },
+      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.negative], expected: kUnboundedBounds },
+      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], expected: kUnboundedBounds },
+      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.negative], expected: kUnboundedBounds },
+      { input: [1, kValue.f32.positive.max], expected: kUnboundedBounds },
+      { input: [1, kValue.f32.negative.min], expected: kUnboundedBounds },
+      { input: [1, 0], expected: kUnboundedBounds },
+      { input: [1, kValue.f32.subnormal.positive.max], expected: kUnboundedBounds },
     ]
   )
   .fn(t => {
@@ -4423,14 +4423,14 @@ g.test('stepInterval_f32')
       { input: [kValue.f32.subnormal.positive.max, kValue.f32.subnormal.negative.min], expected: [0, 1] },
 
       // Infinities
-      { input: [0, kValue.f32.infinity.positive], expected: kIndeterminateBounds },
-      { input: [kValue.f32.infinity.positive, 0], expected: kIndeterminateBounds },
-      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.positive], expected: kIndeterminateBounds },
-      { input: [0, kValue.f32.infinity.negative], expected: kIndeterminateBounds },
-      { input: [kValue.f32.infinity.negative, 0], expected: kIndeterminateBounds },
-      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.negative], expected: kIndeterminateBounds },
-      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], expected: kIndeterminateBounds },
-      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.negative], expected: kIndeterminateBounds },
+      { input: [0, kValue.f32.infinity.positive], expected: kUnboundedBounds },
+      { input: [kValue.f32.infinity.positive, 0], expected: kUnboundedBounds },
+      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.positive], expected: kUnboundedBounds },
+      { input: [0, kValue.f32.infinity.negative], expected: kUnboundedBounds },
+      { input: [kValue.f32.infinity.negative, 0], expected: kUnboundedBounds },
+      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.negative], expected: kUnboundedBounds },
+      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], expected: kUnboundedBounds },
+      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.negative], expected: kUnboundedBounds },
     ]
   )
   .fn(t => {
@@ -4514,14 +4514,14 @@ g.test('subtractionInterval')
           { input: [0, constants.negative.subnormal.min], expected: [0, constants.positive.subnormal.max] },
 
           // Infinities
-          { input: [0, constants.positive.infinity], expected: kIndeterminateBounds },
-          { input: [constants.positive.infinity, 0], expected: kIndeterminateBounds },
-          { input: [constants.positive.infinity, constants.positive.infinity], expected: kIndeterminateBounds },
-          { input: [0, constants.negative.infinity], expected: kIndeterminateBounds },
-          { input: [constants.negative.infinity, 0], expected: kIndeterminateBounds },
-          { input: [constants.negative.infinity, constants.negative.infinity], expected: kIndeterminateBounds },
-          { input: [constants.negative.infinity, constants.positive.infinity], expected: kIndeterminateBounds },
-          { input: [constants.positive.infinity, constants.negative.infinity], expected: kIndeterminateBounds },
+          { input: [0, constants.positive.infinity], expected: kUnboundedBounds },
+          { input: [constants.positive.infinity, 0], expected: kUnboundedBounds },
+          { input: [constants.positive.infinity, constants.positive.infinity], expected: kUnboundedBounds },
+          { input: [0, constants.negative.infinity], expected: kUnboundedBounds },
+          { input: [constants.negative.infinity, 0], expected: kUnboundedBounds },
+          { input: [constants.negative.infinity, constants.negative.infinity], expected: kUnboundedBounds },
+          { input: [constants.negative.infinity, constants.positive.infinity], expected: kUnboundedBounds },
+          { input: [constants.positive.infinity, constants.negative.infinity], expected: kUnboundedBounds },
         ];
       })
   )
@@ -4575,10 +4575,10 @@ g.test('clampMedianInterval_f32')
       { input: [kValue.f32.positive.max, kValue.f32.positive.max, kValue.f32.subnormal.positive.min], expected: kValue.f32.positive.max },
 
       // Infinities
-      { input: [0, 1, kValue.f32.infinity.positive], expected: kIndeterminateBounds },
-      { input: [0, kValue.f32.infinity.positive, kValue.f32.infinity.positive], expected: kIndeterminateBounds },
-      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive, kValue.f32.infinity.positive], expected: kIndeterminateBounds },
-      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive, kValue.f32.infinity.negative], expected: kIndeterminateBounds },
+      { input: [0, 1, kValue.f32.infinity.positive], expected: kUnboundedBounds },
+      { input: [0, kValue.f32.infinity.positive, kValue.f32.infinity.positive], expected: kUnboundedBounds },
+      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive, kValue.f32.infinity.positive], expected: kUnboundedBounds },
+      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive, kValue.f32.infinity.negative], expected: kUnboundedBounds },
     ]
   )
   .fn(t => {
@@ -4625,10 +4625,10 @@ g.test('clampMinMaxInterval_f32')
       { input: [kValue.f32.positive.max, kValue.f32.positive.max, kValue.f32.subnormal.positive.min], expected: [0, kValue.f32.subnormal.positive.min] },
 
       // Infinities
-      { input: [0, 1, kValue.f32.infinity.positive], expected: kIndeterminateBounds },
-      { input: [0, kValue.f32.infinity.positive, kValue.f32.infinity.positive], expected: kIndeterminateBounds },
-      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive, kValue.f32.infinity.positive], expected: kIndeterminateBounds },
-      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive, kValue.f32.infinity.negative], expected: kIndeterminateBounds },
+      { input: [0, 1, kValue.f32.infinity.positive], expected: kUnboundedBounds },
+      { input: [0, kValue.f32.infinity.positive, kValue.f32.infinity.positive], expected: kUnboundedBounds },
+      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive, kValue.f32.infinity.positive], expected: kUnboundedBounds },
+      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive, kValue.f32.infinity.negative], expected: kUnboundedBounds },
     ]
   )
   .fn(t => {
@@ -4674,11 +4674,11 @@ g.test('fmaInterval_f32')
       { input: [kValue.f32.subnormal.positive.max, kValue.f32.subnormal.negative.min, kValue.f32.subnormal.negative.max], expected: [reinterpretU32AsF32(0x80000002), 0] },
 
       // Infinities
-      { input: [0, 1, kValue.f32.infinity.positive], expected: kIndeterminateBounds },
-      { input: [0, kValue.f32.infinity.positive, kValue.f32.infinity.positive], expected: kIndeterminateBounds },
-      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive, kValue.f32.infinity.positive], expected: kIndeterminateBounds },
-      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive, kValue.f32.infinity.negative], expected: kIndeterminateBounds },
-      { input: [kValue.f32.positive.max, kValue.f32.positive.max, kValue.f32.subnormal.positive.min], expected: kIndeterminateBounds },
+      { input: [0, 1, kValue.f32.infinity.positive], expected: kUnboundedBounds },
+      { input: [0, kValue.f32.infinity.positive, kValue.f32.infinity.positive], expected: kUnboundedBounds },
+      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive, kValue.f32.infinity.positive], expected: kUnboundedBounds },
+      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive, kValue.f32.infinity.negative], expected: kUnboundedBounds },
+      { input: [kValue.f32.positive.max, kValue.f32.positive.max, kValue.f32.subnormal.positive.min], expected: kUnboundedBounds },
     ]
   )
   .fn(t => {
@@ -4744,16 +4744,16 @@ g.test('mixImpreciseInterval_f32')
       { input: [-1.0, 1.0, 2.0], expected: 3.0 },
 
       // Infinities
-      { input: [0.0, kValue.f32.infinity.positive, 0.5], expected: kIndeterminateBounds },
-      { input: [kValue.f32.infinity.positive, 0.0, 0.5], expected: kIndeterminateBounds },
-      { input: [kValue.f32.infinity.negative, 1.0, 0.5], expected: kIndeterminateBounds },
-      { input: [1.0, kValue.f32.infinity.negative, 0.5], expected: kIndeterminateBounds },
-      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive, 0.5], expected: kIndeterminateBounds },
-      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.negative, 0.5], expected: kIndeterminateBounds },
-      { input: [0.0, 1.0, kValue.f32.infinity.negative], expected: kIndeterminateBounds },
-      { input: [1.0, 0.0, kValue.f32.infinity.negative], expected: kIndeterminateBounds },
-      { input: [0.0, 1.0, kValue.f32.infinity.positive], expected: kIndeterminateBounds },
-      { input: [1.0, 0.0, kValue.f32.infinity.positive], expected: kIndeterminateBounds },
+      { input: [0.0, kValue.f32.infinity.positive, 0.5], expected: kUnboundedBounds },
+      { input: [kValue.f32.infinity.positive, 0.0, 0.5], expected: kUnboundedBounds },
+      { input: [kValue.f32.infinity.negative, 1.0, 0.5], expected: kUnboundedBounds },
+      { input: [1.0, kValue.f32.infinity.negative, 0.5], expected: kUnboundedBounds },
+      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive, 0.5], expected: kUnboundedBounds },
+      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.negative, 0.5], expected: kUnboundedBounds },
+      { input: [0.0, 1.0, kValue.f32.infinity.negative], expected: kUnboundedBounds },
+      { input: [1.0, 0.0, kValue.f32.infinity.negative], expected: kUnboundedBounds },
+      { input: [0.0, 1.0, kValue.f32.infinity.positive], expected: kUnboundedBounds },
+      { input: [1.0, 0.0, kValue.f32.infinity.positive], expected: kUnboundedBounds },
 
       // Showing how precise and imprecise versions diff
       { input: [kValue.f32.negative.min, 10.0, 1.0], expected: 0.0 },
@@ -4823,16 +4823,16 @@ g.test('mixPreciseInterval_f32')
       { input: [-1.0, 1.0, 2.0], expected: 3.0 },
 
       // Infinities
-      { input: [0.0, kValue.f32.infinity.positive, 0.5], expected: kIndeterminateBounds },
-      { input: [kValue.f32.infinity.positive, 0.0, 0.5], expected: kIndeterminateBounds },
-      { input: [kValue.f32.infinity.negative, 1.0, 0.5], expected: kIndeterminateBounds },
-      { input: [1.0, kValue.f32.infinity.negative, 0.5], expected: kIndeterminateBounds },
-      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive, 0.5], expected: kIndeterminateBounds },
-      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.negative, 0.5], expected: kIndeterminateBounds },
-      { input: [0.0, 1.0, kValue.f32.infinity.negative], expected: kIndeterminateBounds },
-      { input: [1.0, 0.0, kValue.f32.infinity.negative], expected: kIndeterminateBounds },
-      { input: [0.0, 1.0, kValue.f32.infinity.positive], expected: kIndeterminateBounds },
-      { input: [1.0, 0.0, kValue.f32.infinity.positive], expected: kIndeterminateBounds },
+      { input: [0.0, kValue.f32.infinity.positive, 0.5], expected: kUnboundedBounds },
+      { input: [kValue.f32.infinity.positive, 0.0, 0.5], expected: kUnboundedBounds },
+      { input: [kValue.f32.infinity.negative, 1.0, 0.5], expected: kUnboundedBounds },
+      { input: [1.0, kValue.f32.infinity.negative, 0.5], expected: kUnboundedBounds },
+      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive, 0.5], expected: kUnboundedBounds },
+      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.negative, 0.5], expected: kUnboundedBounds },
+      { input: [0.0, 1.0, kValue.f32.infinity.negative], expected: kUnboundedBounds },
+      { input: [1.0, 0.0, kValue.f32.infinity.negative], expected: kUnboundedBounds },
+      { input: [0.0, 1.0, kValue.f32.infinity.positive], expected: kUnboundedBounds },
+      { input: [1.0, 0.0, kValue.f32.infinity.positive], expected: kUnboundedBounds },
 
       // Showing how precise and imprecise versions diff
       { input: [kValue.f32.negative.min, 10.0, 1.0], expected: 10.0 },
@@ -4879,18 +4879,18 @@ g.test('smoothStepInterval_f32')
       { input: [kValue.f32.subnormal.positive.min, 2, 1], expected: [reinterpretU32AsF32(0x3efffff8), reinterpretU32AsF32(0x3f000007)] },  // ~0.5
       { input: [kValue.f32.subnormal.negative.max, 2, 1], expected: [reinterpretU32AsF32(0x3efffff8), reinterpretU32AsF32(0x3f000007)] },  // ~0.5
       { input: [kValue.f32.subnormal.negative.min, 2, 1], expected: [reinterpretU32AsF32(0x3efffff8), reinterpretU32AsF32(0x3f000007)] },  // ~0.5
-      { input: [0, kValue.f32.subnormal.positive.max, 1], expected: kIndeterminateBounds },
-      { input: [0, kValue.f32.subnormal.positive.min, 1], expected: kIndeterminateBounds },
-      { input: [0, kValue.f32.subnormal.negative.max, 1], expected: kIndeterminateBounds },
-      { input: [0, kValue.f32.subnormal.negative.min, 1], expected: kIndeterminateBounds },
+      { input: [0, kValue.f32.subnormal.positive.max, 1], expected: kUnboundedBounds },
+      { input: [0, kValue.f32.subnormal.positive.min, 1], expected: kUnboundedBounds },
+      { input: [0, kValue.f32.subnormal.negative.max, 1], expected: kUnboundedBounds },
+      { input: [0, kValue.f32.subnormal.negative.min, 1], expected: kUnboundedBounds },
 
       // Infinities
-      { input: [0, 2, Number.POSITIVE_INFINITY], expected: kIndeterminateBounds },
-      { input: [0, 2, Number.NEGATIVE_INFINITY], expected: kIndeterminateBounds },
-      { input: [Number.POSITIVE_INFINITY, 2, 1], expected: kIndeterminateBounds },
-      { input: [Number.NEGATIVE_INFINITY, 2, 1], expected: kIndeterminateBounds },
-      { input: [0, Number.POSITIVE_INFINITY, 1], expected: kIndeterminateBounds },
-      { input: [0, Number.NEGATIVE_INFINITY, 1], expected: kIndeterminateBounds },
+      { input: [0, 2, Number.POSITIVE_INFINITY], expected: kUnboundedBounds },
+      { input: [0, 2, Number.NEGATIVE_INFINITY], expected: kUnboundedBounds },
+      { input: [Number.POSITIVE_INFINITY, 2, 1], expected: kUnboundedBounds },
+      { input: [Number.NEGATIVE_INFINITY, 2, 1], expected: kUnboundedBounds },
+      { input: [0, Number.POSITIVE_INFINITY, 1], expected: kUnboundedBounds },
+      { input: [0, Number.NEGATIVE_INFINITY, 1], expected: kUnboundedBounds },
     ]
   )
   .fn(t => {
@@ -4929,8 +4929,8 @@ g.test('unpack2x16floatInterval')
       { input: 0x000083ff, expected: [[kValue.f16.subnormal.negative.min, 0], 0] },
 
       // f16 out of bounds
-      { input: 0x7c000000, expected: [kIndeterminateBounds, kIndeterminateBounds] },
-      { input: 0xffff0000, expected: [kIndeterminateBounds, kIndeterminateBounds] },
+      { input: 0x7c000000, expected: [kUnboundedBounds, kUnboundedBounds] },
+      { input: 0xffff0000, expected: [kUnboundedBounds, kUnboundedBounds] },
     ]
   )
   .fn(t => {
@@ -5180,9 +5180,9 @@ g.test('lengthIntervalVector_f32')
       {input: [0.1, 0.0, 0.0, 0.0], expected: [reinterpretU64AsF64(0x3fb9_9998_9000_0000n), reinterpretU64AsF64(0x3fb9_999a_7000_0000n)] },  // ~0.1
 
       // Test that dot going OOB bounds in the intermediate calculations propagates
-      { input: [kValue.f32.positive.nearest_max, kValue.f32.positive.max, kValue.f32.negative.min], expected: kIndeterminateBounds },
-      { input: [kValue.f32.positive.max, kValue.f32.positive.nearest_max, kValue.f32.negative.min], expected: kIndeterminateBounds },
-      { input: [kValue.f32.negative.min, kValue.f32.positive.max, kValue.f32.positive.nearest_max], expected: kIndeterminateBounds },
+      { input: [kValue.f32.positive.nearest_max, kValue.f32.positive.max, kValue.f32.negative.min], expected: kUnboundedBounds },
+      { input: [kValue.f32.positive.max, kValue.f32.positive.nearest_max, kValue.f32.negative.min], expected: kUnboundedBounds },
+      { input: [kValue.f32.negative.min, kValue.f32.positive.max, kValue.f32.positive.nearest_max], expected: kUnboundedBounds },
     ]
   )
   .fn(t => {
@@ -5207,11 +5207,11 @@ g.test('distanceIntervalVector_f32')
       // to express in a closed human-readable form due to the inherited nature
       // of the errors.
       //
-      // distance(x, y), where x - y = 0 has an acceptance interval of kIndeterminateBounds,
-      // because distance(x, y) = length(x - y), and length(0) = kIndeterminateBounds
+      // distance(x, y), where x - y = 0 has an acceptance interval of kUnboundedBounds,
+      // because distance(x, y) = length(x - y), and length(0) = kUnboundedBounds
 
       // vec2
-      { input: [[1.0, 0.0], [1.0, 0.0]], expected: kIndeterminateBounds },
+      { input: [[1.0, 0.0], [1.0, 0.0]], expected: kUnboundedBounds },
       { input: [[1.0, 0.0], [0.0, 0.0]], expected: [reinterpretU64AsF64(0x3fef_ffff_7000_0000n), reinterpretU64AsF64(0x3ff0_0000_9000_0000n)] },  // ~1
       { input: [[0.0, 0.0], [1.0, 0.0]], expected: [reinterpretU64AsF64(0x3fef_ffff_7000_0000n), reinterpretU64AsF64(0x3ff0_0000_9000_0000n)] },  // ~1
       { input: [[-1.0, 0.0], [0.0, 0.0]], expected: [reinterpretU64AsF64(0x3fef_ffff_7000_0000n), reinterpretU64AsF64(0x3ff0_0000_9000_0000n)] },  // ~1
@@ -5220,7 +5220,7 @@ g.test('distanceIntervalVector_f32')
       { input: [[0.1, 0.0], [0.0, 0.0]], expected: [reinterpretU64AsF64(0x3fb9_9998_9000_0000n), reinterpretU64AsF64(0x3fb9_999a_7000_0000n)] },  // ~0.1
 
       // vec3
-      { input: [[1.0, 0.0, 0.0], [1.0, 0.0, 0.0]], expected: kIndeterminateBounds },
+      { input: [[1.0, 0.0, 0.0], [1.0, 0.0, 0.0]], expected: kUnboundedBounds },
       { input: [[1.0, 0.0, 0.0], [0.0, 0.0, 0.0]], expected: [reinterpretU64AsF64(0x3fef_ffff_7000_0000n), reinterpretU64AsF64(0x3ff0_0000_9000_0000n)] },  // ~1
       { input: [[0.0, 1.0, 0.0], [0.0, 0.0, 0.0]], expected: [reinterpretU64AsF64(0x3fef_ffff_7000_0000n), reinterpretU64AsF64(0x3ff0_0000_9000_0000n)] },  // ~1
       { input: [[0.0, 0.0, 1.0], [0.0, 0.0, 0.0]], expected: [reinterpretU64AsF64(0x3fef_ffff_7000_0000n), reinterpretU64AsF64(0x3ff0_0000_9000_0000n)] },  // ~1
@@ -5235,7 +5235,7 @@ g.test('distanceIntervalVector_f32')
       { input: [[0.0, 0.0, 0.0], [0.1, 0.0, 0.0]], expected: [reinterpretU64AsF64(0x3fb9_9998_9000_0000n), reinterpretU64AsF64(0x3fb9_999a_7000_0000n)] },  // ~0.1
 
       // vec4
-      { input: [[1.0, 0.0, 0.0, 0.0], [1.0, 0.0, 0.0, 0.0]], expected: kIndeterminateBounds },
+      { input: [[1.0, 0.0, 0.0, 0.0], [1.0, 0.0, 0.0, 0.0]], expected: kUnboundedBounds },
       { input: [[1.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0]], expected: [reinterpretU64AsF64(0x3fef_ffff_7000_0000n), reinterpretU64AsF64(0x3ff0_0000_9000_0000n)] },  // ~1
       { input: [[0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 0.0, 0.0]], expected: [reinterpretU64AsF64(0x3fef_ffff_7000_0000n), reinterpretU64AsF64(0x3ff0_0000_9000_0000n)] },  // ~1
       { input: [[0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 0.0, 0.0]], expected: [reinterpretU64AsF64(0x3fef_ffff_7000_0000n), reinterpretU64AsF64(0x3ff0_0000_9000_0000n)] },  // ~1
@@ -5293,12 +5293,12 @@ g.test('dotInterval_f32')
       { input: [[0.1, 0.0, 0.0, 0.0], [1.0, 0.0, 0.0, 0.0]], expected: [reinterpretU64AsF64(0x3fb9_9999_8000_0000n), reinterpretU64AsF64(0x3fb9_9999_a000_0000n)]},  // ~0.1
 
       // Test that going out of bounds in the intermediate calculations is caught correctly.
-      { input: [[kValue.f32.positive.nearest_max, kValue.f32.positive.max, kValue.f32.negative.min], [1.0, 1.0, 1.0]], expected: kIndeterminateBounds },
-      { input: [[kValue.f32.positive.nearest_max, kValue.f32.negative.min, kValue.f32.positive.max], [1.0, 1.0, 1.0]], expected: kIndeterminateBounds },
-      { input: [[kValue.f32.positive.max, kValue.f32.positive.nearest_max, kValue.f32.negative.min], [1.0, 1.0, 1.0]], expected: kIndeterminateBounds },
-      { input: [[kValue.f32.negative.min, kValue.f32.positive.nearest_max, kValue.f32.positive.max], [1.0, 1.0, 1.0]], expected: kIndeterminateBounds },
-      { input: [[kValue.f32.positive.max, kValue.f32.negative.min, kValue.f32.positive.nearest_max], [1.0, 1.0, 1.0]], expected: kIndeterminateBounds },
-      { input: [[kValue.f32.negative.min, kValue.f32.positive.max, kValue.f32.positive.nearest_max], [1.0, 1.0, 1.0]], expected: kIndeterminateBounds },
+      { input: [[kValue.f32.positive.nearest_max, kValue.f32.positive.max, kValue.f32.negative.min], [1.0, 1.0, 1.0]], expected: kUnboundedBounds },
+      { input: [[kValue.f32.positive.nearest_max, kValue.f32.negative.min, kValue.f32.positive.max], [1.0, 1.0, 1.0]], expected: kUnboundedBounds },
+      { input: [[kValue.f32.positive.max, kValue.f32.positive.nearest_max, kValue.f32.negative.min], [1.0, 1.0, 1.0]], expected: kUnboundedBounds },
+      { input: [[kValue.f32.negative.min, kValue.f32.positive.nearest_max, kValue.f32.positive.max], [1.0, 1.0, 1.0]], expected: kUnboundedBounds },
+      { input: [[kValue.f32.positive.max, kValue.f32.negative.min, kValue.f32.positive.nearest_max], [1.0, 1.0, 1.0]], expected: kUnboundedBounds },
+      { input: [[kValue.f32.negative.min, kValue.f32.positive.max, kValue.f32.positive.nearest_max], [1.0, 1.0, 1.0]], expected: kUnboundedBounds },
 
       // https://github.com/gpuweb/cts/issues/2155
       { input: [[kValue.f32.positive.max, 1.0, 2.0, 3.0], [-1.0, kValue.f32.positive.max, -2.0, -3.0]], expected: [-13, 0] },
@@ -5440,15 +5440,15 @@ g.test('reflectInterval_f32')
       { input: [[kValue.f32.subnormal.positive.max, kValue.f32.subnormal.negative.max, 0.0, 0.0], [1.0, 1.0, 1.0, 1.0]], expected: [[reinterpretU32AsF32(0x80fffffe), reinterpretU32AsF32(0x00800001)], [reinterpretU32AsF32(0x80ffffff), reinterpretU32AsF32(0x00000002)], [reinterpretU32AsF32(0x80fffffe), reinterpretU32AsF32(0x00000002)], [reinterpretU32AsF32(0x80fffffe), reinterpretU32AsF32(0x00000002)]] },  // [~0.0, ~0.0, ~0.0, ~0.0]
 
       // Test that dot going OOB bounds in the intermediate calculations propagates
-      { input: [[kValue.f32.positive.nearest_max, kValue.f32.positive.max, kValue.f32.negative.min], [1.0, 1.0, 1.0]], expected: [kIndeterminateBounds, kIndeterminateBounds, kIndeterminateBounds] },
-      { input: [[kValue.f32.positive.nearest_max, kValue.f32.negative.min, kValue.f32.positive.max], [1.0, 1.0, 1.0]], expected: [kIndeterminateBounds, kIndeterminateBounds, kIndeterminateBounds] },
-      { input: [[kValue.f32.positive.max, kValue.f32.positive.nearest_max, kValue.f32.negative.min], [1.0, 1.0, 1.0]], expected: [kIndeterminateBounds, kIndeterminateBounds, kIndeterminateBounds] },
-      { input: [[kValue.f32.negative.min, kValue.f32.positive.nearest_max, kValue.f32.positive.max], [1.0, 1.0, 1.0]], expected: [kIndeterminateBounds, kIndeterminateBounds, kIndeterminateBounds] },
-      { input: [[kValue.f32.positive.max, kValue.f32.negative.min, kValue.f32.positive.nearest_max], [1.0, 1.0, 1.0]], expected: [kIndeterminateBounds, kIndeterminateBounds, kIndeterminateBounds] },
-      { input: [[kValue.f32.negative.min, kValue.f32.positive.max, kValue.f32.positive.nearest_max], [1.0, 1.0, 1.0]], expected: [kIndeterminateBounds, kIndeterminateBounds, kIndeterminateBounds] },
+      { input: [[kValue.f32.positive.nearest_max, kValue.f32.positive.max, kValue.f32.negative.min], [1.0, 1.0, 1.0]], expected: [kUnboundedBounds, kUnboundedBounds, kUnboundedBounds] },
+      { input: [[kValue.f32.positive.nearest_max, kValue.f32.negative.min, kValue.f32.positive.max], [1.0, 1.0, 1.0]], expected: [kUnboundedBounds, kUnboundedBounds, kUnboundedBounds] },
+      { input: [[kValue.f32.positive.max, kValue.f32.positive.nearest_max, kValue.f32.negative.min], [1.0, 1.0, 1.0]], expected: [kUnboundedBounds, kUnboundedBounds, kUnboundedBounds] },
+      { input: [[kValue.f32.negative.min, kValue.f32.positive.nearest_max, kValue.f32.positive.max], [1.0, 1.0, 1.0]], expected: [kUnboundedBounds, kUnboundedBounds, kUnboundedBounds] },
+      { input: [[kValue.f32.positive.max, kValue.f32.negative.min, kValue.f32.positive.nearest_max], [1.0, 1.0, 1.0]], expected: [kUnboundedBounds, kUnboundedBounds, kUnboundedBounds] },
+      { input: [[kValue.f32.negative.min, kValue.f32.positive.max, kValue.f32.positive.nearest_max], [1.0, 1.0, 1.0]], expected: [kUnboundedBounds, kUnboundedBounds, kUnboundedBounds] },
 
       // Test that post-dot going OOB propagates
-      { input: [[kValue.f32.positive.max, 1.0, 2.0, 3.0], [-1.0, kValue.f32.positive.max, -2.0, -3.0]], expected: [kIndeterminateBounds, kIndeterminateBounds, kIndeterminateBounds, kIndeterminateBounds] },
+      { input: [[kValue.f32.positive.max, 1.0, 2.0, 3.0], [-1.0, kValue.f32.positive.max, -2.0, -3.0]], expected: [kUnboundedBounds, kUnboundedBounds, kUnboundedBounds, kUnboundedBounds] },
     ]
   )
   .fn(t => {
@@ -7118,7 +7118,7 @@ interface RefractCase {
         { input: [[1, 1], [0.1, 0], 10], expected: [0, 0] },
 
         // k contains 0
-        { input: [[1, 1], [0.1, 0], 1.005038], expected: [kIndeterminateBounds, kIndeterminateBounds] },
+        { input: [[1, 1], [0.1, 0], 1.005038], expected: [kUnboundedBounds, kUnboundedBounds] },
 
         // k > 0
         // vec2
@@ -7140,12 +7140,12 @@ interface RefractCase {
             [reinterpretU32AsF32(0xc20dfa80), reinterpretU32AsF32(0xc20df500)]] },  // ~-35.494...
 
         // Test that dot going OOB bounds in the intermediate calculations propagates
-        { input: [[kValue.f32.positive.nearest_max, kValue.f32.positive.max, kValue.f32.negative.min], [1.0, 1.0, 1.0], 1], expected: [kIndeterminateBounds, kIndeterminateBounds, kIndeterminateBounds] },
-        { input: [[kValue.f32.positive.nearest_max, kValue.f32.negative.min, kValue.f32.positive.max], [1.0, 1.0, 1.0], 1], expected: [kIndeterminateBounds, kIndeterminateBounds, kIndeterminateBounds] },
-        { input: [[kValue.f32.positive.max, kValue.f32.positive.nearest_max, kValue.f32.negative.min], [1.0, 1.0, 1.0], 1], expected: [kIndeterminateBounds, kIndeterminateBounds, kIndeterminateBounds] },
-        { input: [[kValue.f32.negative.min, kValue.f32.positive.nearest_max, kValue.f32.positive.max], [1.0, 1.0, 1.0], 1], expected: [kIndeterminateBounds, kIndeterminateBounds, kIndeterminateBounds] },
-        { input: [[kValue.f32.positive.max, kValue.f32.negative.min, kValue.f32.positive.nearest_max], [1.0, 1.0, 1.0], 1], expected: [kIndeterminateBounds, kIndeterminateBounds, kIndeterminateBounds] },
-        { input: [[kValue.f32.negative.min, kValue.f32.positive.max, kValue.f32.positive.nearest_max], [1.0, 1.0, 1.0], 1], expected: [kIndeterminateBounds, kIndeterminateBounds, kIndeterminateBounds] },
+        { input: [[kValue.f32.positive.nearest_max, kValue.f32.positive.max, kValue.f32.negative.min], [1.0, 1.0, 1.0], 1], expected: [kUnboundedBounds, kUnboundedBounds, kUnboundedBounds] },
+        { input: [[kValue.f32.positive.nearest_max, kValue.f32.negative.min, kValue.f32.positive.max], [1.0, 1.0, 1.0], 1], expected: [kUnboundedBounds, kUnboundedBounds, kUnboundedBounds] },
+        { input: [[kValue.f32.positive.max, kValue.f32.positive.nearest_max, kValue.f32.negative.min], [1.0, 1.0, 1.0], 1], expected: [kUnboundedBounds, kUnboundedBounds, kUnboundedBounds] },
+        { input: [[kValue.f32.negative.min, kValue.f32.positive.nearest_max, kValue.f32.positive.max], [1.0, 1.0, 1.0], 1], expected: [kUnboundedBounds, kUnboundedBounds, kUnboundedBounds] },
+        { input: [[kValue.f32.positive.max, kValue.f32.negative.min, kValue.f32.positive.nearest_max], [1.0, 1.0, 1.0], 1], expected: [kUnboundedBounds, kUnboundedBounds, kUnboundedBounds] },
+        { input: [[kValue.f32.negative.min, kValue.f32.positive.max, kValue.f32.positive.nearest_max], [1.0, 1.0, 1.0], 1], expected: [kUnboundedBounds, kUnboundedBounds, kUnboundedBounds] },
       ]
     )
     .fn(t => {

--- a/src/webgpu/util/floating_point.ts
+++ b/src/webgpu/util/floating_point.ts
@@ -140,48 +140,48 @@ export class FPInterval {
  * This form can be safely encoded to JSON.
  */
 export type SerializedFPInterval =
-  | { kind: 'f32'; indeterminate: false; begin: number; end: number }
-  | { kind: 'f32'; indeterminate: true }
-  | { kind: 'f16'; indeterminate: false; begin: number; end: number }
-  | { kind: 'f16'; indeterminate: true }
-  | { kind: 'abstract'; indeterminate: false; begin: [number, number]; end: [number, number] }
-  | { kind: 'abstract'; indeterminate: true };
+  | { kind: 'f32'; unbounded: false; begin: number; end: number }
+  | { kind: 'f32'; unbounded: true }
+  | { kind: 'f16'; unbounded: false; begin: number; end: number }
+  | { kind: 'f16'; unbounded: true }
+  | { kind: 'abstract'; unbounded: false; begin: [number, number]; end: [number, number] }
+  | { kind: 'abstract'; unbounded: true };
 
 /** serializeFPInterval() converts a FPInterval to a SerializedFPInterval */
 export function serializeFPInterval(i: FPInterval): SerializedFPInterval {
   const traits = FP[i.kind];
   switch (i.kind) {
     case 'abstract': {
-      if (i === traits.constants().indeterminateInterval) {
-        return { kind: 'abstract', indeterminate: true };
+      if (i === traits.constants().unboundedInterval) {
+        return { kind: 'abstract', unbounded: true };
       } else {
         return {
           kind: 'abstract',
-          indeterminate: false,
+          unbounded: false,
           begin: reinterpretF64AsU32s(i.begin),
           end: reinterpretF64AsU32s(i.end),
         };
       }
     }
     case 'f32': {
-      if (i === traits.constants().indeterminateInterval) {
-        return { kind: 'f32', indeterminate: true };
+      if (i === traits.constants().unboundedInterval) {
+        return { kind: 'f32', unbounded: true };
       } else {
         return {
           kind: 'f32',
-          indeterminate: false,
+          unbounded: false,
           begin: reinterpretF32AsU32(i.begin),
           end: reinterpretF32AsU32(i.end),
         };
       }
     }
     case 'f16': {
-      if (i === traits.constants().indeterminateInterval) {
-        return { kind: 'f16', indeterminate: true };
+      if (i === traits.constants().unboundedInterval) {
+        return { kind: 'f16', unbounded: true };
       } else {
         return {
           kind: 'f16',
-          indeterminate: false,
+          unbounded: false,
           begin: reinterpretF16AsU16(i.begin),
           end: reinterpretF16AsU16(i.end),
         };
@@ -195,8 +195,8 @@ export function serializeFPInterval(i: FPInterval): SerializedFPInterval {
 export function deserializeFPInterval(data: SerializedFPInterval): FPInterval {
   const kind = data.kind;
   const traits = FP[kind];
-  if (data.indeterminate) {
-    return traits.constants().indeterminateInterval;
+  if (data.unbounded) {
+    return traits.constants().unboundedInterval;
   }
   switch (kind) {
     case 'abstract': {
@@ -582,7 +582,7 @@ interface FPConstants {
       sixth: number;
     };
   };
-  indeterminateInterval: FPInterval;
+  unboundedInterval: FPInterval;
   zeroInterval: FPInterval;
   negPiToPiInterval: FPInterval;
   greaterThanZeroInterval: FPInterval;
@@ -591,12 +591,12 @@ interface FPConstants {
     3: FPVector;
     4: FPVector;
   };
-  indeterminateVector: {
+  unboundedVector: {
     2: FPVector;
     3: FPVector;
     4: FPVector;
   };
-  indeterminateMatrix: {
+  unboundedMatrix: {
     2: {
       2: FPMatrix;
       3: FPMatrix;
@@ -820,13 +820,13 @@ export abstract class FPTraits {
    * @param domain interval to restrict inputs to
    * @param impl operation implementation to run if input is within the required domain
    * @returns a ScalarToInterval that calls impl if domain contains the input,
-   *          otherwise it returns an indeterminate interval */
+   *          otherwise it returns an unbounded interval */
   protected limitScalarToIntervalDomain(
     domain: FPInterval,
     impl: ScalarToInterval
   ): ScalarToInterval {
     return (n: number): FPInterval => {
-      return domain.contains(n) ? impl(n) : this.constants().indeterminateInterval;
+      return domain.contains(n) ? impl(n) : this.constants().unboundedInterval;
     };
   }
 
@@ -839,14 +839,14 @@ export abstract class FPTraits {
    * @param domain set of intervals to restrict inputs to
    * @param impl operation implementation to run if input is within the required domain
    * @returns a ScalarPairToInterval that calls impl if domain contains the input,
-   *          otherwise it returns an indeterminate interval */
+   *          otherwise it returns an unbounded interval */
   protected limitScalarPairToIntervalDomain(
     domain: ScalarPairToIntervalDomain,
     impl: ScalarPairToInterval
   ): ScalarPairToInterval {
     return (x: number, y: number): FPInterval => {
       if (!domain.x.some(d => d.contains(x)) || !domain.y.some(d => d.contains(y))) {
-        return this.constants().indeterminateInterval;
+        return this.constants().unboundedInterval;
       }
 
       return impl(x, y);
@@ -996,6 +996,16 @@ export abstract class FPTraits {
   /** Stub for refract generator */
   protected unimplementedRefract(_i: number[], _s: number[], _r: number): FPVector {
     unreachable(`Not yet implemented for ${this.kind}`);
+  }
+
+  /** Version of absoluteErrorInterval that always returns the unboundedInterval */
+  protected unboundedAbsoluteErrorInterval(_n: number, _error_range: number): FPInterval {
+    return this.constants().unboundedInterval;
+  }
+
+  /** Version of ulpInterval that always returns the unboundedInterval */
+  protected unboundedUlpInterval(_n: number, _numULP: number): FPInterval {
+    return this.constants().unboundedInterval;
   }
 
   // Utilities - Defined by subclass
@@ -2099,7 +2109,7 @@ export abstract class FPTraits {
    */
   protected runScalarToIntervalOp(x: FPInterval, op: ScalarToIntervalOp): FPInterval {
     if (!x.isFinite()) {
-      return this.constants().indeterminateInterval;
+      return this.constants().unboundedInterval;
     }
 
     if (op.extrema !== undefined) {
@@ -2109,7 +2119,7 @@ export abstract class FPTraits {
     const result = this.spanIntervals(
       ...x.bounds().map(b => this.roundAndFlushScalarToInterval(b, op))
     );
-    return result.isFinite() ? result : this.constants().indeterminateInterval;
+    return result.isFinite() ? result : this.constants().unboundedInterval;
   }
 
   /**
@@ -2129,7 +2139,7 @@ export abstract class FPTraits {
     op: ScalarPairToIntervalOp
   ): FPInterval {
     if (!x.isFinite() || !y.isFinite()) {
-      return this.constants().indeterminateInterval;
+      return this.constants().unboundedInterval;
     }
 
     if (op.extrema !== undefined) {
@@ -2144,7 +2154,7 @@ export abstract class FPTraits {
     });
 
     const result = this.spanIntervals(...outputs);
-    return result.isFinite() ? result : this.constants().indeterminateInterval;
+    return result.isFinite() ? result : this.constants().unboundedInterval;
   }
 
   /**
@@ -2163,7 +2173,7 @@ export abstract class FPTraits {
     op: ScalarTripleToIntervalOp
   ): FPInterval {
     if (!x.isFinite() || !y.isFinite() || !z.isFinite()) {
-      return this.constants().indeterminateInterval;
+      return this.constants().unboundedInterval;
     }
 
     const outputs = new Set<FPInterval>();
@@ -2176,7 +2186,7 @@ export abstract class FPTraits {
     });
 
     const result = this.spanIntervals(...outputs);
-    return result.isFinite() ? result : this.constants().indeterminateInterval;
+    return result.isFinite() ? result : this.constants().unboundedInterval;
   }
 
   /**
@@ -2189,7 +2199,7 @@ export abstract class FPTraits {
    */
   protected runVectorToIntervalOp(x: FPVector, op: VectorToIntervalOp): FPInterval {
     if (x.some(e => !e.isFinite())) {
-      return this.constants().indeterminateInterval;
+      return this.constants().unboundedInterval;
     }
 
     const x_values = cartesianProduct<number>(...x.map(e => e.bounds()));
@@ -2200,7 +2210,7 @@ export abstract class FPTraits {
     });
 
     const result = this.spanIntervals(...outputs);
-    return result.isFinite() ? result : this.constants().indeterminateInterval;
+    return result.isFinite() ? result : this.constants().unboundedInterval;
   }
 
   /**
@@ -2218,7 +2228,7 @@ export abstract class FPTraits {
     op: VectorPairToIntervalOp
   ): FPInterval {
     if (x.some(e => !e.isFinite()) || y.some(e => !e.isFinite())) {
-      return this.constants().indeterminateInterval;
+      return this.constants().unboundedInterval;
     }
 
     const x_values = cartesianProduct<number>(...x.map(e => e.bounds()));
@@ -2232,7 +2242,7 @@ export abstract class FPTraits {
     });
 
     const result = this.spanIntervals(...outputs);
-    return result.isFinite() ? result : this.constants().indeterminateInterval;
+    return result.isFinite() ? result : this.constants().unboundedInterval;
   }
 
   /**
@@ -2245,7 +2255,7 @@ export abstract class FPTraits {
    */
   protected runVectorToVectorOp(x: FPVector, op: VectorToVectorOp): FPVector {
     if (x.some(e => !e.isFinite())) {
-      return this.constants().indeterminateVector[x.length];
+      return this.constants().unboundedVector[x.length];
     }
 
     const x_values = cartesianProduct<number>(...x.map(e => e.bounds()));
@@ -2258,7 +2268,7 @@ export abstract class FPTraits {
     const result = this.spanVectors(...outputs);
     return result.every(e => e.isFinite())
       ? result
-      : this.constants().indeterminateVector[result.length];
+      : this.constants().unboundedVector[result.length];
   }
 
   /**
@@ -2289,7 +2299,7 @@ export abstract class FPTraits {
    */
   protected runVectorPairToVectorOp(x: FPVector, y: FPVector, op: VectorPairToVectorOp): FPVector {
     if (x.some(e => !e.isFinite()) || y.some(e => !e.isFinite())) {
-      return this.constants().indeterminateVector[x.length];
+      return this.constants().unboundedVector[x.length];
     }
 
     const x_values = cartesianProduct<number>(...x.map(e => e.bounds()));
@@ -2305,7 +2315,7 @@ export abstract class FPTraits {
     const result = this.spanVectors(...outputs);
     return result.every(e => e.isFinite())
       ? result
-      : this.constants().indeterminateVector[result.length];
+      : this.constants().unboundedVector[result.length];
   }
 
   /**
@@ -2351,7 +2361,7 @@ export abstract class FPTraits {
     const num_cols = m.length;
     const num_rows = m[0].length;
     if (m.some(c => c.some(r => !r.isFinite()))) {
-      return this.constants().indeterminateMatrix[num_cols][num_rows];
+      return this.constants().unboundedMatrix[num_cols][num_rows];
     }
 
     const m_flat: FPInterval[] = flatten2DArray(m);
@@ -2372,7 +2382,7 @@ export abstract class FPTraits {
     // arrays.
     return (result as FPInterval[][]).every(c => c.every(r => r.isFinite()))
       ? result
-      : this.constants().indeterminateMatrix[result_cols][result_rows];
+      : this.constants().unboundedMatrix[result_cols][result_rows];
   }
 
   /**
@@ -2418,7 +2428,7 @@ export abstract class FPTraits {
   private AbsoluteErrorIntervalOp(error_range: number): ScalarToIntervalOp {
     const op: ScalarToIntervalOp = {
       impl: (_: number) => {
-        return this.constants().indeterminateInterval;
+        return this.constants().unboundedInterval;
       },
     };
 
@@ -2432,7 +2442,7 @@ export abstract class FPTraits {
         assert(!Number.isNaN(n), `absolute error not defined for NaN`);
         // Return anyInterval if given center n is infinity.
         if (!this.isFinite(n)) {
-          return this.constants().indeterminateInterval;
+          return this.constants().unboundedInterval;
         }
         return this.toInterval([n - error_range, n + error_range]);
       };
@@ -2481,7 +2491,7 @@ export abstract class FPTraits {
   private ULPIntervalOp(numULP: number): ScalarToIntervalOp {
     const op: ScalarToIntervalOp = {
       impl: (_: number) => {
-        return this.constants().indeterminateInterval;
+        return this.constants().unboundedInterval;
       },
     };
 
@@ -2715,7 +2725,7 @@ export abstract class FPTraits {
         }
       ),
       extrema: (y: FPInterval, x: FPInterval): [FPInterval, FPInterval] => {
-        // There is discontinuity, which generates an indeterminate result, at y/x = 0 that will dominate the accuracy
+        // There is discontinuity, which generates an unbounded result, at y/x = 0 that will dominate the accuracy
         if (y.contains(0)) {
           if (x.contains(0)) {
             return [this.toInterval(0), this.toInterval(0)];
@@ -3141,7 +3151,7 @@ export abstract class FPTraits {
         },
         (x: number, y: number): FPInterval => {
           if (y === 0) {
-            return constants.indeterminateInterval;
+            return constants.unboundedInterval;
           }
           return this.ulpInterval(x / y, 2.5);
         }
@@ -3398,7 +3408,7 @@ export abstract class FPTraits {
         const result = e1 * 2 ** e2;
         if (Number.isNaN(result)) {
           // Overflowed TS's number type, so definitely out of bounds for f32
-          return this.constants().indeterminateInterval;
+          return this.constants().unboundedInterval;
         }
         return this.correctlyRoundedInterval(result);
       }
@@ -3826,7 +3836,7 @@ export abstract class FPTraits {
 
     if (!k.isFinite() || k.containsZeroOrSubnormals()) {
       // There is a discontinuity at k == 0, due to sqrt(k) being calculated, so exiting early
-      return this.constants().indeterminateVector[this.toVector(i).length];
+      return this.constants().unboundedVector[this.toVector(i).length];
     }
 
     if (k.end < 0.0) {
@@ -4043,7 +4053,7 @@ export abstract class FPTraits {
    * [0, 0] and [1, 1] indicate that the correct answer in point they encapsulate.
    * [0, 1] should not be treated as a span, i.e. 0.1 is acceptable, but instead
    * indicate either 0.0 or 1.0 are acceptable answers.
-   * [-∞, +∞] is treated as indeterminate interval, since an indeterminate or
+   * [-∞, +∞] is treated as unbounded interval, since an unbounded or
    * infinite value was passed in.
    */
   public abstract readonly stepInterval: (edge: number, x: number) => FPInterval;
@@ -4146,7 +4156,11 @@ export abstract class FPTraits {
 
 // Pre-defined values that get used multiple times in _constants' initializers. Cannot use FPTraits members, since this
 // executes before they are defined.
-const kF32AnyInterval = new FPInterval('f32', Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY);
+const kF32UnboundedInterval = new FPInterval(
+  'f32',
+  Number.NEGATIVE_INFINITY,
+  Number.POSITIVE_INFINITY
+);
 const kF32ZeroInterval = new FPInterval('f32', 0);
 
 class F32Traits extends FPTraits {
@@ -4190,7 +4204,7 @@ class F32Traits extends FPTraits {
         sixth: kValue.f32.negative.pi.sixth,
       },
     },
-    indeterminateInterval: kF32AnyInterval,
+    unboundedInterval: kF32UnboundedInterval,
     zeroInterval: kF32ZeroInterval,
     // Have to use the constants.ts values here, because values defined in the
     // initializer cannot be referenced in the initializer
@@ -4209,61 +4223,111 @@ class F32Traits extends FPTraits {
       3: [kF32ZeroInterval, kF32ZeroInterval, kF32ZeroInterval],
       4: [kF32ZeroInterval, kF32ZeroInterval, kF32ZeroInterval, kF32ZeroInterval],
     },
-    indeterminateVector: {
-      2: [kF32AnyInterval, kF32AnyInterval],
-      3: [kF32AnyInterval, kF32AnyInterval, kF32AnyInterval],
-      4: [kF32AnyInterval, kF32AnyInterval, kF32AnyInterval, kF32AnyInterval],
+    unboundedVector: {
+      2: [kF32UnboundedInterval, kF32UnboundedInterval],
+      3: [kF32UnboundedInterval, kF32UnboundedInterval, kF32UnboundedInterval],
+      4: [
+        kF32UnboundedInterval,
+        kF32UnboundedInterval,
+        kF32UnboundedInterval,
+        kF32UnboundedInterval,
+      ],
     },
-    indeterminateMatrix: {
+    unboundedMatrix: {
       2: {
         2: [
-          [kF32AnyInterval, kF32AnyInterval],
-          [kF32AnyInterval, kF32AnyInterval],
+          [kF32UnboundedInterval, kF32UnboundedInterval],
+          [kF32UnboundedInterval, kF32UnboundedInterval],
         ],
         3: [
-          [kF32AnyInterval, kF32AnyInterval, kF32AnyInterval],
-          [kF32AnyInterval, kF32AnyInterval, kF32AnyInterval],
+          [kF32UnboundedInterval, kF32UnboundedInterval, kF32UnboundedInterval],
+          [kF32UnboundedInterval, kF32UnboundedInterval, kF32UnboundedInterval],
         ],
         4: [
-          [kF32AnyInterval, kF32AnyInterval, kF32AnyInterval, kF32AnyInterval],
-          [kF32AnyInterval, kF32AnyInterval, kF32AnyInterval, kF32AnyInterval],
+          [
+            kF32UnboundedInterval,
+            kF32UnboundedInterval,
+            kF32UnboundedInterval,
+            kF32UnboundedInterval,
+          ],
+          [
+            kF32UnboundedInterval,
+            kF32UnboundedInterval,
+            kF32UnboundedInterval,
+            kF32UnboundedInterval,
+          ],
         ],
       },
       3: {
         2: [
-          [kF32AnyInterval, kF32AnyInterval],
-          [kF32AnyInterval, kF32AnyInterval],
-          [kF32AnyInterval, kF32AnyInterval],
+          [kF32UnboundedInterval, kF32UnboundedInterval],
+          [kF32UnboundedInterval, kF32UnboundedInterval],
+          [kF32UnboundedInterval, kF32UnboundedInterval],
         ],
         3: [
-          [kF32AnyInterval, kF32AnyInterval, kF32AnyInterval],
-          [kF32AnyInterval, kF32AnyInterval, kF32AnyInterval],
-          [kF32AnyInterval, kF32AnyInterval, kF32AnyInterval],
+          [kF32UnboundedInterval, kF32UnboundedInterval, kF32UnboundedInterval],
+          [kF32UnboundedInterval, kF32UnboundedInterval, kF32UnboundedInterval],
+          [kF32UnboundedInterval, kF32UnboundedInterval, kF32UnboundedInterval],
         ],
         4: [
-          [kF32AnyInterval, kF32AnyInterval, kF32AnyInterval, kF32AnyInterval],
-          [kF32AnyInterval, kF32AnyInterval, kF32AnyInterval, kF32AnyInterval],
-          [kF32AnyInterval, kF32AnyInterval, kF32AnyInterval, kF32AnyInterval],
+          [
+            kF32UnboundedInterval,
+            kF32UnboundedInterval,
+            kF32UnboundedInterval,
+            kF32UnboundedInterval,
+          ],
+          [
+            kF32UnboundedInterval,
+            kF32UnboundedInterval,
+            kF32UnboundedInterval,
+            kF32UnboundedInterval,
+          ],
+          [
+            kF32UnboundedInterval,
+            kF32UnboundedInterval,
+            kF32UnboundedInterval,
+            kF32UnboundedInterval,
+          ],
         ],
       },
       4: {
         2: [
-          [kF32AnyInterval, kF32AnyInterval],
-          [kF32AnyInterval, kF32AnyInterval],
-          [kF32AnyInterval, kF32AnyInterval],
-          [kF32AnyInterval, kF32AnyInterval],
+          [kF32UnboundedInterval, kF32UnboundedInterval],
+          [kF32UnboundedInterval, kF32UnboundedInterval],
+          [kF32UnboundedInterval, kF32UnboundedInterval],
+          [kF32UnboundedInterval, kF32UnboundedInterval],
         ],
         3: [
-          [kF32AnyInterval, kF32AnyInterval, kF32AnyInterval],
-          [kF32AnyInterval, kF32AnyInterval, kF32AnyInterval],
-          [kF32AnyInterval, kF32AnyInterval, kF32AnyInterval],
-          [kF32AnyInterval, kF32AnyInterval, kF32AnyInterval],
+          [kF32UnboundedInterval, kF32UnboundedInterval, kF32UnboundedInterval],
+          [kF32UnboundedInterval, kF32UnboundedInterval, kF32UnboundedInterval],
+          [kF32UnboundedInterval, kF32UnboundedInterval, kF32UnboundedInterval],
+          [kF32UnboundedInterval, kF32UnboundedInterval, kF32UnboundedInterval],
         ],
         4: [
-          [kF32AnyInterval, kF32AnyInterval, kF32AnyInterval, kF32AnyInterval],
-          [kF32AnyInterval, kF32AnyInterval, kF32AnyInterval, kF32AnyInterval],
-          [kF32AnyInterval, kF32AnyInterval, kF32AnyInterval, kF32AnyInterval],
-          [kF32AnyInterval, kF32AnyInterval, kF32AnyInterval, kF32AnyInterval],
+          [
+            kF32UnboundedInterval,
+            kF32UnboundedInterval,
+            kF32UnboundedInterval,
+            kF32UnboundedInterval,
+          ],
+          [
+            kF32UnboundedInterval,
+            kF32UnboundedInterval,
+            kF32UnboundedInterval,
+            kF32UnboundedInterval,
+          ],
+          [
+            kF32UnboundedInterval,
+            kF32UnboundedInterval,
+            kF32UnboundedInterval,
+            kF32UnboundedInterval,
+          ],
+          [
+            kF32UnboundedInterval,
+            kF32UnboundedInterval,
+            kF32UnboundedInterval,
+            kF32UnboundedInterval,
+          ],
         ],
       },
     },
@@ -4446,7 +4510,7 @@ class F32Traits extends FPTraits {
     );
     this.unpackDataU32[0] = n;
     if (this.unpackDataF16.some(f => !isFiniteF16(f))) {
-      return [this.constants().indeterminateInterval, this.constants().indeterminateInterval];
+      return [this.constants().unboundedInterval, this.constants().unboundedInterval];
     }
 
     const result: FPVector = [
@@ -4455,7 +4519,7 @@ class F32Traits extends FPTraits {
     ];
 
     if (result.some(r => !r.isFinite())) {
-      return [this.constants().indeterminateInterval, this.constants().indeterminateInterval];
+      return [this.constants().unboundedInterval, this.constants().unboundedInterval];
     }
     return result;
   }
@@ -4554,7 +4618,7 @@ class F32Traits extends FPTraits {
 
 // Pre-defined values that get used multiple times in _constants' initializers. Cannot use FPTraits members, since this
 // executes before they are defined.
-const kAbstractAnyInterval = new FPInterval(
+const kAbstractUnboundedInterval = new FPInterval(
   'abstract',
   Number.NEGATIVE_INFINITY,
   Number.POSITIVE_INFINITY
@@ -4603,7 +4667,7 @@ class FPAbstractTraits extends FPTraits {
         sixth: kValue.f64.negative.pi.sixth,
       },
     },
-    indeterminateInterval: kAbstractAnyInterval,
+    unboundedInterval: kAbstractUnboundedInterval,
     zeroInterval: kAbstractZeroInterval,
     // Have to use the constants.ts values here, because values defined in the
     // initializer cannot be referenced in the initializer
@@ -4627,61 +4691,111 @@ class FPAbstractTraits extends FPTraits {
         kAbstractZeroInterval,
       ],
     },
-    indeterminateVector: {
-      2: [kAbstractAnyInterval, kAbstractAnyInterval],
-      3: [kAbstractAnyInterval, kAbstractAnyInterval, kAbstractAnyInterval],
-      4: [kAbstractAnyInterval, kAbstractAnyInterval, kAbstractAnyInterval, kAbstractAnyInterval],
+    unboundedVector: {
+      2: [kAbstractUnboundedInterval, kAbstractUnboundedInterval],
+      3: [kAbstractUnboundedInterval, kAbstractUnboundedInterval, kAbstractUnboundedInterval],
+      4: [
+        kAbstractUnboundedInterval,
+        kAbstractUnboundedInterval,
+        kAbstractUnboundedInterval,
+        kAbstractUnboundedInterval,
+      ],
     },
-    indeterminateMatrix: {
+    unboundedMatrix: {
       2: {
         2: [
-          [kAbstractAnyInterval, kAbstractAnyInterval],
-          [kAbstractAnyInterval, kAbstractAnyInterval],
+          [kAbstractUnboundedInterval, kAbstractUnboundedInterval],
+          [kAbstractUnboundedInterval, kAbstractUnboundedInterval],
         ],
         3: [
-          [kAbstractAnyInterval, kAbstractAnyInterval, kAbstractAnyInterval],
-          [kAbstractAnyInterval, kAbstractAnyInterval, kAbstractAnyInterval],
+          [kAbstractUnboundedInterval, kAbstractUnboundedInterval, kAbstractUnboundedInterval],
+          [kAbstractUnboundedInterval, kAbstractUnboundedInterval, kAbstractUnboundedInterval],
         ],
         4: [
-          [kAbstractAnyInterval, kAbstractAnyInterval, kAbstractAnyInterval, kAbstractAnyInterval],
-          [kAbstractAnyInterval, kAbstractAnyInterval, kAbstractAnyInterval, kAbstractAnyInterval],
+          [
+            kAbstractUnboundedInterval,
+            kAbstractUnboundedInterval,
+            kAbstractUnboundedInterval,
+            kAbstractUnboundedInterval,
+          ],
+          [
+            kAbstractUnboundedInterval,
+            kAbstractUnboundedInterval,
+            kAbstractUnboundedInterval,
+            kAbstractUnboundedInterval,
+          ],
         ],
       },
       3: {
         2: [
-          [kAbstractAnyInterval, kAbstractAnyInterval],
-          [kAbstractAnyInterval, kAbstractAnyInterval],
-          [kAbstractAnyInterval, kAbstractAnyInterval],
+          [kAbstractUnboundedInterval, kAbstractUnboundedInterval],
+          [kAbstractUnboundedInterval, kAbstractUnboundedInterval],
+          [kAbstractUnboundedInterval, kAbstractUnboundedInterval],
         ],
         3: [
-          [kAbstractAnyInterval, kAbstractAnyInterval, kAbstractAnyInterval],
-          [kAbstractAnyInterval, kAbstractAnyInterval, kAbstractAnyInterval],
-          [kAbstractAnyInterval, kAbstractAnyInterval, kAbstractAnyInterval],
+          [kAbstractUnboundedInterval, kAbstractUnboundedInterval, kAbstractUnboundedInterval],
+          [kAbstractUnboundedInterval, kAbstractUnboundedInterval, kAbstractUnboundedInterval],
+          [kAbstractUnboundedInterval, kAbstractUnboundedInterval, kAbstractUnboundedInterval],
         ],
         4: [
-          [kAbstractAnyInterval, kAbstractAnyInterval, kAbstractAnyInterval, kAbstractAnyInterval],
-          [kAbstractAnyInterval, kAbstractAnyInterval, kAbstractAnyInterval, kAbstractAnyInterval],
-          [kAbstractAnyInterval, kAbstractAnyInterval, kAbstractAnyInterval, kAbstractAnyInterval],
+          [
+            kAbstractUnboundedInterval,
+            kAbstractUnboundedInterval,
+            kAbstractUnboundedInterval,
+            kAbstractUnboundedInterval,
+          ],
+          [
+            kAbstractUnboundedInterval,
+            kAbstractUnboundedInterval,
+            kAbstractUnboundedInterval,
+            kAbstractUnboundedInterval,
+          ],
+          [
+            kAbstractUnboundedInterval,
+            kAbstractUnboundedInterval,
+            kAbstractUnboundedInterval,
+            kAbstractUnboundedInterval,
+          ],
         ],
       },
       4: {
         2: [
-          [kAbstractAnyInterval, kAbstractAnyInterval],
-          [kAbstractAnyInterval, kAbstractAnyInterval],
-          [kAbstractAnyInterval, kAbstractAnyInterval],
-          [kAbstractAnyInterval, kAbstractAnyInterval],
+          [kAbstractUnboundedInterval, kAbstractUnboundedInterval],
+          [kAbstractUnboundedInterval, kAbstractUnboundedInterval],
+          [kAbstractUnboundedInterval, kAbstractUnboundedInterval],
+          [kAbstractUnboundedInterval, kAbstractUnboundedInterval],
         ],
         3: [
-          [kAbstractAnyInterval, kAbstractAnyInterval, kAbstractAnyInterval],
-          [kAbstractAnyInterval, kAbstractAnyInterval, kAbstractAnyInterval],
-          [kAbstractAnyInterval, kAbstractAnyInterval, kAbstractAnyInterval],
-          [kAbstractAnyInterval, kAbstractAnyInterval, kAbstractAnyInterval],
+          [kAbstractUnboundedInterval, kAbstractUnboundedInterval, kAbstractUnboundedInterval],
+          [kAbstractUnboundedInterval, kAbstractUnboundedInterval, kAbstractUnboundedInterval],
+          [kAbstractUnboundedInterval, kAbstractUnboundedInterval, kAbstractUnboundedInterval],
+          [kAbstractUnboundedInterval, kAbstractUnboundedInterval, kAbstractUnboundedInterval],
         ],
         4: [
-          [kAbstractAnyInterval, kAbstractAnyInterval, kAbstractAnyInterval, kAbstractAnyInterval],
-          [kAbstractAnyInterval, kAbstractAnyInterval, kAbstractAnyInterval, kAbstractAnyInterval],
-          [kAbstractAnyInterval, kAbstractAnyInterval, kAbstractAnyInterval, kAbstractAnyInterval],
-          [kAbstractAnyInterval, kAbstractAnyInterval, kAbstractAnyInterval, kAbstractAnyInterval],
+          [
+            kAbstractUnboundedInterval,
+            kAbstractUnboundedInterval,
+            kAbstractUnboundedInterval,
+            kAbstractUnboundedInterval,
+          ],
+          [
+            kAbstractUnboundedInterval,
+            kAbstractUnboundedInterval,
+            kAbstractUnboundedInterval,
+            kAbstractUnboundedInterval,
+          ],
+          [
+            kAbstractUnboundedInterval,
+            kAbstractUnboundedInterval,
+            kAbstractUnboundedInterval,
+            kAbstractUnboundedInterval,
+          ],
+          [
+            kAbstractUnboundedInterval,
+            kAbstractUnboundedInterval,
+            kAbstractUnboundedInterval,
+            kAbstractUnboundedInterval,
+          ],
         ],
       },
     },
@@ -4709,10 +4823,10 @@ class FPAbstractTraits extends FPTraits {
   public readonly scalarBuilder = f64;
 
   // Framework - Fundamental Error Intervals - Overrides
-  public readonly absoluteErrorInterval = this.absoluteErrorIntervalImpl.bind(this);
+  public readonly absoluteErrorInterval = this.unboundedAbsoluteErrorInterval.bind(this);
   public readonly correctlyRoundedInterval = this.correctlyRoundedIntervalImpl.bind(this);
   public readonly correctlyRoundedMatrix = this.correctlyRoundedMatrixImpl.bind(this);
-  public readonly ulpInterval = this.ulpIntervalImpl.bind(this);
+  public readonly ulpInterval = this.unboundedUlpInterval.bind(this);
 
   // Framework - API - Overrides
   public readonly absInterval = this.unimplementedScalarToInterval.bind(this);
@@ -4798,7 +4912,11 @@ class FPAbstractTraits extends FPTraits {
 
 // Pre-defined values that get used multiple times in _constants' initializers. Cannot use FPTraits members, since this
 // executes before they are defined.
-const kF16AnyInterval = new FPInterval('f16', Number.NEGATIVE_INFINITY, Number.POSITIVE_INFINITY);
+const kF16UnboundedInterval = new FPInterval(
+  'f16',
+  Number.NEGATIVE_INFINITY,
+  Number.POSITIVE_INFINITY
+);
 const kF16ZeroInterval = new FPInterval('f16', 0);
 
 // This is implementation is incomplete
@@ -4843,7 +4961,7 @@ class F16Traits extends FPTraits {
         sixth: kValue.f16.negative.pi.sixth,
       },
     },
-    indeterminateInterval: kF16AnyInterval,
+    unboundedInterval: kF16UnboundedInterval,
     zeroInterval: kF16ZeroInterval,
     // Have to use the constants.ts values here, because values defined in the
     // initializer cannot be referenced in the initializer
@@ -4862,61 +4980,111 @@ class F16Traits extends FPTraits {
       3: [kF16ZeroInterval, kF16ZeroInterval, kF16ZeroInterval],
       4: [kF16ZeroInterval, kF16ZeroInterval, kF16ZeroInterval, kF16ZeroInterval],
     },
-    indeterminateVector: {
-      2: [kF16AnyInterval, kF16AnyInterval],
-      3: [kF16AnyInterval, kF16AnyInterval, kF16AnyInterval],
-      4: [kF16AnyInterval, kF16AnyInterval, kF16AnyInterval, kF16AnyInterval],
+    unboundedVector: {
+      2: [kF16UnboundedInterval, kF16UnboundedInterval],
+      3: [kF16UnboundedInterval, kF16UnboundedInterval, kF16UnboundedInterval],
+      4: [
+        kF16UnboundedInterval,
+        kF16UnboundedInterval,
+        kF16UnboundedInterval,
+        kF16UnboundedInterval,
+      ],
     },
-    indeterminateMatrix: {
+    unboundedMatrix: {
       2: {
         2: [
-          [kF16AnyInterval, kF16AnyInterval],
-          [kF16AnyInterval, kF16AnyInterval],
+          [kF16UnboundedInterval, kF16UnboundedInterval],
+          [kF16UnboundedInterval, kF16UnboundedInterval],
         ],
         3: [
-          [kF16AnyInterval, kF16AnyInterval, kF16AnyInterval],
-          [kF16AnyInterval, kF16AnyInterval, kF16AnyInterval],
+          [kF16UnboundedInterval, kF16UnboundedInterval, kF16UnboundedInterval],
+          [kF16UnboundedInterval, kF16UnboundedInterval, kF16UnboundedInterval],
         ],
         4: [
-          [kF16AnyInterval, kF16AnyInterval, kF16AnyInterval, kF16AnyInterval],
-          [kF16AnyInterval, kF16AnyInterval, kF16AnyInterval, kF16AnyInterval],
+          [
+            kF16UnboundedInterval,
+            kF16UnboundedInterval,
+            kF16UnboundedInterval,
+            kF16UnboundedInterval,
+          ],
+          [
+            kF16UnboundedInterval,
+            kF16UnboundedInterval,
+            kF16UnboundedInterval,
+            kF16UnboundedInterval,
+          ],
         ],
       },
       3: {
         2: [
-          [kF16AnyInterval, kF16AnyInterval],
-          [kF16AnyInterval, kF16AnyInterval],
-          [kF16AnyInterval, kF16AnyInterval],
+          [kF16UnboundedInterval, kF16UnboundedInterval],
+          [kF16UnboundedInterval, kF16UnboundedInterval],
+          [kF16UnboundedInterval, kF16UnboundedInterval],
         ],
         3: [
-          [kF16AnyInterval, kF16AnyInterval, kF16AnyInterval],
-          [kF16AnyInterval, kF16AnyInterval, kF16AnyInterval],
-          [kF16AnyInterval, kF16AnyInterval, kF16AnyInterval],
+          [kF16UnboundedInterval, kF16UnboundedInterval, kF16UnboundedInterval],
+          [kF16UnboundedInterval, kF16UnboundedInterval, kF16UnboundedInterval],
+          [kF16UnboundedInterval, kF16UnboundedInterval, kF16UnboundedInterval],
         ],
         4: [
-          [kF16AnyInterval, kF16AnyInterval, kF16AnyInterval, kF16AnyInterval],
-          [kF16AnyInterval, kF16AnyInterval, kF16AnyInterval, kF16AnyInterval],
-          [kF16AnyInterval, kF16AnyInterval, kF16AnyInterval, kF16AnyInterval],
+          [
+            kF16UnboundedInterval,
+            kF16UnboundedInterval,
+            kF16UnboundedInterval,
+            kF16UnboundedInterval,
+          ],
+          [
+            kF16UnboundedInterval,
+            kF16UnboundedInterval,
+            kF16UnboundedInterval,
+            kF16UnboundedInterval,
+          ],
+          [
+            kF16UnboundedInterval,
+            kF16UnboundedInterval,
+            kF16UnboundedInterval,
+            kF16UnboundedInterval,
+          ],
         ],
       },
       4: {
         2: [
-          [kF16AnyInterval, kF16AnyInterval],
-          [kF16AnyInterval, kF16AnyInterval],
-          [kF16AnyInterval, kF16AnyInterval],
-          [kF16AnyInterval, kF16AnyInterval],
+          [kF16UnboundedInterval, kF16UnboundedInterval],
+          [kF16UnboundedInterval, kF16UnboundedInterval],
+          [kF16UnboundedInterval, kF16UnboundedInterval],
+          [kF16UnboundedInterval, kF16UnboundedInterval],
         ],
         3: [
-          [kF16AnyInterval, kF16AnyInterval, kF16AnyInterval],
-          [kF16AnyInterval, kF16AnyInterval, kF16AnyInterval],
-          [kF16AnyInterval, kF16AnyInterval, kF16AnyInterval],
-          [kF16AnyInterval, kF16AnyInterval, kF16AnyInterval],
+          [kF16UnboundedInterval, kF16UnboundedInterval, kF16UnboundedInterval],
+          [kF16UnboundedInterval, kF16UnboundedInterval, kF16UnboundedInterval],
+          [kF16UnboundedInterval, kF16UnboundedInterval, kF16UnboundedInterval],
+          [kF16UnboundedInterval, kF16UnboundedInterval, kF16UnboundedInterval],
         ],
         4: [
-          [kF16AnyInterval, kF16AnyInterval, kF16AnyInterval, kF16AnyInterval],
-          [kF16AnyInterval, kF16AnyInterval, kF16AnyInterval, kF16AnyInterval],
-          [kF16AnyInterval, kF16AnyInterval, kF16AnyInterval, kF16AnyInterval],
-          [kF16AnyInterval, kF16AnyInterval, kF16AnyInterval, kF16AnyInterval],
+          [
+            kF16UnboundedInterval,
+            kF16UnboundedInterval,
+            kF16UnboundedInterval,
+            kF16UnboundedInterval,
+          ],
+          [
+            kF16UnboundedInterval,
+            kF16UnboundedInterval,
+            kF16UnboundedInterval,
+            kF16UnboundedInterval,
+          ],
+          [
+            kF16UnboundedInterval,
+            kF16UnboundedInterval,
+            kF16UnboundedInterval,
+            kF16UnboundedInterval,
+          ],
+          [
+            kF16UnboundedInterval,
+            kF16UnboundedInterval,
+            kF16UnboundedInterval,
+            kF16UnboundedInterval,
+          ],
         ],
       },
     },
@@ -5029,7 +5197,7 @@ class F16Traits extends FPTraits {
   /** quantizeToF16 has no f16 overload. */
   private quantizeToF16IntervalNotAvailable(n: number): FPInterval {
     unreachable("quantizeToF16 don't have f16 overload.");
-    return kF16AnyInterval;
+    return kF16UnboundedInterval;
   }
 }
 


### PR DESCRIPTION
Usage of 'any' and 'indeterminate' for infinite intervals changed to 'unbounded', since 'any' is not in the spec (and ambiguous with TS terms), and 'indeterminate' only applies to concrete values.

AbstractFloat absolute error and ULP intervals changed to always be unbounded.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
