### PR TITLE
Fix handling of batches in case filtering

### DIFF
--- a/src/common/internal/test_group.ts
+++ b/src/common/internal/test_group.ts
@@ -74,6 +74,9 @@ export function makeTestGroupForUnitTesting<F extends Fixture>(
   return new TestGroup(fixture);
 }
 
+/** Parameter name for batch number (see also TestBuilder.batch). */
+const kBatchParamName = 'batch__';
+
 type TestFn<F extends Fixture, P extends {}> = (t: F & { params: P }) => Promise<void> | void;
 type BeforeAllSubcasesFn<S extends SubcaseBatchState, P extends {}> = (
   s: S & { params: P }
@@ -283,7 +286,7 @@ class TestBuilder<S extends SubcaseBatchState, F extends Fixture> {
     for (const [caseParams, subcases] of builderIterateCasesWithSubcases(this.testCases, null)) {
       for (const subcaseParams of subcases ?? [{}]) {
         const params = mergeParams(caseParams, subcaseParams);
-        assert(this.batchSize === 0 || !('batch__' in params));
+        assert(this.batchSize === 0 || !(kBatchParamName in params));
 
         // stringifyPublicParams also checks for invalid params values
         let testcaseString;
@@ -348,24 +351,53 @@ class TestBuilder<S extends SubcaseBatchState, F extends Fixture> {
 
   *iterate(caseFilter: TestParams | null): IterableIterator<RunCase> {
     this.testCases ??= kUnitCaseParamsBuilder;
+
+    // Remove the batch__ from the caseFilter because the params builder doesn't
+    // know about it (we don't add it until later in this function).
+    let filterToBatch: number | undefined;
+    const caseFilterWithoutBatch = caseFilter ? { ...caseFilter } : null;
+    if (caseFilterWithoutBatch && kBatchParamName in caseFilterWithoutBatch) {
+      const batchParam = caseFilterWithoutBatch[kBatchParamName];
+      assert(typeof batchParam === 'number');
+      filterToBatch = batchParam;
+      delete caseFilterWithoutBatch[kBatchParamName];
+    }
+
     for (const [caseParams, subcases] of builderIterateCasesWithSubcases(
       this.testCases,
-      caseFilter
+      caseFilterWithoutBatch
     )) {
+      // If batches are not used, yield just one case.
       if (this.batchSize === 0 || subcases === undefined) {
         yield this.makeCaseSpecific(caseParams, subcases);
-      } else {
-        const subcaseArray = Array.from(subcases);
-        if (subcaseArray.length <= this.batchSize) {
-          yield this.makeCaseSpecific(caseParams, subcaseArray);
-        } else {
-          for (let i = 0; i < subcaseArray.length; i = i + this.batchSize) {
-            yield this.makeCaseSpecific(
-              { ...caseParams, batch__: i / this.batchSize },
-              subcaseArray.slice(i, Math.min(subcaseArray.length, i + this.batchSize))
-            );
-          }
-        }
+        continue;
+      }
+
+      // Same if there ends up being only one batch.
+      const subcaseArray = Array.from(subcases);
+      if (subcaseArray.length <= this.batchSize) {
+        yield this.makeCaseSpecific(caseParams, subcaseArray);
+        continue;
+      }
+
+      // There are multiple batches. Helper function for this case:
+      const makeCaseForBatch = (batch: number) => {
+        const sliceStart = batch * this.batchSize;
+        return this.makeCaseSpecific(
+          { ...caseParams, [kBatchParamName]: batch },
+          subcaseArray.slice(sliceStart, Math.min(subcaseArray.length, sliceStart + this.batchSize))
+        );
+      };
+
+      // If we filter to just one batch, yield it.
+      if (filterToBatch !== undefined) {
+        yield makeCaseForBatch(filterToBatch);
+        continue;
+      }
+
+      // Finally, if not, yield all of the batches.
+      for (let batch = 0; batch * this.batchSize < subcaseArray.length; ++batch) {
+        yield makeCaseForBatch(batch);
       }
     }
   }

--- a/src/common/internal/tree.ts
+++ b/src/common/internal/tree.ts
@@ -350,14 +350,14 @@ export async function loadTreeForQuery(
       subtreeL2.subtreeCounts ??= { tests: 1, nodesWithTODO: 0 };
       if (t.description) setSubtreeDescriptionAndCountTODOs(subtreeL2, t.description);
 
-      let paramsFilter = null;
+      let caseFilter = null;
       if ('params' in queryToLoad) {
-        paramsFilter = queryToLoad.params;
+        caseFilter = queryToLoad.params;
       }
 
       // MAINTENANCE_TODO: If tree generation gets too slow, avoid actually iterating the cases in a
       // file if there's no need to (based on the subqueriesToExpand).
-      for (const c of t.iterate(paramsFilter)) {
+      for (const c of t.iterate(caseFilter)) {
         // iterate() guarantees c's query is equal to or a subset of queryToLoad.
 
         if (queryToLoad instanceof TestQuerySingleCase) {


### PR DESCRIPTION
Fix a bug in for #2890 / #2900

<hr>

**Requirements for PR author:**

- [x] N/A ~All missing test coverage is tracked with "TODO" or `.unimplemented()`.~
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] N/A ~Tests are properly located in the test tree.~
- [x] N/A ~[Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.~
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
