### PR TITLE
Remove TODO about f32(-0.0) printing as '-0.0f'

### DIFF
--- a/src/unittests/conversion.spec.ts
+++ b/src/unittests/conversion.spec.ts
@@ -193,9 +193,11 @@ g.test('floatBitsToULPFromZero,32').fn(t => {
 g.test('scalarWGSL').fn(t => {
   const cases: Array<[Scalar, string]> = [
     [f32(0.0), '0.0f'],
-    // f32(-0.0) should map to '-0.0f'
-    // Tracked by https://github.com/gpuweb/cts/issues/2901
-    [f32(-0.0), '0.0f'],
+    // The number -0.0 can be remapped to 0.0 when stored in a Scalar
+    // object. It is not possible to guarantee that '-0.0f' will
+    // be emitted. So the WGSL scalar value printing does not try
+    // to handle this case.
+    [f32(-0.0), '0.0f'], // -0.0 can be remapped to 0.0
     [f32(1.0), '1.0f'],
     [f32(-1.0), '-1.0f'],
     [f32Bits(0x70000000), '1.5845632502852868e+29f'],


### PR DESCRIPTION
It's not guaranteed that the -0.0 value will survive once it is stored in a Scalar object

Issue: #2901




<hr>

**Requirements for PR author:**

- [ ] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [ ] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
