### PR TITLE
wgsl: f16 built-in execution test for frexp

### DIFF
--- a/src/unittests/floating_point.spec.ts
+++ b/src/unittests/floating_point.spec.ts
@@ -2557,33 +2557,33 @@ g.test('ceilInterval')
         const constants = FP[p.trait].constants();
         // prettier-ignore
         return [
-        { input: 0, expected: 0 },
-        { input: 0.1, expected: 1 },
-        { input: 0.9, expected: 1 },
-        { input: 1.0, expected: 1 },
-        { input: 1.1, expected: 2 },
-        { input: 1.9, expected: 2 },
-        { input: -0.1, expected: 0 },
-        { input: -0.9, expected: 0 },
-        { input: -1.0, expected: -1 },
-        { input: -1.1, expected: -1 },
-        { input: -1.9, expected: -1 },
+          { input: 0, expected: 0 },
+          { input: 0.1, expected: 1 },
+          { input: 0.9, expected: 1 },
+          { input: 1.0, expected: 1 },
+          { input: 1.1, expected: 2 },
+          { input: 1.9, expected: 2 },
+          { input: -0.1, expected: 0 },
+          { input: -0.9, expected: 0 },
+          { input: -1.0, expected: -1 },
+          { input: -1.1, expected: -1 },
+          { input: -1.9, expected: -1 },
 
-        // Edge cases
-        { input: constants.positive.infinity, expected: kUnboundedBounds },
-        { input: constants.negative.infinity, expected: kUnboundedBounds },
-        { input: constants.positive.max, expected: constants.positive.max },
-        { input: constants.positive.min, expected: 1 },
-        { input: constants.negative.min, expected: constants.negative.min },
-        { input: constants.negative.max, expected: 0 },
-        ...kCeilIntervalCases[p.trait],
+          // Edge cases
+          { input: constants.positive.infinity, expected: kUnboundedBounds },
+          { input: constants.negative.infinity, expected: kUnboundedBounds },
+          { input: constants.positive.max, expected: constants.positive.max },
+          { input: constants.positive.min, expected: 1 },
+          { input: constants.negative.min, expected: constants.negative.min },
+          { input: constants.negative.max, expected: 0 },
+          ...kCeilIntervalCases[p.trait],
 
-        // 32-bit subnormals
-        { input: constants.positive.subnormal.max, expected: [0, 1] },
-        { input: constants.positive.subnormal.min, expected: [0, 1] },
-        { input: constants.negative.subnormal.min, expected: 0 },
-        { input: constants.negative.subnormal.max, expected: 0 },
-      ];
+          // 32-bit subnormals
+          { input: constants.positive.subnormal.max, expected: [0, 1] },
+          { input: constants.positive.subnormal.min, expected: [0, 1] },
+          { input: constants.negative.subnormal.min, expected: 0 },
+          { input: constants.negative.subnormal.max, expected: 0 },
+        ];
       })
   )
   .fn(t => {

--- a/src/unittests/maths.spec.ts
+++ b/src/unittests/maths.spec.ts
@@ -1058,20 +1058,9 @@ interface frexpCase {
   exp: number;
 }
 
-g.test('frexp')
-  .paramsSimple<frexpCase>([
-    { input: 0, fract: 0, exp: 0 },
-    { input: -0, fract: -0, exp: 0 },
-    { input: Number.POSITIVE_INFINITY, fract: Number.POSITIVE_INFINITY, exp: 0 },
-    { input: Number.NEGATIVE_INFINITY, fract: Number.NEGATIVE_INFINITY, exp: 0 },
-    { input: 0.5, fract: 0.5, exp: 0 },
-    { input: -0.5, fract: -0.5, exp: 0 },
-    { input: 1, fract: 0.5, exp: 1 },
-    { input: -1, fract: -0.5, exp: 1 },
-    { input: 2, fract: 0.5, exp: 2 },
-    { input: -2, fract: -0.5, exp: 2 },
-    { input: 10000, fract: 0.6103515625, exp: 14 },
-    { input: -10000, fract: -0.6103515625, exp: 14 },
+// prettier-ignore
+const kFrexpCases = {
+  f32: [
     { input: kValue.f32.positive.max, fract: 0.9999999403953552, exp: 128 },
     { input: kValue.f32.positive.min, fract: 0.5, exp: -125 },
     { input: kValue.f32.negative.max, fract: -0.5, exp: -125 },
@@ -1080,15 +1069,68 @@ g.test('frexp')
     { input: kValue.f32.subnormal.positive.min, fract: 0.5, exp: -148 },
     { input: kValue.f32.subnormal.negative.max, fract: -0.5, exp: -148 },
     { input: kValue.f32.subnormal.negative.min, fract: -0.9999998807907104, exp: -126 },
-  ])
+  ] as frexpCase[],
+  f16: [
+    { input: kValue.f16.positive.max, fract: 0.99951171875, exp: 16 },
+    { input: kValue.f16.positive.min, fract: 0.5, exp: -13 },
+    { input: kValue.f16.negative.max, fract: -0.5, exp: -13 },
+    { input: kValue.f16.negative.min, fract: -0.99951171875, exp: 16 },
+    { input: kValue.f16.subnormal.positive.max, fract: 0.9990234375, exp: -14 },
+    { input: kValue.f16.subnormal.positive.min, fract: 0.5, exp: -23 },
+    { input: kValue.f16.subnormal.negative.max, fract: -0.5, exp: -23 },
+    { input: kValue.f16.subnormal.negative.min, fract: -0.9990234375, exp: -14 },
+  ] as frexpCase[],
+  f64: [
+    { input: kValue.f64.positive.max, fract: reinterpretU64AsF64(0x3fef_ffff_ffff_ffffn) /* ~0.9999999999999999 */, exp: 1024 },
+    { input: kValue.f64.positive.min, fract: 0.5, exp: -1021 },
+    { input: kValue.f64.negative.max, fract: -0.5, exp: -1021 },
+    { input: kValue.f64.negative.min, fract: reinterpretU64AsF64(0xbfef_ffff_ffff_ffffn) /* ~-0.9999999999999999 */, exp: 1024 },
+    { input: kValue.f64.subnormal.positive.max, fract: reinterpretU64AsF64(0x3fef_ffff_ffff_fffen) /* ~0.9999999999999998 */, exp: -1022 },
+    { input: kValue.f64.subnormal.positive.min, fract: 0.5, exp: -1073 },
+    { input: kValue.f64.subnormal.negative.max, fract: -0.5, exp: -1073 },
+    { input: kValue.f64.subnormal.negative.min, fract: reinterpretU64AsF64(0xbfef_ffff_ffff_fffen) /* ~-0.9999999999999998 */, exp: -1022 },
+  ] as frexpCase[],
+} as const;
+
+g.test('frexp')
+  .params(u =>
+    u
+      .combine('trait', ['f32', 'f16', 'f64'] as const)
+      .beginSubcases()
+      .expandWithParams<frexpCase>(p => {
+        // prettier-ignore
+        return [
+          // +/- 0.0
+          { input: 0, fract: 0, exp: 0 },
+          { input: -0, fract: -0, exp: 0 },
+          // Normal float values that can be exactly represented by all float types
+          { input: 0.171875, fract: 0.6875, exp: -2 },
+          { input: -0.171875, fract: -0.6875, exp: -2 },
+          { input: 0.5, fract: 0.5, exp: 0 },
+          { input: -0.5, fract: -0.5, exp: 0 },
+          { input: 1, fract: 0.5, exp: 1 },
+          { input: -1, fract: -0.5, exp: 1 },
+          { input: 2, fract: 0.5, exp: 2 },
+          { input: -2, fract: -0.5, exp: 2 },
+          { input: 10000, fract: 0.6103515625, exp: 14 },
+          { input: -10000, fract: -0.6103515625, exp: 14 },
+          // Normal ans subnormal cases that are different for each type
+          ...kFrexpCases[p.trait],
+          // Inf and NaN
+          { input: Number.POSITIVE_INFINITY, fract: Number.POSITIVE_INFINITY, exp: 0 },
+          { input: Number.NEGATIVE_INFINITY, fract: Number.NEGATIVE_INFINITY, exp: 0 },
+          { input: Number.NaN, fract: Number.NaN, exp: 0 },
+        ];
+      })
+  )
   .fn(test => {
     const input = test.params.input;
-    const got = frexp(input);
+    const got = frexp(input, test.params.trait);
     const expect = { fract: test.params.fract, exp: test.params.exp };
 
     test.expect(
       objectEquals(got, expect),
-      `frexp(${input}) returned { fract: ${got.fract}, exp: ${got.exp} }. Expected { fract: ${expect.fract}, exp: ${expect.exp} }`
+      `frexp(${input}, ${test.params.trait}) returned { fract: ${got.fract}, exp: ${got.exp} }. Expected { fract: ${expect.fract}, exp: ${expect.exp} }`
     );
   });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/frexp.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/frexp.spec.ts
@@ -16,12 +16,22 @@ The magnitude of the significand is in the range of [0.5, 1.0) or 0.
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
 import { skipUndefined } from '../../../../../util/compare.js';
-import { f32, i32, toVector, TypeF32, TypeI32, TypeVec } from '../../../../../util/conversion.js';
+import {
+  i32,
+  Scalar,
+  toVector,
+  TypeF32,
+  TypeF16,
+  TypeI32,
+  TypeVec,
+  Vector,
+} from '../../../../../util/conversion.js';
+import { FP } from '../../../../../util/floating_point.js';
 import {
   frexp,
+  fullF16Range,
   fullF32Range,
-  isSubnormalNumberF32,
-  quantizeToF32,
+  vectorF16Range,
   vectorF32Range,
 } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
@@ -45,72 +55,110 @@ function expBuilder(): ShaderBuilder {
   return basicExpressionBuilder(value => `frexp(${value}).exp`);
 }
 
-/* @returns a fract Case for a given vector input */
-function makeVectorCaseFract(v: number[]): Case {
-  v = v.map(quantizeToF32);
-  if (v.some(e => e !== 0 && isSubnormalNumberF32(e))) {
-    return { input: toVector(v, f32), expected: skipUndefined(undefined) };
+/* @returns a fract Case for a given scalar or vector input */
+function makeVectorCaseFract(v: number | number[], trait: 'f32' | 'f16'): Case {
+  const fp = FP[trait];
+  let toInput: (n: number[]) => Scalar | Vector;
+  let toOutput: (n: number[]) => Scalar | Vector;
+  if (v instanceof Array) {
+    // Input is vector
+    toInput = (n: number[]) => toVector(n, fp.scalarBuilder);
+    toOutput = (n: number[]) => toVector(n, fp.scalarBuilder);
+  } else {
+    // Input is scalar, also wrap it in an array.
+    v = [v];
+    toInput = (n: number[]) => fp.scalarBuilder(n[0]);
+    toOutput = (n: number[]) => fp.scalarBuilder(n[0]);
+  }
+
+  v = v.map(fp.quantize);
+  if (v.some(e => e !== 0 && fp.isSubnormal(e))) {
+    return { input: toInput(v), expected: skipUndefined(undefined) };
   }
 
   const fs = v.map(e => {
-    return frexp(e).fract;
+    return frexp(e, trait).fract;
   });
 
-  return { input: toVector(v, f32), expected: toVector(fs, f32) };
+  return { input: toInput(v), expected: toOutput(fs) };
 }
 
-/* @returns an exp Case for a given vector input */
-function makeVectorCaseExp(v: number[]): Case {
-  v = v.map(quantizeToF32);
-  if (v.some(e => e !== 0 && isSubnormalNumberF32(e))) {
-    return { input: toVector(v, f32), expected: skipUndefined(undefined) };
+/* @returns an exp Case for a given scalar or vector input */
+function makeVectorCaseExp(v: number | number[], trait: 'f32' | 'f16'): Case {
+  const fp = FP[trait];
+  let toInput: (n: number[]) => Scalar | Vector;
+  let toOutput: (n: number[]) => Scalar | Vector;
+  if (v instanceof Array) {
+    // Input is vector
+    toInput = (n: number[]) => toVector(n, fp.scalarBuilder);
+    toOutput = (n: number[]) => toVector(n, i32);
+  } else {
+    // Input is scalar, also wrap it in an array.
+    v = [v];
+    toInput = (n: number[]) => fp.scalarBuilder(n[0]);
+    toOutput = (n: number[]) => i32(n[0]);
+  }
+
+  v = v.map(fp.quantize);
+  if (v.some(e => e !== 0 && fp.isSubnormal(e))) {
+    return { input: toInput(v), expected: skipUndefined(undefined) };
   }
 
   const fs = v.map(e => {
-    return frexp(e).exp;
+    return frexp(e, trait).exp;
   });
 
-  return { input: toVector(v, f32), expected: toVector(fs, i32) };
+  return { input: toInput(v), expected: toOutput(fs) };
 }
 
 export const d = makeCaseCache('frexp', {
   f32_fract: () => {
-    const makeCase = (n: number): Case => {
-      n = quantizeToF32(n);
-      if (n !== 0 && isSubnormalNumberF32(n)) {
-        return { input: f32(n), expected: skipUndefined(undefined) };
-      }
-      return { input: f32(n), expected: f32(frexp(n).fract) };
-    };
-    return fullF32Range().map(makeCase);
+    return fullF32Range().map(v => makeVectorCaseFract(v, 'f32'));
   },
   f32_exp: () => {
-    const makeCase = (n: number): Case => {
-      n = quantizeToF32(n);
-      if (n !== 0 && isSubnormalNumberF32(n)) {
-        return { input: f32(n), expected: skipUndefined(undefined) };
-      }
-      return { input: f32(n), expected: i32(frexp(n).exp) };
-    };
-    return fullF32Range().map(makeCase);
+    return fullF32Range().map(v => makeVectorCaseExp(v, 'f32'));
   },
   f32_vec2_fract: () => {
-    return vectorF32Range(2).map(makeVectorCaseFract);
+    return vectorF32Range(2).map(v => makeVectorCaseFract(v, 'f32'));
   },
   f32_vec2_exp: () => {
-    return vectorF32Range(2).map(makeVectorCaseExp);
+    return vectorF32Range(2).map(v => makeVectorCaseExp(v, 'f32'));
   },
   f32_vec3_fract: () => {
-    return vectorF32Range(3).map(makeVectorCaseFract);
+    return vectorF32Range(3).map(v => makeVectorCaseFract(v, 'f32'));
   },
   f32_vec3_exp: () => {
-    return vectorF32Range(3).map(makeVectorCaseExp);
+    return vectorF32Range(3).map(v => makeVectorCaseExp(v, 'f32'));
   },
   f32_vec4_fract: () => {
-    return vectorF32Range(4).map(makeVectorCaseFract);
+    return vectorF32Range(4).map(v => makeVectorCaseFract(v, 'f32'));
   },
   f32_vec4_exp: () => {
-    return vectorF32Range(4).map(makeVectorCaseExp);
+    return vectorF32Range(4).map(v => makeVectorCaseExp(v, 'f32'));
+  },
+  f16_fract: () => {
+    return fullF16Range().map(v => makeVectorCaseFract(v, 'f16'));
+  },
+  f16_exp: () => {
+    return fullF16Range().map(v => makeVectorCaseExp(v, 'f16'));
+  },
+  f16_vec2_fract: () => {
+    return vectorF16Range(2).map(v => makeVectorCaseFract(v, 'f16'));
+  },
+  f16_vec2_exp: () => {
+    return vectorF16Range(2).map(v => makeVectorCaseExp(v, 'f16'));
+  },
+  f16_vec3_fract: () => {
+    return vectorF16Range(3).map(v => makeVectorCaseFract(v, 'f16'));
+  },
+  f16_vec3_exp: () => {
+    return vectorF16Range(3).map(v => makeVectorCaseExp(v, 'f16'));
+  },
+  f16_vec4_fract: () => {
+    return vectorF16Range(4).map(v => makeVectorCaseFract(v, 'f16'));
+  },
+  f16_vec4_exp: () => {
+    return vectorF16Range(4).map(v => makeVectorCaseExp(v, 'f16'));
   },
 });
 
@@ -120,7 +168,7 @@ g.test('f32_fract')
     `
 T is f32
 
-struct __frexp_result {
+struct __frexp_result_f32 {
   fract : f32, // fract part
   exp : i32  // exponent part
 }
@@ -138,7 +186,7 @@ g.test('f32_exp')
     `
 T is f32
 
-struct __frexp_result {
+struct __frexp_result_f32 {
   fract : f32, // fract part
   exp : i32  // exponent part
 }
@@ -156,7 +204,7 @@ g.test('f32_vec2_fract')
     `
 T is vec2<f32>
 
-struct __frexp_result {
+struct __frexp_result_vec2_f32 {
   fract : vec2<f32>, // fract part
   exp : vec2<i32>  // exponent part
 }
@@ -264,14 +312,20 @@ g.test('f16_fract')
     `
 T is f16
 
-struct __frexp_result {
+struct __frexp_result_f16 {
   fract : f16, // fract part
   exp : i32  // exponent part
 }
 `
   )
   .params(u => u.combine('inputSource', allInputSources))
-  .unimplemented();
+  .beforeAllSubcases(t => {
+    t.selectDeviceOrSkipTestCase('shader-f16');
+  })
+  .fn(async t => {
+    const cases = await d.get('f16_fract');
+    await run(t, fractBuilder(), [TypeF16], TypeF16, t.params, cases);
+  });
 
 g.test('f16_exp')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
@@ -279,14 +333,20 @@ g.test('f16_exp')
     `
 T is f16
 
-struct __frexp_result {
+struct __frexp_result_f16 {
   fract : f16, // fract part
   exp : i32  // exponent part
 }
 `
   )
   .params(u => u.combine('inputSource', allInputSources))
-  .unimplemented();
+  .beforeAllSubcases(t => {
+    t.selectDeviceOrSkipTestCase('shader-f16');
+  })
+  .fn(async t => {
+    const cases = await d.get('f16_exp');
+    await run(t, expBuilder(), [TypeF16], TypeI32, t.params, cases);
+  });
 
 g.test('f16_vec2_fract')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
@@ -294,14 +354,20 @@ g.test('f16_vec2_fract')
     `
 T is vec2<f16>
 
-struct __frexp_result {
+struct __frexp_result_vec2_f16 {
   fract : vec2<f16>, // fract part
   exp : vec2<i32>  // exponent part
 }
 `
   )
   .params(u => u.combine('inputSource', allInputSources))
-  .unimplemented();
+  .beforeAllSubcases(t => {
+    t.selectDeviceOrSkipTestCase('shader-f16');
+  })
+  .fn(async t => {
+    const cases = await d.get('f16_vec2_fract');
+    await run(t, fractBuilder(), [TypeVec(2, TypeF16)], TypeVec(2, TypeF16), t.params, cases);
+  });
 
 g.test('f16_vec2_exp')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
@@ -316,7 +382,13 @@ struct __frexp_result_vec2_f16 {
 `
   )
   .params(u => u.combine('inputSource', allInputSources))
-  .unimplemented();
+  .beforeAllSubcases(t => {
+    t.selectDeviceOrSkipTestCase('shader-f16');
+  })
+  .fn(async t => {
+    const cases = await d.get('f16_vec2_exp');
+    await run(t, expBuilder(), [TypeVec(2, TypeF16)], TypeVec(2, TypeI32), t.params, cases);
+  });
 
 g.test('f16_vec3_fract')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
@@ -331,7 +403,13 @@ struct __frexp_result_vec3_f16 {
 `
   )
   .params(u => u.combine('inputSource', allInputSources))
-  .unimplemented();
+  .beforeAllSubcases(t => {
+    t.selectDeviceOrSkipTestCase('shader-f16');
+  })
+  .fn(async t => {
+    const cases = await d.get('f16_vec3_fract');
+    await run(t, fractBuilder(), [TypeVec(3, TypeF16)], TypeVec(3, TypeF16), t.params, cases);
+  });
 
 g.test('f16_vec3_exp')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
@@ -346,7 +424,13 @@ struct __frexp_result_vec3_f16 {
 `
   )
   .params(u => u.combine('inputSource', allInputSources))
-  .unimplemented();
+  .beforeAllSubcases(t => {
+    t.selectDeviceOrSkipTestCase('shader-f16');
+  })
+  .fn(async t => {
+    const cases = await d.get('f16_vec3_exp');
+    await run(t, expBuilder(), [TypeVec(3, TypeF16)], TypeVec(3, TypeI32), t.params, cases);
+  });
 
 g.test('f16_vec4_fract')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
@@ -361,7 +445,13 @@ struct __frexp_result_vec4_f16 {
 `
   )
   .params(u => u.combine('inputSource', allInputSources))
-  .unimplemented();
+  .beforeAllSubcases(t => {
+    t.selectDeviceOrSkipTestCase('shader-f16');
+  })
+  .fn(async t => {
+    const cases = await d.get('f16_vec4_fract');
+    await run(t, fractBuilder(), [TypeVec(4, TypeF16)], TypeVec(4, TypeF16), t.params, cases);
+  });
 
 g.test('f16_vec4_exp')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
@@ -376,4 +466,10 @@ struct __frexp_result_vec4_f16 {
 `
   )
   .params(u => u.combine('inputSource', allInputSources))
-  .unimplemented();
+  .beforeAllSubcases(t => {
+    t.selectDeviceOrSkipTestCase('shader-f16');
+  })
+  .fn(async t => {
+    const cases = await d.get('f16_vec4_exp');
+    await run(t, expBuilder(), [TypeVec(4, TypeF16)], TypeVec(4, TypeI32), t.params, cases);
+  });

--- a/src/webgpu/util/math.ts
+++ b/src/webgpu/util/math.ts
@@ -1,5 +1,9 @@
 import { assert } from '../../common/util/util.js';
-import { Float16Array } from '../../external/petamoriken/float16/float16.js';
+import {
+  Float16Array,
+  getFloat16,
+  setFloat16,
+} from '../../external/petamoriken/float16/float16.js';
 
 import { kBit, kValue } from './constants.js';
 import {
@@ -622,56 +626,135 @@ export function correctlyRoundedF16(n: number): number[] {
 }
 
 /**
- * Once-allocated ArrayBuffer/views to avoid overhead of allocation in frexp
- *
- * This makes frexp non-reentrant due to shared state between calls.
- */
-const frexpData = new ArrayBuffer(4);
-const frexpDataU32 = new Uint32Array(frexpData);
-const frexpDataF32 = new Float32Array(frexpData);
-
-/**
  * Calculates WGSL frexp
  *
  * Splits val into a fraction and an exponent so that
  * val = fraction * 2 ^ exponent.
  * The fraction is 0.0 or its magnitude is in the range [0.5, 1.0).
  *
- * Inspired by golang's implementation of frexp.
- *
- * This code is non-reentrant due to the use of a non-local data buffer and
- * views.
- *
- * @param val the f32 to split
+ * @param val the float to split
+ * @param trait the float type, f32 or f16 or f64
  * @returns the results of splitting val
  */
-export function frexp(val: number): { fract: number; exp: number } {
-  frexpDataF32[0] = val;
-  // Do not directly use val after this point, so that changes are reflected in
-  // both the f32 and u32 views.
+export function frexp(val: number, trait: 'f32' | 'f16' | 'f64'): { fract: number; exp: number } {
+  const buffer = new ArrayBuffer(8);
+  const dataView = new DataView(buffer);
 
-  // Handles 0 and -0
-  if (frexpDataF32[0] === 0) {
-    return { fract: frexpDataF32[0], exp: 0 };
+  // expBitCount and fractBitCount is the bitwidth of exponent and fractional part of the given FP type.
+  // expBias is the bias constant of exponent of the given FP type.
+  // Biased exponent (unsigned integer, i.e. the exponent part of float) = unbiased exponent (signed integer) + expBias.
+  let expBitCount: number, fractBitCount: number, expBias: number;
+  // To handle the exponent bits of given FP types (f16, f32, and f64), considering the highest 16
+  // bits is enough.
+  // expMaskForHigh16Bits indicates the exponent bitfield in the highest 16 bits of the given FP
+  // type, and targetExpBitsForHigh16Bits is the exponent bits that corresponding to unbiased
+  // exponent -1, i.e. the exponent bits when the FP values is in range [0.5, 1.0).
+  let expMaskForHigh16Bits: number, targetExpBitsForHigh16Bits: number;
+  // Helper function that store the given FP value into buffer as the given FP types
+  let setFloatToBuffer: (v: number) => void;
+  // Helper function that read back FP value from buffer as the given FP types
+  let getFloatFromBuffer: () => number;
+
+  let isFinite: (v: number) => boolean;
+  let isSubnormal: (v: number) => boolean;
+
+  if (trait === 'f32') {
+    // f32 bit pattern: s_eeeeeeee_fffffff_ffffffffffffffff
+    expBitCount = 8;
+    fractBitCount = 23;
+    expBias = 127;
+    // The exponent bitmask for high 16 bits of f32.
+    expMaskForHigh16Bits = 0x7f80;
+    // The target exponent bits is equal to those for f32 0.5 = 0x3f000000.
+    targetExpBitsForHigh16Bits = 0x3f00;
+    isFinite = isFiniteF32;
+    isSubnormal = isSubnormalNumberF32;
+    // Enforce big-endian so that offset 0 is highest byte.
+    setFloatToBuffer = (v: number) => dataView.setFloat32(0, v, false);
+    getFloatFromBuffer = () => dataView.getFloat32(0, false);
+  } else if (trait === 'f16') {
+    // f16 bit pattern: s_eeeee_ffffffffff
+    expBitCount = 5;
+    fractBitCount = 10;
+    expBias = 15;
+    // The exponent bitmask for 16 bits of f16.
+    expMaskForHigh16Bits = 0x7c00;
+    // The target exponent bits is equal to those for f16 0.5 = 0x3800.
+    targetExpBitsForHigh16Bits = 0x3800;
+    isFinite = isFiniteF16;
+    isSubnormal = isSubnormalNumberF16;
+    // Enforce big-endian so that offset 0 is highest byte.
+    setFloatToBuffer = (v: number) => setFloat16(dataView, 0, v, false);
+    getFloatFromBuffer = () => getFloat16(dataView, 0, false);
+  } else {
+    assert(trait === 'f64');
+    // f64 bit pattern: s_eeeeeeeeeee_ffff_ffffffffffffffffffffffffffffffffffffffffffffffff
+    expBitCount = 11;
+    fractBitCount = 52;
+    expBias = 1023;
+    // The exponent bitmask for 16 bits of f64.
+    expMaskForHigh16Bits = 0x7ff0;
+    // The target exponent bits is equal to those for f64 0.5 = 0x3fe0_0000_0000_0000.
+    targetExpBitsForHigh16Bits = 0x3fe0;
+    isFinite = Number.isFinite;
+    isSubnormal = isSubnormalNumberF64;
+    // Enforce big-endian so that offset 0 is highest byte.
+    setFloatToBuffer = (v: number) => dataView.setFloat64(0, v, false);
+    getFloatFromBuffer = () => dataView.getFloat64(0, false);
+  }
+  // Helper function that extract the unbiased exponent of the float in buffer.
+  const extractUnbiasedExpFromNormalFloatInBuffer = () => {
+    // Assert the float in buffer is finite normal float.
+    assert(isFinite(getFloatFromBuffer()) && !isSubnormal(getFloatFromBuffer()));
+    // Get the highest 16 bits of float as uint16, which can contain the whole exponent part for both f16, f32, and f64.
+    const high16BitsAsUint16 = dataView.getUint16(0, false);
+    // Return the unbiased exp by masking, shifting and unbiasing.
+    return ((high16BitsAsUint16 & expMaskForHigh16Bits) >> (16 - 1 - expBitCount)) - expBias;
+  };
+  // Helper function that modify the exponent of float in buffer to make it in range [0.5, 1.0).
+  // By setting the unbiased exponent to -1, the fp value will be in range 2**-1 * [1.0, 2.0), i.e. [0.5, 1.0).
+  const modifyExpOfNormalFloatInBuffer = () => {
+    // Assert the float in buffer is finite normal float.
+    assert(isFinite(getFloatFromBuffer()) && !isSubnormal(getFloatFromBuffer()));
+    // Get the highest 16 bits of float as uint16, which contains the whole exponent part for both f16, f32, and f64.
+    const high16BitsAsUint16 = dataView.getUint16(0, false);
+    // Modify the exponent bits.
+    const modifiedHigh16Bits =
+      (high16BitsAsUint16 & ~expMaskForHigh16Bits) | targetExpBitsForHigh16Bits;
+    // Set back to buffer
+    dataView.setUint16(0, modifiedHigh16Bits, false);
+  };
+
+  // +/- 0.0
+  if (val === 0) {
+    return { fract: val, exp: 0 };
+  }
+  // NaN and Inf
+  if (!isFinite(val)) {
+    return { fract: val, exp: 0 };
   }
 
-  // Covers NaNs, OOB and Infinities
-  if (!isFiniteF32(frexpDataF32[0])) {
-    return { fract: frexpDataF32[0], exp: 0 };
-  }
+  setFloatToBuffer(val);
+  // Don't use val below. Use helper functions working with buffer instead.
 
-  // Normalize if subnormal
   let exp = 0;
-  if (isSubnormalNumberF32(frexpDataF32[0])) {
-    frexpDataF32[0] = frexpDataF32[0] * (1 << 23);
-    exp = -23;
+  // Normailze the value if it is subnormal. Increase the exponent by multiplying a subnormal value
+  // with 2**fractBitCount will result in a finite normal FP value of the given FP type.
+  if (isSubnormal(getFloatFromBuffer())) {
+    setFloatToBuffer(getFloatFromBuffer() * 2 ** fractBitCount);
+    exp = -fractBitCount;
   }
-  exp += ((frexpDataU32[0] >> 23) & 0xff) - 126; // shift & mask, minus the bias + 1
+  // A normal FP value v is represented as v = ((-1)**s)*(2**(unbiased exponent))*f, where f is in
+  // range [1.0, 2.0). By moving a factor 2 from f to exponent, we have
+  // v = ((-1)**s)*(2**(unbiased exponent + 1))*(f / 2), where (f / 2) is in range [0.5, 1.0), so
+  // the exp = (unbiased exponent + 1) and fract = ((-1)**s)*(f / 2) is what we expect to get from
+  // frexp function. Note that fract and v only differs in exponent bitfield as long as v is normal.
+  // Calc the result exp by getting the unbiased float exponent and plus 1.
+  exp += extractUnbiasedExpFromNormalFloatInBuffer() + 1;
+  // Modify the exponent of float in buffer to make it be in range [0.5, 1.0) to get fract.
+  modifyExpOfNormalFloatInBuffer();
 
-  frexpDataU32[0] &= 0x807fffff; // mask the exponent bits
-  frexpDataU32[0] |= 0x3f000000; // extract the mantissa bits
-  const fract = frexpDataF32[0]; // Convert from bits to number
-  return { fract, exp };
+  return { fract: getFloatFromBuffer(), exp };
 }
 
 /**


### PR DESCRIPTION
This PR make frexp function in util/math.ts handle f16 and f64 as well as f32, and add f16 execution test for built-in frexp.

Issue: #1248, #2587

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
