### PR TITLE
Revert "Optimize loadTreeForQuery by filtering eagerly in ParamsBuilder (#2890)"

### DIFF
--- a/src/common/framework/params_builder.ts
+++ b/src/common/framework/params_builder.ts
@@ -1,9 +1,6 @@
-import { Merged, mergeParams, mergeParamsChecked } from '../internal/params_utils.js';
-import { comparePublicParamsPaths, Ordering } from '../internal/query/compare.js';
+import { Merged, assertMergedWithoutOverlap, mergeParams } from '../internal/params_utils.js';
 import { stringifyPublicParams } from '../internal/query/stringify_params.js';
 import { assert, mapLazy } from '../util/util.js';
-
-import { TestParams } from './fixture.js';
 
 // ================================================================
 // "Public" ParamsBuilder API / Documentation
@@ -105,32 +102,27 @@ export type CaseSubcaseIterable<CaseP, SubcaseP> = Iterable<
  * Base class for `CaseParamsBuilder` and `SubcaseParamsBuilder`.
  */
 export abstract class ParamsBuilderBase<CaseP extends {}, SubcaseP extends {}> {
-  protected readonly cases: (caseFilter: TestParams | null) => Generator<CaseP>;
+  protected readonly cases: () => Generator<CaseP>;
 
-  constructor(cases: (caseFilter: TestParams | null) => Generator<CaseP>) {
+  constructor(cases: () => Generator<CaseP>) {
     this.cases = cases;
   }
 
   /**
    * Hidden from test files. Use `builderIterateCasesWithSubcases` to access this.
    */
-  protected abstract iterateCasesWithSubcases(
-    caseFilter: TestParams | null
-  ): CaseSubcaseIterable<CaseP, SubcaseP>;
+  protected abstract iterateCasesWithSubcases(): CaseSubcaseIterable<CaseP, SubcaseP>;
 }
 
 /**
  * Calls the (normally hidden) `iterateCasesWithSubcases()` method.
  */
-export function builderIterateCasesWithSubcases(
-  builder: ParamsBuilderBase<{}, {}>,
-  caseFilter: TestParams | null
-) {
+export function builderIterateCasesWithSubcases(builder: ParamsBuilderBase<{}, {}>) {
   interface IterableParamsBuilder {
-    iterateCasesWithSubcases(caseFilter: TestParams | null): CaseSubcaseIterable<{}, {}>;
+    iterateCasesWithSubcases(): CaseSubcaseIterable<{}, {}>;
   }
 
-  return ((builder as unknown) as IterableParamsBuilder).iterateCasesWithSubcases(caseFilter);
+  return ((builder as unknown) as IterableParamsBuilder).iterateCasesWithSubcases();
 }
 
 /**
@@ -144,66 +136,31 @@ export function builderIterateCasesWithSubcases(
 export class CaseParamsBuilder<CaseP extends {}>
   extends ParamsBuilderBase<CaseP, {}>
   implements Iterable<CaseP>, ParamsBuilder {
-  *iterateCasesWithSubcases(caseFilter: TestParams | null): CaseSubcaseIterable<CaseP, {}> {
-    for (const caseP of this.cases(caseFilter)) {
-      if (caseFilter) {
-        // this.cases() only filters out cases which conflict with caseFilter. Now that we have
-        // the final caseP, filter out cases which are missing keys that caseFilter requires.
-        const ordering = comparePublicParamsPaths(caseP, caseFilter);
-        if (ordering === Ordering.StrictSuperset || ordering === Ordering.Unordered) {
-          continue;
-        }
-      }
-
-      yield [caseP, undefined];
+  *iterateCasesWithSubcases(): CaseSubcaseIterable<CaseP, {}> {
+    for (const a of this.cases()) {
+      yield [a, undefined];
     }
   }
 
   [Symbol.iterator](): Iterator<CaseP> {
-    return this.cases(null);
+    return this.cases();
   }
 
   /** @inheritDoc */
   expandWithParams<NewP extends {}>(
-    expander: (_: CaseP) => Iterable<NewP>
+    expander: (_: Merged<{}, CaseP>) => Iterable<NewP>
   ): CaseParamsBuilder<Merged<CaseP, NewP>> {
-    const baseGenerator = this.cases;
-    return new CaseParamsBuilder(function* (caseFilter) {
-      for (const a of baseGenerator(caseFilter)) {
-        for (const b of expander(a)) {
-          if (caseFilter) {
-            // If the expander generated any key-value pair that conflicts with caseFilter, skip.
-            if (Object.entries(b).some(([k, v]) => k in caseFilter && caseFilter[k] !== v)) {
-              continue;
-            }
-          }
-
-          yield mergeParamsChecked(a, b);
-        }
-      }
-    });
+    const newGenerator = genExpandWithParams(this.cases, expander);
+    return new CaseParamsBuilder(() => newGenerator({}));
   }
 
   /** @inheritDoc */
   expand<NewPKey extends string, NewPValue>(
     key: NewPKey,
-    expander: (_: CaseP) => Iterable<NewPValue>
+    expander: (_: Merged<{}, CaseP>) => Iterable<NewPValue>
   ): CaseParamsBuilder<Merged<CaseP, { [name in NewPKey]: NewPValue }>> {
-    const baseGenerator = this.cases;
-    return new CaseParamsBuilder(function* (caseFilter) {
-      for (const a of baseGenerator(caseFilter)) {
-        assert(!(key in a), `New key '${key}' already exists in ${JSON.stringify(a)}`);
-
-        const caseFilterV = caseFilter?.[key];
-        for (const v of expander(a)) {
-          // If the expander generated a value for this key that conflicts with caseFilter, skip.
-          if (caseFilter && (caseFilterV as {}) !== v) {
-            continue;
-          }
-          yield { ...a, [key]: v } as Merged<CaseP, { [name in NewPKey]: NewPValue }>;
-        }
-      }
-    });
+    const newGenerator = genExpand(this.cases, key, expander);
+    return new CaseParamsBuilder(() => newGenerator({}));
   }
 
   /** @inheritDoc */
@@ -232,17 +189,13 @@ export class CaseParamsBuilder<CaseP extends {}>
   }
 
   /** @inheritDoc */
-  filter(pred: (_: CaseP) => boolean): CaseParamsBuilder<CaseP> {
-    const baseGenerator = this.cases;
-    return new CaseParamsBuilder(function* (caseFilter) {
-      for (const a of baseGenerator(caseFilter)) {
-        if (pred(a)) yield a;
-      }
-    });
+  filter(pred: (_: Merged<{}, CaseP>) => boolean): CaseParamsBuilder<CaseP> {
+    const newGenerator = filterGenerator(this.cases, pred);
+    return new CaseParamsBuilder(() => newGenerator({}));
   }
 
   /** @inheritDoc */
-  unless(pred: (_: CaseP) => boolean): CaseParamsBuilder<CaseP> {
+  unless(pred: (_: Merged<{}, CaseP>) => boolean): CaseParamsBuilder<CaseP> {
     return this.filter(x => !pred(x));
   }
 
@@ -252,9 +205,12 @@ export class CaseParamsBuilder<CaseP extends {}>
    * generate new subcases instead of new cases.
    */
   beginSubcases(): SubcaseParamsBuilder<CaseP, {}> {
-    return new SubcaseParamsBuilder(this.cases, function* () {
-      yield {};
-    });
+    return new SubcaseParamsBuilder(
+      () => this.cases(),
+      function* () {
+        yield {};
+      }
+    );
   }
 }
 
@@ -279,25 +235,13 @@ export class SubcaseParamsBuilder<CaseP extends {}, SubcaseP extends {}>
   implements ParamsBuilder {
   protected readonly subcases: (_: CaseP) => Generator<SubcaseP>;
 
-  constructor(
-    cases: (caseFilter: TestParams | null) => Generator<CaseP>,
-    generator: (_: CaseP) => Generator<SubcaseP>
-  ) {
+  constructor(cases: () => Generator<CaseP>, generator: (_: CaseP) => Generator<SubcaseP>) {
     super(cases);
     this.subcases = generator;
   }
 
-  *iterateCasesWithSubcases(caseFilter: TestParams | null): CaseSubcaseIterable<CaseP, SubcaseP> {
-    for (const caseP of this.cases(caseFilter)) {
-      if (caseFilter) {
-        // this.cases() only filters out cases which conflict with caseFilter. Now that we have
-        // the final caseP, filter out cases which are missing keys that caseFilter requires.
-        const ordering = comparePublicParamsPaths(caseP, caseFilter);
-        if (ordering === Ordering.StrictSuperset || ordering === Ordering.Unordered) {
-          continue;
-        }
-      }
-
+  *iterateCasesWithSubcases(): CaseSubcaseIterable<CaseP, SubcaseP> {
+    for (const caseP of this.cases()) {
       const subcases = Array.from(this.subcases(caseP));
       if (subcases.length) {
         yield [caseP, subcases];
@@ -309,14 +253,7 @@ export class SubcaseParamsBuilder<CaseP extends {}, SubcaseP extends {}>
   expandWithParams<NewP extends {}>(
     expander: (_: Merged<CaseP, SubcaseP>) => Iterable<NewP>
   ): SubcaseParamsBuilder<CaseP, Merged<SubcaseP, NewP>> {
-    const baseGenerator = this.subcases;
-    return new SubcaseParamsBuilder(this.cases, function* (base) {
-      for (const a of baseGenerator(base)) {
-        for (const b of expander(mergeParams(base, a))) {
-          yield mergeParamsChecked(a, b);
-        }
-      }
-    });
+    return new SubcaseParamsBuilder(this.cases, genExpandWithParams(this.subcases, expander));
   }
 
   /** @inheritDoc */
@@ -324,17 +261,7 @@ export class SubcaseParamsBuilder<CaseP extends {}, SubcaseP extends {}>
     key: NewPKey,
     expander: (_: Merged<CaseP, SubcaseP>) => Iterable<NewPValue>
   ): SubcaseParamsBuilder<CaseP, Merged<SubcaseP, { [name in NewPKey]: NewPValue }>> {
-    const baseGenerator = this.subcases;
-    return new SubcaseParamsBuilder(this.cases, function* (base) {
-      for (const a of baseGenerator(base)) {
-        const before = mergeParams(base, a);
-        assert(!(key in before), () => `Key '${key}' already exists in ${JSON.stringify(before)}`);
-
-        for (const v of expander(before)) {
-          yield { ...a, [key]: v } as Merged<SubcaseP, { [k in NewPKey]: NewPValue }>;
-        }
-      }
-    });
+    return new SubcaseParamsBuilder(this.cases, genExpand(this.subcases, key, expander));
   }
 
   /** @inheritDoc */
@@ -356,18 +283,61 @@ export class SubcaseParamsBuilder<CaseP extends {}, SubcaseP extends {}>
 
   /** @inheritDoc */
   filter(pred: (_: Merged<CaseP, SubcaseP>) => boolean): SubcaseParamsBuilder<CaseP, SubcaseP> {
-    const baseGenerator = this.subcases;
-    return new SubcaseParamsBuilder(this.cases, function* (base) {
-      for (const a of baseGenerator(base)) {
-        if (pred(mergeParams(base, a))) yield a;
-      }
-    });
+    return new SubcaseParamsBuilder(this.cases, filterGenerator(this.subcases, pred));
   }
 
   /** @inheritDoc */
   unless(pred: (_: Merged<CaseP, SubcaseP>) => boolean): SubcaseParamsBuilder<CaseP, SubcaseP> {
     return this.filter(x => !pred(x));
   }
+}
+
+/** Creates a generator function for expandWithParams() methods above. */
+function genExpandWithParams<Base, A, B>(
+  baseGenerator: (_: Base) => Generator<A>,
+  expander: (_: Merged<Base, A>) => Iterable<B>
+): (_: Base) => Generator<Merged<A, B>> {
+  return function* (base: Base) {
+    for (const a of baseGenerator(base)) {
+      for (const b of expander(mergeParams(base, a))) {
+        const merged = mergeParams(a, b);
+        assertMergedWithoutOverlap([a, b], merged);
+
+        yield merged;
+      }
+    }
+  };
+}
+
+/** Creates a generator function for expand() methods above. */
+function genExpand<Base, A, NewPKey extends string, NewPValue>(
+  baseGenerator: (_: Base) => Generator<A>,
+  key: NewPKey,
+  expander: (_: Merged<Base, A>) => Iterable<NewPValue>
+): (_: Base) => Generator<Merged<A, { [k in NewPKey]: NewPValue }>> {
+  return function* (base: Base) {
+    for (const a of baseGenerator(base)) {
+      const before = mergeParams(base, a);
+      assert(!(key in before), () => `Key '${key}' already exists in ${JSON.stringify(before)}`);
+
+      for (const v of expander(before)) {
+        yield { ...a, [key]: v } as Merged<A, { [k in NewPKey]: NewPValue }>;
+      }
+    }
+  };
+}
+
+function filterGenerator<Base, A>(
+  baseGenerator: (_: Base) => Generator<A>,
+  pred: (_: Merged<Base, A>) => boolean
+): (_: Base) => Generator<A> {
+  return function* (base: Base) {
+    for (const a of baseGenerator(base)) {
+      if (pred(mergeParams(base, a))) {
+        yield a;
+      }
+    }
+  };
 }
 
 /** Assert an object is not a Generator (a thing returned from a generator function). */

--- a/src/common/internal/params_utils.ts
+++ b/src/common/internal/params_utils.ts
@@ -124,15 +124,10 @@ export function mergeParams<A extends {}, B extends {}>(a: A, b: B): Merged<A, B
   return { ...a, ...b } as Merged<A, B>;
 }
 
-/**
- * Merges two objects into one `{ ...a, ...b }` and asserts they had no overlapping keys.
- * This is slower than {@link mergeParams}.
- */
-export function mergeParamsChecked<A extends {}, B extends {}>(a: A, b: B): Merged<A, B> {
-  const merged = mergeParams(a, b);
+/** Asserts that the result of a mergeParams didn't have overlap. This is not extremely fast. */
+export function assertMergedWithoutOverlap([a, b]: [{}, {}], merged: {}): void {
   assert(
     Object.keys(merged).length === Object.keys(a).length + Object.keys(b).length,
     () => `Duplicate key between ${JSON.stringify(a)} and ${JSON.stringify(b)}`
   );
-  return merged;
 }

--- a/src/common/internal/tree.ts
+++ b/src/common/internal/tree.ts
@@ -4,7 +4,7 @@ import { assert, now } from '../util/util.js';
 
 import { TestFileLoader } from './file_loader.js';
 import { TestParamsRW } from './params_utils.js';
-import { comparePublicParamsPaths, compareQueries, Ordering } from './query/compare.js';
+import { compareQueries, Ordering } from './query/compare.js';
 import {
   TestQuery,
   TestQueryMultiCase,
@@ -350,26 +350,21 @@ export async function loadTreeForQuery(
       subtreeL2.subtreeCounts ??= { tests: 1, nodesWithTODO: 0 };
       if (t.description) setSubtreeDescriptionAndCountTODOs(subtreeL2, t.description);
 
-      let paramsFilter = null;
-      if ('params' in queryToLoad) {
-        paramsFilter = queryToLoad.params;
-      }
-
       // MAINTENANCE_TODO: If tree generation gets too slow, avoid actually iterating the cases in a
       // file if there's no need to (based on the subqueriesToExpand).
-      for (const c of t.iterate(paramsFilter)) {
-        // iterate() guarantees c's query is equal to or a subset of queryToLoad.
-
-        if (queryToLoad instanceof TestQuerySingleCase) {
-          // A subset is OK if it's TestQueryMultiCase, but for SingleCase it must match exactly.
-          const ordering = comparePublicParamsPaths(c.id.params, queryToLoad.params);
-          if (ordering !== Ordering.Equal) {
+      for (const c of t.iterate()) {
+        {
+          const queryL3 = new TestQuerySingleCase(suite, entry.file, c.id.test, c.id.params);
+          const orderingL3 = compareQueries(queryL3, queryToLoad);
+          if (orderingL3 === Ordering.Unordered || orderingL3 === Ordering.StrictSuperset) {
+            // Case is not matched by this query.
             continue;
           }
         }
 
         // Leaf for case is suite:a,b:c,d:x=1;y=2
         addLeafForCase(subtreeL2, c, isCollapsible);
+
         foundCase = true;
       }
     }

--- a/src/unittests/loaders_and_trees.spec.ts
+++ b/src/unittests/loaders_and_trees.spec.ts
@@ -209,7 +209,6 @@ g.test('case').fn(async t => {
   t.shouldReject('Error', t.load('suite1:baz:zed,:*'));
 
   t.shouldReject('Error', t.load('suite1:baz:zed:'));
-  t.shouldReject('Error', t.load('suite1:baz:zed:a=1'));
   t.shouldReject('Error', t.load('suite1:baz:zed:a=1;b=2*'));
   t.shouldReject('Error', t.load('suite1:baz:zed:a=1;b=2;'));
   t.shouldReject('SyntaxError', t.load('suite1:baz:zed:a=1;b=2,')); // tries to parse '2,' as JSON

--- a/src/unittests/params_builder_and_utils.spec.ts
+++ b/src/unittests/params_builder_and_utils.spec.ts
@@ -2,7 +2,6 @@ export const description = `
 Unit tests for parameterization helpers.
 `;
 
-import { TestParams } from '../common/framework/fixture.js';
 import {
   kUnitCaseParamsBuilder,
   CaseSubcaseIterable,
@@ -11,8 +10,8 @@ import {
 } from '../common/framework/params_builder.js';
 import { makeTestGroup } from '../common/framework/test_group.js';
 import {
+  assertMergedWithoutOverlap,
   mergeParams,
-  mergeParamsChecked,
   publicParamsEquals,
 } from '../common/internal/params_utils.js';
 import { assert, objectEquals } from '../common/util/util.js';
@@ -22,12 +21,12 @@ import { UnitTest } from './unit_test.js';
 class ParamsTest extends UnitTest {
   expectParams<CaseP, SubcaseP>(
     act: ParamsBuilderBase<CaseP, SubcaseP>,
-    exp: CaseSubcaseIterable<{}, {}>,
-    caseFilter: TestParams | null = null
+    exp: CaseSubcaseIterable<{}, {}>
   ): void {
-    const a = Array.from(
-      builderIterateCasesWithSubcases(act, caseFilter)
-    ).map(([caseP, subcases]) => [caseP, subcases ? Array.from(subcases) : undefined]);
+    const a = Array.from(builderIterateCasesWithSubcases(act)).map(([caseP, subcases]) => [
+      caseP,
+      subcases ? Array.from(subcases) : undefined,
+    ]);
     const e = Array.from(exp);
     this.expect(
       objectEquals(a, e),
@@ -48,20 +47,6 @@ g.test('combine').fn(t => {
     [{ hello: 2 }, undefined],
     [{ hello: 3 }, undefined],
   ]);
-  t.expectParams<{ hello: number }, {}>(
-    u.combine('hello', [1, 2, 3]),
-    [
-      [{ hello: 1 }, undefined],
-      [{ hello: 2 }, undefined],
-      [{ hello: 3 }, undefined],
-    ],
-    {}
-  );
-  t.expectParams<{ hello: number }, {}>(
-    u.combine('hello', [1, 2, 3]),
-    [[{ hello: 2 }, undefined]],
-    { hello: 2 }
-  );
   t.expectParams<{ hello: 1 | 2 | 3 }, {}>(u.combine('hello', [1, 2, 3] as const), [
     [{ hello: 1 }, undefined],
     [{ hello: 2 }, undefined],
@@ -70,14 +55,6 @@ g.test('combine').fn(t => {
   t.expectParams<{}, { hello: number }>(u.beginSubcases().combine('hello', [1, 2, 3]), [
     [{}, [{ hello: 1 }, { hello: 2 }, { hello: 3 }]],
   ]);
-  t.expectParams<{}, { hello: number }>(
-    u.beginSubcases().combine('hello', [1, 2, 3]),
-    [[{}, [{ hello: 1 }, { hello: 2 }, { hello: 3 }]]],
-    {}
-  );
-  t.expectParams<{}, { hello: number }>(u.beginSubcases().combine('hello', [1, 2, 3]), [], {
-    hello: 2,
-  });
   t.expectParams<{}, { hello: 1 | 2 | 3 }>(u.beginSubcases().combine('hello', [1, 2, 3] as const), [
     [{}, [{ hello: 1 }, { hello: 2 }, { hello: 3 }]],
   ]);
@@ -233,14 +210,6 @@ g.test('expandP').fn(t => {
       [{ w: 5 }, undefined],
     ]
   );
-  t.expectParams<{ z: number | undefined; w: number | undefined }, {}>(
-    u.expandWithParams(function* () {
-      yield* kUnitCaseParamsBuilder.combine('z', [3, 4]);
-      yield { w: 5 };
-    }),
-    [[{ z: 3 }, undefined]],
-    { z: 3 }
-  );
   t.expectParams<{}, { z: number | undefined; w: number | undefined }>(
     u.beginSubcases().expandWithParams(function* () {
       yield* kUnitCaseParamsBuilder.combine('z', [3, 4]);
@@ -250,8 +219,17 @@ g.test('expandP').fn(t => {
   );
 
   // more complex
-  {
-    const p = u
+  t.expectParams<
+    {
+      a: boolean;
+      x: number | undefined;
+      y: number | undefined;
+      z: number | undefined;
+      w: number | undefined;
+    },
+    {}
+  >(
+    u
       .combineWithParams([
         { a: true, x: 1 },
         { a: false, y: 2 },
@@ -263,39 +241,13 @@ g.test('expandP').fn(t => {
         } else {
           yield { w: 5 };
         }
-      });
-    type T = {
-      a: boolean;
-      x: number | undefined;
-      y: number | undefined;
-      z: number | undefined;
-      w: number | undefined;
-    };
-    t.expectParams<T, {}>(p, [
+      }),
+    [
       [{ a: true, x: 1, z: 3 }, undefined],
       [{ a: true, x: 1, z: 4 }, undefined],
       [{ a: false, y: 2, w: 5 }, undefined],
-    ]);
-    t.expectParams<T, {}>(
-      p,
-      [
-        [{ a: true, x: 1, z: 3 }, undefined],
-        [{ a: true, x: 1, z: 4 }, undefined],
-        [{ a: false, y: 2, w: 5 }, undefined],
-      ],
-      {}
-    );
-    t.expectParams<T, {}>(
-      p,
-      [
-        [{ a: true, x: 1, z: 3 }, undefined],
-        [{ a: true, x: 1, z: 4 }, undefined],
-      ],
-      { a: true }
-    );
-    t.expectParams<T, {}>(p, [[{ a: false, y: 2, w: 5 }, undefined]], { a: false });
-  }
-
+    ]
+  );
   t.expectParams<
     { a: boolean; x: number | undefined; y: number | undefined },
     { z: number | undefined; w: number | undefined }
@@ -402,7 +354,7 @@ g.test('invalid,shadowing').fn(t => {
       });
     // Iterating causes merging e.g. ({x:1}, {x:3}), which fails.
     t.shouldThrow('Error', () => {
-      Array.from(p.iterateCasesWithSubcases(null));
+      Array.from(p.iterateCasesWithSubcases());
     });
   }
   // Existing SubcaseP is shadowed by a new SubcaseP.
@@ -422,7 +374,7 @@ g.test('invalid,shadowing').fn(t => {
       });
     // Iterating causes merging e.g. ({x:1}, {x:3}), which fails.
     t.shouldThrow('Error', () => {
-      Array.from(p.iterateCasesWithSubcases(null));
+      Array.from(p.iterateCasesWithSubcases());
     });
   }
   // Existing CaseP is shadowed by a new SubcaseP.
@@ -440,19 +392,18 @@ g.test('invalid,shadowing').fn(t => {
           yield { w: 5 };
         }
       });
-    const cases = Array.from(p.iterateCasesWithSubcases(null));
+    const cases = Array.from(p.iterateCasesWithSubcases());
     // Iterating cases is fine...
     for (const [caseP, subcases] of cases) {
       assert(subcases !== undefined);
       // Iterating subcases is fine...
       for (const subcaseP of subcases) {
+        const merged = mergeParams(caseP, subcaseP);
         if (caseP.a) {
           assert(subcases !== undefined);
-
           // Only errors once we try to merge e.g. ({x:1}, {x:3}).
-          mergeParams(caseP, subcaseP);
           t.shouldThrow('Error', () => {
-            mergeParamsChecked(caseP, subcaseP);
+            assertMergedWithoutOverlap([caseP, subcaseP], merged);
           });
         }
       }

--- a/src/unittests/test_group_test.ts
+++ b/src/unittests/test_group_test.ts
@@ -9,7 +9,7 @@ export class TestGroupTest extends UnitTest {
   async run(g: IterableTestGroup): Promise<LogResults> {
     const logger = new Logger({ overrideDebugMode: true });
     for (const t of g.iterate()) {
-      for (const rc of t.iterate(null)) {
+      for (const rc of t.iterate()) {
         const query = new TestQuerySingleCase('xx', ['yy'], rc.id.test, rc.id.params);
         const [rec] = logger.record(query.toString());
         await rc.run(rec, query, []);
@@ -21,7 +21,7 @@ export class TestGroupTest extends UnitTest {
   expectCases(g: IterableTestGroup, cases: TestCaseID[]): void {
     const gcases = [];
     for (const t of g.iterate()) {
-      gcases.push(...Array.from(t.iterate(null), c => c.id));
+      gcases.push(...Array.from(t.iterate(), c => c.id));
     }
     this.expect(
       objectEquals(gcases, cases),


### PR DESCRIPTION
This reverts commit dd5eaefef03496b34d15cf24c19db2022b7c45d6.

It broke some queries, e.g.: https://gpuweb.github.io/cts/standalone/?q=webgpu:api,operation,memory_sync,buffer,multiple_buffers:rw:boundary=%22command-buffer%22;readOp=%22b2b-copy%22;readContext=%22command-encoder%22;writeOp=%22b2b-copy%22;writeContext=%22command-encoder%22



Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [ ] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [ ] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
