### PR TITLE
Add support for structs to framework and use for modf

### DIFF
--- a/src/unittests/floating_point.spec.ts
+++ b/src/unittests/floating_point.spec.ts
@@ -5,7 +5,13 @@ Floating Point unit tests.
 import { makeTestGroup } from '../common/framework/test_group.js';
 import { objectEquals, unreachable } from '../common/util/util.js';
 import { kValue } from '../webgpu/util/constants.js';
-import { FP, FPInterval, FPIntervalParam, IntervalBounds } from '../webgpu/util/floating_point.js';
+import {
+  FP,
+  FPInterval,
+  FPIntervalParam,
+  FPStruct,
+  IntervalBounds,
+} from '../webgpu/util/floating_point.js';
 import {
   reinterpretU16AsF16,
   reinterpretU32AsF32,
@@ -7081,15 +7087,15 @@ g.test('modfInterval_f32')
     ]
   )
   .fn(t => {
-    const expected = {
-      fract: FP.f32.toInterval(t.params.fract),
-      whole: FP.f32.toInterval(t.params.whole),
-    };
+    const expected = new FPStruct(
+      FP.f32.toInterval(t.params.fract),
+      FP.f32.toInterval(t.params.whole)
+    );
 
     const got = FP.f32.modfInterval(t.params.input);
     t.expect(
       objectEquals(expected, got),
-      `f32.modfInterval([${t.params.input}) returned { fract: [${got.fract}], whole: [${got.whole}] }. Expected { fract: [${expected.fract}], whole: [${expected.whole}] }`
+      `f32.modfInterval([${t.params.input}) returned { fract: [${got.elements[0]}], whole: [${got.elements[1]}] }. Expected { fract: [${expected.elements[0]}], whole: [${expected.elements[1]}] }`
     );
   });
 

--- a/src/webgpu/shader/validation/expression/call/builtin/abs.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/abs.spec.ts
@@ -7,7 +7,7 @@ import { makeTestGroup } from '../../../../../../common/framework/test_group.js'
 import { keysOf, objectsToRecord } from '../../../../../../common/util/data_tables.js';
 import {
   TypeF16,
-  elementType,
+  elementScalarType,
   kAllFloatAndIntegerScalarsAndVectors,
 } from '../../../../../util/conversion.js';
 import { ShaderValidationTest } from '../../../shader_validation_test.js';
@@ -38,7 +38,7 @@ Validates that constant evaluation and override evaluation of ${builtin}() never
       .expand('value', u => fullRangeForType(kValuesTypes[u.type]))
   )
   .beforeAllSubcases(t => {
-    if (elementType(kValuesTypes[t.params.type]) === TypeF16) {
+    if (elementScalarType(kValuesTypes[t.params.type]) === TypeF16) {
       t.selectDeviceOrSkipTestCase('shader-f16');
     }
   })

--- a/src/webgpu/shader/validation/expression/call/builtin/acos.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/acos.spec.ts
@@ -8,7 +8,7 @@ import { keysOf, objectsToRecord } from '../../../../../../common/util/data_tabl
 import {
   TypeF16,
   TypeF32,
-  elementType,
+  elementScalarType,
   kAllFloatScalarsAndVectors,
   kAllIntegerScalarsAndVectors,
 } from '../../../../../util/conversion.js';
@@ -42,7 +42,7 @@ Validates that constant evaluation and override evaluation of ${builtin}() rejec
       .expand('value', u => unique(kMinusTwoToTwo, fullRangeForType(kValuesTypes[u.type])))
   )
   .beforeAllSubcases(t => {
-    if (elementType(kValuesTypes[t.params.type]) === TypeF16) {
+    if (elementScalarType(kValuesTypes[t.params.type]) === TypeF16) {
       t.selectDeviceOrSkipTestCase('shader-f16');
     }
   })

--- a/src/webgpu/shader/validation/expression/call/builtin/acosh.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/acosh.spec.ts
@@ -8,7 +8,7 @@ import { keysOf, objectsToRecord } from '../../../../../../common/util/data_tabl
 import {
   TypeF16,
   TypeF32,
-  elementType,
+  elementScalarType,
   kAllFloatScalarsAndVectors,
   kAllIntegerScalarsAndVectors,
 } from '../../../../../util/conversion.js';
@@ -43,13 +43,13 @@ Validates that constant evaluation and override evaluation of ${builtin}() rejec
       .expand('value', u => unique(fullRangeForType(kValuesTypes[u.type]), kMinusTwoToTwo))
   )
   .beforeAllSubcases(t => {
-    if (elementType(kValuesTypes[t.params.type]) === TypeF16) {
+    if (elementScalarType(kValuesTypes[t.params.type]) === TypeF16) {
       t.selectDeviceOrSkipTestCase('shader-f16');
     }
   })
   .fn(t => {
     const type = kValuesTypes[t.params.type];
-    const expectedResult = isRepresentable(Math.acosh(t.params.value), elementType(type));
+    const expectedResult = isRepresentable(Math.acosh(t.params.value), elementScalarType(type));
     validateConstOrOverrideBuiltinEval(
       t,
       builtin,

--- a/src/webgpu/shader/validation/expression/call/builtin/asin.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/asin.spec.ts
@@ -8,7 +8,7 @@ import { keysOf, objectsToRecord } from '../../../../../../common/util/data_tabl
 import {
   TypeF16,
   TypeF32,
-  elementType,
+  elementScalarType,
   kAllFloatScalarsAndVectors,
   kAllIntegerScalarsAndVectors,
 } from '../../../../../util/conversion.js';
@@ -42,7 +42,7 @@ Validates that constant evaluation and override evaluation of ${builtin}() rejec
       .expand('value', u => unique(kMinusTwoToTwo, fullRangeForType(kValuesTypes[u.type])))
   )
   .beforeAllSubcases(t => {
-    if (elementType(kValuesTypes[t.params.type]) === TypeF16) {
+    if (elementScalarType(kValuesTypes[t.params.type]) === TypeF16) {
       t.selectDeviceOrSkipTestCase('shader-f16');
     }
   })

--- a/src/webgpu/shader/validation/expression/call/builtin/asinh.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/asinh.spec.ts
@@ -8,7 +8,7 @@ import { keysOf, objectsToRecord } from '../../../../../../common/util/data_tabl
 import {
   TypeF16,
   TypeF32,
-  elementType,
+  elementScalarType,
   kAllFloatScalarsAndVectors,
   kAllIntegerScalarsAndVectors,
 } from '../../../../../util/conversion.js';
@@ -45,13 +45,13 @@ Validates that constant evaluation and override evaluation of ${builtin}() rejec
       )
   )
   .beforeAllSubcases(t => {
-    if (elementType(kValuesTypes[t.params.type]) === TypeF16) {
+    if (elementScalarType(kValuesTypes[t.params.type]) === TypeF16) {
       t.selectDeviceOrSkipTestCase('shader-f16');
     }
   })
   .fn(t => {
     const type = kValuesTypes[t.params.type];
-    const expectedResult = isRepresentable(Math.asinh(t.params.value), elementType(type));
+    const expectedResult = isRepresentable(Math.asinh(t.params.value), elementScalarType(type));
     validateConstOrOverrideBuiltinEval(
       t,
       builtin,

--- a/src/webgpu/shader/validation/expression/call/builtin/atan.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/atan.spec.ts
@@ -8,7 +8,7 @@ import { keysOf, objectsToRecord } from '../../../../../../common/util/data_tabl
 import {
   TypeF16,
   TypeF32,
-  elementType,
+  elementScalarType,
   kAllFloatScalarsAndVectors,
   kAllIntegerScalarsAndVectors,
 } from '../../../../../util/conversion.js';
@@ -43,13 +43,13 @@ Validates that constant evaluation and override evaluation of ${builtin}() rejec
       .expand('value', u => unique(kMinus3PiTo3Pi, fullRangeForType(kValuesTypes[u.type])))
   )
   .beforeAllSubcases(t => {
-    if (elementType(kValuesTypes[t.params.type]) === TypeF16) {
+    if (elementScalarType(kValuesTypes[t.params.type]) === TypeF16) {
       t.selectDeviceOrSkipTestCase('shader-f16');
     }
   })
   .fn(t => {
     const type = kValuesTypes[t.params.type];
-    const smallestPositive = fpTraitsFor(elementType(type)).constants().positive.min;
+    const smallestPositive = fpTraitsFor(elementScalarType(type)).constants().positive.min;
     const expectedResult = Math.abs(Math.cos(t.params.value)) > smallestPositive;
     validateConstOrOverrideBuiltinEval(
       t,

--- a/src/webgpu/shader/validation/expression/call/builtin/atan2.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/atan2.spec.ts
@@ -10,7 +10,7 @@ import {
   TypeF32,
   Vector,
   VectorType,
-  elementType,
+  elementScalarType,
   kAllFloatScalarsAndVectors,
   kAllIntegerScalarsAndVectors,
 } from '../../../../../util/conversion.js';
@@ -46,7 +46,7 @@ Validates that constant evaluation and override evaluation of ${builtin}() rejec
       .expand('x', u => unique(kMinus3PiTo3Pi, fullRangeForType(kValuesTypes[u.type], 4)))
   )
   .beforeAllSubcases(t => {
-    if (elementType(kValuesTypes[t.params.type]) === TypeF16) {
+    if (elementScalarType(kValuesTypes[t.params.type]) === TypeF16) {
       t.selectDeviceOrSkipTestCase('shader-f16');
     }
   })
@@ -54,7 +54,7 @@ Validates that constant evaluation and override evaluation of ${builtin}() rejec
     const type = kValuesTypes[t.params.type];
     const expectedResult = isRepresentable(
       Math.abs(Math.atan2(t.params.y, t.params.x)),
-      elementType(type)
+      elementScalarType(type)
     );
     validateConstOrOverrideBuiltinEval(
       t,

--- a/src/webgpu/shader/validation/expression/call/builtin/atanh.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/atanh.spec.ts
@@ -8,7 +8,7 @@ import { keysOf, objectsToRecord } from '../../../../../../common/util/data_tabl
 import {
   TypeF16,
   TypeF32,
-  elementType,
+  elementScalarType,
   kAllFloatScalarsAndVectors,
   kAllIntegerScalarsAndVectors,
 } from '../../../../../util/conversion.js';
@@ -42,7 +42,7 @@ Validates that constant evaluation and override evaluation of ${builtin}() rejec
       .expand('value', u => unique(kMinusTwoToTwo, fullRangeForType(kValuesTypes[u.type])))
   )
   .beforeAllSubcases(t => {
-    if (elementType(kValuesTypes[t.params.type]) === TypeF16) {
+    if (elementScalarType(kValuesTypes[t.params.type]) === TypeF16) {
       t.selectDeviceOrSkipTestCase('shader-f16');
     }
   })

--- a/src/webgpu/shader/validation/expression/call/builtin/ceil.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/ceil.spec.ts
@@ -8,7 +8,7 @@ import { keysOf, objectsToRecord } from '../../../../../../common/util/data_tabl
 import {
   TypeF16,
   TypeF32,
-  elementType,
+  elementScalarType,
   kAllFloatScalarsAndVectors,
   kAllIntegerScalarsAndVectors,
 } from '../../../../../util/conversion.js';
@@ -39,7 +39,7 @@ Validates that constant evaluation and override evaluation of ${builtin}() never
       .expand('value', u => fullRangeForType(kValuesTypes[u.type]))
   )
   .beforeAllSubcases(t => {
-    if (elementType(kValuesTypes[t.params.type]) === TypeF16) {
+    if (elementScalarType(kValuesTypes[t.params.type]) === TypeF16) {
       t.selectDeviceOrSkipTestCase('shader-f16');
     }
   })

--- a/src/webgpu/shader/validation/expression/call/builtin/clamp.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/clamp.spec.ts
@@ -7,7 +7,7 @@ import { makeTestGroup } from '../../../../../../common/framework/test_group.js'
 import { keysOf, objectsToRecord } from '../../../../../../common/util/data_tables.js';
 import {
   TypeF16,
-  elementType,
+  elementScalarType,
   kAllFloatAndIntegerScalarsAndVectors,
 } from '../../../../../util/conversion.js';
 import { ShaderValidationTest } from '../../../shader_validation_test.js';
@@ -40,7 +40,7 @@ Validates that constant evaluation and override evaluation of ${builtin}() rejec
       .expand('high', u => fullRangeForType(kValuesTypes[u.type], 4))
   )
   .beforeAllSubcases(t => {
-    if (elementType(kValuesTypes[t.params.type]) === TypeF16) {
+    if (elementScalarType(kValuesTypes[t.params.type]) === TypeF16) {
       t.selectDeviceOrSkipTestCase('shader-f16');
     }
   })

--- a/src/webgpu/shader/validation/expression/call/builtin/const_override_validation.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/const_override_validation.ts
@@ -4,7 +4,7 @@ import {
   Type,
   TypeF16,
   Value,
-  elementType,
+  elementScalarType,
   elementsOf,
   isAbstractType,
 } from '../../../../../util/conversion.js';
@@ -76,7 +76,7 @@ export type ConstantOrOverrideStage = 'constant' | 'override';
  * @returns true if evaluation stage @p stage supports expressions of type @p.
  */
 export function stageSupportsType(stage: ConstantOrOverrideStage, type: Type) {
-  if (stage === 'override' && isAbstractType(elementType(type)!)) {
+  if (stage === 'override' && isAbstractType(elementScalarType(type)!)) {
     // Abstract numerics are concretized before being used in an override expression.
     return false;
   }
@@ -99,7 +99,7 @@ export function validateConstOrOverrideBuiltinEval(
   args: Value[],
   stage: ConstantOrOverrideStage
 ) {
-  const elTys = args.map(arg => elementType(arg.type)!);
+  const elTys = args.map(arg => elementScalarType(arg.type)!);
   const enables = elTys.some(ty => ty === TypeF16) ? 'enable f16;' : '';
 
   switch (stage) {
@@ -145,7 +145,7 @@ export function fullRangeForType(type: Type, count?: number) {
   if (count === undefined) {
     count = 25;
   }
-  switch (elementType(type)?.kind) {
+  switch (elementScalarType(type)?.kind) {
     case 'abstract-float':
       return fullF64Range({
         pos_sub: Math.ceil((count * 1) / 5),

--- a/src/webgpu/shader/validation/expression/call/builtin/cos.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/cos.spec.ts
@@ -8,7 +8,7 @@ import { keysOf, objectsToRecord } from '../../../../../../common/util/data_tabl
 import {
   TypeF16,
   TypeF32,
-  elementType,
+  elementScalarType,
   kAllFloatScalarsAndVectors,
   kAllIntegerScalarsAndVectors,
 } from '../../../../../util/conversion.js';
@@ -42,7 +42,7 @@ Validates that constant evaluation and override evaluation of ${builtin}() rejec
       .expand('value', u => unique(kMinus3PiTo3Pi, fullRangeForType(kValuesTypes[u.type])))
   )
   .beforeAllSubcases(t => {
-    if (elementType(kValuesTypes[t.params.type]) === TypeF16) {
+    if (elementScalarType(kValuesTypes[t.params.type]) === TypeF16) {
       t.selectDeviceOrSkipTestCase('shader-f16');
     }
   })

--- a/src/webgpu/shader/validation/expression/call/builtin/cosh.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/cosh.spec.ts
@@ -8,7 +8,7 @@ import { keysOf, objectsToRecord } from '../../../../../../common/util/data_tabl
 import {
   TypeF16,
   TypeF32,
-  elementType,
+  elementScalarType,
   kAllFloatScalarsAndVectors,
   kAllIntegerScalarsAndVectors,
 } from '../../../../../util/conversion.js';
@@ -41,13 +41,13 @@ Validates that constant evaluation and override evaluation of ${builtin}() rejec
       .expand('value', u => fullRangeForType(kValuesTypes[u.type]))
   )
   .beforeAllSubcases(t => {
-    if (elementType(kValuesTypes[t.params.type]) === TypeF16) {
+    if (elementScalarType(kValuesTypes[t.params.type]) === TypeF16) {
       t.selectDeviceOrSkipTestCase('shader-f16');
     }
   })
   .fn(t => {
     const type = kValuesTypes[t.params.type];
-    const expectedResult = isRepresentable(Math.cosh(t.params.value), elementType(type));
+    const expectedResult = isRepresentable(Math.cosh(t.params.value), elementScalarType(type));
     validateConstOrOverrideBuiltinEval(
       t,
       builtin,

--- a/src/webgpu/shader/validation/expression/call/builtin/degrees.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/degrees.spec.ts
@@ -8,7 +8,7 @@ import { keysOf, objectsToRecord } from '../../../../../../common/util/data_tabl
 import {
   TypeF16,
   TypeF32,
-  elementType,
+  elementScalarType,
   kAllFloatScalarsAndVectors,
   kAllIntegerScalarsAndVectors,
 } from '../../../../../util/conversion.js';
@@ -41,13 +41,16 @@ Validates that constant evaluation and override evaluation of ${builtin}() input
       .expand('value', u => fullRangeForType(kValuesTypes[u.type]))
   )
   .beforeAllSubcases(t => {
-    if (elementType(kValuesTypes[t.params.type]) === TypeF16) {
+    if (elementScalarType(kValuesTypes[t.params.type]) === TypeF16) {
       t.selectDeviceOrSkipTestCase('shader-f16');
     }
   })
   .fn(t => {
     const type = kValuesTypes[t.params.type];
-    const expectedResult = isRepresentable((t.params.value * 180) / Math.PI, elementType(type));
+    const expectedResult = isRepresentable(
+      (t.params.value * 180) / Math.PI,
+      elementScalarType(type)
+    );
     validateConstOrOverrideBuiltinEval(
       t,
       builtin,

--- a/src/webgpu/shader/validation/expression/call/builtin/exp.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/exp.spec.ts
@@ -9,7 +9,7 @@ import { kValue } from '../../../../../util/constants.js';
 import {
   TypeF16,
   TypeF32,
-  elementType,
+  elementScalarType,
   kAllFloatScalarsAndVectors,
   kAllIntegerScalarsAndVectors,
 } from '../../../../../util/conversion.js';
@@ -65,13 +65,13 @@ Validates that constant evaluation and override evaluation of ${builtin}() rejec
       ])
   )
   .beforeAllSubcases(t => {
-    if (elementType(kValuesTypes[t.params.type]) === TypeF16) {
+    if (elementScalarType(kValuesTypes[t.params.type]) === TypeF16) {
       t.selectDeviceOrSkipTestCase('shader-f16');
     }
   })
   .fn(t => {
     const type = kValuesTypes[t.params.type];
-    const expectedResult = isRepresentable(Math.exp(t.params.value), elementType(type));
+    const expectedResult = isRepresentable(Math.exp(t.params.value), elementScalarType(type));
     validateConstOrOverrideBuiltinEval(
       t,
       builtin,

--- a/src/webgpu/shader/validation/expression/call/builtin/exp2.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/exp2.spec.ts
@@ -9,7 +9,7 @@ import { kValue } from '../../../../../util/constants.js';
 import {
   TypeF16,
   TypeF32,
-  elementType,
+  elementScalarType,
   kAllFloatScalarsAndVectors,
   kAllIntegerScalarsAndVectors,
 } from '../../../../../util/conversion.js';
@@ -65,13 +65,13 @@ Validates that constant evaluation and override evaluation of ${builtin}() rejec
       ])
   )
   .beforeAllSubcases(t => {
-    if (elementType(kValuesTypes[t.params.type]) === TypeF16) {
+    if (elementScalarType(kValuesTypes[t.params.type]) === TypeF16) {
       t.selectDeviceOrSkipTestCase('shader-f16');
     }
   })
   .fn(t => {
     const type = kValuesTypes[t.params.type];
-    const expectedResult = isRepresentable(Math.pow(2, t.params.value), elementType(type));
+    const expectedResult = isRepresentable(Math.pow(2, t.params.value), elementScalarType(type));
     validateConstOrOverrideBuiltinEval(
       t,
       builtin,

--- a/src/webgpu/shader/validation/expression/call/builtin/inverseSqrt.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/inverseSqrt.spec.ts
@@ -8,7 +8,7 @@ import { keysOf, objectsToRecord } from '../../../../../../common/util/data_tabl
 import {
   TypeF16,
   TypeF32,
-  elementType,
+  elementScalarType,
   kAllFloatScalarsAndVectors,
   kAllIntegerScalarsAndVectors,
 } from '../../../../../util/conversion.js';
@@ -43,14 +43,14 @@ Validates that constant evaluation and override evaluation of ${builtin}() input
       .expand('value', u => unique(kMinusTwoToTwo, fullRangeForType(kValuesTypes[u.type])))
   )
   .beforeAllSubcases(t => {
-    if (elementType(kValuesTypes[t.params.type]) === TypeF16) {
+    if (elementScalarType(kValuesTypes[t.params.type]) === TypeF16) {
       t.selectDeviceOrSkipTestCase('shader-f16');
     }
   })
   .fn(t => {
     const type = kValuesTypes[t.params.type];
     const expectedResult =
-      t.params.value > 0 && isRepresentable(1 / Math.sqrt(t.params.value), elementType(type));
+      t.params.value > 0 && isRepresentable(1 / Math.sqrt(t.params.value), elementScalarType(type));
     validateConstOrOverrideBuiltinEval(
       t,
       builtin,

--- a/src/webgpu/shader/validation/expression/call/builtin/length.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/length.spec.ts
@@ -9,7 +9,7 @@ import {
   ScalarType,
   TypeF16,
   TypeF32,
-  elementType,
+  elementScalarType,
   kAllFloatScalars,
   kAllFloatVector2,
   kAllFloatVector3,
@@ -76,7 +76,7 @@ the input scalar value always compiles without error
       .expand('value', u => fullRangeForType(kScalarTypes[u.type]))
   )
   .beforeAllSubcases(t => {
-    if (elementType(kScalarTypes[t.params.type]) === TypeF16) {
+    if (elementScalarType(kScalarTypes[t.params.type]) === TypeF16) {
       t.selectDeviceOrSkipTestCase('shader-f16');
     }
   })
@@ -108,11 +108,11 @@ Validates that constant evaluation and override evaluation of ${builtin}() with 
       .beginSubcases()
       .expand('x', u => fullRangeForType(kVec2Types[u.type], 5))
       .expand('y', u => fullRangeForType(kVec2Types[u.type], 5))
-      .expand('_result', u => [calculate([u.x, u.y], elementType(kVec2Types[u.type]))])
+      .expand('_result', u => [calculate([u.x, u.y], elementScalarType(kVec2Types[u.type]))])
       .filter(u => u._result.isResultRepresentable === u._result.isIntermediateRepresentable)
   )
   .beforeAllSubcases(t => {
-    if (elementType(kVec2Types[t.params.type]) === TypeF16) {
+    if (elementScalarType(kVec2Types[t.params.type]) === TypeF16) {
       t.selectDeviceOrSkipTestCase('shader-f16');
     }
   })
@@ -144,11 +144,11 @@ Validates that constant evaluation and override evaluation of ${builtin}() with 
       .expand('x', u => fullRangeForType(kVec3Types[u.type], 4))
       .expand('y', u => fullRangeForType(kVec3Types[u.type], 4))
       .expand('z', u => fullRangeForType(kVec3Types[u.type], 4))
-      .expand('_result', u => [calculate([u.x, u.y, u.z], elementType(kVec3Types[u.type]))])
+      .expand('_result', u => [calculate([u.x, u.y, u.z], elementScalarType(kVec3Types[u.type]))])
       .filter(u => u._result.isResultRepresentable === u._result.isIntermediateRepresentable)
   )
   .beforeAllSubcases(t => {
-    if (elementType(kVec3Types[t.params.type]) === TypeF16) {
+    if (elementScalarType(kVec3Types[t.params.type]) === TypeF16) {
       t.selectDeviceOrSkipTestCase('shader-f16');
     }
   })
@@ -181,11 +181,13 @@ Validates that constant evaluation and override evaluation of ${builtin}() with 
       .expand('y', u => fullRangeForType(kVec4Types[u.type], 3))
       .expand('z', u => fullRangeForType(kVec4Types[u.type], 3))
       .expand('w', u => fullRangeForType(kVec4Types[u.type], 3))
-      .expand('_result', u => [calculate([u.x, u.y, u.z, u.w], elementType(kVec4Types[u.type]))])
+      .expand('_result', u => [
+        calculate([u.x, u.y, u.z, u.w], elementScalarType(kVec4Types[u.type])),
+      ])
       .filter(u => u._result.isResultRepresentable === u._result.isIntermediateRepresentable)
   )
   .beforeAllSubcases(t => {
-    if (elementType(kVec4Types[t.params.type]) === TypeF16) {
+    if (elementScalarType(kVec4Types[t.params.type]) === TypeF16) {
       t.selectDeviceOrSkipTestCase('shader-f16');
     }
   })

--- a/src/webgpu/shader/validation/expression/call/builtin/log.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/log.spec.ts
@@ -8,7 +8,7 @@ import { keysOf, objectsToRecord } from '../../../../../../common/util/data_tabl
 import {
   TypeF16,
   TypeF32,
-  elementType,
+  elementScalarType,
   kAllFloatScalarsAndVectors,
   kAllIntegerScalarsAndVectors,
 } from '../../../../../util/conversion.js';
@@ -40,7 +40,7 @@ Validates that constant evaluation and override evaluation of ${builtin}() input
       .expand('value', u => fullRangeForType(kValuesTypes[u.type]))
   )
   .beforeAllSubcases(t => {
-    if (elementType(kValuesTypes[t.params.type]) === TypeF16) {
+    if (elementScalarType(kValuesTypes[t.params.type]) === TypeF16) {
       t.selectDeviceOrSkipTestCase('shader-f16');
     }
   })

--- a/src/webgpu/shader/validation/expression/call/builtin/log2.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/log2.spec.ts
@@ -8,7 +8,7 @@ import { keysOf, objectsToRecord } from '../../../../../../common/util/data_tabl
 import {
   TypeF16,
   TypeF32,
-  elementType,
+  elementScalarType,
   kAllFloatScalarsAndVectors,
   kAllIntegerScalarsAndVectors,
 } from '../../../../../util/conversion.js';
@@ -40,7 +40,7 @@ Validates that constant evaluation and override evaluation of ${builtin}() input
       .expand('value', u => fullRangeForType(kValuesTypes[u.type]))
   )
   .beforeAllSubcases(t => {
-    if (elementType(kValuesTypes[t.params.type]) === TypeF16) {
+    if (elementScalarType(kValuesTypes[t.params.type]) === TypeF16) {
       t.selectDeviceOrSkipTestCase('shader-f16');
     }
   })

--- a/src/webgpu/shader/validation/expression/call/builtin/modf.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/modf.spec.ts
@@ -8,7 +8,7 @@ import { keysOf, objectsToRecord } from '../../../../../../common/util/data_tabl
 import {
   TypeF16,
   TypeF32,
-  elementType,
+  elementScalarType,
   kAllFloatScalarsAndVectors,
   kAllIntegerScalarsAndVectors,
 } from '../../../../../util/conversion.js';
@@ -40,7 +40,7 @@ Validates that constant evaluation and override evaluation of ${builtin}() rejec
       .expand('value', u => fullRangeForType(kValuesTypes[u.type]))
   )
   .beforeAllSubcases(t => {
-    if (elementType(kValuesTypes[t.params.type]) === TypeF16) {
+    if (elementScalarType(kValuesTypes[t.params.type]) === TypeF16) {
       t.selectDeviceOrSkipTestCase('shader-f16');
     }
   })

--- a/src/webgpu/shader/validation/expression/call/builtin/radians.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/radians.spec.ts
@@ -8,7 +8,7 @@ import { keysOf, objectsToRecord } from '../../../../../../common/util/data_tabl
 import {
   TypeF16,
   TypeF32,
-  elementType,
+  elementScalarType,
   kAllFloatScalarsAndVectors,
   kAllIntegerScalarsAndVectors,
 } from '../../../../../util/conversion.js';
@@ -40,7 +40,7 @@ Validates that constant evaluation and override evaluation of ${builtin}() input
       .expand('value', u => fullRangeForType(kValuesTypes[u.type]))
   )
   .beforeAllSubcases(t => {
-    if (elementType(kValuesTypes[t.params.type]) === TypeF16) {
+    if (elementScalarType(kValuesTypes[t.params.type]) === TypeF16) {
       t.selectDeviceOrSkipTestCase('shader-f16');
     }
   })

--- a/src/webgpu/shader/validation/expression/call/builtin/round.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/round.spec.ts
@@ -8,7 +8,7 @@ import { keysOf, objectsToRecord } from '../../../../../../common/util/data_tabl
 import {
   TypeF16,
   TypeF32,
-  elementType,
+  elementScalarType,
   kAllFloatScalarsAndVectors,
   kAllIntegerScalarsAndVectors,
 } from '../../../../../util/conversion.js';
@@ -40,7 +40,7 @@ Validates that constant evaluation and override evaluation of ${builtin}() input
       .filter(u => stageSupportsType(u.stage, kValuesTypes[u.type]))
       .beginSubcases()
       .expand('value', u => {
-        const constants = fpTraitsFor(elementType(kValuesTypes[u.type])).constants();
+        const constants = fpTraitsFor(elementScalarType(kValuesTypes[u.type])).constants();
         return unique(fullRangeForType(kValuesTypes[u.type]), [
           constants.negative.min + 0.1,
           constants.positive.max - 0.1,
@@ -48,7 +48,7 @@ Validates that constant evaluation and override evaluation of ${builtin}() input
       })
   )
   .beforeAllSubcases(t => {
-    if (elementType(kValuesTypes[t.params.type]) === TypeF16) {
+    if (elementScalarType(kValuesTypes[t.params.type]) === TypeF16) {
       t.selectDeviceOrSkipTestCase('shader-f16');
     }
   })

--- a/src/webgpu/shader/validation/expression/call/builtin/saturate.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/saturate.spec.ts
@@ -8,7 +8,7 @@ import { keysOf, objectsToRecord } from '../../../../../../common/util/data_tabl
 import {
   TypeF16,
   TypeF32,
-  elementType,
+  elementScalarType,
   kAllFloatScalarsAndVectors,
   kAllIntegerScalarsAndVectors,
 } from '../../../../../util/conversion.js';
@@ -40,7 +40,7 @@ Validates that constant evaluation and override evaluation of ${builtin}() input
       .expand('value', u => fullRangeForType(kValuesTypes[u.type]))
   )
   .beforeAllSubcases(t => {
-    if (elementType(kValuesTypes[t.params.type]) === TypeF16) {
+    if (elementScalarType(kValuesTypes[t.params.type]) === TypeF16) {
       t.selectDeviceOrSkipTestCase('shader-f16');
     }
   })

--- a/src/webgpu/shader/validation/expression/call/builtin/sign.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/sign.spec.ts
@@ -8,7 +8,7 @@ import { keysOf, objectsToRecord } from '../../../../../../common/util/data_tabl
 import {
   TypeF16,
   TypeF32,
-  elementType,
+  elementScalarType,
   kAllFloatAndSignedIntegerScalarsAndVectors,
   kAllUnsignedIntegerScalarsAndVectors,
 } from '../../../../../util/conversion.js';
@@ -40,7 +40,7 @@ Validates that constant evaluation and override evaluation of ${builtin}() input
       .expand('value', u => fullRangeForType(kValuesTypes[u.type]))
   )
   .beforeAllSubcases(t => {
-    if (elementType(kValuesTypes[t.params.type]) === TypeF16) {
+    if (elementScalarType(kValuesTypes[t.params.type]) === TypeF16) {
       t.selectDeviceOrSkipTestCase('shader-f16');
     }
   })

--- a/src/webgpu/shader/validation/expression/call/builtin/sin.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/sin.spec.ts
@@ -8,7 +8,7 @@ import { keysOf, objectsToRecord } from '../../../../../../common/util/data_tabl
 import {
   TypeF16,
   TypeF32,
-  elementType,
+  elementScalarType,
   kAllFloatScalarsAndVectors,
   kAllIntegerScalarsAndVectors,
 } from '../../../../../util/conversion.js';
@@ -42,7 +42,7 @@ Validates that constant evaluation and override evaluation of ${builtin}() rejec
       .expand('value', u => unique(kMinus3PiTo3Pi, fullRangeForType(kValuesTypes[u.type])))
   )
   .beforeAllSubcases(t => {
-    if (elementType(kValuesTypes[t.params.type]) === TypeF16) {
+    if (elementScalarType(kValuesTypes[t.params.type]) === TypeF16) {
       t.selectDeviceOrSkipTestCase('shader-f16');
     }
   })

--- a/src/webgpu/shader/validation/expression/call/builtin/sinh.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/sinh.spec.ts
@@ -8,7 +8,7 @@ import { keysOf, objectsToRecord } from '../../../../../../common/util/data_tabl
 import {
   TypeF16,
   TypeF32,
-  elementType,
+  elementScalarType,
   kAllFloatScalarsAndVectors,
   kAllIntegerScalarsAndVectors,
 } from '../../../../../util/conversion.js';
@@ -41,13 +41,13 @@ Validates that constant evaluation and override evaluation of ${builtin}() rejec
       .expand('value', u => fullRangeForType(kValuesTypes[u.type]))
   )
   .beforeAllSubcases(t => {
-    if (elementType(kValuesTypes[t.params.type]) === TypeF16) {
+    if (elementScalarType(kValuesTypes[t.params.type]) === TypeF16) {
       t.selectDeviceOrSkipTestCase('shader-f16');
     }
   })
   .fn(t => {
     const type = kValuesTypes[t.params.type];
-    const expectedResult = isRepresentable(Math.sinh(t.params.value), elementType(type));
+    const expectedResult = isRepresentable(Math.sinh(t.params.value), elementScalarType(type));
     validateConstOrOverrideBuiltinEval(
       t,
       builtin,

--- a/src/webgpu/shader/validation/expression/call/builtin/sqrt.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/sqrt.spec.ts
@@ -8,7 +8,7 @@ import { keysOf, objectsToRecord } from '../../../../../../common/util/data_tabl
 import {
   TypeF16,
   TypeF32,
-  elementType,
+  elementScalarType,
   kAllFloatScalarsAndVectors,
   kAllIntegerScalarsAndVectors,
 } from '../../../../../util/conversion.js';
@@ -43,14 +43,14 @@ Validates that constant evaluation and override evaluation of ${builtin}() input
       .expand('value', u => unique(kMinusTwoToTwo, fullRangeForType(kValuesTypes[u.type])))
   )
   .beforeAllSubcases(t => {
-    if (elementType(kValuesTypes[t.params.type]) === TypeF16) {
+    if (elementScalarType(kValuesTypes[t.params.type]) === TypeF16) {
       t.selectDeviceOrSkipTestCase('shader-f16');
     }
   })
   .fn(t => {
     const type = kValuesTypes[t.params.type];
     const expectedResult =
-      t.params.value >= 0 && isRepresentable(Math.sqrt(t.params.value), elementType(type));
+      t.params.value >= 0 && isRepresentable(Math.sqrt(t.params.value), elementScalarType(type));
     validateConstOrOverrideBuiltinEval(
       t,
       builtin,

--- a/src/webgpu/shader/validation/expression/call/builtin/tan.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/tan.spec.ts
@@ -8,7 +8,7 @@ import { keysOf, objectsToRecord } from '../../../../../../common/util/data_tabl
 import {
   TypeF16,
   TypeF32,
-  elementType,
+  elementScalarType,
   kAllFloatScalarsAndVectors,
   kAllIntegerScalarsAndVectors,
 } from '../../../../../util/conversion.js';
@@ -43,13 +43,13 @@ Validates that constant evaluation and override evaluation of ${builtin}() rejec
       .expand('value', u => unique(kMinus3PiTo3Pi, fullRangeForType(kValuesTypes[u.type])))
   )
   .beforeAllSubcases(t => {
-    if (elementType(kValuesTypes[t.params.type]) === TypeF16) {
+    if (elementScalarType(kValuesTypes[t.params.type]) === TypeF16) {
       t.selectDeviceOrSkipTestCase('shader-f16');
     }
   })
   .fn(t => {
     const type = kValuesTypes[t.params.type];
-    const smallestPositive = fpTraitsFor(elementType(type)).constants().positive.min;
+    const smallestPositive = fpTraitsFor(elementScalarType(type)).constants().positive.min;
     const expectedResult = Math.abs(Math.cos(t.params.value)) > smallestPositive;
     validateConstOrOverrideBuiltinEval(
       t,

--- a/src/webgpu/util/floating_point.ts
+++ b/src/webgpu/util/floating_point.ts
@@ -265,6 +265,16 @@ export type FPMatrix =
       [FPInterval, FPInterval, FPInterval, FPInterval]
     ];
 
+export type FPValue = FPInterval | FPVector | FPMatrix | FPStruct;
+
+/** Container representing a struct of FP values */
+export class FPStruct {
+  readonly elements: FPValue[];
+  constructor(...elements: FPValue[]) {
+    this.elements = elements;
+  }
+}
+
 // Utilities
 
 /** @returns input with an appended 0, if inputs contains non-zero subnormals */
@@ -989,7 +999,7 @@ export abstract class FPTraits {
   }
 
   /** Stub for modf generator */
-  protected unimplementedModf(_x: number): { fract: FPInterval; whole: FPInterval } {
+  protected unimplementedModf(_x: number): FPStruct {
     unreachable(`Not yet implemented for ${this.kind}`);
   }
 
@@ -3589,14 +3599,14 @@ export abstract class FPTraits {
   /** All acceptance interval functions for mix(x, y, z) */
   public abstract readonly mixIntervals: ScalarTripleToInterval[];
 
-  protected modfIntervalImpl(n: number): { fract: FPInterval; whole: FPInterval } {
+  protected modfIntervalImpl(n: number): FPStruct {
     const fract = this.correctlyRoundedInterval(n % 1.0);
     const whole = this.correctlyRoundedInterval(n - (n % 1.0));
-    return { fract, whole };
+    return new FPStruct(fract, whole);
   }
 
   /** Calculate an acceptance interval of modf(x) */
-  public abstract readonly modfInterval: (n: number) => { fract: FPInterval; whole: FPInterval };
+  public abstract readonly modfInterval: (n: number) => FPStruct;
 
   private readonly MultiplicationInnerOp = {
     impl: (x: number, y: number): FPInterval => {


### PR DESCRIPTION
This adds support for structs both in the input specifying code and expectation code.

modf executions tests ares re-written to use this new support to demonstrate it working and flesh out the details.

Future PRs will convert other tests to use structs instead of multiple passes or other hacks.

Issue #2028

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
