### PR TITLE
Add `generate-cache` step to `grunt pre`

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -32,7 +32,7 @@ module.exports = function (grunt) {
       },
       'generate-cache': {
         cmd: 'node',
-        args: ['tools/gen_cache', 'out/data', 'src/webgpu'],
+        args: ['tools/gen_cache', 'out', 'src/webgpu'],
       },
       unittest: {
         cmd: 'node',
@@ -193,6 +193,7 @@ module.exports = function (grunt) {
     'run:generate-listings',
     'build-wpt',
     'run:build-out-node',
+    'run:generate-cache',
     'build-done-message',
     'ts:check',
     'run:presubmit',

--- a/src/common/tools/gen_cache.ts
+++ b/src/common/tools/gen_cache.ts
@@ -14,22 +14,30 @@ DataCache will load this instead of building the expensive data at CTS runtime.
 Options:
   --help          Print this message and exit.
   --list          Print the list of output files without writing them.
+  --verbose       Print each action taken.
 `);
   process.exit(rc);
 }
 
 let mode: 'emit' | 'list' = 'emit';
+let verbose = false;
 
 const nonFlagsArgs: string[] = [];
 for (const a of process.argv) {
   if (a.startsWith('-')) {
-    if (a === '--list') {
-      mode = 'list';
-    } else if (a === '--help') {
-      usage(0);
-    } else {
-      console.log('unrecognized flag: ', a);
-      usage(1);
+    switch (a) {
+      case '--list':
+        mode = 'list';
+        break;
+      case '--help':
+        usage(0);
+        break;
+      case '--verbose':
+        verbose = true;
+        break;
+      default:
+        console.log('unrecognized flag: ', a);
+        usage(1);
     }
   } else {
     nonFlagsArgs.push(a);
@@ -127,6 +135,9 @@ and
 
         switch (mode) {
           case 'emit': {
+            if (verbose) {
+              console.log(`building '${outPath}'`);
+            }
             const data = await cacheable.build();
             const serialized = cacheable.serialize(data);
             fs.mkdirSync(path.dirname(outPath), { recursive: true });


### PR DESCRIPTION
This is run by `npm test`, and should catch cache file collision issues which have caused reverts in the past.

Also add a `--verbose` flag to the tool to see what its up to.

Issue: #2913