### PR TITLE
Prevent details toggle if user is selecting text

### DIFF
--- a/src/common/runtime/standalone.ts
+++ b/src/common/runtime/standalone.ts
@@ -390,6 +390,19 @@ function makeTreeNodeHeaderHTML(
   const div = $('<details>').addClass('nodeheader');
   const header = $('<summary>').appendTo(div);
 
+  // prevent toggling if user is selecting text from an input element
+  {
+    let lastNodeName = '';
+    div.on('pointerdown', event => {
+      lastNodeName = event.target.nodeName;
+    });
+    div.on('click', event => {
+      if (lastNodeName === 'INPUT') {
+        event.preventDefault();
+      }
+    });
+  }
+
   const setChecked = () => {
     div.prop('open', true); // (does not fire onChange)
     onChange(true);
@@ -610,8 +623,11 @@ void (async () => {
 
   tree.dissolveSingleChildTrees();
 
+  console.log('h1');
   const { runSubtree, generateSubtreeHTML } = makeSubtreeHTML(tree.root, 1);
+  console.log('h2');
   const setTreeCheckedRecursively = generateSubtreeHTML(resultsVis);
+  console.log('h3');
 
   document.getElementById('expandall')!.addEventListener('click', () => {
     setTreeCheckedRecursively();

--- a/src/common/runtime/standalone.ts
+++ b/src/common/runtime/standalone.ts
@@ -458,6 +458,9 @@ function makeTreeNodeHeaderHTML(
       .attr('type', 'text')
       .prop('readonly', true)
       .addClass('nodequery')
+      .on('click', event => {
+        (event.target as HTMLInputElement).select();
+      })
       .val(n.query.toString())
       .appendTo(nodecolumns);
     if (n.subtreeCounts) {
@@ -623,11 +626,8 @@ void (async () => {
 
   tree.dissolveSingleChildTrees();
 
-  console.log('h1');
   const { runSubtree, generateSubtreeHTML } = makeSubtreeHTML(tree.root, 1);
-  console.log('h2');
   const setTreeCheckedRecursively = generateSubtreeHTML(resultsVis);
-  console.log('h3');
 
   document.getElementById('expandall')!.addEventListener('click', () => {
     setTreeCheckedRecursively();


### PR DESCRIPTION
I've been having issues selecting queries. 

https://github.com/gpuweb/cts/assets/234804/d731d569-c58f-4d8e-9961-33a62c14e1df

This is actually a bug in Chrome and Webkit though not Firefox. 

This is a workaround.

Other thoughts:

* I thought about making it auto-select the entire query. I like it! But it might not be intuitive
* I thought about adding an icon to copy the query. As it is I either have to drag select the entire query or triple click. Triple click seems to be a little wonky, especially on a heavy page (if lots of tests are expanded)





<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
