### PR TITLE
wgsl: f16 built-in execution test for sign and step

### DIFF
--- a/src/unittests/floating_point.spec.ts
+++ b/src/unittests/floating_point.spec.ts
@@ -4422,7 +4422,7 @@ g.test('remainderInterval_f32')
     );
   });
 
-g.test('stepInterval_f32')
+g.test('stepInterval')
   .params(u =>
     u
       .combine('trait', ['f32', 'f16'] as const)

--- a/src/unittests/floating_point.spec.ts
+++ b/src/unittests/floating_point.spec.ts
@@ -3246,37 +3246,37 @@ g.test('roundInterval')
         const constants = FP[p.trait].constants();
         // prettier-ignore
         return [
-      { input: 0, expected: 0 },
-      { input: 0.1, expected: 0 },
-      { input: 0.5, expected: 0 },  // Testing tie breaking
-      { input: 0.9, expected: 1 },
-      { input: 1.0, expected: 1 },
-      { input: 1.1, expected: 1 },
-      { input: 1.5, expected: 2 },  // Testing tie breaking
-      { input: 1.9, expected: 2 },
-      { input: -0.1, expected: 0 },
-      { input: -0.5, expected: 0 },  // Testing tie breaking
-      { input: -0.9, expected: -1 },
-      { input: -1.0, expected: -1 },
-      { input: -1.1, expected: -1 },
-      { input: -1.5, expected: -2 },  // Testing tie breaking
-      { input: -1.9, expected: -2 },
+          { input: 0, expected: 0 },
+          { input: 0.1, expected: 0 },
+          { input: 0.5, expected: 0 },  // Testing tie breaking
+          { input: 0.9, expected: 1 },
+          { input: 1.0, expected: 1 },
+          { input: 1.1, expected: 1 },
+          { input: 1.5, expected: 2 },  // Testing tie breaking
+          { input: 1.9, expected: 2 },
+          { input: -0.1, expected: 0 },
+          { input: -0.5, expected: 0 },  // Testing tie breaking
+          { input: -0.9, expected: -1 },
+          { input: -1.0, expected: -1 },
+          { input: -1.1, expected: -1 },
+          { input: -1.5, expected: -2 },  // Testing tie breaking
+          { input: -1.9, expected: -2 },
 
-      // Edge cases
-      { input: constants.positive.infinity, expected: kUnboundedBounds },
-      { input: constants.negative.infinity, expected: kUnboundedBounds },
-      { input: constants.positive.max, expected: constants.positive.max },
-      { input: constants.positive.min, expected: 0 },
-      { input: constants.negative.min, expected: constants.negative.min },
-      { input: constants.negative.max, expected: 0 },
-      ...kRoundIntervalCases[p.trait],
+          // Edge cases
+          { input: constants.positive.infinity, expected: kUnboundedBounds },
+          { input: constants.negative.infinity, expected: kUnboundedBounds },
+          { input: constants.positive.max, expected: constants.positive.max },
+          { input: constants.positive.min, expected: 0 },
+          { input: constants.negative.min, expected: constants.negative.min },
+          { input: constants.negative.max, expected: 0 },
+          ...kRoundIntervalCases[p.trait],
 
-      // 32-bit subnormals
-      { input: constants.positive.subnormal.max, expected: 0 },
-      { input: constants.positive.subnormal.min, expected: 0 },
-      { input: constants.negative.subnormal.min, expected: 0 },
-      { input: constants.negative.subnormal.max, expected: 0 },
-    ];
+          // 32-bit subnormals
+          { input: constants.positive.subnormal.max, expected: 0 },
+          { input: constants.positive.subnormal.min, expected: 0 },
+          { input: constants.negative.subnormal.min, expected: 0 },
+          { input: constants.negative.subnormal.max, expected: 0 },
+        ];
       })
   )
   .fn(t => {
@@ -3327,35 +3327,42 @@ g.test('saturateInterval_f32')
     );
   });
 
-g.test('signInterval_f32')
-  .paramsSubcasesOnly<ScalarToIntervalCase>(
-    // prettier-ignore
-    [
-      { input: kValue.f32.infinity.negative, expected: kUnboundedBounds },
-      { input: kValue.f32.negative.min, expected: -1 },
-      { input: -10, expected: -1 },
-      { input: -1, expected: -1 },
-      { input: -0.1, expected: -1 },
-      { input: kValue.f32.negative.max, expected:  -1 },
-      { input: kValue.f32.subnormal.negative.min, expected: [-1, 0] },
-      { input: kValue.f32.subnormal.negative.max, expected: [-1, 0] },
-      { input: 0, expected: 0 },
-      { input: kValue.f32.subnormal.positive.max, expected: [0, 1] },
-      { input: kValue.f32.subnormal.positive.min, expected: [0, 1] },
-      { input: kValue.f32.positive.min, expected: 1 },
-      { input: 0.1, expected: 1 },
-      { input: 1, expected: 1 },
-      { input: 10, expected: 1 },
-      { input: kValue.f32.positive.max, expected: 1 },
-      { input: kValue.f32.infinity.positive, expected: kUnboundedBounds },
-    ]
+g.test('signInterval')
+  .params(u =>
+    u
+      .combine('trait', ['f32', 'f16'] as const)
+      .beginSubcases()
+      .expandWithParams<ScalarToIntervalCase>(p => {
+        const constants = FP[p.trait].constants();
+        // prettier-ignore
+        return [
+          { input: constants.negative.infinity, expected: kUnboundedBounds },
+          { input: constants.negative.min, expected: -1 },
+          { input: -10, expected: -1 },
+          { input: -1, expected: -1 },
+          { input: -0.1, expected: -1 },
+          { input: constants.negative.max, expected:  -1 },
+          { input: constants.negative.subnormal.min, expected: [-1, 0] },
+          { input: constants.negative.subnormal.max, expected: [-1, 0] },
+          { input: 0, expected: 0 },
+          { input: constants.positive.subnormal.max, expected: [0, 1] },
+          { input: constants.positive.subnormal.min, expected: [0, 1] },
+          { input: constants.positive.min, expected: 1 },
+          { input: 0.1, expected: 1 },
+          { input: 1, expected: 1 },
+          { input: 10, expected: 1 },
+          { input: constants.positive.max, expected: 1 },
+          { input: constants.positive.infinity, expected: kUnboundedBounds },
+        ];
+      })
   )
   .fn(t => {
-    const expected = FP.f32.toInterval(t.params.expected);
-    const got = FP.f32.signInterval(t.params.input);
+    const trait = FP[t.params.trait];
+    const expected = trait.toInterval(t.params.expected);
+    const got = trait.signInterval(t.params.input);
     t.expect(
       objectEquals(expected, got),
-      `f32.signInterval(${t.params.input}) returned ${got}. Expected ${expected}`
+      `${t.params.trait}.signInterval(${t.params.input}) returned ${got}. Expected ${expected}`
     );
   });
 
@@ -4416,78 +4423,85 @@ g.test('remainderInterval_f32')
   });
 
 g.test('stepInterval_f32')
-  .paramsSubcasesOnly<ScalarPairToIntervalCase>(
-    // prettier-ignore
-    [
-      // 32-bit normals
-      { input: [0, 0], expected: 1 },
-      { input: [1, 1], expected: 1 },
-      { input: [0, 1], expected: 1 },
-      { input: [1, 0], expected: 0 },
-      { input: [-1, -1], expected: 1 },
-      { input: [0, -1], expected: 0 },
-      { input: [-1, 0], expected: 1 },
-      { input: [-1, 1], expected: 1 },
-      { input: [1, -1], expected: 0 },
+  .params(u =>
+    u
+      .combine('trait', ['f32', 'f16'] as const)
+      .beginSubcases()
+      .expandWithParams<ScalarPairToIntervalCase>(p => {
+        const constants = FP[p.trait].constants();
+        // prettier-ignore
+        return [
+          // 32-bit normals
+          { input: [0, 0], expected: 1 },
+          { input: [1, 1], expected: 1 },
+          { input: [0, 1], expected: 1 },
+          { input: [1, 0], expected: 0 },
+          { input: [-1, -1], expected: 1 },
+          { input: [0, -1], expected: 0 },
+          { input: [-1, 0], expected: 1 },
+          { input: [-1, 1], expected: 1 },
+          { input: [1, -1], expected: 0 },
 
-      // 64-bit normals
-      { input: [0.1, 0.1], expected: [0, 1] },
-      { input: [0, 0.1], expected: 1 },
-      { input: [0.1, 0], expected: 0 },
-      { input: [0.1, 1], expected: 1 },
-      { input: [1, 0.1], expected: 0 },
-      { input: [-0.1, -0.1], expected: [0, 1] },
-      { input: [0, -0.1], expected: 0 },
-      { input: [-0.1, 0], expected: 1 },
-      { input: [-0.1, -1], expected: 0 },
-      { input: [-1, -0.1], expected: 1 },
+          // 64-bit normals
+          { input: [0.1, 0.1], expected: [0, 1] },
+          { input: [0, 0.1], expected: 1 },
+          { input: [0.1, 0], expected: 0 },
+          { input: [0.1, 1], expected: 1 },
+          { input: [1, 0.1], expected: 0 },
+          { input: [-0.1, -0.1], expected: [0, 1] },
+          { input: [0, -0.1], expected: 0 },
+          { input: [-0.1, 0], expected: 1 },
+          { input: [-0.1, -1], expected: 0 },
+          { input: [-1, -0.1], expected: 1 },
 
-      // Subnormals
-      { input: [0, kValue.f32.subnormal.positive.max], expected: 1 },
-      { input: [0, kValue.f32.subnormal.positive.min], expected: 1 },
-      { input: [0, kValue.f32.subnormal.negative.max], expected: [0, 1] },
-      { input: [0, kValue.f32.subnormal.negative.min], expected: [0, 1] },
-      { input: [1, kValue.f32.subnormal.positive.max], expected: 0 },
-      { input: [1, kValue.f32.subnormal.positive.min], expected: 0 },
-      { input: [1, kValue.f32.subnormal.negative.max], expected: 0 },
-      { input: [1, kValue.f32.subnormal.negative.min], expected: 0 },
-      { input: [-1, kValue.f32.subnormal.positive.max], expected: 1 },
-      { input: [-1, kValue.f32.subnormal.positive.min], expected: 1 },
-      { input: [-1, kValue.f32.subnormal.negative.max], expected: 1 },
-      { input: [-1, kValue.f32.subnormal.negative.min], expected: 1 },
-      { input: [kValue.f32.subnormal.positive.max, 0], expected: [0, 1] },
-      { input: [kValue.f32.subnormal.positive.min, 0], expected: [0, 1] },
-      { input: [kValue.f32.subnormal.negative.max, 0], expected: 1 },
-      { input: [kValue.f32.subnormal.negative.min, 0], expected: 1 },
-      { input: [kValue.f32.subnormal.positive.max, 1], expected: 1 },
-      { input: [kValue.f32.subnormal.positive.min, 1], expected: 1 },
-      { input: [kValue.f32.subnormal.negative.max, 1], expected: 1 },
-      { input: [kValue.f32.subnormal.negative.min, 1], expected: 1 },
-      { input: [kValue.f32.subnormal.positive.max, -1], expected: 0 },
-      { input: [kValue.f32.subnormal.positive.min, -1], expected: 0 },
-      { input: [kValue.f32.subnormal.negative.max, -1], expected: 0 },
-      { input: [kValue.f32.subnormal.negative.min, -1], expected: 0 },
-      { input: [kValue.f32.subnormal.negative.min, kValue.f32.subnormal.positive.max], expected: 1 },
-      { input: [kValue.f32.subnormal.positive.max, kValue.f32.subnormal.negative.min], expected: [0, 1] },
+          // Subnormals
+          { input: [0, constants.positive.subnormal.max], expected: 1 },
+          { input: [0, constants.positive.subnormal.min], expected: 1 },
+          { input: [0, constants.negative.subnormal.max], expected: [0, 1] },
+          { input: [0, constants.negative.subnormal.min], expected: [0, 1] },
+          { input: [1, constants.positive.subnormal.max], expected: 0 },
+          { input: [1, constants.positive.subnormal.min], expected: 0 },
+          { input: [1, constants.negative.subnormal.max], expected: 0 },
+          { input: [1, constants.negative.subnormal.min], expected: 0 },
+          { input: [-1, constants.positive.subnormal.max], expected: 1 },
+          { input: [-1, constants.positive.subnormal.min], expected: 1 },
+          { input: [-1, constants.negative.subnormal.max], expected: 1 },
+          { input: [-1, constants.negative.subnormal.min], expected: 1 },
+          { input: [constants.positive.subnormal.max, 0], expected: [0, 1] },
+          { input: [constants.positive.subnormal.min, 0], expected: [0, 1] },
+          { input: [constants.negative.subnormal.max, 0], expected: 1 },
+          { input: [constants.negative.subnormal.min, 0], expected: 1 },
+          { input: [constants.positive.subnormal.max, 1], expected: 1 },
+          { input: [constants.positive.subnormal.min, 1], expected: 1 },
+          { input: [constants.negative.subnormal.max, 1], expected: 1 },
+          { input: [constants.negative.subnormal.min, 1], expected: 1 },
+          { input: [constants.positive.subnormal.max, -1], expected: 0 },
+          { input: [constants.positive.subnormal.min, -1], expected: 0 },
+          { input: [constants.negative.subnormal.max, -1], expected: 0 },
+          { input: [constants.negative.subnormal.min, -1], expected: 0 },
+          { input: [constants.negative.subnormal.min, constants.positive.subnormal.max], expected: 1 },
+          { input: [constants.positive.subnormal.max, constants.negative.subnormal.min], expected: [0, 1] },
 
-      // Infinities
-      { input: [0, kValue.f32.infinity.positive], expected: kUnboundedBounds },
-      { input: [kValue.f32.infinity.positive, 0], expected: kUnboundedBounds },
-      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.positive], expected: kUnboundedBounds },
-      { input: [0, kValue.f32.infinity.negative], expected: kUnboundedBounds },
-      { input: [kValue.f32.infinity.negative, 0], expected: kUnboundedBounds },
-      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.negative], expected: kUnboundedBounds },
-      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive], expected: kUnboundedBounds },
-      { input: [kValue.f32.infinity.positive, kValue.f32.infinity.negative], expected: kUnboundedBounds },
-    ]
+          // Infinities
+          { input: [0, constants.positive.infinity], expected: kUnboundedBounds },
+          { input: [constants.positive.infinity, 0], expected: kUnboundedBounds },
+          { input: [constants.positive.infinity, constants.positive.infinity], expected: kUnboundedBounds },
+          { input: [0, constants.negative.infinity], expected: kUnboundedBounds },
+          { input: [constants.negative.infinity, 0], expected: kUnboundedBounds },
+          { input: [constants.negative.infinity, constants.negative.infinity], expected: kUnboundedBounds },
+          { input: [constants.negative.infinity, constants.positive.infinity], expected: kUnboundedBounds },
+          { input: [constants.positive.infinity, constants.negative.infinity], expected: kUnboundedBounds },
+        ];
+      })
   )
   .fn(t => {
+    const trait = FP[t.params.trait];
     const [edge, x] = t.params.input;
-    const expected = FP.f32.toInterval(t.params.expected);
-    const got = FP.f32.stepInterval(edge, x);
+    const expected = trait.toInterval(t.params.expected);
+    const got = trait.stepInterval(edge, x);
     t.expect(
       objectEquals(expected, got),
-      `f32.stepInterval(${edge}, ${x}) returned ${got}. Expected ${expected}`
+      `${t.params.trait}.stepInterval(${edge}, ${x}) returned ${got}. Expected ${expected}`
     );
   });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/sign.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/sign.spec.ts
@@ -9,9 +9,9 @@ Returns the sign of e. Component-wise when T is a vector.
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
-import { i32, TypeF32, TypeI32 } from '../../../../../util/conversion.js';
+import { i32, TypeF32, TypeF16, TypeI32 } from '../../../../../util/conversion.js';
 import { FP } from '../../../../../util/floating_point.js';
-import { fullF32Range, fullI32Range } from '../../../../../util/math.js';
+import { fullF32Range, fullF16Range, fullI32Range } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
 import { allInputSources, run } from '../../expression.js';
 
@@ -22,6 +22,9 @@ export const g = makeTestGroup(GPUTest);
 export const d = makeCaseCache('sign', {
   f32: () => {
     return FP.f32.generateScalarToIntervalCases(fullF32Range(), 'unfiltered', FP.f32.signInterval);
+  },
+  f16: () => {
+    return FP.f16.generateScalarToIntervalCases(fullF16Range(), 'unfiltered', FP.f16.signInterval);
   },
   i32: () =>
     fullI32Range().map(i => {
@@ -74,4 +77,10 @@ g.test('f16')
   .params(u =>
     u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
-  .unimplemented();
+  .beforeAllSubcases(t => {
+    t.selectDeviceOrSkipTestCase('shader-f16');
+  })
+  .fn(async t => {
+    const cases = await d.get('f16');
+    await run(t, builtin('sign'), [TypeF16], TypeF16, t.params, cases);
+  });

--- a/src/webgpu/shader/execution/expression/call/builtin/step.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/step.spec.ts
@@ -10,9 +10,9 @@ Returns 1.0 if edge ≤ x, and 0.0 otherwise. Component-wise when T is a vector.
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
 import { anyOf } from '../../../../../util/compare.js';
-import { TypeF32 } from '../../../../../util/conversion.js';
+import { TypeF32, TypeF16 } from '../../../../../util/conversion.js';
 import { FP } from '../../../../../util/floating_point.js';
-import { fullF32Range } from '../../../../../util/math.js';
+import { fullF32Range, fullF16Range } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
 import { allInputSources, Case, run } from '../../expression.js';
 
@@ -20,40 +20,36 @@ import { builtin } from './builtin.js';
 
 export const g = makeTestGroup(GPUTest);
 
+// stepInterval's return value can't always be interpreted as a single acceptance
+// interval, valid result may be 0.0 or 1.0 or both of them, but will never be a
+// value in interval (0.0, 1.0).
+// See the comment block on stepInterval for more details
+const makeCase = (trait: 'f32' | 'f16', edge: number, x: number): Case => {
+  const FPTrait = FP[trait];
+  edge = FPTrait.quantize(edge);
+  x = FPTrait.quantize(x);
+  const expected = FPTrait.stepInterval(edge, x);
+
+  // [0, 0], [1, 1], or [-∞, +∞] cases
+  if (expected.isPoint() || !expected.isFinite()) {
+    return { input: [FPTrait.scalarBuilder(edge), FPTrait.scalarBuilder(x)], expected };
+  }
+
+  // [0, 1] case, valid result is either 0.0 or 1.0.
+  const zeroInterval = FPTrait.toInterval(0);
+  const oneInterval = FPTrait.toInterval(1);
+  return {
+    input: [FPTrait.scalarBuilder(edge), FPTrait.scalarBuilder(x)],
+    expected: anyOf(zeroInterval, oneInterval),
+  };
+};
+
 export const d = makeCaseCache('step', {
   f32: () => {
-    const zeroInterval = FP.f32.toInterval(0);
-    const oneInterval = FP.f32.toInterval(1);
-
-    // stepInterval's return value isn't always interpreted as an acceptance
-    // interval, so makeBinaryToF32IntervalCase cannot be used here.
-    // See the comment block on stepInterval for more details
-    const makeCase = (edge: number, x: number): Case => {
-      edge = FP.f32.quantize(edge);
-      x = FP.f32.quantize(x);
-      const expected = FP.f32.stepInterval(edge, x);
-
-      // [0, 0], [1, 1], or [-∞, +∞] cases
-      if (expected.isPoint() || !expected.isFinite()) {
-        return { input: [FP.f32.scalarBuilder(edge), FP.f32.scalarBuilder(x)], expected };
-      }
-
-      // [0, 1] case
-      return {
-        input: [FP.f32.scalarBuilder(edge), FP.f32.scalarBuilder(x)],
-        expected: anyOf(zeroInterval, oneInterval),
-      };
-    };
-
-    const range = fullF32Range();
-    const cases: Array<Case> = [];
-    range.forEach(edge => {
-      range.forEach(x => {
-        cases.push(makeCase(edge, x));
-      });
-    });
-
-    return cases;
+    return fullF32Range().flatMap(edge => fullF32Range().map(x => makeCase('f32', edge, x)));
+  },
+  f16: () => {
+    return fullF16Range().flatMap(edge => fullF16Range().map(x => makeCase('f16', edge, x)));
   },
 });
 
@@ -82,4 +78,10 @@ g.test('f16')
   .params(u =>
     u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
-  .unimplemented();
+  .beforeAllSubcases(t => {
+    t.selectDeviceOrSkipTestCase('shader-f16');
+  })
+  .fn(async t => {
+    const cases = await d.get('f16');
+    await run(t, builtin('step'), [TypeF16, TypeF16], TypeF16, t.params, cases);
+  });

--- a/src/webgpu/util/floating_point.ts
+++ b/src/webgpu/util/floating_point.ts
@@ -5181,12 +5181,12 @@ class F16Traits extends FPTraits {
   public readonly remainderInterval = this.unimplementedScalarPairToInterval.bind(this);
   public readonly roundInterval = this.roundIntervalImpl.bind(this);
   public readonly saturateInterval = this.unimplementedScalarToInterval.bind(this);
-  public readonly signInterval = this.unimplementedScalarToInterval.bind(this);
+  public readonly signInterval = this.signIntervalImpl.bind(this);
   public readonly sinInterval = this.sinIntervalImpl.bind(this);
   public readonly sinhInterval = this.unimplementedScalarToInterval.bind(this);
   public readonly smoothStepInterval = this.unimplementedScalarTripleToInterval.bind(this);
   public readonly sqrtInterval = this.sqrtIntervalImpl.bind(this);
-  public readonly stepInterval = this.unimplementedScalarPairToInterval.bind(this);
+  public readonly stepInterval = this.stepIntervalImpl.bind(this);
   public readonly subtractionInterval = this.subtractionIntervalImpl.bind(this);
   public readonly subtractionMatrixMatrixInterval = this.unimplementedMatrixPairToMatrix.bind(this);
   public readonly tanInterval = this.unimplementedScalarToInterval.bind(this);


### PR DESCRIPTION
This PR add execution tests for f16 built-in sign and step.

Issue: #1248, #2583, #2529

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
