### PR TITLE
wgsl: Add f16 negation execution tests

### DIFF
--- a/src/unittests/floating_point.spec.ts
+++ b/src/unittests/floating_point.spec.ts
@@ -3110,6 +3110,27 @@ const kNegationIntervalCases = {
     { input: kValue.f32.subnormal.negative.min, expected: [0, kValue.f32.subnormal.positive.max] },
     { input: kValue.f32.subnormal.negative.max, expected: [0, kValue.f32.subnormal.positive.min] },
   ] as ScalarToIntervalCase[],
+  f16: [
+    // Edge cases
+    { input: kValue.f16.infinity.positive, expected: kUnboundedBounds },
+    { input: kValue.f16.infinity.negative, expected: kUnboundedBounds },
+    { input: kValue.f16.positive.max, expected: kValue.f16.negative.min },
+    { input: kValue.f16.positive.min, expected: kValue.f16.negative.max },
+    { input: kValue.f16.negative.min, expected: kValue.f16.positive.max },
+    { input: kValue.f16.negative.max, expected: kValue.f16.positive.min },
+
+    // Normals
+    { input: 0.1, expected: [kMinusOneULPFunctions['f16'](reinterpretU16AsF16(0xae66)), reinterpretU16AsF16(0xae66)] }, // ~-0.1
+    { input: 1.9, expected: [reinterpretU16AsF16(0xbf9a), kPlusOneULPFunctions['f16'](reinterpretU16AsF16(0xbf9a))] },  // ~-1.9
+    { input: -0.1, expected: [reinterpretU16AsF16(0x2e66), kPlusOneULPFunctions['f16'](reinterpretU16AsF16(0x2e66))] }, // ~0.1
+    { input: -1.9, expected: [kMinusOneULPFunctions['f16'](reinterpretU16AsF16(0x3f9a)), reinterpretU16AsF16(0x3f9a)] },  // ~1.9
+
+    // Subnormals
+    { input: kValue.f16.subnormal.positive.max, expected: [kValue.f16.subnormal.negative.min, 0] },
+    { input: kValue.f16.subnormal.positive.min, expected: [kValue.f16.subnormal.negative.max, 0] },
+    { input: kValue.f16.subnormal.negative.min, expected: [0, kValue.f16.subnormal.positive.max] },
+    { input: kValue.f16.subnormal.negative.max, expected: [0, kValue.f16.subnormal.positive.min] },
+  ] as ScalarToIntervalCase[],
   abstract: [
     // Edge cases
     { input: kValue.f64.infinity.positive, expected: kUnboundedBounds },
@@ -3136,7 +3157,7 @@ const kNegationIntervalCases = {
 g.test('negationInterval')
   .params(u =>
     u
-      .combine('trait', ['f32', 'abstract'] as const)
+      .combine('trait', ['f32', 'f16', 'abstract'] as const)
       .beginSubcases()
       .expandWithParams<ScalarToIntervalCase>(p => {
         // prettier-ignore

--- a/src/webgpu/shader/execution/expression/unary/f16_arithmetic.spec.ts
+++ b/src/webgpu/shader/execution/expression/unary/f16_arithmetic.spec.ts
@@ -1,0 +1,44 @@
+export const description = `
+Execution Tests for the f16 arithmetic unary expression operations
+`;
+
+import { makeTestGroup } from '../../../../../common/framework/test_group.js';
+import { GPUTest } from '../../../../gpu_test.js';
+import { TypeF16 } from '../../../../util/conversion.js';
+import { FP } from '../../../../util/floating_point.js';
+import { fullF16Range } from '../../../../util/math.js';
+import { makeCaseCache } from '../case_cache.js';
+import { allInputSources, run } from '../expression.js';
+
+import { unary } from './unary.js';
+
+export const g = makeTestGroup(GPUTest);
+
+export const d = makeCaseCache('unary/f16_arithmetic', {
+  negation: () => {
+    return FP.f16.generateScalarToIntervalCases(
+      fullF16Range({ neg_norm: 250, neg_sub: 20, pos_sub: 20, pos_norm: 250 }),
+      'unfiltered',
+      FP.f16.negationInterval
+    );
+  },
+});
+
+g.test('negation')
+  .specURL('https://www.w3.org/TR/WGSL/#floating-point-evaluation')
+  .desc(
+    `
+Expression: -x
+Accuracy: Correctly rounded
+`
+  )
+  .params(u =>
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
+  )
+  .beforeAllSubcases(t => {
+    t.selectDeviceOrSkipTestCase({ requiredFeatures: ['shader-f16'] });
+  })
+  .fn(async t => {
+    const cases = await d.get('negation');
+    await run(t, unary('-'), [TypeF16], TypeF16, t.params, cases);
+  });

--- a/src/webgpu/util/floating_point.ts
+++ b/src/webgpu/util/floating_point.ts
@@ -5171,7 +5171,7 @@ class F16Traits extends FPTraits {
   public readonly multiplicationVectorMatrixInterval = this.unimplementedVectorMatrixToVector.bind(
     this
   );
-  public readonly negationInterval = this.unimplementedScalarToInterval.bind(this);
+  public readonly negationInterval = this.negationIntervalImpl.bind(this);
   public readonly normalizeInterval = this.unimplementedVectorToVector.bind(this);
   public readonly powInterval = this.unimplementedScalarPairToInterval.bind(this);
   public readonly quantizeToF16Interval = this.quantizeToF16IntervalNotAvailable.bind(this);


### PR DESCRIPTION
Issue #1626

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
