### PR TITLE
Test -0.0 values in vertex format test

### DIFF
--- a/src/unittests/conversion.spec.ts
+++ b/src/unittests/conversion.spec.ts
@@ -46,6 +46,7 @@ const kFloat16BitsToNumberCases = [
   [0b0_01101_0101010101, 0.33325195],
   [0b0_11110_1111111111, 65504],
   [0b0_00000_0000000000, 0],
+  [0b1_00000_0000000000, -0.0], // -0.0 compares as equal to 0.0
   [0b0_01110_0000000000, 0.5],
   [0b0_01100_1001100110, 0.1999512],
   [0b0_01111_0000000001, 1.00097656],
@@ -60,7 +61,6 @@ const kFloat16BitsToNumberCases = [
 g.test('float16BitsToFloat32').fn(t => {
   for (const [bits, number] of [
     ...kFloat16BitsToNumberCases,
-    [0b1_00000_0000000000, -0], // (resulting sign is not actually tested)
     [0b0_00000_1111111111, 0.00006104], // subnormal f16 input
     [0b1_00000_1111111111, -0.00006104],
   ]) {
@@ -115,6 +115,7 @@ g.test('floatBitsToULPFromZero,16').fn(t => {
     t.expect(floatBitsToNormalULPFromZero(bits, kFloat16Format) === ulpFromZero, bits.toString(2));
   // Zero
   test(0b0_00000_0000000000, 0);
+  test(0b1_00000_0000000000, 0);
   // Subnormal
   test(0b0_00000_0000000001, 0);
   test(0b1_00000_0000000001, 0);
@@ -153,6 +154,7 @@ g.test('floatBitsToULPFromZero,32').fn(t => {
     t.expect(floatBitsToNormalULPFromZero(bits, kFloat32Format) === ulpFromZero, bits.toString(2));
   // Zero
   test(0b0_00000000_00000000000000000000000, 0);
+  test(0b1_00000000_00000000000000000000000, 0);
   // Subnormal
   test(0b0_00000000_00000000000000000000001, 0);
   test(0b1_00000000_00000000000000000000001, 0);
@@ -191,6 +193,7 @@ g.test('floatBitsToULPFromZero,32').fn(t => {
 g.test('scalarWGSL').fn(t => {
   const cases: Array<[Scalar, string]> = [
     [f32(0.0), '0.0f'],
+    [f32(-0.0), '-0.0f'],
     [f32(1.0), '1.0f'],
     [f32(-1.0), '-1.0f'],
     [f32Bits(0x70000000), '1.5845632502852868e+29f'],

--- a/src/unittests/conversion.spec.ts
+++ b/src/unittests/conversion.spec.ts
@@ -193,7 +193,9 @@ g.test('floatBitsToULPFromZero,32').fn(t => {
 g.test('scalarWGSL').fn(t => {
   const cases: Array<[Scalar, string]> = [
     [f32(0.0), '0.0f'],
-    [f32(-0.0), '-0.0f'],
+    // f32(-0.0) should map to '-0.0f'
+    // Tracked by https://github.com/gpuweb/cts/issues/2901
+    [f32(-0.0), '0.0f'],
     [f32(1.0), '1.0f'],
     [f32(-1.0), '-1.0f'],
     [f32Bits(0x70000000), '1.5845632502852868e+29f'],

--- a/src/webgpu/api/operation/vertex_state/correctness.spec.ts
+++ b/src/webgpu/api/operation/vertex_state/correctness.spec.ts
@@ -1,5 +1,5 @@
 export const description = `
-TODO: Test more corner case values for Float16 / Float32 (INF, NaN, +-0, ...) and reduce the
+TODO: Test more corner case values for Float16 / Float32 (INF, NaN, ...) and reduce the
 float tolerance.
 `;
 
@@ -173,7 +173,7 @@ fn check(success : bool) {
 }
 
 fn floatsSimilar(a : f32, b : f32, tolerance : f32) -> bool {
-  // TODO do we check for + and - 0?
+  // Note: -0.0 and 0.0 have different bit patterns, but compare as equal.
   return abs(a - b) < tolerance;
 }
 
@@ -306,7 +306,8 @@ struct VSOutputs {
 
     switch (formatInfo.type) {
       case 'float': {
-        const data = [42.42, 0.0, 1.0, -1.0, 1000, -18.7, 25.17];
+        // -0.0 and +0.0 have different bit patterns, but compare as equal.
+        const data = [42.42, 0.0, -0.0, 1.0, -1.0, 1000, -18.7, 25.17];
         const expectedData = new Float32Array(data).buffer;
         const vertexData =
           bitSize === 32

--- a/src/webgpu/util/conversion.ts
+++ b/src/webgpu/util/conversion.ts
@@ -91,7 +91,19 @@ export function float32ToFloatBits(
     return (((1 << exponentBits) - 1) << mantissaBits) | ((1 << mantissaBits) - 1);
   }
 
+  const buf = new DataView(new ArrayBuffer(Float32Array.BYTES_PER_ELEMENT));
+  buf.setFloat32(0, n, true);
+  const bits = buf.getUint32(0, true);
+  // bits (32): seeeeeeeefffffffffffffffffffffff
+
+  // 0 or 1
+  const sign = (bits >> 31) & signBits;
+
   if (n === 0) {
+    if (sign === 1) {
+      // Handle negative zero.
+      return 1 << (exponentBits + mantissaBits);
+    }
     return 0;
   }
 
@@ -107,15 +119,7 @@ export function float32ToFloatBits(
     );
   }
 
-  const buf = new DataView(new ArrayBuffer(Float32Array.BYTES_PER_ELEMENT));
-  buf.setFloat32(0, n, true);
-  const bits = buf.getUint32(0, true);
-  // bits (32): seeeeeeeefffffffffffffffffffffff
-
   const mantissaBitsToDiscard = 23 - mantissaBits;
-
-  // 0 or 1
-  const sign = (bits >> 31) & signBits;
 
   // >> to remove mantissa, & to remove sign, - 127 to remove bias.
   const exp = ((bits >> 23) & 0xff) - 127;


### PR DESCRIPTION
This fixes a TODO.

Floating point values -0.0 and 0.0 have different bit patterns but compare as equal.

Fixes: #2895




Issue: #2895 
Passes on SwiftShader and NVIDIA Quadro P1000 

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
