### PR TITLE
wgsl: Rework AF support to be two-pass

### DIFF
--- a/src/webgpu/shader/execution/expression/unary/unary.ts
+++ b/src/webgpu/shader/execution/expression/unary/unary.ts
@@ -4,7 +4,3 @@ import { basicExpressionBuilder, ShaderBuilder } from '../expression.js';
 export function unary(op: string): ShaderBuilder {
   return basicExpressionBuilder(value => `${op}(${value})`);
 }
-
-export function assignment(): ShaderBuilder {
-  return basicExpressionBuilder(value => `${value}`);
-}

--- a/src/webgpu/util/conversion.ts
+++ b/src/webgpu/util/conversion.ts
@@ -1183,6 +1183,18 @@ export function reinterpretU16AsF16(u16: number): number {
   return new Float16Array(array.buffer)[0];
 }
 
+/** @returns the possible upper 32-bits of an abstract-float as an u32 */
+export function abstractFloatUpperBits(val: number): Scalar[] {
+  return isSubnormalNumberF64(val)
+    ? [u32(0x80000000), u32(0x00000000)]
+    : [u32(reinterpretF64AsU32s(val)[1])];
+}
+
+/** @returns the possible lower 32-bits of an abstract-float as an u32 */
+export function abstractFloatLowerBits(val: number): Scalar[] {
+  return isSubnormalNumberF64(val) ? [u32(0x00000000)] : [u32(reinterpretF64AsU32s(val)[0])];
+}
+
 /**
  * Class that encapsulates a vector value.
  */


### PR DESCRIPTION
This will allow for properly supporting vector results in future PRs.

Issue #2755

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
