### PR TITLE
Switch GitHub Actions to an LTS version of Node (15 -> 16)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,7 +16,7 @@ jobs:
           git checkout ${{ github.event.pull_request.head.sha }}
       - uses: actions/setup-node@v2-beta
         with:
-          node-version: "15.x"
+          node-version: "16.x"
       - run: npm ci
       - run: npm test
       - run: |

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -13,7 +13,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-node@v2-beta
         with:
-          node-version: "15.x"
+          node-version: "16.x"
       - run: npm ci
       - run: |
           npm test

--- a/.github/workflows/wpt.yml
+++ b/.github/workflows/wpt.yml
@@ -16,7 +16,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-node@v3
         with:
-          node-version: "15.x"
+          node-version: "16.x"
       - run: npm ci
       - run: npm run wpt
       - name: copy out-wpt to wpt tree
@@ -26,4 +26,3 @@ jobs:
       - name: test wpt lint
         run: ./wpt lint
         working-directory: ./wpt
-


### PR DESCRIPTION
This should clear up a bunch of version support warnings in dependencies. Also, in another PR I noticed that `npm ci` for some reason didn't catch when package-lock.json wasn't updated. Hoping that this will also fix that.

Issue: none

<hr>

**Requirements N/A**