### PR TITLE
Optimize check for duplicate parameters

### DIFF
--- a/src/common/internal/params_utils.ts
+++ b/src/common/internal/params_utils.ts
@@ -119,9 +119,15 @@ export type MergedFromFlat<A, B> = {
   [K in keyof A | keyof B]: K extends keyof B ? B[K] : K extends keyof A ? A[K] : never;
 };
 
+/** Merges two objects into one `{ ...a, ...b }` and return it with a flattened type. */
 export function mergeParams<A extends {}, B extends {}>(a: A, b: B): Merged<A, B> {
-  for (const key of Object.keys(a)) {
-    assert(!(key in b), 'Duplicate key: ' + key);
-  }
   return { ...a, ...b } as Merged<A, B>;
+}
+
+/** Asserts that the result of a mergeParams didn't have overlap. This is not extremely fast. */
+export function assertMergedWithoutOverlap([a, b]: [{}, {}], merged: {}): void {
+  assert(
+    Object.keys(merged).length === Object.keys(a).length + Object.keys(b).length,
+    () => `Duplicate key between ${JSON.stringify(a)} and ${JSON.stringify(b)}`
+  );
 }

--- a/src/unittests/params_builder_and_utils.spec.ts
+++ b/src/unittests/params_builder_and_utils.spec.ts
@@ -9,7 +9,11 @@ import {
   builderIterateCasesWithSubcases,
 } from '../common/framework/params_builder.js';
 import { makeTestGroup } from '../common/framework/test_group.js';
-import { mergeParams, publicParamsEquals } from '../common/internal/params_utils.js';
+import {
+  assertMergedWithoutOverlap,
+  mergeParams,
+  publicParamsEquals,
+} from '../common/internal/params_utils.js';
 import { assert, objectEquals } from '../common/util/util.js';
 
 import { UnitTest } from './unit_test.js';
@@ -348,7 +352,7 @@ g.test('invalid,shadowing').fn(t => {
           yield { w: 5 };
         }
       });
-    // Iterating causes e.g. mergeParams({x:1}, {x:3}), which fails.
+    // Iterating causes merging e.g. ({x:1}, {x:3}), which fails.
     t.shouldThrow('Error', () => {
       Array.from(p.iterateCasesWithSubcases());
     });
@@ -368,7 +372,7 @@ g.test('invalid,shadowing').fn(t => {
           yield { w: 5 };
         }
       });
-    // Iterating causes e.g. mergeParams({x:1}, {x:3}), which fails.
+    // Iterating causes merging e.g. ({x:1}, {x:3}), which fails.
     t.shouldThrow('Error', () => {
       Array.from(p.iterateCasesWithSubcases());
     });
@@ -394,14 +398,13 @@ g.test('invalid,shadowing').fn(t => {
       assert(subcases !== undefined);
       // Iterating subcases is fine...
       for (const subcaseP of subcases) {
+        const merged = mergeParams(caseP, subcaseP);
         if (caseP.a) {
           assert(subcases !== undefined);
-          // Only errors once we try to e.g. mergeParams({x:1}, {x:3}).
+          // Only errors once we try to merge e.g. ({x:1}, {x:3}).
           t.shouldThrow('Error', () => {
-            mergeParams(caseP, subcaseP);
+            assertMergedWithoutOverlap([caseP, subcaseP], merged);
           });
-        } else {
-          mergeParams(caseP, subcaseP);
         }
       }
     }


### PR DESCRIPTION
mergeParams is hot code because it gets called a lot in combinatoric case parameter generation (sometimes redundantly). Optimize the check for duplicate keys by moving it out of mergeParams.

On my machine, on a particularly heavily parameterized test: `webgpu:api,validation,encoding,cmds,render,draw:vertex_buffer_OOB:*` loadTreeForQuery goes from 360ms to 240ms with this change.

Issue: https://crbug.com/1470849

<hr>

**Requirements for PR author:**

- [ ] ~All missing test coverage is tracked with "TODO" or `.unimplemented()`.~
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] ~Tests are properly located in the test tree.~
- [ ] ~[Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.~
- [ ] ~Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**~
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
