### PR TITLE
Standalone: print the runtime of the test run (button click) to the console

### DIFF
--- a/src/common/runtime/standalone.ts
+++ b/src/common/runtime/standalone.ts
@@ -410,7 +410,14 @@ function makeTreeNodeHeaderHTML(
     .addClass(isLeaf ? 'leafrun' : 'subtreerun')
     .attr('alt', runtext)
     .attr('title', runtext)
-    .on('click', () => void runSubtree())
+    .on('click', async () => {
+      console.log(`Starting run for ${n.query}`);
+      const startTime = performance.now();
+      await runSubtree();
+      const dt = performance.now() - startTime;
+      const dtMinutes = dt / 1000 / 60;
+      console.log(`Finished run: ${dt.toFixed(1)} ms = ${dtMinutes.toFixed(1)} min`);
+    })
     .appendTo(header);
   $('<a>')
     .addClass('nodelink')


### PR DESCRIPTION
Helpful for measuring test runtime broadly when looking for optimizations.

Issue: None

<hr>

**Requirements for PR author:**

- [ ] ~All missing test coverage is tracked with "TODO" or `.unimplemented()`.~
- [ ] ~New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.~
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] ~Tests are properly located in the test tree.~
- [ ] ~[Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.~
- [ ] ~Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**~
- [ ] ~Helpers and types promote readability and maintainability.~

When landing this PR, be sure to make any necessary issue status updates.
