### PR TITLE
Configure vscode to use our local copy of tsc instead of its own

### DIFF
--- a/cts.code-workspace
+++ b/cts.code-workspace
@@ -34,7 +34,8 @@
     // Configure VSCode to use the right style when automatically adding imports on autocomplete.
     "typescript.preferences.importModuleSpecifier": "relative",
     "typescript.preferences.importModuleSpecifierEnding": "js",
-    "typescript.preferences.quoteStyle": "single"
+    "typescript.preferences.quoteStyle": "single",
+    "typescript.tsdk": "cts/node_modules/typescript/lib"
   },
   "tasks": {
     "version": "2.0.0",


### PR DESCRIPTION
This may avoid spurious errors due to using the wrong tsc version.

Issue: none

<hr>

**Requirements not applicable**