### PR TITLE
wgsl: f16 built-in execution test for bitcast

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/bitcast.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/bitcast.spec.ts
@@ -119,23 +119,30 @@ const f16ZerosInterval: FPInterval = new FPInterval('f16', -0.0, 0.0);
 
 /**
  * @returns an u32 whose lower and higher 16bits are the two elements of the
- * given array of two u16 respectively.
+ * given array of two u16 respectively, in little-endian.
  */
 function u16x2ToU32(u16x2: number[]): number {
   assert(u16x2.length === 2);
-  const array = new Uint16Array(2);
-  [array[0], array[1]] = u16x2;
-  return new Uint32Array(array.buffer)[0];
+  // Create a DataView with 4 bytes buffer.
+  const buffer = new ArrayBuffer(4);
+  const view = new DataView(buffer);
+  // Enforce little-endian.
+  view.setUint16(0, u16x2[0], true);
+  view.setUint16(2, u16x2[1], true);
+  return view.getUint32(0, true);
 }
 
 /**
- * @returns an array of two u16, respectively the lower and higher 16bits of given u32.
+ * @returns an array of two u16, respectively the lower and higher 16bits of
+ * given u32 in little-endian.
  */
 function u32ToU16x2(u32: number): number[] {
-  const array = new Uint32Array(1);
-  array[0] = u32;
-  const dst_array = new Uint16Array(array.buffer);
-  return [dst_array[0], dst_array[1]];
+  // Create a DataView with 4 bytes buffer.
+  const buffer = new ArrayBuffer(4);
+  const view = new DataView(buffer);
+  // Enforce little-endian.
+  view.setUint32(0, u32, true);
+  return [view.getUint16(0, true), view.getUint16(2, true)];
 }
 
 /**

--- a/src/webgpu/shader/execution/expression/call/builtin/bitcast.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/bitcast.spec.ts
@@ -42,10 +42,9 @@ import {
   TypeU32,
   TypeF16,
   TypeVec,
-  vec2,
-  vec4,
   Vector,
   Scalar,
+  toVector,
 } from '../../../../../util/conversion.js';
 import { FPInterval, FP } from '../../../../../util/floating_point.js';
 import {
@@ -144,7 +143,7 @@ function u32ToU16x2(u32: number): number[] {
  */
 function u16x2ToVec2F16(u16x2: number[]): Vector {
   assert(u16x2.length === 2);
-  return vec2(f16(reinterpretU16AsF16(u16x2[0])), f16(reinterpretU16AsF16(u16x2[1])));
+  return toVector(u16x2.map(reinterpretU16AsF16), f16);
 }
 
 /**
@@ -152,12 +151,7 @@ function u16x2ToVec2F16(u16x2: number[]): Vector {
  */
 function u16x4ToVec4F16(u16x4: number[]): Vector {
   assert(u16x4.length === 4);
-  return vec4(
-    f16(reinterpretU16AsF16(u16x4[0])),
-    f16(reinterpretU16AsF16(u16x4[1])),
-    f16(reinterpretU16AsF16(u16x4[2])),
-    f16(reinterpretU16AsF16(u16x4[3]))
-  );
+  return toVector(u16x4.map(reinterpretU16AsF16), f16);
 }
 
 /**
@@ -594,8 +588,8 @@ function bitcastVec4F16ToVec2U32Comparator(vec4F16InU16x4: number[]): Comparator
     return alwaysPass('any vec2<u32>');
   }
   return anyOf(
-    ...cartesianProduct(...expectationsPerElement.map(e => e.possibleExpectations)).map(e =>
-      vec2(e[0] as Scalar, e[1] as Scalar)
+    ...cartesianProduct(...expectationsPerElement.map(e => e.possibleExpectations)).map(
+      e => new Vector(e as Scalar[])
     )
   );
 }
@@ -616,8 +610,8 @@ function bitcastVec4F16ToVec2I32Comparator(vec4F16InU16x4: number[]): Comparator
     return alwaysPass('any vec2<i32>');
   }
   return anyOf(
-    ...cartesianProduct(...expectationsPerElement.map(e => e.possibleExpectations)).map(e =>
-      vec2(e[0] as Scalar, e[1] as Scalar)
+    ...cartesianProduct(...expectationsPerElement.map(e => e.possibleExpectations)).map(
+      e => new Vector(e as Scalar[])
     )
   );
 }
@@ -732,32 +726,32 @@ export const d = makeCaseCache('bitcast', {
   // vec2<i32>, vec2<u32>, vec2<f32> to vec4<f16>
   vec2_i32_to_vec4_f16_inf_nan: () =>
     slidingSlice(i32RangeForF16Vec2FiniteInfNaN, 2).map(e => ({
-      input: vec2(i32(e[0]), i32(e[1])),
+      input: toVector(e, i32),
       expected: bitcastVec2I32ToVec4F16Comparator(e),
     })),
   vec2_i32_to_vec4_f16: () =>
     slidingSlice(i32RangeForF16Vec2Finite, 2).map(e => ({
-      input: vec2(i32(e[0]), i32(e[1])),
+      input: toVector(e, i32),
       expected: bitcastVec2I32ToVec4F16Comparator(e),
     })),
   vec2_u32_to_vec4_f16_inf_nan: () =>
     slidingSlice(u32RangeForF16Vec2FiniteInfNaN, 2).map(e => ({
-      input: vec2(u32(e[0]), u32(e[1])),
+      input: toVector(e, u32),
       expected: bitcastVec2U32ToVec4F16Comparator(e),
     })),
   vec2_u32_to_vec4_f16: () =>
     slidingSlice(u32RangeForF16Vec2Finite, 2).map(e => ({
-      input: vec2(u32(e[0]), u32(e[1])),
+      input: toVector(e, u32),
       expected: bitcastVec2U32ToVec4F16Comparator(e),
     })),
   vec2_f32_inf_nan_to_vec4_f16_inf_nan: () =>
     slidingSlice(f32RangeWithInfAndNaNForF16Vec2FiniteInfNaN, 2).map(e => ({
-      input: vec2(f32(e[0]), f32(e[1])),
+      input: toVector(e, f32),
       expected: bitcastVec2F32ToVec4F16Comparator(e),
     })),
   vec2_f32_to_vec4_f16: () =>
     slidingSlice(f32FiniteRangeForF16Vec2Finite, 2).map(e => ({
-      input: vec2(f32(e[0]), f32(e[1])),
+      input: toVector(e, f32),
       expected: bitcastVec2F32ToVec4F16Comparator(e),
     })),
 

--- a/src/webgpu/shader/execution/expression/call/builtin/bitcast.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/bitcast.spec.ts
@@ -20,34 +20,50 @@ T is i32, u32, f32
 
 import { TestParams } from '../../../../../../common/framework/fixture.js';
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
+import { assert } from '../../../../../../common/util/util.js';
 import { GPUTest } from '../../../../../gpu_test.js';
 import { Comparator, alwaysPass, anyOf } from '../../../../../util/compare.js';
 import { kBit, kValue } from '../../../../../util/constants.js';
 import {
   reinterpretI32AsF32,
+  reinterpretI32AsU32,
   reinterpretF32AsI32,
   reinterpretF32AsU32,
   reinterpretU32AsF32,
   reinterpretU32AsI32,
+  reinterpretU16AsF16,
+  reinterpretF16AsU16,
   f32,
   i32,
   u32,
-  Type,
+  f16,
   TypeF32,
   TypeI32,
   TypeU32,
+  TypeF16,
+  TypeVec,
+  vec2,
+  vec4,
+  Vector,
+  Scalar,
 } from '../../../../../util/conversion.js';
+import { FPInterval, FP } from '../../../../../util/floating_point.js';
 import {
   fullF32Range,
   fullI32Range,
   fullU32Range,
+  fullF16Range,
   linearRange,
   isSubnormalNumberF32,
+  isSubnormalNumberF16,
+  cartesianProduct,
+  isFiniteF32,
+  isFiniteF16,
 } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
-import { allInputSources, run, CaseList, InputSource, ShaderBuilder } from '../../expression.js';
+import { allInputSources, run, ShaderBuilder } from '../../expression.js';
 
-import { builtin } from './builtin.js';
+import { builtinWithPredeclaration } from './builtin.js';
 
 export const g = makeTestGroup(GPUTest);
 
@@ -71,44 +87,195 @@ const f32InfAndNaNInI32 = f32InfAndNaNInU32.map(u => reinterpretU32AsI32(u));
 const f32ZerosInU32 = [0, kBit.f32.negative.zero];
 const f32ZerosInF32 = f32ZerosInU32.map(u => reinterpretU32AsF32(u));
 const f32ZerosInI32 = f32ZerosInU32.map(u => reinterpretU32AsI32(u));
+const f32ZerosInterval: FPInterval = new FPInterval('f32', -0.0, 0.0);
 
 // f32FiniteRange is a list of finite f32s. fullF32Range() already
 // has +0, we only need to add -0.
 const f32FiniteRange: number[] = [...fullF32Range(), kValue.f32.negative.zero];
 const f32RangeWithInfAndNaN: number[] = [...f32FiniteRange, ...f32InfAndNaNInF32];
 
+// F16 values, finite, Inf/NaN, and zeros. Represented in float and u16.
+const f16FiniteInF16: number[] = [...fullF16Range(), kValue.f16.negative.zero];
+const f16FiniteInU16: number[] = f16FiniteInF16.map(u => reinterpretF16AsU16(u));
+
+const f16InfAndNaNInU16: number[] = [
+  // Cover NaNs evenly in integer space.
+  // The positive NaN with the lowest integer representation is the integer
+  // for infinity, plus one.
+  // The positive NaN with the highest integer representation is u16 0x7fff i.e. 32767.
+  ...linearRange(kBit.f16.infinity.positive + 1, 32767, numNaNs).map(v => Math.ceil(v)),
+  // The negative NaN with the lowest integer representation is the integer
+  // for negative infinity, plus one.
+  // The negative NaN with the highest integer representation is u16 0xffff i.e. 65535
+  ...linearRange(kBit.f16.infinity.negative + 1, 65535, numNaNs).map(v => Math.floor(v)),
+  kBit.f16.infinity.positive,
+  kBit.f16.infinity.negative,
+];
+const f16InfAndNaNInF16 = f16InfAndNaNInU16.map(u => reinterpretU16AsF16(u));
+
+const f16ZerosInU16 = [kBit.f16.negative.zero, 0];
+
+// f16 interval that match +/-0.0.
+const f16ZerosInterval: FPInterval = new FPInterval('f16', -0.0, 0.0);
+
+/**
+ * @returns an u32 whose lower and higher 16bits are the two elements of the
+ * given array of two u16 respectively.
+ */
+function u16x2ToU32(u16x2: number[]): number {
+  assert(u16x2.length === 2);
+  const array = new Uint16Array(2);
+  [array[0], array[1]] = u16x2;
+  return new Uint32Array(array.buffer)[0];
+}
+
+/**
+ * @returns an array of two u16, respectively the lower and higher 16bits of given u32.
+ */
+function u32ToU16x2(u32: number): number[] {
+  const array = new Uint32Array(1);
+  array[0] = u32;
+  const dst_array = new Uint16Array(array.buffer);
+  return [dst_array[0], dst_array[1]];
+}
+
+/**
+ * @returns a vec2<f16> from an array of two u16.
+ */
+function u16x2ToVec2F16(u16x2: number[]): Vector {
+  assert(u16x2.length === 2);
+  return vec2(f16(reinterpretU16AsF16(u16x2[0])), f16(reinterpretU16AsF16(u16x2[1])));
+}
+
+/**
+ * @returns a vec4<f16> from an array of four u16.
+ */
+function u16x4ToVec4F16(u16x4: number[]): Vector {
+  assert(u16x4.length === 4);
+  return vec4(
+    f16(reinterpretU16AsF16(u16x4[0])),
+    f16(reinterpretU16AsF16(u16x4[1])),
+    f16(reinterpretU16AsF16(u16x4[2])),
+    f16(reinterpretU16AsF16(u16x4[3]))
+  );
+}
+
+/**
+ * @returns true if and only if a given u32 can bitcast to a vec2<f16> with all elements
+ * being finite f16 values.
+ */
+function canU32BitcastToFiniteVec2F16(u32: number): boolean {
+  return u32ToU16x2(u32)
+    .map(u16 => isFiniteF16(reinterpretU16AsF16(u16)))
+    .reduce((a, b) => a && b, true);
+}
+
+/**
+ * @returns an array of N elements with the i-th element being an array of len elements
+ * [a_i, a_((i+1)%N), ..., a_((i+len-1)%N)], for the input array of N element [a_1, ... a_N]
+ * and the given len. For example, slidingSlice([1, 2, 3], 2) result in
+ * [[1, 2], [2, 3], [3, 1]].
+ * This helper function is used for generating vector cases from scalar values array.
+ */
+function slidingSlice(input: number[], len: number) {
+  const result: number[][] = [];
+  for (let i = 0; i < input.length; i++) {
+    const sub: number[] = [];
+    for (let j = 0; j < len; j++) {
+      sub.push(input[(i + j) % input.length]);
+    }
+    result.push(sub);
+  }
+  return result;
+}
+
+// vec2<f16> interesting (zeros, Inf, and NaN) values for testing cases.
+// vec2<f16> values that has at least one Inf/NaN f16 element, reinterpreted as u32/i32.
+const f16Vec2InfAndNaNInU32 = [
+  ...cartesianProduct(f16InfAndNaNInU16, [...f16InfAndNaNInU16, ...f16FiniteInU16]),
+  ...cartesianProduct(f16FiniteInU16, f16InfAndNaNInU16),
+].map(u16x2ToU32);
+const f16Vec2InfAndNaNInI32 = f16Vec2InfAndNaNInU32.map(u => reinterpretU32AsI32(u));
+// vec2<f16> values with two f16 0.0 element, reinterpreted as u32/i32.
+const f16Vec2ZerosInU32 = cartesianProduct(f16ZerosInU16, f16ZerosInU16).map(u16x2ToU32);
+const f16Vec2ZerosInI32 = f16Vec2ZerosInU32.map(u => reinterpretU32AsI32(u));
+
+// i32/u32/f32 range for bitcasting to vec2<f16>
+// u32 values for bitcasting to vec2<f16> finite, Inf, and NaN.
+const u32RangeForF16Vec2FiniteInfNaN: number[] = [
+  ...fullU32Range(),
+  ...f16Vec2ZerosInU32,
+  ...f16Vec2InfAndNaNInU32,
+];
+// u32 values for bitcasting to finite only vec2<f16>, used for constant evaluation.
+const u32RangeForF16Vec2Finite: number[] = u32RangeForF16Vec2FiniteInfNaN.filter(
+  canU32BitcastToFiniteVec2F16
+);
+// i32 values for bitcasting to vec2<f16> finite, zeros, Inf, and NaN.
+const i32RangeForF16Vec2FiniteInfNaN: number[] = [
+  ...fullI32Range(),
+  ...f16Vec2ZerosInI32,
+  ...f16Vec2InfAndNaNInI32,
+];
+// i32 values for bitcasting to finite only vec2<f16>, used for constant evaluation.
+const i32RangeForF16Vec2Finite: number[] = i32RangeForF16Vec2FiniteInfNaN.filter(u =>
+  canU32BitcastToFiniteVec2F16(reinterpretI32AsU32(u))
+);
+// f32 values with finite/Inf/NaN f32, for bitcasting to vec2<f16> finite, zeros, Inf, and NaN.
+const f32RangeWithInfAndNaNForF16Vec2FiniteInfNaN: number[] = [
+  ...f32RangeWithInfAndNaN,
+  ...u32RangeForF16Vec2FiniteInfNaN.map(reinterpretU32AsF32),
+];
+// Finite f32 values for bitcasting to finite only vec2<f16>, used for constant evaluation.
+const f32FiniteRangeForF16Vec2Finite: number[] = f32RangeWithInfAndNaNForF16Vec2FiniteInfNaN
+  .filter(isFiniteF32)
+  .filter(u => canU32BitcastToFiniteVec2F16(reinterpretF32AsU32(u)));
+
+// vec2<f16> cases for bitcasting to i32/u32/f32, by combining f16 values into pairs
+const f16Vec2FiniteInU16x2 = slidingSlice(f16FiniteInU16, 2);
+const f16Vec2FiniteInfNanInU16x2 = slidingSlice([...f16FiniteInU16, ...f16InfAndNaNInU16], 2);
+// vec4<f16> cases for bitcasting to vec2<i32/u32/f32>, by combining f16 values 4-by-4
+const f16Vec2FiniteInU16x4 = slidingSlice(f16FiniteInU16, 4);
+const f16Vec2FiniteInfNanInU16x4 = slidingSlice([...f16FiniteInU16, ...f16InfAndNaNInU16], 4);
+
+// alwaysPass comparator for i32/u32/f32 cases. For f32/f16 we also use unbound interval, which
+// allow per-element unbounded expectation for vector.
 const anyF32 = alwaysPass('any f32');
 const anyI32 = alwaysPass('any i32');
 const anyU32 = alwaysPass('any u32');
 
-const i32RangeWithBitsForInfAndNaNAndZeros: number[] = [
+// Unbounded FPInterval
+const f32UnboundedInterval = FP.f32.constants().unboundedInterval;
+const f16UnboundedInterval = FP.f16.constants().unboundedInterval;
+
+// i32 and u32 cases for bitcasting to f32.
+// i32 cases for bitcasting to f32 finite, zeros, Inf, and NaN.
+const i32RangeForF32FiniteInfNaN: number[] = [
   ...fullI32Range(),
   ...f32ZerosInI32,
   ...f32InfAndNaNInI32,
 ];
-const i32RangeWithFiniteF32: number[] = i32RangeWithBitsForInfAndNaNAndZeros.filter(i =>
-  isFinite(reinterpretI32AsF32(i))
+// i32 cases for bitcasting to f32 finite only.
+const i32RangeForF32Finite: number[] = i32RangeForF32FiniteInfNaN.filter(i =>
+  isFiniteF32(reinterpretI32AsF32(i))
 );
-
-const u32RangeWithBitsForInfAndNaNAndZeros: number[] = [
+// u32 cases for bitcasting to f32 finite, zeros, Inf, and NaN.
+const u32RangeForF32FiniteInfNaN: number[] = [
   ...fullU32Range(),
   ...f32ZerosInU32,
   ...f32InfAndNaNInU32,
 ];
-const u32RangeWithFiniteF32: number[] = u32RangeWithBitsForInfAndNaNAndZeros.filter(u =>
-  isFinite(reinterpretU32AsF32(u))
+// u32 cases for bitcasting to f32 finite only.
+const u32RangeForF32Finite: number[] = u32RangeForF32FiniteInfNaN.filter(u =>
+  isFiniteF32(reinterpretU32AsF32(u))
 );
-
-function isFinite(f: number): boolean {
-  return !(Number.isNaN(f) || f === Number.POSITIVE_INFINITY || f === Number.NEGATIVE_INFINITY);
-}
 
 /**
  * @returns a Comparator for checking if a f32 value is a valid
  * bitcast conversion from f32.
  */
 function bitcastF32ToF32Comparator(f: number): Comparator {
-  if (!isFinite(f)) return anyF32;
+  if (!isFiniteF32(f)) return anyF32;
   const acceptable: number[] = [f, ...(isSubnormalNumberF32(f) ? f32ZerosInF32 : [])];
   return anyOf(...acceptable.map(f32));
 }
@@ -118,7 +285,7 @@ function bitcastF32ToF32Comparator(f: number): Comparator {
  * bitcast conversion from f32.
  */
 function bitcastF32ToU32Comparator(f: number): Comparator {
-  if (!isFinite(f)) return anyU32;
+  if (!isFiniteF32(f)) return anyU32;
   const acceptable: number[] = [
     reinterpretF32AsU32(f),
     ...(isSubnormalNumberF32(f) ? f32ZerosInU32 : []),
@@ -131,7 +298,7 @@ function bitcastF32ToU32Comparator(f: number): Comparator {
  * bitcast conversion from f32.
  */
 function bitcastF32ToI32Comparator(f: number): Comparator {
-  if (!isFinite(f)) return anyI32;
+  if (!isFiniteF32(f)) return anyI32;
   const acceptable: number[] = [
     reinterpretF32AsI32(f),
     ...(isSubnormalNumberF32(f) ? f32ZerosInI32 : []),
@@ -145,7 +312,7 @@ function bitcastF32ToI32Comparator(f: number): Comparator {
  */
 function bitcastI32ToF32Comparator(i: number): Comparator {
   const f: number = reinterpretI32AsF32(i);
-  if (!isFinite(f)) return anyI32;
+  if (!isFiniteF32(f)) return anyI32;
   // Positive or negative zero bit pattern map to any zero.
   if (f32ZerosInI32.includes(i)) return anyOf(...f32ZerosInF32.map(f32));
   const acceptable: number[] = [f, ...(isSubnormalNumberF32(f) ? f32ZerosInF32 : [])];
@@ -158,11 +325,317 @@ function bitcastI32ToF32Comparator(i: number): Comparator {
  */
 function bitcastU32ToF32Comparator(u: number): Comparator {
   const f: number = reinterpretU32AsF32(u);
-  if (!isFinite(f)) return anyU32;
+  if (!isFiniteF32(f)) return anyU32;
   // Positive or negative zero bit pattern map to any zero.
   if (f32ZerosInU32.includes(u)) return anyOf(...f32ZerosInF32.map(f32));
   const acceptable: number[] = [f, ...(isSubnormalNumberF32(f) ? f32ZerosInF32 : [])];
   return anyOf(...acceptable.map(f32));
+}
+
+/**
+ * @returns an array of expected f16 FPInterval for the given bitcasted f16 value, which may be
+ * subnormal, Inf, or NaN. Test cases that bitcasted to vector of f16 use this function to get
+ * per-element expectation and build vector expectation using cartesianProduct.
+ */
+function generateF16ExpectationIntervals(bitcastedF16ValueInU16: number): FPInterval[] {
+  // If the bitcasted f16 value is inf or nan, the result is unbounded
+  if (!isFiniteF16(bitcastedF16ValueInU16)) {
+    return [f16UnboundedInterval];
+  }
+  // If the casted f16 value is +/-0.0, the result can be one of both. Note that in JS -0.0 === 0.0.
+  if (bitcastedF16ValueInU16 === 0.0) {
+    return [f16ZerosInterval];
+  }
+  const exactInterval = FP.f16.toInterval(bitcastedF16ValueInU16);
+  // If the casted f16 value is subnormal, it also may be flushed to +/-0.0.
+  return [
+    exactInterval,
+    ...(isSubnormalNumberF16(bitcastedF16ValueInU16) ? [f16ZerosInterval] : []),
+  ];
+}
+
+/**
+ * @returns a Comparator for checking if a f16 value is a valid
+ * bitcast conversion from f16.
+ */
+function bitcastF16ToF16Comparator(f: number): Comparator {
+  if (!isFiniteF16(f)) return anyOf(f16UnboundedInterval);
+  return anyOf(...generateF16ExpectationIntervals(f));
+}
+
+/**
+ * @returns a Comparator for checking if a vec2<f16>is a valid bitcast
+ * conversion from u32.
+ */
+function bitcastU32ToVec2F16Comparator(u: number): Comparator {
+  const bitcastedVec2F16InU16x2 = u32ToU16x2(u).map(reinterpretU16AsF16);
+  // Generate expection for vec2 f16 result, by generating expected intervals for each elements and
+  // then do cartesian product.
+  const expectedIntervalsCombination = cartesianProduct(
+    ...bitcastedVec2F16InU16x2.map(generateF16ExpectationIntervals)
+  );
+  return anyOf(...expectedIntervalsCombination);
+}
+
+/**
+ * @returns a Comparator for checking if a vec2<f16> value is a valid
+ * bitcast conversion from i32.
+ */
+function bitcastI32ToVec2F16Comparator(i: number): Comparator {
+  const bitcastedVec2F16InU16x2 = u32ToU16x2(reinterpretI32AsU32(i)).map(reinterpretU16AsF16);
+  // Generate expection for vec2 f16 result, by generating expected intervals for each elements and
+  // then do cartesian product.
+  const expectedIntervalsCombination = cartesianProduct(
+    ...bitcastedVec2F16InU16x2.map(generateF16ExpectationIntervals)
+  );
+  return anyOf(...expectedIntervalsCombination);
+}
+
+/**
+ * @returns a Comparator for checking if a vec2<f16> value is a valid
+ * bitcast conversion from f32.
+ */
+function bitcastF32ToVec2F16Comparator(f: number): Comparator {
+  // If input f32 is not finite, it can be evaluated to any value and thus any result f16 vec2 is
+  // possible.
+  if (!isFiniteF32(f)) {
+    return anyOf([f16UnboundedInterval, f16UnboundedInterval]);
+  }
+  const bitcastedVec2F16InU16x2 = u32ToU16x2(reinterpretF32AsU32(f)).map(reinterpretU16AsF16);
+  // Generate expection for vec2 f16 result, by generating expected intervals for each elements and
+  // then do cartesian product.
+  const expectedIntervalsCombination = cartesianProduct(
+    ...bitcastedVec2F16InU16x2.map(generateF16ExpectationIntervals)
+  );
+  return anyOf(...expectedIntervalsCombination);
+}
+
+/**
+ * @returns a Comparator for checking if a vec4<f16> is a valid
+ * bitcast conversion from vec2<u32>.
+ */
+function bitcastVec2U32ToVec4F16Comparator(u32x2: number[]): Comparator {
+  assert(u32x2.length === 2);
+  const bitcastedVec4F16InU16x4 = u32x2.flatMap(u32ToU16x2).map(reinterpretU16AsF16);
+  // Generate expection for vec4 f16 result, by generating expected intervals for each elements and
+  // then do cartesian product.
+  const expectedIntervalsCombination = cartesianProduct(
+    ...bitcastedVec4F16InU16x4.map(generateF16ExpectationIntervals)
+  );
+  return anyOf(...expectedIntervalsCombination);
+}
+
+/**
+ * @returns a Comparator for checking if a vec4<f16> is a valid
+ * bitcast conversion from vec2<i32>.
+ */
+function bitcastVec2I32ToVec4F16Comparator(i32x2: number[]): Comparator {
+  assert(i32x2.length === 2);
+  const bitcastedVec4F16InU16x4 = i32x2
+    .map(reinterpretI32AsU32)
+    .flatMap(u32ToU16x2)
+    .map(reinterpretU16AsF16);
+  // Generate expection for vec4 f16 result, by generating expected intervals for each elements and
+  // then do cartesian product.
+  const expectedIntervalsCombination = cartesianProduct(
+    ...bitcastedVec4F16InU16x4.map(generateF16ExpectationIntervals)
+  );
+  return anyOf(...expectedIntervalsCombination);
+}
+
+/**
+ * @returns a Comparator for checking if a vec4<f16> is a valid
+ * bitcast conversion from vec2<f32>.
+ */
+function bitcastVec2F32ToVec4F16Comparator(f32x2: number[]): Comparator {
+  assert(f32x2.length === 2);
+  const bitcastedVec4F16InU16x4 = f32x2
+    .map(reinterpretF32AsU32)
+    .flatMap(u32ToU16x2)
+    .map(reinterpretU16AsF16);
+  // Generate expection for vec4 f16 result, by generating expected intervals for each elements and
+  // then do cartesian product.
+  const expectedIntervalsCombination = cartesianProduct(
+    ...bitcastedVec4F16InU16x4.map(generateF16ExpectationIntervals)
+  );
+  return anyOf(...expectedIntervalsCombination);
+}
+
+// Structure that store the expectations of a single 32bit scalar/element bitcasted from two f16.
+interface ExpectionFor32BitsScalarFromF16x2 {
+  // possibleExpectations is Scalar array if the expectation is for i32/u32 and FPInterval array for
+  // f32. Note that if the expectation for i32/u32 is unbound, possibleExpectations is meaningless.
+  possibleExpectations: (Scalar | FPInterval)[];
+  isUnbounded: boolean;
+}
+
+/**
+ * @returns the array of possible 16bits, represented in u16, that bitcasted
+ * from a given finite f16 represented in u16, handling the possible subnormal
+ * flushing. Used to build up 32bits or larger results.
+ */
+function possibleBitsInU16FromFiniteF16InU16(f16InU16: number): number[] {
+  const h = reinterpretU16AsF16(f16InU16);
+  assert(isFiniteF16(h));
+  return [f16InU16, ...(isSubnormalNumberF16(h) ? f16ZerosInU16 : [])];
+}
+
+/**
+ * @returns the expectation for a single 32bit scalar bitcasted from given pair of
+ * f16, result in ExpectionFor32BitsScalarFromF16x2.
+ */
+function possible32BitScalarIntervalsFromF16x2(
+  f16x2InU16x2: number[],
+  type: 'i32' | 'u32' | 'f32'
+): ExpectionFor32BitsScalarFromF16x2 {
+  assert(f16x2InU16x2.length === 2);
+  let reinterpretFromU32: (x: number) => number;
+  let expectationsForValue: (x: number) => Scalar[] | FPInterval[];
+  let unboundedExpectations: FPInterval[] | Scalar[];
+  if (type === 'u32') {
+    reinterpretFromU32 = (x: number) => x;
+    expectationsForValue = x => [u32(x)];
+    unboundedExpectations = [u32(0)];
+  } else if (type === 'i32') {
+    reinterpretFromU32 = (x: number) => reinterpretU32AsI32(x);
+    expectationsForValue = x => [i32(x)];
+    unboundedExpectations = [i32(0)];
+  } else {
+    assert(type === 'f32');
+    reinterpretFromU32 = (x: number) => reinterpretU32AsF32(x);
+    expectationsForValue = x => {
+      // Handle the possible Inf/NaN/zeros and subnormal cases for f32 result.
+      if (!isFiniteF32(x)) {
+        return [f32UnboundedInterval];
+      }
+      // If the casted f16 value is +/-0.0, the result can be one of both. Note that in JS -0.0 === 0.0.
+      if (x === 0.0) {
+        return [f32ZerosInterval];
+      }
+      const exactInterval = FP.f32.toInterval(x);
+      // If the casted f16 value is subnormal, it also may be flushed to +/-0.0.
+      return [exactInterval, ...(isSubnormalNumberF32(x) ? [f32ZerosInterval] : [])];
+    };
+    unboundedExpectations = [f32UnboundedInterval];
+  }
+  // Return unbounded expection if f16 Inf/NaN occurs
+  if (
+    !isFiniteF16(reinterpretU16AsF16(f16x2InU16x2[0])) ||
+    !isFiniteF16(reinterpretU16AsF16(f16x2InU16x2[1]))
+  ) {
+    return { possibleExpectations: unboundedExpectations, isUnbounded: true };
+  }
+  const possibleU16Bits = f16x2InU16x2.map(possibleBitsInU16FromFiniteF16InU16);
+  const possibleExpectations = cartesianProduct(...possibleU16Bits).flatMap<Scalar | FPInterval>(
+    (possibleBitsU16x2: number[]) => {
+      assert(possibleBitsU16x2.length === 2);
+      return expectationsForValue(reinterpretFromU32(u16x2ToU32(possibleBitsU16x2)));
+    }
+  );
+  return { possibleExpectations, isUnbounded: false };
+}
+
+/**
+ * @returns a Comparator for checking if a u32 value is a valid
+ * bitcast conversion from vec2 f16.
+ */
+function bitcastVec2F16ToU32Comparator(vec2F16InU16x2: number[]): Comparator {
+  assert(vec2F16InU16x2.length === 2);
+  const expectations = possible32BitScalarIntervalsFromF16x2(vec2F16InU16x2, 'u32');
+  // Return alwaysPass if result is expected unbounded.
+  if (expectations.isUnbounded) {
+    return alwaysPass('any u32');
+  }
+  return anyOf(...expectations.possibleExpectations);
+}
+
+/**
+ * @returns a Comparator for checking if a i32 value is a valid
+ * bitcast conversion from vec2 f16.
+ */
+function bitcastVec2F16ToI32Comparator(vec2F16InU16x2: number[]): Comparator {
+  assert(vec2F16InU16x2.length === 2);
+  const expectations = possible32BitScalarIntervalsFromF16x2(vec2F16InU16x2, 'i32');
+  // Return alwaysPass if result is expected unbounded.
+  if (expectations.isUnbounded) {
+    return alwaysPass('any i32');
+  }
+  return anyOf(...expectations.possibleExpectations);
+}
+
+/**
+ * @returns a Comparator for checking if a i32 value is a valid
+ * bitcast conversion from vec2 f16.
+ */
+function bitcastVec2F16ToF32Comparator(vec2F16InU16x2: number[]): Comparator {
+  assert(vec2F16InU16x2.length === 2);
+  const expectations = possible32BitScalarIntervalsFromF16x2(vec2F16InU16x2, 'f32');
+  // Return alwaysPass if result is expected unbounded.
+  if (expectations.isUnbounded) {
+    return alwaysPass('any f32');
+  }
+  return anyOf(...expectations.possibleExpectations);
+}
+
+/**
+ * @returns a Comparator for checking if a vec2 u32 value is a valid
+ * bitcast conversion from vec4 f16.
+ */
+function bitcastVec4F16ToVec2U32Comparator(vec4F16InU16x4: number[]): Comparator {
+  assert(vec4F16InU16x4.length === 4);
+  const expectationsPerElement = [vec4F16InU16x4.slice(0, 2), vec4F16InU16x4.slice(2, 4)].map(e =>
+    possible32BitScalarIntervalsFromF16x2(e, 'u32')
+  );
+  // Return alwaysPass if any element is expected unbounded. Although it may be only one unbounded
+  // element in the result vector, currently we don't have a way to build a comparator that expect
+  // only one element of i32/u32 vector unbounded.
+  if (expectationsPerElement.map(e => e.isUnbounded).reduce((a, b) => a || b, false)) {
+    return alwaysPass('any vec2<u32>');
+  }
+  return anyOf(
+    ...cartesianProduct(...expectationsPerElement.map(e => e.possibleExpectations)).map(e =>
+      vec2(e[0] as Scalar, e[1] as Scalar)
+    )
+  );
+}
+
+/**
+ * @returns a Comparator for checking if a vec2 i32 value is a valid
+ * bitcast conversion from vec4 f16.
+ */
+function bitcastVec4F16ToVec2I32Comparator(vec4F16InU16x4: number[]): Comparator {
+  assert(vec4F16InU16x4.length === 4);
+  const expectationsPerElement = [vec4F16InU16x4.slice(0, 2), vec4F16InU16x4.slice(2, 4)].map(e =>
+    possible32BitScalarIntervalsFromF16x2(e, 'i32')
+  );
+  // Return alwaysPass if any element is expected unbounded. Although it may be only one unbounded
+  // element in the result vector, currently we don't have a way to build a comparator that expect
+  // only one element of i32/u32 vector unbounded.
+  if (expectationsPerElement.map(e => e.isUnbounded).reduce((a, b) => a || b, false)) {
+    return alwaysPass('any vec2<i32>');
+  }
+  return anyOf(
+    ...cartesianProduct(...expectationsPerElement.map(e => e.possibleExpectations)).map(e =>
+      vec2(e[0] as Scalar, e[1] as Scalar)
+    )
+  );
+}
+
+/**
+ * @returns a Comparator for checking if a vec2 f32 value is a valid
+ * bitcast conversion from vec4 f16.
+ */
+function bitcastVec4F16ToVec2F32Comparator(vec4F16InU16x4: number[]): Comparator {
+  assert(vec4F16InU16x4.length === 4);
+  const expectationsPerElement = [vec4F16InU16x4.slice(0, 2), vec4F16InU16x4.slice(2, 4)].map(e =>
+    possible32BitScalarIntervalsFromF16x2(e, 'f32')
+  );
+  return anyOf(
+    ...cartesianProduct(...expectationsPerElement.map(e => e.possibleExpectations)).map(e => [
+      e[0] as FPInterval,
+      e[1] as FPInterval,
+    ])
+  );
 }
 
 export const d = makeCaseCache('bitcast', {
@@ -176,27 +649,34 @@ export const d = makeCaseCache('bitcast', {
     })),
   f32_to_f32: () =>
     f32FiniteRange.map(e => ({ input: f32(e), expected: bitcastF32ToF32Comparator(e) })),
+  f16_inf_nan_to_f16: () =>
+    [...f16FiniteInF16, ...f16InfAndNaNInF16].map(e => ({
+      input: f16(e),
+      expected: bitcastF16ToF16Comparator(e),
+    })),
+  f16_to_f16: () =>
+    f16FiniteInF16.map(e => ({ input: f16(e), expected: bitcastF16ToF16Comparator(e) })),
 
   // i32,u32,f32 to different i32,u32,f32
   i32_to_u32: () => fullI32Range().map(e => ({ input: i32(e), expected: u32(e) })),
   i32_to_f32: () =>
-    i32RangeWithFiniteF32.map(e => ({
+    i32RangeForF32Finite.map(e => ({
       input: i32(e),
       expected: bitcastI32ToF32Comparator(e),
     })),
   i32_to_f32_inf_nan: () =>
-    i32RangeWithBitsForInfAndNaNAndZeros.map(e => ({
+    i32RangeForF32FiniteInfNaN.map(e => ({
       input: i32(e),
       expected: bitcastI32ToF32Comparator(e),
     })),
   u32_to_i32: () => fullU32Range().map(e => ({ input: u32(e), expected: i32(e) })),
   u32_to_f32: () =>
-    u32RangeWithFiniteF32.map(e => ({
+    u32RangeForF32Finite.map(e => ({
       input: u32(e),
       expected: bitcastU32ToF32Comparator(e),
     })),
   u32_to_f32_inf_nan: () =>
-    u32RangeWithBitsForInfAndNaNAndZeros.map(e => ({
+    u32RangeForF32FiniteInfNaN.map(e => ({
       input: u32(e),
       expected: bitcastU32ToF32Comparator(e),
     })),
@@ -215,6 +695,142 @@ export const d = makeCaseCache('bitcast', {
     })),
   f32_to_u32: () =>
     f32FiniteRange.map(e => ({ input: f32(e), expected: bitcastF32ToU32Comparator(e) })),
+
+  // i32,u32,f32 to vec2<f16>
+  u32_to_vec2_f16_inf_nan: () =>
+    u32RangeForF16Vec2FiniteInfNaN.map(e => ({
+      input: u32(e),
+      expected: bitcastU32ToVec2F16Comparator(e),
+    })),
+  u32_to_vec2_f16: () =>
+    u32RangeForF16Vec2Finite.map(e => ({
+      input: u32(e),
+      expected: bitcastU32ToVec2F16Comparator(e),
+    })),
+  i32_to_vec2_f16_inf_nan: () =>
+    i32RangeForF16Vec2FiniteInfNaN.map(e => ({
+      input: i32(e),
+      expected: bitcastI32ToVec2F16Comparator(e),
+    })),
+  i32_to_vec2_f16: () =>
+    i32RangeForF16Vec2Finite.map(e => ({
+      input: i32(e),
+      expected: bitcastI32ToVec2F16Comparator(e),
+    })),
+  f32_inf_nan_to_vec2_f16_inf_nan: () =>
+    f32RangeWithInfAndNaNForF16Vec2FiniteInfNaN.map(e => ({
+      input: f32(e),
+      expected: bitcastF32ToVec2F16Comparator(e),
+    })),
+  f32_to_vec2_f16: () =>
+    f32FiniteRangeForF16Vec2Finite.map(e => ({
+      input: f32(e),
+      expected: bitcastF32ToVec2F16Comparator(e),
+    })),
+
+  // vec2<i32>, vec2<u32>, vec2<f32> to vec4<f16>
+  vec2_i32_to_vec4_f16_inf_nan: () =>
+    slidingSlice(i32RangeForF16Vec2FiniteInfNaN, 2).map(e => ({
+      input: vec2(i32(e[0]), i32(e[1])),
+      expected: bitcastVec2I32ToVec4F16Comparator(e),
+    })),
+  vec2_i32_to_vec4_f16: () =>
+    slidingSlice(i32RangeForF16Vec2Finite, 2).map(e => ({
+      input: vec2(i32(e[0]), i32(e[1])),
+      expected: bitcastVec2I32ToVec4F16Comparator(e),
+    })),
+  vec2_u32_to_vec4_f16_inf_nan: () =>
+    slidingSlice(u32RangeForF16Vec2FiniteInfNaN, 2).map(e => ({
+      input: vec2(u32(e[0]), u32(e[1])),
+      expected: bitcastVec2U32ToVec4F16Comparator(e),
+    })),
+  vec2_u32_to_vec4_f16: () =>
+    slidingSlice(u32RangeForF16Vec2Finite, 2).map(e => ({
+      input: vec2(u32(e[0]), u32(e[1])),
+      expected: bitcastVec2U32ToVec4F16Comparator(e),
+    })),
+  vec2_f32_inf_nan_to_vec4_f16_inf_nan: () =>
+    slidingSlice(f32RangeWithInfAndNaNForF16Vec2FiniteInfNaN, 2).map(e => ({
+      input: vec2(f32(e[0]), f32(e[1])),
+      expected: bitcastVec2F32ToVec4F16Comparator(e),
+    })),
+  vec2_f32_to_vec4_f16: () =>
+    slidingSlice(f32FiniteRangeForF16Vec2Finite, 2).map(e => ({
+      input: vec2(f32(e[0]), f32(e[1])),
+      expected: bitcastVec2F32ToVec4F16Comparator(e),
+    })),
+
+  // vec2<f16> to i32, u32, f32
+  vec2_f16_to_u32: () =>
+    f16Vec2FiniteInU16x2.map(e => ({
+      input: u16x2ToVec2F16(e),
+      expected: bitcastVec2F16ToU32Comparator(e),
+    })),
+  vec2_f16_inf_nan_to_u32: () =>
+    f16Vec2FiniteInfNanInU16x2.map(e => ({
+      input: u16x2ToVec2F16(e),
+      expected: bitcastVec2F16ToU32Comparator(e),
+    })),
+  vec2_f16_to_i32: () =>
+    f16Vec2FiniteInU16x2.map(e => ({
+      input: u16x2ToVec2F16(e),
+      expected: bitcastVec2F16ToI32Comparator(e),
+    })),
+  vec2_f16_inf_nan_to_i32: () =>
+    f16Vec2FiniteInfNanInU16x2.map(e => ({
+      input: u16x2ToVec2F16(e),
+      expected: bitcastVec2F16ToI32Comparator(e),
+    })),
+  vec2_f16_to_f32_finite: () =>
+    f16Vec2FiniteInU16x2
+      .filter(u16x2 => isFiniteF32(reinterpretU32AsF32(u16x2ToU32(u16x2))))
+      .map(e => ({
+        input: u16x2ToVec2F16(e),
+        expected: bitcastVec2F16ToF32Comparator(e),
+      })),
+  vec2_f16_inf_nan_to_f32: () =>
+    f16Vec2FiniteInfNanInU16x2.map(e => ({
+      input: u16x2ToVec2F16(e),
+      expected: bitcastVec2F16ToF32Comparator(e),
+    })),
+
+  // vec4<f16> to vec2 of i32, u32, f32
+  vec4_f16_to_vec2_u32: () =>
+    f16Vec2FiniteInU16x4.map(e => ({
+      input: u16x4ToVec4F16(e),
+      expected: bitcastVec4F16ToVec2U32Comparator(e),
+    })),
+  vec4_f16_inf_nan_to_vec2_u32: () =>
+    f16Vec2FiniteInfNanInU16x4.map(e => ({
+      input: u16x4ToVec4F16(e),
+      expected: bitcastVec4F16ToVec2U32Comparator(e),
+    })),
+  vec4_f16_to_vec2_i32: () =>
+    f16Vec2FiniteInU16x4.map(e => ({
+      input: u16x4ToVec4F16(e),
+      expected: bitcastVec4F16ToVec2I32Comparator(e),
+    })),
+  vec4_f16_inf_nan_to_vec2_i32: () =>
+    f16Vec2FiniteInfNanInU16x4.map(e => ({
+      input: u16x4ToVec4F16(e),
+      expected: bitcastVec4F16ToVec2I32Comparator(e),
+    })),
+  vec4_f16_to_vec2_f32_finite: () =>
+    f16Vec2FiniteInU16x4
+      .filter(
+        u16x4 =>
+          isFiniteF32(reinterpretU32AsF32(u16x2ToU32(u16x4.slice(0, 2)))) &&
+          isFiniteF32(reinterpretU32AsF32(u16x2ToU32(u16x4.slice(2, 4))))
+      )
+      .map(e => ({
+        input: u16x4ToVec4F16(e),
+        expected: bitcastVec4F16ToVec2F32Comparator(e),
+      })),
+  vec4_f16_inf_nan_to_vec2_f32: () =>
+    f16Vec2FiniteInfNanInU16x4.map(e => ({
+      input: u16x4ToVec4F16(e),
+      expected: bitcastVec4F16ToVec2F32Comparator(e),
+    })),
 });
 
 /**
@@ -227,17 +843,10 @@ function bitcastBuilder(canonicalDestType: string, params: TestParams): ShaderBu
     ? `vec${params.vectorize}<${canonicalDestType}>`
     : canonicalDestType;
 
-  if (params.alias) {
-    return (
-      parameterTypes: Array<Type>,
-      resultType: Type,
-      cases: CaseList,
-      inputSource: InputSource
-    ) =>
-      `alias myalias = ${destType};\n` +
-      builtin(`bitcast<myalias>`)(parameterTypes, resultType, cases, inputSource);
-  }
-  return builtin(`bitcast<${destType}>`);
+  return builtinWithPredeclaration(
+    `bitcast<${destType}>`,
+    params.alias ? `alias myalias = ${destType};` : ''
+  );
 }
 
 // Identity cases
@@ -399,140 +1008,264 @@ g.test('f16_to_f16')
       .combine('vectorize', [undefined, 2, 3, 4] as const)
       .combine('alias', [false, true])
   )
-  .unimplemented();
+  .beforeAllSubcases(t => {
+    t.selectDeviceOrSkipTestCase('shader-f16');
+  })
+  .fn(async t => {
+    const cases = await d.get(
+      // Infinities and NaNs are errors in const-eval.
+      t.params.inputSource === 'const' ? 'f16_to_f16' : 'f16_inf_nan_to_f16'
+    );
+    await run(t, bitcastBuilder('f16', t.params), [TypeF16], TypeF16, t.params, cases);
+  });
 
 // f16: 32-bit scalar numeric to vec2<f16>
 g.test('i32_to_vec2h')
   .specURL('https://www.w3.org/TR/WGSL/#bitcast-builtin')
   .desc(`bitcast i32 to vec2h tests`)
-  .params(u =>
-    u
-      .combine('inputSource', allInputSources)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
-      .combine('alias', [false, true])
-  )
-  .unimplemented();
+  .params(u => u.combine('inputSource', allInputSources).combine('alias', [false, true]))
+  .beforeAllSubcases(t => {
+    t.selectDeviceOrSkipTestCase('shader-f16');
+  })
+  .fn(async t => {
+    const cases = await d.get(
+      // Infinities and NaNs are errors in const-eval.
+      t.params.inputSource === 'const' ? 'i32_to_vec2_f16' : 'i32_to_vec2_f16_inf_nan'
+    );
+    await run(
+      t,
+      bitcastBuilder('vec2<f16>', t.params),
+      [TypeI32],
+      TypeVec(2, TypeF16),
+      t.params,
+      cases
+    );
+  });
 
 g.test('u32_to_vec2h')
   .specURL('https://www.w3.org/TR/WGSL/#bitcast-builtin')
   .desc(`bitcast u32 to vec2h tests`)
-  .params(u =>
-    u
-      .combine('inputSource', allInputSources)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
-      .combine('alias', [false, true])
-  )
-  .unimplemented();
+  .params(u => u.combine('inputSource', allInputSources).combine('alias', [false, true]))
+  .beforeAllSubcases(t => {
+    t.selectDeviceOrSkipTestCase('shader-f16');
+  })
+  .fn(async t => {
+    const cases = await d.get(
+      // Infinities and NaNs are errors in const-eval.
+      t.params.inputSource === 'const' ? 'u32_to_vec2_f16' : 'u32_to_vec2_f16_inf_nan'
+    );
+    await run(
+      t,
+      bitcastBuilder('vec2<f16>', t.params),
+      [TypeU32],
+      TypeVec(2, TypeF16),
+      t.params,
+      cases
+    );
+  });
 
 g.test('f32_to_vec2h')
   .specURL('https://www.w3.org/TR/WGSL/#bitcast-builtin')
   .desc(`bitcast u32 to vec2h tests`)
-  .params(u =>
-    u
-      .combine('inputSource', allInputSources)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
-      .combine('alias', [false, true])
-  )
-  .unimplemented();
+  .params(u => u.combine('inputSource', allInputSources).combine('alias', [false, true]))
+  .beforeAllSubcases(t => {
+    t.selectDeviceOrSkipTestCase('shader-f16');
+  })
+  .fn(async t => {
+    const cases = await d.get(
+      // Infinities and NaNs are errors in const-eval.
+      t.params.inputSource === 'const' ? 'f32_to_vec2_f16' : 'f32_inf_nan_to_vec2_f16_inf_nan'
+    );
+    await run(
+      t,
+      bitcastBuilder('vec2<f16>', t.params),
+      [TypeF32],
+      TypeVec(2, TypeF16),
+      t.params,
+      cases
+    );
+  });
 
 // f16: vec2<32-bit scalar numeric> to vec4<f16>
 g.test('vec2i_to_vec4h')
   .specURL('https://www.w3.org/TR/WGSL/#bitcast-builtin')
   .desc(`bitcast vec2i to vec4h tests`)
-  .params(u =>
-    u
-      .combine('inputSource', allInputSources)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
-      .combine('alias', [false, true])
-  )
-  .unimplemented();
+  .params(u => u.combine('inputSource', allInputSources).combine('alias', [false, true]))
+  .beforeAllSubcases(t => {
+    t.selectDeviceOrSkipTestCase('shader-f16');
+  })
+  .fn(async t => {
+    const cases = await d.get(
+      // Infinities and NaNs are errors in const-eval.
+      t.params.inputSource === 'const' ? 'vec2_i32_to_vec4_f16' : 'vec2_i32_to_vec4_f16_inf_nan'
+    );
+    await run(
+      t,
+      bitcastBuilder('vec4<f16>', t.params),
+      [TypeVec(2, TypeI32)],
+      TypeVec(4, TypeF16),
+      t.params,
+      cases
+    );
+  });
 
 g.test('vec2u_to_vec4h')
   .specURL('https://www.w3.org/TR/WGSL/#bitcast-builtin')
   .desc(`bitcast vec2u to vec4h tests`)
-  .params(u =>
-    u
-      .combine('inputSource', allInputSources)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
-      .combine('alias', [false, true])
-  )
-  .unimplemented();
+  .params(u => u.combine('inputSource', allInputSources).combine('alias', [false, true]))
+  .beforeAllSubcases(t => {
+    t.selectDeviceOrSkipTestCase('shader-f16');
+  })
+  .fn(async t => {
+    const cases = await d.get(
+      // Infinities and NaNs are errors in const-eval.
+      t.params.inputSource === 'const' ? 'vec2_u32_to_vec4_f16' : 'vec2_u32_to_vec4_f16_inf_nan'
+    );
+    await run(
+      t,
+      bitcastBuilder('vec4<f16>', t.params),
+      [TypeVec(2, TypeU32)],
+      TypeVec(4, TypeF16),
+      t.params,
+      cases
+    );
+  });
 
 g.test('vec2f_to_vec4h')
   .specURL('https://www.w3.org/TR/WGSL/#bitcast-builtin')
   .desc(`bitcast vec2f to vec2h tests`)
-  .params(u =>
-    u
-      .combine('inputSource', allInputSources)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
-      .combine('alias', [false, true])
-  )
-  .unimplemented();
+  .params(u => u.combine('inputSource', allInputSources).combine('alias', [false, true]))
+  .beforeAllSubcases(t => {
+    t.selectDeviceOrSkipTestCase('shader-f16');
+  })
+  .fn(async t => {
+    const cases = await d.get(
+      // Infinities and NaNs are errors in const-eval.
+      t.params.inputSource === 'const'
+        ? 'vec2_f32_to_vec4_f16'
+        : 'vec2_f32_inf_nan_to_vec4_f16_inf_nan'
+    );
+    await run(
+      t,
+      bitcastBuilder('vec4<f16>', t.params),
+      [TypeVec(2, TypeF32)],
+      TypeVec(4, TypeF16),
+      t.params,
+      cases
+    );
+  });
 
 // f16: vec2<f16> to 32-bit scalar numeric
 g.test('vec2h_to_i32')
   .specURL('https://www.w3.org/TR/WGSL/#bitcast-builtin')
   .desc(`bitcast vec2h to i32 tests`)
-  .params(u =>
-    u
-      .combine('inputSource', allInputSources)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
-      .combine('alias', [false, true])
-  )
-  .unimplemented();
+  .params(u => u.combine('inputSource', allInputSources).combine('alias', [false, true]))
+  .beforeAllSubcases(t => {
+    t.selectDeviceOrSkipTestCase('shader-f16');
+  })
+  .fn(async t => {
+    const cases = await d.get(
+      // Infinities and NaNs are errors in const-eval.
+      t.params.inputSource === 'const' ? 'vec2_f16_to_i32' : 'vec2_f16_inf_nan_to_i32'
+    );
+    await run(t, bitcastBuilder('i32', t.params), [TypeVec(2, TypeF16)], TypeI32, t.params, cases);
+  });
 
 g.test('vec2h_to_u32')
   .specURL('https://www.w3.org/TR/WGSL/#bitcast-builtin')
   .desc(`bitcast vec2h to u32 tests`)
-  .params(u =>
-    u
-      .combine('inputSource', allInputSources)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
-      .combine('alias', [false, true])
-  )
-  .unimplemented();
+  .params(u => u.combine('inputSource', allInputSources).combine('alias', [false, true]))
+  .beforeAllSubcases(t => {
+    t.selectDeviceOrSkipTestCase('shader-f16');
+  })
+  .fn(async t => {
+    const cases = await d.get(
+      // Infinities and NaNs are errors in const-eval.
+      t.params.inputSource === 'const' ? 'vec2_f16_to_u32' : 'vec2_f16_inf_nan_to_u32'
+    );
+    await run(t, bitcastBuilder('u32', t.params), [TypeVec(2, TypeF16)], TypeU32, t.params, cases);
+  });
 
 g.test('vec2h_to_f32')
   .specURL('https://www.w3.org/TR/WGSL/#bitcast-builtin')
   .desc(`bitcast vec2h to f32 tests`)
-  .params(u =>
-    u
-      .combine('inputSource', allInputSources)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
-      .combine('alias', [false, true])
-  )
-  .unimplemented();
+  .params(u => u.combine('inputSource', allInputSources).combine('alias', [false, true]))
+  .beforeAllSubcases(t => {
+    t.selectDeviceOrSkipTestCase('shader-f16');
+  })
+  .fn(async t => {
+    const cases = await d.get(
+      // Infinities and NaNs are errors in const-eval.
+      t.params.inputSource === 'const' ? 'vec2_f16_to_f32_finite' : 'vec2_f16_inf_nan_to_f32'
+    );
+    await run(t, bitcastBuilder('f32', t.params), [TypeVec(2, TypeF16)], TypeF32, t.params, cases);
+  });
 
 // f16: vec4<f16> to vec2<32-bit scalar numeric>
 g.test('vec4h_to_vec2i')
   .specURL('https://www.w3.org/TR/WGSL/#bitcast-builtin')
   .desc(`bitcast vec4h to vec2i tests`)
-  .params(u =>
-    u
-      .combine('inputSource', allInputSources)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
-      .combine('alias', [false, true])
-  )
-  .unimplemented();
+  .params(u => u.combine('inputSource', allInputSources).combine('alias', [false, true]))
+  .beforeAllSubcases(t => {
+    t.selectDeviceOrSkipTestCase('shader-f16');
+  })
+  .fn(async t => {
+    const cases = await d.get(
+      // Infinities and NaNs are errors in const-eval.
+      t.params.inputSource === 'const' ? 'vec4_f16_to_vec2_i32' : 'vec4_f16_inf_nan_to_vec2_i32'
+    );
+    await run(
+      t,
+      bitcastBuilder('vec2<i32>', t.params),
+      [TypeVec(4, TypeF16)],
+      TypeVec(2, TypeI32),
+      t.params,
+      cases
+    );
+  });
 
 g.test('vec4h_to_vec2u')
   .specURL('https://www.w3.org/TR/WGSL/#bitcast-builtin')
   .desc(`bitcast vec4h to vec2u tests`)
-  .params(u =>
-    u
-      .combine('inputSource', allInputSources)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
-      .combine('alias', [false, true])
-  )
-  .unimplemented();
+  .params(u => u.combine('inputSource', allInputSources).combine('alias', [false, true]))
+  .beforeAllSubcases(t => {
+    t.selectDeviceOrSkipTestCase('shader-f16');
+  })
+  .fn(async t => {
+    const cases = await d.get(
+      // Infinities and NaNs are errors in const-eval.
+      t.params.inputSource === 'const' ? 'vec4_f16_to_vec2_u32' : 'vec4_f16_inf_nan_to_vec2_u32'
+    );
+    await run(
+      t,
+      bitcastBuilder('vec2<u32>', t.params),
+      [TypeVec(4, TypeF16)],
+      TypeVec(2, TypeU32),
+      t.params,
+      cases
+    );
+  });
 
 g.test('vec4h_to_vec2f')
   .specURL('https://www.w3.org/TR/WGSL/#bitcast-builtin')
   .desc(`bitcast vec4h to vec2f tests`)
-  .params(u =>
-    u
-      .combine('inputSource', allInputSources)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
-      .combine('alias', [false, true])
-  )
-  .unimplemented();
+  .params(u => u.combine('inputSource', allInputSources).combine('alias', [false, true]))
+  .beforeAllSubcases(t => {
+    t.selectDeviceOrSkipTestCase('shader-f16');
+  })
+  .fn(async t => {
+    const cases = await d.get(
+      // Infinities and NaNs are errors in const-eval.
+      t.params.inputSource === 'const'
+        ? 'vec4_f16_to_vec2_f32_finite'
+        : 'vec4_f16_inf_nan_to_vec2_f32'
+    );
+    await run(
+      t,
+      bitcastBuilder('vec2<f32>', t.params),
+      [TypeVec(4, TypeF16)],
+      TypeVec(2, TypeF32),
+      t.params,
+      cases
+    );
+  });

--- a/src/webgpu/shader/execution/expression/call/builtin/builtin.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/builtin.ts
@@ -1,6 +1,18 @@
-import { basicExpressionBuilder, ShaderBuilder } from '../../expression.js';
+import {
+  basicExpressionBuilder,
+  basicExpressionWithPredeclarationBuilder,
+  ShaderBuilder,
+} from '../../expression.js';
 
 /* @returns a ShaderBuilder that calls the builtin with the given name */
 export function builtin(name: string): ShaderBuilder {
   return basicExpressionBuilder(values => `${name}(${values.join(', ')})`);
+}
+
+/* @returns a ShaderBuilder that calls the builtin with the given name and has given predeclaration */
+export function builtinWithPredeclaration(name: string, predeclaration: string): ShaderBuilder {
+  return basicExpressionWithPredeclarationBuilder(
+    values => `${name}(${values.join(', ')})`,
+    predeclaration
+  );
 }

--- a/src/webgpu/shader/execution/expression/expression.ts
+++ b/src/webgpu/shader/execution/expression/expression.ts
@@ -501,107 +501,107 @@ export type ExpressionBuilder = (values: Array<string>) => string;
  * Returns a ShaderBuilder that builds a basic expression test shader.
  * @param expressionBuilder the expression builder
  */
-export function basicExpressionBuilder(expressionBuilder: ExpressionBuilder): ShaderBuilder {
-  return (
-    parameterTypes: Array<Type>,
-    resultType: Type,
-    cases: CaseList,
-    inputSource: InputSource
-  ) => {
-    if (inputSource === 'const') {
-      //////////////////////////////////////////////////////////////////////////
-      // Constant eval
-      //////////////////////////////////////////////////////////////////////////
-      let body = '';
-      if (
-        scalarTypeOf(resultType).kind !== 'abstract-float' &&
-        parameterTypes.some(ty => scalarTypeOf(ty).kind === 'abstract-float')
-      ) {
-        // Directly assign the expression to the output, to avoid an
-        // intermediate store, which will concretize the value early
-        body = cases
-          .map(
-            (c, i) =>
-              `  outputs[${i}].value = ${toStorage(
-                resultType,
-                expressionBuilder(map(c.input, v => v.wgsl()))
-              )};`
-          )
-          .join('\n  ');
-      } else if (scalarTypeOf(resultType).kind === 'abstract-float') {
-        // AbstractFloats are f64s under the hood. WebGPU does not support
-        // putting f64s in buffers, so the result needs to be split up into u32s
-        // and rebuilt in the test framework.
-        //
-        // This is complicated by the fact that user defined functions cannot
-        // take/return AbstractFloats, and AbstractFloats cannot be stored in
-        // variables, so the code cannot just inject a simple utility function
-        // at the top of the shader, instead this snippet needs to be inlined
-        // everywhere the test needs to return an AbstractFloat.
-        //
-        // select is used below, since ifs are not available during constant
-        // eval. This has the side effect of short-circuiting doesn't occur, so
-        // both sides of the select have to evaluate and be valid.
-        //
-        // This snippet implements FTZ for subnormals to bypass the need for
-        // complex subnormal specific logic.
-        //
-        // Expressions resulting in subnormals can still be reasonably tested,
-        // since this snippet will return 0 with the correct sign, which is
-        // always in the acceptance interval for a subnormal result, since an
-        // implementation may FTZ.
-        //
-        // Document for the snippet is included here in this code block, since
-        // shader length affects compilation time  significantly on some
-        // backends.
-        //
-        // Snippet with documentation:
-        //   const kExponentBias = 1022;
-        //
-        //   // Detect if the value is zero or subnormal, so that FTZ behaviour
-        //   // can occur
-        //   const subnormal_or_zero : bool = (${expr} <= ${kValue.f64.subnormal.positive.max}) && (${expr} >= ${kValue.f64.subnormal.negative.min});
-        //
-        //   // MSB of the upper u32 is 1 if the value is negative, otherwise 0
-        //   // Extract the sign bit early, so that abs() can be used with
-        //   // frexp() so negative cases do not need to be handled
-        //   const sign_bit : u32 = select(0, 0x80000000, ${expr} < 0);
-        //
-        //   // Use frexp() to obtain the exponent and fractional parts, and
-        //   // then perform FTZ if needed
-        //   const f = frexp(abs(${expr}));
-        //   const f_fract = select(f.fract, 0, subnormal_or_zero);
-        //   const f_exp = select(f.exp, -kExponentBias, subnormal_or_zero);
-        //
-        //   // Adjust for the exponent bias and shift for storing in bits
-        //   // [20..31] of the upper u32
-        //   const exponent_bits : u32 = (f_exp + kExponentBias) << 20;
-        //
-        //   // Extract the portion of the mantissa that appears in upper u32 as
-        //   // a float for later use
-        //   const high_mantissa = ldexp(f_fract, 21);
-        //
-        //   // Extract the portion of the mantissa that appears in upper u32 as
-        //   // as bits. This value is masked, because normals will explicitly
-        //   // have the implicit leading 1 that should not be in the final
-        //   // result.
-        //   const high_mantissa_bits : u32 = u32(ldexp(f_fract, 21)) & 0x000fffff;
-        //
-        //   // Calculate the mantissa stored in the lower u32 as a float
-        //   const low_mantissa = f_fract - ldexp(floor(high_mantissa), -21);
-        //
-        //   // Convert the lower u32 mantissa to bits
-        //   const low_mantissa_bits = u32(ldexp(low_mantissa, 53));
-        //
-        //   // Pack the result into 2x u32s for writing out to the testing
-        //   // framework
-        //   outputs[${i}].value.x = low_mantissa_bits;
-        //   outputs[${i}].value.y = sign_bit | exponent_bits | high_mantissa_bits;
-        body = cases
-          .map((c, i) => {
-            const expr = `${expressionBuilder(map(c.input, v => v.wgsl()))}`;
-            // prettier-ignore
-            return `  {
+function basicExpressionShaderBody(
+  expressionBuilder: ExpressionBuilder,
+  parameterTypes: Array<Type>,
+  resultType: Type,
+  cases: CaseList,
+  inputSource: InputSource
+): string {
+  if (inputSource === 'const') {
+    //////////////////////////////////////////////////////////////////////////
+    // Constant eval
+    //////////////////////////////////////////////////////////////////////////
+    let body = '';
+    if (
+      scalarTypeOf(resultType).kind !== 'abstract-float' &&
+      parameterTypes.some(ty => scalarTypeOf(ty).kind === 'abstract-float')
+    ) {
+      // Directly assign the expression to the output, to avoid an
+      // intermediate store, which will concretize the value early
+      body = cases
+        .map(
+          (c, i) =>
+            `  outputs[${i}].value = ${toStorage(
+              resultType,
+              expressionBuilder(map(c.input, v => v.wgsl()))
+            )};`
+        )
+        .join('\n  ');
+    } else if (scalarTypeOf(resultType).kind === 'abstract-float') {
+      // AbstractFloats are f64s under the hood. WebGPU does not support
+      // putting f64s in buffers, so the result needs to be split up into u32s
+      // and rebuilt in the test framework.
+      //
+      // This is complicated by the fact that user defined functions cannot
+      // take/return AbstractFloats, and AbstractFloats cannot be stored in
+      // variables, so the code cannot just inject a simple utility function
+      // at the top of the shader, instead this snippet needs to be inlined
+      // everywhere the test needs to return an AbstractFloat.
+      //
+      // select is used below, since ifs are not available during constant
+      // eval. This has the side effect of short-circuiting doesn't occur, so
+      // both sides of the select have to evaluate and be valid.
+      //
+      // This snippet implements FTZ for subnormals to bypass the need for
+      // complex subnormal specific logic.
+      //
+      // Expressions resulting in subnormals can still be reasonably tested,
+      // since this snippet will return 0 with the correct sign, which is
+      // always in the acceptance interval for a subnormal result, since an
+      // implementation may FTZ.
+      //
+      // Document for the snippet is included here in this code block, since
+      // shader length affects compilation time  significantly on some
+      // backends.
+      //
+      // Snippet with documentation:
+      //   const kExponentBias = 1022;
+      //
+      //   // Detect if the value is zero or subnormal, so that FTZ behaviour
+      //   // can occur
+      //   const subnormal_or_zero : bool = (${expr} <= ${kValue.f64.subnormal.positive.max}) && (${expr} >= ${kValue.f64.subnormal.negative.min});
+      //
+      //   // MSB of the upper u32 is 1 if the value is negative, otherwise 0
+      //   // Extract the sign bit early, so that abs() can be used with
+      //   // frexp() so negative cases do not need to be handled
+      //   const sign_bit : u32 = select(0, 0x80000000, ${expr} < 0);
+      //
+      //   // Use frexp() to obtain the exponent and fractional parts, and
+      //   // then perform FTZ if needed
+      //   const f = frexp(abs(${expr}));
+      //   const f_fract = select(f.fract, 0, subnormal_or_zero);
+      //   const f_exp = select(f.exp, -kExponentBias, subnormal_or_zero);
+      //
+      //   // Adjust for the exponent bias and shift for storing in bits
+      //   // [20..31] of the upper u32
+      //   const exponent_bits : u32 = (f_exp + kExponentBias) << 20;
+      //
+      //   // Extract the portion of the mantissa that appears in upper u32 as
+      //   // a float for later use
+      //   const high_mantissa = ldexp(f_fract, 21);
+      //
+      //   // Extract the portion of the mantissa that appears in upper u32 as
+      //   // as bits. This value is masked, because normals will explicitly
+      //   // have the implicit leading 1 that should not be in the final
+      //   // result.
+      //   const high_mantissa_bits : u32 = u32(ldexp(f_fract, 21)) & 0x000fffff;
+      //
+      //   // Calculate the mantissa stored in the lower u32 as a float
+      //   const low_mantissa = f_fract - ldexp(floor(high_mantissa), -21);
+      //
+      //   // Convert the lower u32 mantissa to bits
+      //   const low_mantissa_bits = u32(ldexp(low_mantissa, 53));
+      //
+      //   // Pack the result into 2x u32s for writing out to the testing
+      //   // framework
+      //   outputs[${i}].value.x = low_mantissa_bits;
+      //   outputs[${i}].value.y = sign_bit | exponent_bits | high_mantissa_bits;
+      body = cases
+        .map((c, i) => {
+          const expr = `${expressionBuilder(map(c.input, v => v.wgsl()))}`;
+          // prettier-ignore
+          return `  {
     const kExponentBias = 1022;
     const subnormal_or_zero : bool = (${expr} <= ${kValue.f64.subnormal.positive.max}) && (${expr} >= ${kValue.f64.subnormal.negative.min});
     const sign_bit : u32 = select(0, 0x80000000, ${expr} < 0);
@@ -616,25 +616,23 @@ export function basicExpressionBuilder(expressionBuilder: ExpressionBuilder): Sh
     outputs[${i}].value.x = low_mantissa_bits;
     outputs[${i}].value.y = sign_bit | exponent_bits | high_mantissa_bits;
   }`;
-          })
-          .join('\n  ');
-      } else if (globalTestConfig.unrollConstEvalLoops) {
-        body = cases
-          .map((_, i) => {
-            const value = `values[${i}]`;
-            return `  outputs[${i}].value = ${toStorage(resultType, value)};`;
-          })
-          .join('\n  ');
-      } else {
-        body = `
+        })
+        .join('\n  ');
+    } else if (globalTestConfig.unrollConstEvalLoops) {
+      body = cases
+        .map((_, i) => {
+          const value = `values[${i}]`;
+          return `  outputs[${i}].value = ${toStorage(resultType, value)};`;
+        })
+        .join('\n  ');
+    } else {
+      body = `
   for (var i = 0u; i < ${cases.length}; i++) {
     outputs[i].value = ${toStorage(resultType, `values[i]`)};
   }`;
-      }
+    }
 
-      return `
-${wgslHeader(parameterTypes, resultType)}
-
+    return `
 ${wgslOutputs(resultType, cases.length)}
 
 ${wgslValuesArray(parameterTypes, resultType, cases, expressionBuilder)}
@@ -643,20 +641,18 @@ ${wgslValuesArray(parameterTypes, resultType, cases, expressionBuilder)}
 fn main() {
 ${body}
 }`;
-    } else {
-      //////////////////////////////////////////////////////////////////////////
-      // Runtime eval
-      //////////////////////////////////////////////////////////////////////////
+  } else {
+    //////////////////////////////////////////////////////////////////////////
+    // Runtime eval
+    //////////////////////////////////////////////////////////////////////////
 
-      // returns the WGSL expression to load the ith parameter of the given type from the input buffer
-      const paramExpr = (ty: Type, i: number) => fromStorage(ty, `inputs[i].param${i}`);
+    // returns the WGSL expression to load the ith parameter of the given type from the input buffer
+    const paramExpr = (ty: Type, i: number) => fromStorage(ty, `inputs[i].param${i}`);
 
-      // resolves to the expression that calls the builtin
-      const expr = toStorage(resultType, expressionBuilder(parameterTypes.map(paramExpr)));
+    // resolves to the expression that calls the builtin
+    const expr = toStorage(resultType, expressionBuilder(parameterTypes.map(paramExpr)));
 
-      return `
-${wgslHeader(parameterTypes, resultType)}
-
+    return `
 struct Input {
 ${parameterTypes
   .map((ty, i) => `  @size(${valueStride(ty)}) param${i} : ${storageType(ty)},`)
@@ -674,7 +670,49 @@ fn main() {
   }
 }
 `;
-    }
+  }
+}
+
+/**
+ * Returns a ShaderBuilder that builds a basic expression test shader.
+ * @param expressionBuilder the expression builder
+ */
+export function basicExpressionBuilder(expressionBuilder: ExpressionBuilder): ShaderBuilder {
+  return (
+    parameterTypes: Array<Type>,
+    resultType: Type,
+    cases: CaseList,
+    inputSource: InputSource
+  ) => {
+    return `\
+${wgslHeader(parameterTypes, resultType)}
+
+${basicExpressionShaderBody(expressionBuilder, parameterTypes, resultType, cases, inputSource)}`;
+  };
+}
+
+/**
+ * Returns a ShaderBuilder that builds a basic expression test shader with given predeclaration
+ * string goes after WGSL header (i.e. enable directives) if any but before anything else.
+ * @param expressionBuilder the expression builder
+ * @param predeclaration the predeclaration string
+ */
+export function basicExpressionWithPredeclarationBuilder(
+  expressionBuilder: ExpressionBuilder,
+  predeclaration: string
+): ShaderBuilder {
+  return (
+    parameterTypes: Array<Type>,
+    resultType: Type,
+    cases: CaseList,
+    inputSource: InputSource
+  ) => {
+    return `\
+${wgslHeader(parameterTypes, resultType)}
+
+${predeclaration}
+
+${basicExpressionShaderBody(expressionBuilder, parameterTypes, resultType, cases, inputSource)}`;
   };
 }
 


### PR DESCRIPTION
This PR add execution tests for `bitcast` built-in from and to f16 types.

Issue: #1248, #1609

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
