### PR TITLE
[wgsl] Test negative one case for firstLeadingBit

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/firstLeadingBit.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/firstLeadingBit.spec.ts
@@ -150,6 +150,9 @@ g.test('i32')
       // Zero
       { input: i32Bits(0b00000000000000000000000000000000), expected: i32(-1) },
 
+      // Negative One
+      { input: i32Bits(0b11111111111111111111111111111111), expected: i32(-1) },
+
       // One
       { input: i32Bits(0b00000000000000000000000000000001), expected: i32(0) },
 


### PR DESCRIPTION
This corner case was missing from the signed integer test.

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
