### PR TITLE
Compat: Test vertex_index, instance_index limits

### DIFF
--- a/src/webgpu/compat/api/validation/render_pipeline/vertex_state.spec.ts
+++ b/src/webgpu/compat/api/validation/render_pipeline/vertex_state.spec.ts
@@ -1,0 +1,91 @@
+export const description = `
+Tests limitations of createRenderPipeline related to vertex state in compat mode.
+`;
+
+import { makeTestGroup } from '../../../../../common/framework/test_group.js';
+import { range } from '../../../../../common/util/util.js';
+import { CompatibilityTest } from '../../../compatibility_test.js';
+
+export const g = makeTestGroup(CompatibilityTest);
+
+g.test('maxVertexAttributesVertexIndexInstanceIndex')
+  .desc(
+    `
+Tests @builtin(vertex_index) and @builtin(instance_index) each count as an attribute.
+
+- Test that you can use maxVertexAttributes
+- Test that you can not use maxVertexAttributes and @builtin(vertex_index)
+- Test that you can not use maxVertexAttributes and @builtin(instance_index)
+- Test that you can use maxVertexAttributes - 1 and @builtin(vertex_index)
+- Test that you can use maxVertexAttributes - 1 and @builtin(instance_index)
+- Test that you can not use maxVertexAttributes - 1 and both @builtin(vertex_index) and @builtin(instance_index)
+- Test that you can use maxVertexAttributes - 2 and both @builtin(vertex_index) and @builtin(instance_index)
+    `
+  )
+  .params(u =>
+    u
+      .combine('useVertexIndex', [false, true] as const)
+      .combine('useInstanceIndex', [false, true] as const)
+      .combine('numAttribsToReserve', [0, 1, 2] as const)
+      .combine('isAsync', [false, true] as const)
+  )
+  .fn(t => {
+    const { useVertexIndex, useInstanceIndex, numAttribsToReserve, isAsync } = t.params;
+    const numAttribs = t.device.limits.maxVertexAttributes - numAttribsToReserve;
+
+    const numBuiltinsUsed = (useVertexIndex ? 1 : 0) + (useInstanceIndex ? 1 : 0);
+    const isValid = numAttribs + numBuiltinsUsed <= t.device.limits.maxVertexAttributes;
+
+    const inputs = range(numAttribs, i => `@location(${i}) v${i}: vec4f`);
+    const outputs = range(numAttribs, i => `v${i}`);
+
+    if (useVertexIndex) {
+      inputs.push('@builtin(vertex_index) vNdx: u32');
+      outputs.push('vec4f(f32(vNdx))');
+    }
+
+    if (useInstanceIndex) {
+      inputs.push('@builtin(instance_index) iNdx: u32');
+      outputs.push('vec4f(f32(iNdx))');
+    }
+
+    const module = t.device.createShaderModule({
+      code: `
+        @fragment fn fs() -> @location(0) vec4f {
+            return vec4f(1);
+        }
+        @vertex fn vs(${inputs.join(', ')}) -> @builtin(position) vec4f {
+            return ${outputs.join(' + ')};
+        }
+      `,
+    });
+
+    const pipelineDescriptor: GPURenderPipelineDescriptor = {
+      layout: 'auto',
+      vertex: {
+        module,
+        entryPoint: 'vs',
+        buffers: [
+          {
+            arrayStride: 16,
+            attributes: range(numAttribs, i => ({
+              shaderLocation: i,
+              format: 'float32x4',
+              offset: 0,
+            })),
+          },
+        ],
+      },
+      fragment: {
+        module,
+        entryPoint: 'fs',
+        targets: [
+          {
+            format: 'rgba8unorm',
+          },
+        ],
+      },
+    };
+
+    t.doCreateRenderPipelineTest(isAsync, isValid, pipelineDescriptor);
+  });

--- a/src/webgpu/listing_meta.json
+++ b/src/webgpu/listing_meta.json
@@ -823,6 +823,7 @@
   "webgpu:compat,api,validation,encoding,programmable,pipeline_bind_group_compat:twoDifferentTextureViews,render_pass,used:*": { "subcaseMS": 0.000 },
   "webgpu:compat,api,validation,render_pipeline,fragment_state:colorState:*": { "subcaseMS": 32.604 },
   "webgpu:compat,api,validation,render_pipeline,shader_module:sample_mask:*": { "subcaseMS": 14.801 },
+  "webgpu:compat,api,validation,render_pipeline,vertex_state:maxVertexAttributesVertexIndexInstanceIndex:*": { "subcaseMS": 3.7 },
   "webgpu:compat,api,validation,texture,createTexture:unsupportedTextureFormats:*": { "subcaseMS": 0.700 },
   "webgpu:compat,api,validation,texture,createTexture:unsupportedTextureViewFormats:*": { "subcaseMS": 0.601 },
   "webgpu:compat,api,validation,texture,cubeArray:cube_array:*": { "subcaseMS": 13.701 },


### PR DESCRIPTION
@builtin(vertex_index) and @buildin(instance_index) each take an attribute in compat mode

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
