### PR TITLE
Remove orientation from several texture copy tests

### DIFF
--- a/src/webgpu/web_platform/copyToTexture/ImageData.spec.ts
+++ b/src/webgpu/web_platform/copyToTexture/ImageData.spec.ts
@@ -39,7 +39,6 @@ g.test('from_ImageData')
   )
   .params(u =>
     u
-      .combine('orientation', ['none', 'flipY'] as const)
       .combine('srcDoFlipYDuringCopy', [true, false])
       .combine('dstColorFormat', kValidTextureFormatsForCopyE2T)
       .combine('dstPremultiplied', [true, false])
@@ -54,7 +53,6 @@ g.test('from_ImageData')
     const {
       width,
       height,
-      orientation,
       dstColorFormat,
       dstPremultiplied,
       srcDoFlipYDuringCopy,
@@ -87,7 +85,7 @@ g.test('from_ImageData')
     });
 
     const expFormat = kTextureFormatInfo[dstColorFormat].baseFormat ?? dstColorFormat;
-    const flipSrcBeforeCopy = orientation === 'flipY';
+    const flipSrcBeforeCopy = false;
     const texelViewExpected = t.getExpectedDstPixelsFromSrcPixels({
       srcPixels: imageData.data,
       srcOrigin: [0, 0],
@@ -155,14 +153,13 @@ g.test('copy_subrect_from_ImageData')
   )
   .params(u =>
     u
-      .combine('orientation', ['none', 'flipY'] as const)
       .combine('srcDoFlipYDuringCopy', [true, false])
       .combine('dstPremultiplied', [true, false])
       .beginSubcases()
       .combine('copySubRectInfo', kCopySubrectInfo)
   )
   .fn(t => {
-    const { copySubRectInfo, orientation, dstPremultiplied, srcDoFlipYDuringCopy } = t.params;
+    const { copySubRectInfo, dstPremultiplied, srcDoFlipYDuringCopy } = t.params;
 
     const testColors = kTestColorsAll;
     const { srcOrigin, dstOrigin, srcSize, dstSize, copyExtent } = copySubRectInfo;
@@ -192,7 +189,7 @@ g.test('copy_subrect_from_ImageData')
         GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
     });
 
-    const flipSrcBeforeCopy = orientation === 'flipY';
+    const flipSrcBeforeCopy = false;
     const texelViewExpected = t.getExpectedDstPixelsFromSrcPixels({
       srcPixels: imageData.data,
       srcOrigin,

--- a/src/webgpu/web_platform/copyToTexture/ImageData.spec.ts
+++ b/src/webgpu/web_platform/copyToTexture/ImageData.spec.ts
@@ -50,13 +50,7 @@ g.test('from_ImageData')
     t.skipIfTextureFormatNotSupported(t.params.dstColorFormat);
   })
   .fn(t => {
-    const {
-      width,
-      height,
-      dstColorFormat,
-      dstPremultiplied,
-      srcDoFlipYDuringCopy,
-    } = t.params;
+    const { width, height, dstColorFormat, dstPremultiplied, srcDoFlipYDuringCopy } = t.params;
 
     const testColors = kTestColorsAll;
 

--- a/src/webgpu/web_platform/copyToTexture/image.spec.ts
+++ b/src/webgpu/web_platform/copyToTexture/image.spec.ts
@@ -53,7 +53,6 @@ g.test('from_image')
   )
   .params(u =>
     u
-      .combine('orientation', ['none', 'flipY'] as const)
       .combine('srcDoFlipYDuringCopy', [true, false])
       .combine('dstColorFormat', kValidTextureFormatsForCopyE2T)
       .combine('dstPremultiplied', [true, false])
@@ -69,7 +68,6 @@ g.test('from_image')
     const {
       width,
       height,
-      orientation,
       dstColorFormat,
       dstPremultiplied,
       srcDoFlipYDuringCopy,
@@ -117,7 +115,7 @@ g.test('from_image')
     });
 
     const expFormat = kTextureFormatInfo[dstColorFormat].baseFormat ?? dstColorFormat;
-    const flipSrcBeforeCopy = orientation === 'flipY';
+    const flipSrcBeforeCopy = false;
     const texelViewExpected = t.getExpectedDstPixelsFromSrcPixels({
       srcPixels: imageData.data,
       srcOrigin: [0, 0],
@@ -186,7 +184,6 @@ g.test('copy_subrect_from_2D_Canvas')
   )
   .params(u =>
     u
-      .combine('orientation', ['none', 'flipY'] as const)
       .combine('srcDoFlipYDuringCopy', [true, false])
       .combine('dstPremultiplied', [true, false])
       .beginSubcases()
@@ -196,7 +193,7 @@ g.test('copy_subrect_from_2D_Canvas')
     if (typeof HTMLImageElement === 'undefined') t.skip('HTMLImageElement not available');
   })
   .fn(async t => {
-    const { copySubRectInfo, orientation, dstPremultiplied, srcDoFlipYDuringCopy } = t.params;
+    const { copySubRectInfo, dstPremultiplied, srcDoFlipYDuringCopy } = t.params;
 
     const { srcOrigin, dstOrigin, srcSize, dstSize, copyExtent } = copySubRectInfo;
     const kColorFormat = 'rgba8unorm';
@@ -242,7 +239,7 @@ g.test('copy_subrect_from_2D_Canvas')
         GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
     });
 
-    const flipSrcBeforeCopy = orientation === 'flipY';
+    const flipSrcBeforeCopy = false;
     const texelViewExpected = t.getExpectedDstPixelsFromSrcPixels({
       srcPixels: imageData.data,
       srcOrigin,

--- a/src/webgpu/web_platform/copyToTexture/image.spec.ts
+++ b/src/webgpu/web_platform/copyToTexture/image.spec.ts
@@ -65,13 +65,7 @@ g.test('from_image')
     if (typeof HTMLImageElement === 'undefined') t.skip('HTMLImageElement not available');
   })
   .fn(async t => {
-    const {
-      width,
-      height,
-      dstColorFormat,
-      dstPremultiplied,
-      srcDoFlipYDuringCopy,
-    } = t.params;
+    const { width, height, dstColorFormat, dstPremultiplied, srcDoFlipYDuringCopy } = t.params;
 
     const imageCanvas = document.createElement('canvas');
     imageCanvas.width = width;


### PR DESCRIPTION
The orientation argument for these tests was copied from tests which use an `ImageBitmap` source. Because `CreateImageBitmap()` has an `imageOrientation` option it made sense to test against all variants of it. However, other tests, such as those that consume `ImageData` directly, don't have any native mechanism for Y-flipping the source. The data could be generated Y-flipped, but that doesn't increase coverage of any implementation features. Despite not flipping the source orientation, however, the test was still expected the data to be flipped.

By removing this argument and no longer testing for flipped source data, these tests all begin passing with no loss of platform coverage.

Fixes [dawn issue 2017](https://bugs.chromium.org/p/dawn/issues/detail?id=2017)

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
