### PR TITLE
Only trigger WPT Lint test on pull_request

### DIFF
--- a/.github/workflows/wpt.yml
+++ b/.github/workflows/wpt.yml
@@ -1,8 +1,6 @@
 name: WPT Lint Test
 
 on:
-  push:
-    branches-ignore: [gh-pages]
   pull_request:
     branches: [main]
   workflow_dispatch:
@@ -26,4 +24,3 @@ jobs:
       - name: test wpt lint
         run: ./wpt lint
         working-directory: ./wpt
-


### PR DESCRIPTION
Previously it was run every time a branch other than wpt-lint was pushed (including on branches in contributors' forks). This doesn't really achieve anything. (We could run it on main to make sure main stays green, but all that really matters is that PRs can be landed.)

Issue: none

<hr>

**Review requirements not applicable**