### PR TITLE
wgsl: Add execution tests for AF negation

### DIFF
--- a/src/webgpu/shader/execution/expression/expression.ts
+++ b/src/webgpu/shader/execution/expression/expression.ts
@@ -70,6 +70,9 @@ export type InputSource =
 /** All possible input sources */
 export const allInputSources: InputSource[] = ['const', 'uniform', 'storage_r', 'storage_rw'];
 
+/** Just constant input source */
+export const onlyConstInputSource: InputSource[] = ['const'];
+
 /** Configuration for running a expression test */
 export type Config = {
   // Where the input values are read from
@@ -85,6 +88,22 @@ export type Config = {
 
 // Helper for returning the stride for a given Type
 function valueStride(ty: Type): number {
+  // AbstractFloats are passed out of the shader via a struct of 2x u32s and
+  // unpacking containers as arrays
+  if (scalarTypeOf(ty).kind === 'abstract-float') {
+    if (ty instanceof ScalarType) {
+      return 16;
+    }
+    if (ty instanceof VectorType) {
+      if (ty.width === 2) {
+        return 16;
+      }
+      // vec3s have padding to make them the same size as vec4s
+      return 32;
+    }
+    unreachable('Matrices of AbstractFloats have not yet been implemented');
+  }
+
   if (ty instanceof MatrixType) {
     switch (ty.cols) {
       case 2:
@@ -135,10 +154,11 @@ function valueStrides(tys: Type[]): number {
 // Helper for returning the WGSL storage type for the given Type.
 function storageType(ty: Type): Type {
   if (ty instanceof ScalarType) {
-    assert(ty.kind !== 'f64', `'No storage type defined for 'f64' values`);
-    if (ty.kind === 'abstract-float') {
-      return TypeVec(2, TypeU32);
-    }
+    assert(ty.kind !== 'f64', `No storage type defined for 'f64' values`);
+    assert(
+      ty.kind !== 'abstract-float',
+      `Custom handling is implemented for 'abstract-float' values`
+    );
     if (ty.kind === 'bool') {
       return TypeU32;
     }
@@ -161,7 +181,7 @@ function fromStorage(ty: Type, expr: string): string {
   if (ty instanceof VectorType) {
     assert(
       ty.elementType.kind !== 'abstract-float',
-      `AbstractFloat values should not be in input storage`
+      `AbstractFloat values cannot appear in input storage`
     );
     assert(ty.elementType.kind !== 'f64', `'No storage type defined for 'f64' values`);
     if (ty.elementType.kind === 'bool') {
@@ -176,7 +196,7 @@ function toStorage(ty: Type, expr: string): string {
   if (ty instanceof ScalarType) {
     assert(
       ty.kind !== 'abstract-float',
-      `AbstractFloat values have custom code writing to input storage`
+      `AbstractFloat values have custom code for writing to storage`
     );
     assert(ty.kind !== 'f64', `No storage type defined for 'f64' values`);
     if (ty.kind === 'bool') {
@@ -186,7 +206,7 @@ function toStorage(ty: Type, expr: string): string {
   if (ty instanceof VectorType) {
     assert(
       ty.elementType.kind !== 'abstract-float',
-      `AbstractFloat values have custom code writing to input storage`
+      `AbstractFloat values have custom code for writing to storage`
     );
     assert(ty.elementType.kind !== 'f64', `'No storage type defined for 'f64' values`);
     if (ty.elementType.kind === 'bool') {
@@ -438,11 +458,40 @@ export type ShaderBuilder = (
  * Helper that returns the WGSL to declare the output storage buffer for a shader
  */
 function wgslOutputs(resultType: Type, count: number): string {
-  return `
+  let output_struct = undefined;
+  if (scalarTypeOf(resultType).kind !== 'abstract-float') {
+    output_struct = `
 struct Output {
   @size(${valueStride(resultType)}) value : ${storageType(resultType)}
+};`;
+  } else {
+    if (resultType instanceof ScalarType) {
+      output_struct = `struct AF {
+  low: u32,
+  high: u32,
 };
-@group(0) @binding(0) var<storage, read_write> outputs : array<Output, ${count}>;`;
+
+struct Output {
+  @size(${valueStride(resultType)}) value: AF,
+};`;
+    }
+    if (resultType instanceof VectorType) {
+      const dim = resultType.width;
+      output_struct = `struct AF {
+  low: u32,
+  high: u32,
+};
+
+struct Output {
+  @size(${valueStride(resultType)}) value: array<AF, ${dim}>,
+};`;
+    }
+    // TBD: Implement Matrix result support
+  }
+  assert(output_struct !== undefined, `No implementation for result type '${resultType}'`);
+  return `${output_struct}
+@group(0) @binding(0) var<storage, read_write> outputs : array<Output, ${count}>;
+`;
 }
 
 /**
@@ -454,10 +503,6 @@ function wgslValuesArray(
   cases: CaseList,
   expressionBuilder: ExpressionBuilder
 ): string {
-  // AbstractFloat values cannot be stored in an array
-  if (parameterTypes.some(ty => scalarTypeOf(ty).kind === 'abstract-float')) {
-    return '';
-  }
   return `
 const values = array(
   ${cases.map(c => expressionBuilder(map(c.input, v => v.wgsl()))).join(',\n  ')}
@@ -508,15 +553,16 @@ function basicExpressionShaderBody(
   cases: CaseList,
   inputSource: InputSource
 ): string {
+  assert(
+    scalarTypeOf(resultType).kind !== 'abstract-float',
+    `abstractFloatShaderBuilder should be used when result type is 'abstract-float`
+  );
   if (inputSource === 'const') {
     //////////////////////////////////////////////////////////////////////////
     // Constant eval
     //////////////////////////////////////////////////////////////////////////
     let body = '';
-    if (
-      scalarTypeOf(resultType).kind !== 'abstract-float' &&
-      parameterTypes.some(ty => scalarTypeOf(ty).kind === 'abstract-float')
-    ) {
+    if (parameterTypes.some(ty => scalarTypeOf(ty).kind === 'abstract-float')) {
       // Directly assign the expression to the output, to avoid an
       // intermediate store, which will concretize the value early
       body = cases
@@ -527,96 +573,6 @@ function basicExpressionShaderBody(
               expressionBuilder(map(c.input, v => v.wgsl()))
             )};`
         )
-        .join('\n  ');
-    } else if (scalarTypeOf(resultType).kind === 'abstract-float') {
-      // AbstractFloats are f64s under the hood. WebGPU does not support
-      // putting f64s in buffers, so the result needs to be split up into u32s
-      // and rebuilt in the test framework.
-      //
-      // This is complicated by the fact that user defined functions cannot
-      // take/return AbstractFloats, and AbstractFloats cannot be stored in
-      // variables, so the code cannot just inject a simple utility function
-      // at the top of the shader, instead this snippet needs to be inlined
-      // everywhere the test needs to return an AbstractFloat.
-      //
-      // select is used below, since ifs are not available during constant
-      // eval. This has the side effect of short-circuiting doesn't occur, so
-      // both sides of the select have to evaluate and be valid.
-      //
-      // This snippet implements FTZ for subnormals to bypass the need for
-      // complex subnormal specific logic.
-      //
-      // Expressions resulting in subnormals can still be reasonably tested,
-      // since this snippet will return 0 with the correct sign, which is
-      // always in the acceptance interval for a subnormal result, since an
-      // implementation may FTZ.
-      //
-      // Document for the snippet is included here in this code block, since
-      // shader length affects compilation time  significantly on some
-      // backends.
-      //
-      // Snippet with documentation:
-      //   const kExponentBias = 1022;
-      //
-      //   // Detect if the value is zero or subnormal, so that FTZ behaviour
-      //   // can occur
-      //   const subnormal_or_zero : bool = (${expr} <= ${kValue.f64.subnormal.positive.max}) && (${expr} >= ${kValue.f64.subnormal.negative.min});
-      //
-      //   // MSB of the upper u32 is 1 if the value is negative, otherwise 0
-      //   // Extract the sign bit early, so that abs() can be used with
-      //   // frexp() so negative cases do not need to be handled
-      //   const sign_bit : u32 = select(0, 0x80000000, ${expr} < 0);
-      //
-      //   // Use frexp() to obtain the exponent and fractional parts, and
-      //   // then perform FTZ if needed
-      //   const f = frexp(abs(${expr}));
-      //   const f_fract = select(f.fract, 0, subnormal_or_zero);
-      //   const f_exp = select(f.exp, -kExponentBias, subnormal_or_zero);
-      //
-      //   // Adjust for the exponent bias and shift for storing in bits
-      //   // [20..31] of the upper u32
-      //   const exponent_bits : u32 = (f_exp + kExponentBias) << 20;
-      //
-      //   // Extract the portion of the mantissa that appears in upper u32 as
-      //   // a float for later use
-      //   const high_mantissa = ldexp(f_fract, 21);
-      //
-      //   // Extract the portion of the mantissa that appears in upper u32 as
-      //   // as bits. This value is masked, because normals will explicitly
-      //   // have the implicit leading 1 that should not be in the final
-      //   // result.
-      //   const high_mantissa_bits : u32 = u32(ldexp(f_fract, 21)) & 0x000fffff;
-      //
-      //   // Calculate the mantissa stored in the lower u32 as a float
-      //   const low_mantissa = f_fract - ldexp(floor(high_mantissa), -21);
-      //
-      //   // Convert the lower u32 mantissa to bits
-      //   const low_mantissa_bits = u32(ldexp(low_mantissa, 53));
-      //
-      //   // Pack the result into 2x u32s for writing out to the testing
-      //   // framework
-      //   outputs[${i}].value.x = low_mantissa_bits;
-      //   outputs[${i}].value.y = sign_bit | exponent_bits | high_mantissa_bits;
-      body = cases
-        .map((c, i) => {
-          const expr = `${expressionBuilder(map(c.input, v => v.wgsl()))}`;
-          // prettier-ignore
-          return `  {
-    const kExponentBias = 1022;
-    const subnormal_or_zero : bool = (${expr} <= ${kValue.f64.subnormal.positive.max}) && (${expr} >= ${kValue.f64.subnormal.negative.min});
-    const sign_bit : u32 = select(0, 0x80000000, ${expr} < 0);
-    const f = frexp(abs(${expr}));
-    const f_fract = select(f.fract, 0, subnormal_or_zero);
-    const f_exp = select(f.exp, -kExponentBias, subnormal_or_zero);
-    const exponent_bits : u32 = (f_exp + kExponentBias) << 20;
-    const high_mantissa = ldexp(f_fract, 21);
-    const high_mantissa_bits : u32 = u32(ldexp(f_fract, 21)) & 0x000fffff;
-    const low_mantissa = f_fract - ldexp(floor(high_mantissa), -21);
-    const low_mantissa_bits = u32(ldexp(low_mantissa, 53));
-    outputs[${i}].value.x = low_mantissa_bits;
-    outputs[${i}].value.y = sign_bit | exponent_bits | high_mantissa_bits;
-  }`;
-        })
         .join('\n  ');
     } else if (globalTestConfig.unrollConstEvalLoops) {
       body = cases
@@ -805,6 +761,163 @@ fn main() {
 }
 `;
     }
+  };
+}
+
+/**
+ * @returns a string that extracts the value of an AbstractFloat into an output
+ *          destination
+ * @param expr expression for an AbstractFloat value, if working with vectors or
+ *             matrices, this string needs to include indexing into the
+ *             container.
+ * @param case_idx index in the case output array to assign the result
+ * @param accessor string representing how access the AF that needs to be extracted.
+ *              For scalars this should be left as ''.
+ *              For vectors and matrices this will be an indexing operation,
+ *              i.e. '[i]'
+ * */
+function abstractFloatSnippet(expr: string, case_idx: number, accessor: string = ''): string {
+  // AbstractFloats are f64s under the hood. WebGPU does not support
+  // putting f64s in buffers, so the result needs to be split up into u32s
+  // and rebuilt in the test framework.
+  //
+  // Since there is no 64-bit data type that can be used as an element for a
+  // vector or a matrix in WGSL, the testing framework needs to pass the u32s
+  // via a struct with two u32s, and deconstruct vectors and matrices into
+  // arrays.
+  //
+  // This is complicated by the fact that user defined functions cannot
+  // take/return AbstractFloats, and AbstractFloats cannot be stored in
+  // variables, so the code cannot just inject a simple utility function
+  // at the top of the shader, instead this snippet needs to be inlined
+  // everywhere the test needs to return an AbstractFloat.
+  //
+  // select is used below, since ifs are not available during constant
+  // eval. This has the side effect of short-circuiting doesn't occur, so
+  // both sides of the select have to evaluate and be valid.
+  //
+  // This snippet implements FTZ for subnormals to bypass the need for
+  // complex subnormal specific logic.
+  //
+  // Expressions resulting in subnormals can still be reasonably tested,
+  // since this snippet will return 0 with the correct sign, which is
+  // always in the acceptance interval for a subnormal result, since an
+  // implementation may FTZ.
+  //
+  // Documentation for the snippet working with scalar results is included here
+  // in this code block, since shader length affects compilation time
+  // significantly on some backends. The code for vectors and matrices basically
+  // the same thing, with extra indexing operations.
+  //
+  // Snippet with documentation:
+  //   const kExponentBias = 1022;
+  //
+  //   // Detect if the value is zero or subnormal, so that FTZ behaviour
+  //   // can occur
+  //   const subnormal_or_zero : bool = (${expr} <= ${kValue.f64.subnormal.positive.max}) && (${expr} >= ${kValue.f64.subnormal.negative.min});
+  //
+  //   // MSB of the upper u32 is 1 if the value is negative, otherwise 0
+  //   // Extract the sign bit early, so that abs() can be used with
+  //   // frexp() so negative cases do not need to be handled
+  //   const sign_bit : u32 = select(0, 0x80000000, ${expr} < 0);
+  //
+  //   // Use frexp() to obtain the exponent and fractional parts, and
+  //   // then perform FTZ if needed
+  //   const f = frexp(abs(${expr}));
+  //   const f_fract = select(f.fract, 0, subnormal_or_zero);
+  //   const f_exp = select(f.exp, -kExponentBias, subnormal_or_zero);
+  //
+  //   // Adjust for the exponent bias and shift for storing in bits
+  //   // [20..31] of the upper u32
+  //   const exponent_bits : u32 = (f_exp + kExponentBias) << 20;
+  //
+  //   // Extract the portion of the mantissa that appears in upper u32 as
+  //   // a float for later use
+  //   const high_mantissa = ldexp(f_fract, 21);
+  //
+  //   // Extract the portion of the mantissa that appears in upper u32 as
+  //   // as bits. This value is masked, because normals will explicitly
+  //   // have the implicit leading 1 that should not be in the final
+  //   // result.
+  //   const high_mantissa_bits : u32 = u32(ldexp(f_fract, 21)) & 0x000fffff;
+  //
+  //   // Calculate the mantissa stored in the lower u32 as a float
+  //   const low_mantissa = f_fract - ldexp(floor(high_mantissa), -21);
+  //
+  //   // Convert the lower u32 mantissa to bits
+  //   const low_mantissa_bits = u32(ldexp(low_mantissa, 53));
+  //
+  //   outputs[${i}].value.high = sign_bit | exponent_bits | high_mantissa_bits;
+  //   outputs[${i}].value.low = low_mantissa_bits;
+  // prettier-ignore
+  return `  {
+    const kExponentBias = 1022;
+    const subnormal_or_zero : bool = (${expr}${accessor} <= ${kValue.f64.subnormal.positive.max}) && (${expr}${accessor} >= ${kValue.f64.subnormal.negative.min});
+    const sign_bit : u32 = select(0, 0x80000000, ${expr}${accessor} < 0);
+    const f = frexp(abs(${expr}${accessor}));
+    const f_fract = select(f.fract, 0, subnormal_or_zero);
+    const f_exp = select(f.exp, -kExponentBias, subnormal_or_zero);
+    const exponent_bits : u32 = (f_exp + kExponentBias) << 20;
+    const high_mantissa = ldexp(f_fract, 21);
+    const high_mantissa_bits : u32 = u32(ldexp(f_fract, 21)) & 0x000fffff;
+    const low_mantissa = f_fract - ldexp(floor(high_mantissa), -21);
+    const low_mantissa_bits = u32(ldexp(low_mantissa, 53));
+    outputs[${case_idx}].value${accessor}.high = sign_bit | exponent_bits | high_mantissa_bits;
+    outputs[${case_idx}].value${accessor}.low = low_mantissa_bits;
+  }`;
+}
+
+/** @returns a string for a specific case that has a AbstractFloat result */
+function abstractFloatCaseBody(expr: string, resultType: Type, i: number): string {
+  if (resultType instanceof ScalarType) {
+    return abstractFloatSnippet(expr, i);
+  }
+
+  if (resultType instanceof VectorType) {
+    return [...Array(resultType.width).keys()]
+      .map(dim_idx => abstractFloatSnippet(expr, i, `[${dim_idx}]`))
+      .join('  \n');
+  }
+  // TDB implement matrix support
+
+  unreachable(`Results of type '${resultType}' not yet implemented`);
+}
+
+/**
+ * @returns a ShaderBuilder that builds a test shader hands AbstractFloat results.
+ * @param expressionBuilder an expression builder that will return AbstractFloats
+ */
+export function abstractFloatShaderBuilder(expressionBuilder: ExpressionBuilder): ShaderBuilder {
+  return (
+    parameterTypes: Array<Type>,
+    resultType: Type,
+    cases: CaseList,
+    inputSource: InputSource
+  ) => {
+    assert(inputSource === 'const', 'AbstractFloat results are only defined for const-eval');
+    assert(
+      scalarTypeOf(resultType).kind === 'abstract-float',
+      `Expected resultType of 'abstract-float', received '${scalarTypeOf(resultType).kind}' instead`
+    );
+
+    const body = cases
+      .map((c, i) => {
+        const expr = `${expressionBuilder(map(c.input, v => v.wgsl()))}`;
+        return abstractFloatCaseBody(expr, resultType, i);
+      })
+      .join('\n  ');
+
+    return `
+${wgslHeader(parameterTypes, resultType)}
+
+${wgslOutputs(resultType, cases.length)}
+
+${wgslValuesArray(parameterTypes, resultType, cases, expressionBuilder)}
+
+@compute @workgroup_size(1)
+fn main() {
+${body}
+}`;
   };
 }
 

--- a/src/webgpu/shader/execution/expression/unary/af_arithmetic.spec.ts
+++ b/src/webgpu/shader/execution/expression/unary/af_arithmetic.spec.ts
@@ -1,0 +1,44 @@
+export const description = `
+Execution Tests for AbstractFloat arithmetic unary expression operations
+`;
+
+import { makeTestGroup } from '../../../../../common/framework/test_group.js';
+import { GPUTest } from '../../../../gpu_test.js';
+import { TypeAbstractFloat } from '../../../../util/conversion.js';
+import { FP } from '../../../../util/floating_point.js';
+import { fullF64Range } from '../../../../util/math.js';
+import { makeCaseCache } from '../case_cache.js';
+import { onlyConstInputSource, run } from '../expression.js';
+
+import { abstract_unary } from './unary.js';
+
+export const g = makeTestGroup(GPUTest);
+
+export const d = makeCaseCache('unary/f32_arithmetic', {
+  negation: () => {
+    return FP.abstract.generateScalarToIntervalCases(
+      fullF64Range({ neg_norm: 250, neg_sub: 20, pos_sub: 20, pos_norm: 250 }),
+      // [0, 1, 2],
+      'unfiltered',
+      FP.abstract.negationInterval
+    );
+  },
+});
+
+g.test('negation')
+  .specURL('https://www.w3.org/TR/WGSL/#floating-point-evaluation')
+  .desc(
+    `
+Expression: -x
+Accuracy: Correctly rounded
+`
+  )
+  .params(u =>
+    u
+      .combine('inputSource', onlyConstInputSource)
+      .combine('vectorize', [undefined, 2, 3, 4] as const)
+  )
+  .fn(async t => {
+    const cases = await d.get('negation');
+    await run(t, abstract_unary('-'), [TypeAbstractFloat], TypeAbstractFloat, t.params, cases, 1);
+  });

--- a/src/webgpu/shader/execution/expression/unary/af_arithmetic.spec.ts
+++ b/src/webgpu/shader/execution/expression/unary/af_arithmetic.spec.ts
@@ -18,7 +18,6 @@ export const d = makeCaseCache('unary/f32_arithmetic', {
   negation: () => {
     return FP.abstract.generateScalarToIntervalCases(
       fullF64Range({ neg_norm: 250, neg_sub: 20, pos_sub: 20, pos_norm: 250 }),
-      // [0, 1, 2],
       'unfiltered',
       FP.abstract.negationInterval
     );

--- a/src/webgpu/shader/execution/expression/unary/af_assignment.spec.ts
+++ b/src/webgpu/shader/execution/expression/unary/af_assignment.spec.ts
@@ -14,9 +14,21 @@ import {
   reinterpretU64AsF64,
 } from '../../../../util/math.js';
 import { makeCaseCache } from '../case_cache.js';
-import { allInputSources, run } from '../expression.js';
+import {
+  abstractFloatShaderBuilder,
+  basicExpressionBuilder,
+  onlyConstInputSource,
+  run,
+  ShaderBuilder,
+} from '../expression.js';
 
-import { assignment } from './unary.js';
+function concrete_assignment(): ShaderBuilder {
+  return basicExpressionBuilder(value => `${value}`);
+}
+
+function abstract_assignment(): ShaderBuilder {
+  return abstractFloatShaderBuilder(value => `${value}`);
+}
 
 export const g = makeTestGroup(GPUTest);
 
@@ -68,10 +80,10 @@ g.test('abstract')
 testing that extracting abstract floats works
 `
   )
-  .params(u => u.combine('inputSource', [allInputSources[0]])) // Only defined for const-eval
+  .params(u => u.combine('inputSource', onlyConstInputSource))
   .fn(async t => {
     const cases = await d.get('abstract');
-    await run(t, assignment(), [TypeAbstractFloat], TypeAbstractFloat, t.params, cases, 1);
+    await run(t, abstract_assignment(), [TypeAbstractFloat], TypeAbstractFloat, t.params, cases, 1);
   });
 
 g.test('f32')
@@ -81,10 +93,10 @@ g.test('f32')
 concretizing to f32
 `
   )
-  .params(u => u.combine('inputSource', [allInputSources[0]])) // Only defined for const-eval
+  .params(u => u.combine('inputSource', onlyConstInputSource))
   .fn(async t => {
     const cases = await d.get('f32');
-    await run(t, assignment(), [TypeAbstractFloat], TypeF32, t.params, cases);
+    await run(t, concrete_assignment(), [TypeAbstractFloat], TypeF32, t.params, cases);
   });
 
 g.test('f16')
@@ -97,8 +109,8 @@ concretizing to f16
   .beforeAllSubcases(t => {
     t.selectDeviceOrSkipTestCase({ requiredFeatures: ['shader-f16'] });
   })
-  .params(u => u.combine('inputSource', [allInputSources[0]])) // Only defined for const-eval
+  .params(u => u.combine('inputSource', onlyConstInputSource))
   .fn(async t => {
     const cases = await d.get('f16');
-    await run(t, assignment(), [TypeAbstractFloat], TypeF16, t.params, cases);
+    await run(t, concrete_assignment(), [TypeAbstractFloat], TypeF16, t.params, cases);
   });

--- a/src/webgpu/shader/execution/expression/unary/unary.ts
+++ b/src/webgpu/shader/execution/expression/unary/unary.ts
@@ -1,10 +1,15 @@
-import { basicExpressionBuilder, ShaderBuilder } from '../expression.js';
+import {
+  abstractFloatShaderBuilder,
+  basicExpressionBuilder,
+  ShaderBuilder,
+} from '../expression.js';
 
 /* @returns a ShaderBuilder that evaluates a prefix unary operation */
 export function unary(op: string): ShaderBuilder {
   return basicExpressionBuilder(value => `${op}(${value})`);
 }
 
-export function assignment(): ShaderBuilder {
-  return basicExpressionBuilder(value => `${value}`);
+/* @returns a ShaderBuilder that evaluates a prefix unary operation that returns AbstractFloats */
+export function abstract_unary(op: string): ShaderBuilder {
+  return abstractFloatShaderBuilder(value => `${op}(${value})`);
 }

--- a/src/webgpu/util/floating_point.ts
+++ b/src/webgpu/util/floating_point.ts
@@ -5,9 +5,9 @@ import { Case, IntervalFilter } from '../shader/execution/expression/expression.
 import { anyOf } from './compare.js';
 import { kValue } from './constants.js';
 import {
+  abstractFloat,
   f16,
   f32,
-  f64,
   isFloatType,
   reinterpretF16AsU16,
   reinterpretF32AsU32,
@@ -4820,7 +4820,7 @@ class FPAbstractTraits extends FPTraits {
   public readonly isSubnormal = isSubnormalNumberF64;
   public readonly flushSubnormal = flushSubnormalNumberF64;
   public readonly oneULP = oneULPF64;
-  public readonly scalarBuilder = f64;
+  public readonly scalarBuilder = abstractFloat;
 
   // Framework - Fundamental Error Intervals - Overrides
   public readonly absoluteErrorInterval = this.unboundedAbsoluteErrorInterval.bind(this);
@@ -4886,7 +4886,7 @@ class FPAbstractTraits extends FPTraits {
   public readonly multiplicationVectorMatrixInterval = this.unimplementedVectorMatrixToVector.bind(
     this
   );
-  public readonly negationInterval = this.unimplementedScalarToInterval.bind(this);
+  public readonly negationInterval = this.negationIntervalImpl.bind(this);
   public readonly normalizeInterval = this.unimplementedVectorToVector.bind(this);
   public readonly powInterval = this.unimplementedScalarPairToInterval.bind(this);
   public readonly quantizeToF16Interval = this.unimplementedScalarToInterval.bind(this);


### PR DESCRIPTION
This refactors the existing code to have a clearer separation from the non-AF test running code, reworks it to have the resultant value in a struct and implements vector support.

Issue #1626

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
