### PR TITLE
Reland "Optimize loadTreeForQuery by filtering eagerly in ParamsBuilder"

### DIFF
--- a/src/common/framework/params_builder.ts
+++ b/src/common/framework/params_builder.ts
@@ -194,11 +194,13 @@ export class CaseParamsBuilder<CaseP extends {}>
       for (const a of baseGenerator(caseFilter)) {
         assert(!(key in a), `New key '${key}' already exists in ${JSON.stringify(a)}`);
 
-        const caseFilterV = caseFilter?.[key];
         for (const v of expander(a)) {
           // If the expander generated a value for this key that conflicts with caseFilter, skip.
-          if (caseFilter && (caseFilterV as {}) !== v) {
-            continue;
+          if (caseFilter && key in caseFilter) {
+            // Cast through unknown to avoid having to constrain NewPValue throughout the call stack
+            if (caseFilter[key] !== (v as unknown)) {
+              continue;
+            }
           }
           yield { ...a, [key]: v } as Merged<CaseP, { [name in NewPKey]: NewPValue }>;
         }

--- a/src/common/internal/params_utils.ts
+++ b/src/common/internal/params_utils.ts
@@ -124,10 +124,15 @@ export function mergeParams<A extends {}, B extends {}>(a: A, b: B): Merged<A, B
   return { ...a, ...b } as Merged<A, B>;
 }
 
-/** Asserts that the result of a mergeParams didn't have overlap. This is not extremely fast. */
-export function assertMergedWithoutOverlap([a, b]: [{}, {}], merged: {}): void {
+/**
+ * Merges two objects into one `{ ...a, ...b }` and asserts they had no overlapping keys.
+ * This is slower than {@link mergeParams}.
+ */
+export function mergeParamsChecked<A extends {}, B extends {}>(a: A, b: B): Merged<A, B> {
+  const merged = mergeParams(a, b);
   assert(
     Object.keys(merged).length === Object.keys(a).length + Object.keys(b).length,
     () => `Duplicate key between ${JSON.stringify(a)} and ${JSON.stringify(b)}`
   );
+  return merged;
 }

--- a/src/common/internal/test_group.ts
+++ b/src/common/internal/test_group.ts
@@ -65,7 +65,7 @@ export interface IterableTest {
   testPath: string[];
   description: string | undefined;
   readonly testCreationStack: Error;
-  iterate(): Iterable<RunCase>;
+  iterate(caseFilter: TestParams | null): Iterable<RunCase>;
 }
 
 export function makeTestGroupForUnitTesting<F extends Fixture>(
@@ -280,7 +280,7 @@ class TestBuilder<S extends SubcaseBatchState, F extends Fixture> {
     }
 
     const seen = new Set<string>();
-    for (const [caseParams, subcases] of builderIterateCasesWithSubcases(this.testCases)) {
+    for (const [caseParams, subcases] of builderIterateCasesWithSubcases(this.testCases, null)) {
       for (const subcaseParams of subcases ?? [{}]) {
         const params = mergeParams(caseParams, subcaseParams);
         assert(this.batchSize === 0 || !('batch__' in params));
@@ -332,45 +332,37 @@ class TestBuilder<S extends SubcaseBatchState, F extends Fixture> {
     }
   }
 
-  *iterate(): IterableIterator<RunCase> {
+  private makeCaseSpecific(params: {}, subcases: Iterable<{}> | undefined) {
     assert(this.testFn !== undefined, 'No test function (.fn()) for test');
+    return new RunCaseSpecific(
+      this.testPath,
+      params,
+      this.isUnimplemented,
+      subcases,
+      this.fixture,
+      this.testFn,
+      this.beforeFn,
+      this.testCreationStack
+    );
+  }
+
+  *iterate(caseFilter: TestParams | null): IterableIterator<RunCase> {
     this.testCases ??= kUnitCaseParamsBuilder;
-    for (const [caseParams, subcases] of builderIterateCasesWithSubcases(this.testCases)) {
+    for (const [caseParams, subcases] of builderIterateCasesWithSubcases(
+      this.testCases,
+      caseFilter
+    )) {
       if (this.batchSize === 0 || subcases === undefined) {
-        yield new RunCaseSpecific(
-          this.testPath,
-          caseParams,
-          this.isUnimplemented,
-          subcases,
-          this.fixture,
-          this.testFn,
-          this.beforeFn,
-          this.testCreationStack
-        );
+        yield this.makeCaseSpecific(caseParams, subcases);
       } else {
         const subcaseArray = Array.from(subcases);
         if (subcaseArray.length <= this.batchSize) {
-          yield new RunCaseSpecific(
-            this.testPath,
-            caseParams,
-            this.isUnimplemented,
-            subcaseArray,
-            this.fixture,
-            this.testFn,
-            this.beforeFn,
-            this.testCreationStack
-          );
+          yield this.makeCaseSpecific(caseParams, subcaseArray);
         } else {
           for (let i = 0; i < subcaseArray.length; i = i + this.batchSize) {
-            yield new RunCaseSpecific(
-              this.testPath,
+            yield this.makeCaseSpecific(
               { ...caseParams, batch__: i / this.batchSize },
-              this.isUnimplemented,
-              subcaseArray.slice(i, Math.min(subcaseArray.length, i + this.batchSize)),
-              this.fixture,
-              this.testFn,
-              this.beforeFn,
-              this.testCreationStack
+              subcaseArray.slice(i, Math.min(subcaseArray.length, i + this.batchSize))
             );
           }
         }

--- a/src/common/internal/tree.ts
+++ b/src/common/internal/tree.ts
@@ -4,7 +4,7 @@ import { assert, now } from '../util/util.js';
 
 import { TestFileLoader } from './file_loader.js';
 import { TestParamsRW } from './params_utils.js';
-import { compareQueries, Ordering } from './query/compare.js';
+import { comparePublicParamsPaths, compareQueries, Ordering } from './query/compare.js';
 import {
   TestQuery,
   TestQueryMultiCase,
@@ -350,21 +350,26 @@ export async function loadTreeForQuery(
       subtreeL2.subtreeCounts ??= { tests: 1, nodesWithTODO: 0 };
       if (t.description) setSubtreeDescriptionAndCountTODOs(subtreeL2, t.description);
 
+      let paramsFilter = null;
+      if ('params' in queryToLoad) {
+        paramsFilter = queryToLoad.params;
+      }
+
       // MAINTENANCE_TODO: If tree generation gets too slow, avoid actually iterating the cases in a
       // file if there's no need to (based on the subqueriesToExpand).
-      for (const c of t.iterate()) {
-        {
-          const queryL3 = new TestQuerySingleCase(suite, entry.file, c.id.test, c.id.params);
-          const orderingL3 = compareQueries(queryL3, queryToLoad);
-          if (orderingL3 === Ordering.Unordered || orderingL3 === Ordering.StrictSuperset) {
-            // Case is not matched by this query.
+      for (const c of t.iterate(paramsFilter)) {
+        // iterate() guarantees c's query is equal to or a subset of queryToLoad.
+
+        if (queryToLoad instanceof TestQuerySingleCase) {
+          // A subset is OK if it's TestQueryMultiCase, but for SingleCase it must match exactly.
+          const ordering = comparePublicParamsPaths(c.id.params, queryToLoad.params);
+          if (ordering !== Ordering.Equal) {
             continue;
           }
         }
 
         // Leaf for case is suite:a,b:c,d:x=1;y=2
         addLeafForCase(subtreeL2, c, isCollapsible);
-
         foundCase = true;
       }
     }

--- a/src/unittests/loaders_and_trees.spec.ts
+++ b/src/unittests/loaders_and_trees.spec.ts
@@ -209,6 +209,7 @@ g.test('case').fn(async t => {
   t.shouldReject('Error', t.load('suite1:baz:zed,:*'));
 
   t.shouldReject('Error', t.load('suite1:baz:zed:'));
+  t.shouldReject('Error', t.load('suite1:baz:zed:a=1'));
   t.shouldReject('Error', t.load('suite1:baz:zed:a=1;b=2*'));
   t.shouldReject('Error', t.load('suite1:baz:zed:a=1;b=2;'));
   t.shouldReject('SyntaxError', t.load('suite1:baz:zed:a=1;b=2,')); // tries to parse '2,' as JSON

--- a/src/unittests/params_builder_and_utils.spec.ts
+++ b/src/unittests/params_builder_and_utils.spec.ts
@@ -238,6 +238,26 @@ g.test('expandP').fn(t => {
       yield* kUnitCaseParamsBuilder.combine('z', [3, 4]);
       yield { w: 5 };
     }),
+    [
+      [{ z: 3 }, undefined],
+      [{ z: 4 }, undefined],
+      [{ w: 5 }, undefined],
+    ],
+    {}
+  );
+  t.expectParams<{ z: number | undefined; w: number | undefined }, {}>(
+    u.expandWithParams(function* () {
+      yield* kUnitCaseParamsBuilder.combine('z', [3, 4]);
+      yield { w: 5 };
+    }),
+    [[{ z: 4 }, undefined]],
+    { z: 4 }
+  );
+  t.expectParams<{ z: number | undefined; w: number | undefined }, {}>(
+    u.expandWithParams(function* () {
+      yield* kUnitCaseParamsBuilder.combine('z', [3, 4]);
+      yield { w: 5 };
+    }),
     [[{ z: 3 }, undefined]],
     { z: 3 }
   );
@@ -336,6 +356,25 @@ g.test('expand').fn(t => {
       [{ z: 3 }, undefined],
       [{ z: 4 }, undefined],
     ]
+  );
+  t.expectParams<{ z: number }, {}>(
+    u.expand('z', function* () {
+      yield 3;
+      yield 4;
+    }),
+    [
+      [{ z: 3 }, undefined],
+      [{ z: 4 }, undefined],
+    ],
+    {}
+  );
+  t.expectParams<{ z: number }, {}>(
+    u.expand('z', function* () {
+      yield 3;
+      yield 4;
+    }),
+    [[{ z: 3 }, undefined]],
+    { z: 3 }
   );
   t.expectParams<{}, { z: number }>(
     u.beginSubcases().expand('z', function* () {

--- a/src/unittests/params_builder_and_utils.spec.ts
+++ b/src/unittests/params_builder_and_utils.spec.ts
@@ -2,6 +2,7 @@ export const description = `
 Unit tests for parameterization helpers.
 `;
 
+import { TestParams } from '../common/framework/fixture.js';
 import {
   kUnitCaseParamsBuilder,
   CaseSubcaseIterable,
@@ -10,8 +11,8 @@ import {
 } from '../common/framework/params_builder.js';
 import { makeTestGroup } from '../common/framework/test_group.js';
 import {
-  assertMergedWithoutOverlap,
   mergeParams,
+  mergeParamsChecked,
   publicParamsEquals,
 } from '../common/internal/params_utils.js';
 import { assert, objectEquals } from '../common/util/util.js';
@@ -21,12 +22,12 @@ import { UnitTest } from './unit_test.js';
 class ParamsTest extends UnitTest {
   expectParams<CaseP, SubcaseP>(
     act: ParamsBuilderBase<CaseP, SubcaseP>,
-    exp: CaseSubcaseIterable<{}, {}>
+    exp: CaseSubcaseIterable<{}, {}>,
+    caseFilter: TestParams | null = null
   ): void {
-    const a = Array.from(builderIterateCasesWithSubcases(act)).map(([caseP, subcases]) => [
-      caseP,
-      subcases ? Array.from(subcases) : undefined,
-    ]);
+    const a = Array.from(
+      builderIterateCasesWithSubcases(act, caseFilter)
+    ).map(([caseP, subcases]) => [caseP, subcases ? Array.from(subcases) : undefined]);
     const e = Array.from(exp);
     this.expect(
       objectEquals(a, e),
@@ -47,6 +48,20 @@ g.test('combine').fn(t => {
     [{ hello: 2 }, undefined],
     [{ hello: 3 }, undefined],
   ]);
+  t.expectParams<{ hello: number }, {}>(
+    u.combine('hello', [1, 2, 3]),
+    [
+      [{ hello: 1 }, undefined],
+      [{ hello: 2 }, undefined],
+      [{ hello: 3 }, undefined],
+    ],
+    {}
+  );
+  t.expectParams<{ hello: number }, {}>(
+    u.combine('hello', [1, 2, 3]),
+    [[{ hello: 2 }, undefined]],
+    { hello: 2 }
+  );
   t.expectParams<{ hello: 1 | 2 | 3 }, {}>(u.combine('hello', [1, 2, 3] as const), [
     [{ hello: 1 }, undefined],
     [{ hello: 2 }, undefined],
@@ -55,6 +70,14 @@ g.test('combine').fn(t => {
   t.expectParams<{}, { hello: number }>(u.beginSubcases().combine('hello', [1, 2, 3]), [
     [{}, [{ hello: 1 }, { hello: 2 }, { hello: 3 }]],
   ]);
+  t.expectParams<{}, { hello: number }>(
+    u.beginSubcases().combine('hello', [1, 2, 3]),
+    [[{}, [{ hello: 1 }, { hello: 2 }, { hello: 3 }]]],
+    {}
+  );
+  t.expectParams<{}, { hello: number }>(u.beginSubcases().combine('hello', [1, 2, 3]), [], {
+    hello: 2,
+  });
   t.expectParams<{}, { hello: 1 | 2 | 3 }>(u.beginSubcases().combine('hello', [1, 2, 3] as const), [
     [{}, [{ hello: 1 }, { hello: 2 }, { hello: 3 }]],
   ]);
@@ -210,6 +233,14 @@ g.test('expandP').fn(t => {
       [{ w: 5 }, undefined],
     ]
   );
+  t.expectParams<{ z: number | undefined; w: number | undefined }, {}>(
+    u.expandWithParams(function* () {
+      yield* kUnitCaseParamsBuilder.combine('z', [3, 4]);
+      yield { w: 5 };
+    }),
+    [[{ z: 3 }, undefined]],
+    { z: 3 }
+  );
   t.expectParams<{}, { z: number | undefined; w: number | undefined }>(
     u.beginSubcases().expandWithParams(function* () {
       yield* kUnitCaseParamsBuilder.combine('z', [3, 4]);
@@ -219,17 +250,8 @@ g.test('expandP').fn(t => {
   );
 
   // more complex
-  t.expectParams<
-    {
-      a: boolean;
-      x: number | undefined;
-      y: number | undefined;
-      z: number | undefined;
-      w: number | undefined;
-    },
-    {}
-  >(
-    u
+  {
+    const p = u
       .combineWithParams([
         { a: true, x: 1 },
         { a: false, y: 2 },
@@ -241,13 +263,39 @@ g.test('expandP').fn(t => {
         } else {
           yield { w: 5 };
         }
-      }),
-    [
+      });
+    type T = {
+      a: boolean;
+      x: number | undefined;
+      y: number | undefined;
+      z: number | undefined;
+      w: number | undefined;
+    };
+    t.expectParams<T, {}>(p, [
       [{ a: true, x: 1, z: 3 }, undefined],
       [{ a: true, x: 1, z: 4 }, undefined],
       [{ a: false, y: 2, w: 5 }, undefined],
-    ]
-  );
+    ]);
+    t.expectParams<T, {}>(
+      p,
+      [
+        [{ a: true, x: 1, z: 3 }, undefined],
+        [{ a: true, x: 1, z: 4 }, undefined],
+        [{ a: false, y: 2, w: 5 }, undefined],
+      ],
+      {}
+    );
+    t.expectParams<T, {}>(
+      p,
+      [
+        [{ a: true, x: 1, z: 3 }, undefined],
+        [{ a: true, x: 1, z: 4 }, undefined],
+      ],
+      { a: true }
+    );
+    t.expectParams<T, {}>(p, [[{ a: false, y: 2, w: 5 }, undefined]], { a: false });
+  }
+
   t.expectParams<
     { a: boolean; x: number | undefined; y: number | undefined },
     { z: number | undefined; w: number | undefined }
@@ -354,7 +402,7 @@ g.test('invalid,shadowing').fn(t => {
       });
     // Iterating causes merging e.g. ({x:1}, {x:3}), which fails.
     t.shouldThrow('Error', () => {
-      Array.from(p.iterateCasesWithSubcases());
+      Array.from(p.iterateCasesWithSubcases(null));
     });
   }
   // Existing SubcaseP is shadowed by a new SubcaseP.
@@ -374,7 +422,7 @@ g.test('invalid,shadowing').fn(t => {
       });
     // Iterating causes merging e.g. ({x:1}, {x:3}), which fails.
     t.shouldThrow('Error', () => {
-      Array.from(p.iterateCasesWithSubcases());
+      Array.from(p.iterateCasesWithSubcases(null));
     });
   }
   // Existing CaseP is shadowed by a new SubcaseP.
@@ -392,18 +440,19 @@ g.test('invalid,shadowing').fn(t => {
           yield { w: 5 };
         }
       });
-    const cases = Array.from(p.iterateCasesWithSubcases());
+    const cases = Array.from(p.iterateCasesWithSubcases(null));
     // Iterating cases is fine...
     for (const [caseP, subcases] of cases) {
       assert(subcases !== undefined);
       // Iterating subcases is fine...
       for (const subcaseP of subcases) {
-        const merged = mergeParams(caseP, subcaseP);
         if (caseP.a) {
           assert(subcases !== undefined);
+
           // Only errors once we try to merge e.g. ({x:1}, {x:3}).
+          mergeParams(caseP, subcaseP);
           t.shouldThrow('Error', () => {
-            assertMergedWithoutOverlap([caseP, subcaseP], merged);
+            mergeParamsChecked(caseP, subcaseP);
           });
         }
       }

--- a/src/unittests/test_group_test.ts
+++ b/src/unittests/test_group_test.ts
@@ -9,7 +9,7 @@ export class TestGroupTest extends UnitTest {
   async run(g: IterableTestGroup): Promise<LogResults> {
     const logger = new Logger({ overrideDebugMode: true });
     for (const t of g.iterate()) {
-      for (const rc of t.iterate()) {
+      for (const rc of t.iterate(null)) {
         const query = new TestQuerySingleCase('xx', ['yy'], rc.id.test, rc.id.params);
         const [rec] = logger.record(query.toString());
         await rc.run(rec, query, []);
@@ -21,7 +21,7 @@ export class TestGroupTest extends UnitTest {
   expectCases(g: IterableTestGroup, cases: TestCaseID[]): void {
     const gcases = [];
     for (const t of g.iterate()) {
-      gcases.push(...Array.from(t.iterate(), c => c.id));
+      gcases.push(...Array.from(t.iterate(null), c => c.id));
     }
     this.expect(
       objectEquals(gcases, cases),


### PR DESCRIPTION
First commit is a clean reland:
> Revert "Revert "Optimize loadTreeForQuery by filtering eagerly in ParamsBuilder (#2890)" (#2900)"
> This reverts commit https://github.com/gpuweb/cts/commit/d2d4ab2cfaabd01982c2445277350efa3b7f437b.

Second commit is the bugfix for that change.