### PR TITLE
Add unorm10-10-10-2 vertex format

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@types/pngjs": "^6.0.1",
         "@types/serve-index": "^1.9.1",
         "@typescript-eslint/parser": "^4.33.0",
-        "@webgpu/types": "gpuweb/types#d1d74def71a13a2318828139994afd1b9c3f987c",
+        "@webgpu/types": "^0.1.37",
         "ansi-colors": "4.1.1",
         "babel-plugin-add-header-comment": "^1.0.3",
         "babel-plugin-const-enum": "^1.2.0",
@@ -1262,11 +1262,10 @@
       }
     },
     "node_modules/@webgpu/types": {
-      "version": "0.1.35",
-      "resolved": "git+ssh://git@github.com/gpuweb/types.git#d1d74def71a13a2318828139994afd1b9c3f987c",
-      "integrity": "sha512-6mh8zm/DDdtY6c+DXRmYc/7wJ1RQitFFmQiviwV8BK1XB75lXigN8AC8netNUO4XWTm7zEZevWgdMzXgThwOtA==",
-      "dev": true,
-      "license": "BSD-3-Clause"
+      "version": "0.1.37",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.37.tgz",
+      "integrity": "sha512-hfndFDYk5AlZUE/qZ1kSuZHLobxzsbn7/jdJEJfmn4kg3rTM0+A+5TC/+z7lg3L74tSNEtZUVk7ojXw31wzeFw==",
+      "dev": true
     },
     "node_modules/abbrev": {
       "version": "1.1.1",
@@ -9884,10 +9883,10 @@
       }
     },
     "@webgpu/types": {
-      "version": "git+ssh://git@github.com/gpuweb/types.git#d1d74def71a13a2318828139994afd1b9c3f987c",
-      "integrity": "sha512-6mh8zm/DDdtY6c+DXRmYc/7wJ1RQitFFmQiviwV8BK1XB75lXigN8AC8netNUO4XWTm7zEZevWgdMzXgThwOtA==",
-      "dev": true,
-      "from": "@webgpu/types@gpuweb/types#d1d74def71a13a2318828139994afd1b9c3f987c"
+      "version": "0.1.37",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.37.tgz",
+      "integrity": "sha512-hfndFDYk5AlZUE/qZ1kSuZHLobxzsbn7/jdJEJfmn4kg3rTM0+A+5TC/+z7lg3L74tSNEtZUVk7ojXw31wzeFw==",
+      "dev": true
     },
     "abbrev": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@types/pngjs": "^6.0.1",
     "@types/serve-index": "^1.9.1",
     "@typescript-eslint/parser": "^4.33.0",
-    "@webgpu/types": "gpuweb/types#d1d74def71a13a2318828139994afd1b9c3f987c",
+    "@webgpu/types": "^0.1.37",
     "ansi-colors": "4.1.1",
     "babel-plugin-add-header-comment": "^1.0.3",
     "babel-plugin-const-enum": "^1.2.0",

--- a/src/webgpu/api/operation/vertex_state/correctness.spec.ts
+++ b/src/webgpu/api/operation/vertex_state/correctness.spec.ts
@@ -427,7 +427,7 @@ struct VSOutputs {
 
       case 'unorm': {
         if (formatInfo.bytesPerComponent === 'packed') {
-          assert(format === 'rgb10a2'); // This is the only packed format for now.
+          assert(format === 'unorm10-10-10-2'); // This is the only packed format for now.
           assert(bitSize === 0);
 
           /* prettier-ignore */

--- a/src/webgpu/api/operation/vertex_state/correctness.spec.ts
+++ b/src/webgpu/api/operation/vertex_state/correctness.spec.ts
@@ -61,6 +61,20 @@ function mapStateAttribs<V, A1, A2>(
   return buffers.map(b => mapBufferAttribs(b, f));
 }
 
+function makeRgb10a2(rgba: Array<number>): number {
+  const [r, g, b, a] = rgba;
+  assert((r & 0x3ff) === r);
+  assert((g & 0x3ff) === g);
+  assert((b & 0x3ff) === b);
+  assert((a & 0x3) === a);
+  return r | (g << 10) | (b << 20) | (a << 30);
+}
+
+function normalizeRgb10a2(rgba: number, index: number): number {
+  const normalizationFactor = index % 4 === 3 ? 3 : 1023;
+  return rgba / normalizationFactor;
+}
+
 type TestData = {
   shaderBaseType: string;
   floatTolerance?: number;
@@ -308,7 +322,8 @@ struct VSOutputs {
   // test value in a test is still meaningful.
   generateTestData(format: GPUVertexFormat): TestData {
     const formatInfo = kVertexFormatInfo[format];
-    const bitSize = formatInfo.bytesPerComponent * 8;
+    const bitSize =
+      formatInfo.bytesPerComponent === 'packed' ? 0 : formatInfo.bytesPerComponent * 8;
 
     switch (formatInfo.type) {
       case 'float': {
@@ -411,6 +426,28 @@ struct VSOutputs {
       }
 
       case 'unorm': {
+        if (formatInfo.bytesPerComponent === 'packed') {
+          assert(format === 'rgb10a2'); // This is the only packed format for now.
+          assert(bitSize === 0);
+
+          /* prettier-ignore */
+          const data = [
+            [0, 0, 0, 0],
+            [1023, 1023, 1023, 3],
+            [243, 567, 765, 2],
+          ];
+          const vertexData = new Uint32Array(data.map(makeRgb10a2)).buffer;
+          const expectedData = new Float32Array(data.flat().map(normalizeRgb10a2)).buffer;
+
+          return {
+            shaderBaseType: 'f32',
+            testComponentCount: data.flat().length,
+            expectedData,
+            vertexData,
+            floatTolerance: 0.1 / 1023,
+          };
+        }
+
         /* prettier-ignore */
         const data = [
           42,
@@ -561,7 +598,7 @@ struct VSOutputs {
         this.interleaveVertexDataInto(vertexData, attrib.vertexData, {
           targetStride: buffer.arrayStride,
           offset: (buffer.vbOffset ?? 0) + attrib.offset,
-          size: formatInfo.componentCount * formatInfo.bytesPerComponent,
+          size: formatInfo.byteSize,
         });
       }
 
@@ -653,7 +690,7 @@ g.test('setVertexBuffer_offset_and_attribute_offset')
       .combine('arrayStride', [128])
       .expand('offset', p => {
         const formatInfo = kVertexFormatInfo[p.format];
-        const formatSize = formatInfo.bytesPerComponent * formatInfo.componentCount;
+        const formatSize = formatInfo.byteSize;
         return new Set([
           0,
           4,
@@ -701,7 +738,7 @@ g.test('non_zero_array_stride_and_attribute_offset')
       .beginSubcases()
       .expand('arrayStrideVariant', p => {
         const formatInfo = kVertexFormatInfo[p.format];
-        const formatSize = formatInfo.bytesPerComponent * formatInfo.componentCount;
+        const formatSize = formatInfo.byteSize;
 
         return [
           { mult: 0, add: align(formatSize, 4) },
@@ -711,7 +748,7 @@ g.test('non_zero_array_stride_and_attribute_offset')
       })
       .expand('offsetVariant', p => {
         const formatInfo = kVertexFormatInfo[p.format];
-        const formatSize = formatInfo.bytesPerComponent * formatInfo.componentCount;
+        const formatSize = formatInfo.byteSize;
         return [
           { mult: 0, add: 0 },
           { mult: 0, add: formatSize },
@@ -727,7 +764,7 @@ g.test('non_zero_array_stride_and_attribute_offset')
     const { format, arrayStrideVariant, offsetVariant } = t.params;
     const arrayStride = t.makeLimitVariant('maxVertexBufferArrayStride', arrayStrideVariant);
     const formatInfo = kVertexFormatInfo[format];
-    const formatSize = formatInfo.bytesPerComponent * formatInfo.componentCount;
+    const formatSize = formatInfo.byteSize;
     const offset = clamp(makeValueTestVariant(arrayStride, offsetVariant), {
       min: 0,
       max: arrayStride - formatSize,
@@ -803,7 +840,7 @@ g.test('vertex_buffer_used_multiple_times_overlapped')
     const kVertexCount = 20;
     const kInstanceCount = 1;
     const formatInfo = kVertexFormatInfo[format];
-    const formatByteSize = formatInfo.bytesPerComponent * formatInfo.componentCount;
+    const formatByteSize = formatInfo.byteSize;
     // We need to align so the offset for non-0 setVertexBuffer don't fail validation.
     const alignedFormatByteSize = align(formatByteSize, 4);
 
@@ -907,7 +944,7 @@ g.test('vertex_buffer_used_multiple_times_interleaved')
     const kVertexCount = 20;
     const kInstanceCount = 1;
     const formatInfo = kVertexFormatInfo[format];
-    const formatByteSize = formatInfo.bytesPerComponent * formatInfo.componentCount;
+    const formatByteSize = formatInfo.byteSize;
     // We need to align so the offset for non-0 setVertexBuffer don't fail validation.
     const alignedFormatByteSize = align(formatByteSize, 4);
 
@@ -1014,7 +1051,7 @@ g.test('array_stride_zero')
       .combine('stepMode', ['vertex', 'instance'] as const)
       .expand('offsetVariant', p => {
         const formatInfo = kVertexFormatInfo[p.format];
-        const formatSize = formatInfo.bytesPerComponent * formatInfo.componentCount;
+        const formatSize = formatInfo.byteSize;
         return filterUniqueValueTestVariants([
           { mult: 0, add: 0 },
           { mult: 0, add: 4 },

--- a/src/webgpu/api/validation/encoding/cmds/render/draw.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/render/draw.spec.ts
@@ -445,7 +445,7 @@ success/error as expected. Such set of buffer parameters should include cases li
     } = t.params;
 
     const attributeFormatInfo = kVertexFormatInfo[attributeFormat];
-    const formatSize = attributeFormatInfo.bytesPerComponent * attributeFormatInfo.componentCount;
+    const formatSize = attributeFormatInfo.byteSize;
     const attributeOffset = attributeOffsetFactor * Math.min(4, formatSize);
     const lastStride = attributeOffset + formatSize;
     let arrayStride = 0;
@@ -609,7 +609,7 @@ buffer slot and index buffer will cause no validation error, with completely/par
     // Compute the array stride for vertex step mode and instance step mode attribute
     const attributeFormat = 'float32x4';
     const attributeFormatInfo = kVertexFormatInfo[attributeFormat];
-    const formatSize = attributeFormatInfo.bytesPerComponent * attributeFormatInfo.componentCount;
+    const formatSize = attributeFormatInfo.byteSize;
     const attributeOffset = 0;
     const lastStride = attributeOffset + formatSize;
     let arrayStride = 0;

--- a/src/webgpu/api/validation/render_pipeline/vertex_state.spec.ts
+++ b/src/webgpu/api/validation/render_pipeline/vertex_state.spec.ts
@@ -605,8 +605,7 @@ g.test('vertex_attribute_offset_alignment')
         { mult: 1, add: 0 },
       ])
       .expand('offsetVariant', p => {
-        const { bytesPerComponent, componentCount } = kVertexFormatInfo[p.format];
-        const formatSize = bytesPerComponent * componentCount;
+        const formatSize = kVertexFormatInfo[p.format].byteSize;
         return filterUniqueValueTestVariants([
           { mult: 0, add: 0 },
           { mult: 0, add: Math.floor(formatSize / 2) },
@@ -661,7 +660,7 @@ g.test('vertex_attribute_offset_alignment')
     vertexBuffers[vertexBufferIndex] = { arrayStride, attributes };
 
     const formatInfo = kVertexFormatInfo[format];
-    const formatSize = formatInfo.bytesPerComponent * formatInfo.componentCount;
+    const formatSize = formatInfo.byteSize;
     const success = offset % Math.min(4, formatSize) === 0;
 
     t.testVertexState(success, vertexBuffers);
@@ -688,8 +687,7 @@ g.test('vertex_attribute_contained_in_stride')
       ])
       .expand('offsetVariant', function* (p) {
         // Compute a bunch of test offsets to test.
-        const { bytesPerComponent, componentCount } = kVertexFormatInfo[p.format];
-        const formatSize = bytesPerComponent * componentCount;
+        const formatSize = kVertexFormatInfo[p.format].byteSize;
         yield { mult: 0, add: 0 };
         yield { mult: 0, add: 4 };
         yield { mult: 1, add: -formatSize };
@@ -746,8 +744,7 @@ g.test('vertex_attribute_contained_in_stride')
     const vertexBuffers = [];
     vertexBuffers[vertexBufferIndex] = { arrayStride, attributes };
 
-    const formatInfo = kVertexFormatInfo[format];
-    const formatSize = formatInfo.bytesPerComponent * formatInfo.componentCount;
+    const formatSize = kVertexFormatInfo[format].byteSize;
     const limit = arrayStride === 0 ? t.device.limits.maxVertexBufferArrayStride : arrayStride;
 
     const success = offset + formatSize <= limit;

--- a/src/webgpu/capability_info.ts
+++ b/src/webgpu/capability_info.ts
@@ -235,11 +235,13 @@ export const kTextureViewDimensions = keysOf(kTextureViewDimensionInfo);
 // Exists just for documentation. Otherwise could be inferred by `makeTable`.
 export type VertexFormatInfo = {
   /** Number of bytes in each component. */
-  readonly bytesPerComponent: 1 | 2 | 4;
+  readonly bytesPerComponent: 1 | 2 | 4 | 'packed';
   /** The data encoding (float, normalized, or integer) for each component. */
   readonly type: 'float' | 'unorm' | 'snorm' | 'uint' | 'sint';
   /** Number of components. */
   readonly componentCount: 1 | 2 | 3 | 4;
+  /** Size in bytes. */
+  readonly byteSize: 2 | 4 | 8 | 12 | 16;
   /** The completely matching WGSL type for vertex format */
   readonly wgslType:
     | 'f32'
@@ -260,41 +262,43 @@ export type VertexFormatInfo = {
 export const kVertexFormatInfo: {
   readonly [k in GPUVertexFormat]: VertexFormatInfo;
 } = /* prettier-ignore */ makeTable(
-               ['bytesPerComponent',  'type', 'componentCount',  'wgslType'] as const,
-               [                   ,        ,                 ,            ] as const, {
+               ['bytesPerComponent',   'type', 'componentCount', 'byteSize',  'wgslType'] as const,
+               [                   ,         ,                 ,           ,            ] as const, {
   // 8 bit components
-  'uint8x2':   [                  1,  'uint',                2, 'vec2<u32>'],
-  'uint8x4':   [                  1,  'uint',                4, 'vec4<u32>'],
-  'sint8x2':   [                  1,  'sint',                2, 'vec2<i32>'],
-  'sint8x4':   [                  1,  'sint',                4, 'vec4<i32>'],
-  'unorm8x2':  [                  1, 'unorm',                2, 'vec2<f32>'],
-  'unorm8x4':  [                  1, 'unorm',                4, 'vec4<f32>'],
-  'snorm8x2':  [                  1, 'snorm',                2, 'vec2<f32>'],
-  'snorm8x4':  [                  1, 'snorm',                4, 'vec4<f32>'],
+  'uint8x2':   [                  1,   'uint',                2,          2, 'vec2<u32>'],
+  'uint8x4':   [                  1,   'uint',                4,          4, 'vec4<u32>'],
+  'sint8x2':   [                  1,   'sint',                2,          2, 'vec2<i32>'],
+  'sint8x4':   [                  1,   'sint',                4,          4, 'vec4<i32>'],
+  'unorm8x2':  [                  1,  'unorm',                2,          2, 'vec2<f32>'],
+  'unorm8x4':  [                  1,  'unorm',                4,          4, 'vec4<f32>'],
+  'snorm8x2':  [                  1,  'snorm',                2,          2, 'vec2<f32>'],
+  'snorm8x4':  [                  1,  'snorm',                4,          4, 'vec4<f32>'],
   // 16 bit components
-  'uint16x2':  [                  2,  'uint',                2, 'vec2<u32>'],
-  'uint16x4':  [                  2,  'uint',                4, 'vec4<u32>'],
-  'sint16x2':  [                  2,  'sint',                2, 'vec2<i32>'],
-  'sint16x4':  [                  2,  'sint',                4, 'vec4<i32>'],
-  'unorm16x2': [                  2, 'unorm',                2, 'vec2<f32>'],
-  'unorm16x4': [                  2, 'unorm',                4, 'vec4<f32>'],
-  'snorm16x2': [                  2, 'snorm',                2, 'vec2<f32>'],
-  'snorm16x4': [                  2, 'snorm',                4, 'vec4<f32>'],
-  'float16x2': [                  2, 'float',                2, 'vec2<f32>'],
-  'float16x4': [                  2, 'float',                4, 'vec4<f32>'],
+  'uint16x2':  [                  2,   'uint',                2,          4, 'vec2<u32>'],
+  'uint16x4':  [                  2,   'uint',                4,          8, 'vec4<u32>'],
+  'sint16x2':  [                  2,   'sint',                2,          4, 'vec2<i32>'],
+  'sint16x4':  [                  2,   'sint',                4,          8, 'vec4<i32>'],
+  'unorm16x2': [                  2,  'unorm',                2,          4, 'vec2<f32>'],
+  'unorm16x4': [                  2,  'unorm',                4,          8, 'vec4<f32>'],
+  'snorm16x2': [                  2,  'snorm',                2,          4, 'vec2<f32>'],
+  'snorm16x4': [                  2,  'snorm',                4,          8, 'vec4<f32>'],
+  'float16x2': [                  2,  'float',                2,          4, 'vec2<f32>'],
+  'float16x4': [                  2,  'float',                4,          8, 'vec4<f32>'],
   // 32 bit components
-  'float32':   [                  4, 'float',                1,       'f32'],
-  'float32x2': [                  4, 'float',                2, 'vec2<f32>'],
-  'float32x3': [                  4, 'float',                3, 'vec3<f32>'],
-  'float32x4': [                  4, 'float',                4, 'vec4<f32>'],
-  'uint32':    [                  4,  'uint',                1,       'u32'],
-  'uint32x2':  [                  4,  'uint',                2, 'vec2<u32>'],
-  'uint32x3':  [                  4,  'uint',                3, 'vec3<u32>'],
-  'uint32x4':  [                  4,  'uint',                4, 'vec4<u32>'],
-  'sint32':    [                  4,  'sint',                1,       'i32'],
-  'sint32x2':  [                  4,  'sint',                2, 'vec2<i32>'],
-  'sint32x3':  [                  4,  'sint',                3, 'vec3<i32>'],
-  'sint32x4':  [                  4,  'sint',                4, 'vec4<i32>']
+  'float32':   [                  4,  'float',                1,          4,       'f32'],
+  'float32x2': [                  4,  'float',                2,          8, 'vec2<f32>'],
+  'float32x3': [                  4,  'float',                3,         12, 'vec3<f32>'],
+  'float32x4': [                  4,  'float',                4,         16, 'vec4<f32>'],
+  'uint32':    [                  4,   'uint',                1,          4,       'u32'],
+  'uint32x2':  [                  4,   'uint',                2,          8, 'vec2<u32>'],
+  'uint32x3':  [                  4,   'uint',                3,         12, 'vec3<u32>'],
+  'uint32x4':  [                  4,   'uint',                4,         16, 'vec4<u32>'],
+  'sint32':    [                  4,   'sint',                1,          4,       'i32'],
+  'sint32x2':  [                  4,   'sint',                2,          8, 'vec2<i32>'],
+  'sint32x3':  [                  4,   'sint',                3,         12, 'vec3<i32>'],
+  'sint32x4':  [                  4,   'sint',                4,         16, 'vec4<i32>'],
+  // 32 bit packed
+  'rgb10a2':   [           'packed',  'unorm',                4,          4, 'vec4<f32>']
 } as const);
 /** List of all GPUVertexFormat values. */
 export const kVertexFormats = keysOf(kVertexFormatInfo);

--- a/src/webgpu/capability_info.ts
+++ b/src/webgpu/capability_info.ts
@@ -262,43 +262,43 @@ export type VertexFormatInfo = {
 export const kVertexFormatInfo: {
   readonly [k in GPUVertexFormat]: VertexFormatInfo;
 } = /* prettier-ignore */ makeTable(
-               ['bytesPerComponent',   'type', 'componentCount', 'byteSize',  'wgslType'] as const,
-               [                   ,         ,                 ,           ,            ] as const, {
+                     ['bytesPerComponent',   'type', 'componentCount', 'byteSize',  'wgslType'] as const,
+                     [                   ,         ,                 ,           ,            ] as const, {
   // 8 bit components
-  'uint8x2':   [                  1,   'uint',                2,          2, 'vec2<u32>'],
-  'uint8x4':   [                  1,   'uint',                4,          4, 'vec4<u32>'],
-  'sint8x2':   [                  1,   'sint',                2,          2, 'vec2<i32>'],
-  'sint8x4':   [                  1,   'sint',                4,          4, 'vec4<i32>'],
-  'unorm8x2':  [                  1,  'unorm',                2,          2, 'vec2<f32>'],
-  'unorm8x4':  [                  1,  'unorm',                4,          4, 'vec4<f32>'],
-  'snorm8x2':  [                  1,  'snorm',                2,          2, 'vec2<f32>'],
-  'snorm8x4':  [                  1,  'snorm',                4,          4, 'vec4<f32>'],
+  'uint8x2':         [                  1,   'uint',                2,          2, 'vec2<u32>'],
+  'uint8x4':         [                  1,   'uint',                4,          4, 'vec4<u32>'],
+  'sint8x2':         [                  1,   'sint',                2,          2, 'vec2<i32>'],
+  'sint8x4':         [                  1,   'sint',                4,          4, 'vec4<i32>'],
+  'unorm8x2':        [                  1,  'unorm',                2,          2, 'vec2<f32>'],
+  'unorm8x4':        [                  1,  'unorm',                4,          4, 'vec4<f32>'],
+  'snorm8x2':        [                  1,  'snorm',                2,          2, 'vec2<f32>'],
+  'snorm8x4':        [                  1,  'snorm',                4,          4, 'vec4<f32>'],
   // 16 bit components
-  'uint16x2':  [                  2,   'uint',                2,          4, 'vec2<u32>'],
-  'uint16x4':  [                  2,   'uint',                4,          8, 'vec4<u32>'],
-  'sint16x2':  [                  2,   'sint',                2,          4, 'vec2<i32>'],
-  'sint16x4':  [                  2,   'sint',                4,          8, 'vec4<i32>'],
-  'unorm16x2': [                  2,  'unorm',                2,          4, 'vec2<f32>'],
-  'unorm16x4': [                  2,  'unorm',                4,          8, 'vec4<f32>'],
-  'snorm16x2': [                  2,  'snorm',                2,          4, 'vec2<f32>'],
-  'snorm16x4': [                  2,  'snorm',                4,          8, 'vec4<f32>'],
-  'float16x2': [                  2,  'float',                2,          4, 'vec2<f32>'],
-  'float16x4': [                  2,  'float',                4,          8, 'vec4<f32>'],
+  'uint16x2':        [                  2,   'uint',                2,          4, 'vec2<u32>'],
+  'uint16x4':        [                  2,   'uint',                4,          8, 'vec4<u32>'],
+  'sint16x2':        [                  2,   'sint',                2,          4, 'vec2<i32>'],
+  'sint16x4':        [                  2,   'sint',                4,          8, 'vec4<i32>'],
+  'unorm16x2':       [                  2,  'unorm',                2,          4, 'vec2<f32>'],
+  'unorm16x4':       [                  2,  'unorm',                4,          8, 'vec4<f32>'],
+  'snorm16x2':       [                  2,  'snorm',                2,          4, 'vec2<f32>'],
+  'snorm16x4':       [                  2,  'snorm',                4,          8, 'vec4<f32>'],
+  'float16x2':       [                  2,  'float',                2,          4, 'vec2<f32>'],
+  'float16x4':       [                  2,  'float',                4,          8, 'vec4<f32>'],
   // 32 bit components
-  'float32':   [                  4,  'float',                1,          4,       'f32'],
-  'float32x2': [                  4,  'float',                2,          8, 'vec2<f32>'],
-  'float32x3': [                  4,  'float',                3,         12, 'vec3<f32>'],
-  'float32x4': [                  4,  'float',                4,         16, 'vec4<f32>'],
-  'uint32':    [                  4,   'uint',                1,          4,       'u32'],
-  'uint32x2':  [                  4,   'uint',                2,          8, 'vec2<u32>'],
-  'uint32x3':  [                  4,   'uint',                3,         12, 'vec3<u32>'],
-  'uint32x4':  [                  4,   'uint',                4,         16, 'vec4<u32>'],
-  'sint32':    [                  4,   'sint',                1,          4,       'i32'],
-  'sint32x2':  [                  4,   'sint',                2,          8, 'vec2<i32>'],
-  'sint32x3':  [                  4,   'sint',                3,         12, 'vec3<i32>'],
-  'sint32x4':  [                  4,   'sint',                4,         16, 'vec4<i32>'],
+  'float32':         [                  4,  'float',                1,          4,       'f32'],
+  'float32x2':       [                  4,  'float',                2,          8, 'vec2<f32>'],
+  'float32x3':       [                  4,  'float',                3,         12, 'vec3<f32>'],
+  'float32x4':       [                  4,  'float',                4,         16, 'vec4<f32>'],
+  'uint32':          [                  4,   'uint',                1,          4,       'u32'],
+  'uint32x2':        [                  4,   'uint',                2,          8, 'vec2<u32>'],
+  'uint32x3':        [                  4,   'uint',                3,         12, 'vec3<u32>'],
+  'uint32x4':        [                  4,   'uint',                4,         16, 'vec4<u32>'],
+  'sint32':          [                  4,   'sint',                1,          4,       'i32'],
+  'sint32x2':        [                  4,   'sint',                2,          8, 'vec2<i32>'],
+  'sint32x3':        [                  4,   'sint',                3,         12, 'vec3<i32>'],
+  'sint32x4':        [                  4,   'sint',                4,         16, 'vec4<i32>'],
   // 32 bit packed
-  'rgb10a2':   [           'packed',  'unorm',                4,          4, 'vec4<f32>']
+  'unorm10-10-10-2': [           'packed',  'unorm',                4,          4, 'vec4<f32>']
 } as const);
 /** List of all GPUVertexFormat values. */
 export const kVertexFormats = keysOf(kVertexFormatInfo);


### PR DESCRIPTION
This PR adds support for unorm10-10-10-2 vertex format.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

It is currently tested against my Chromium build with https://dawn-review.googlesource.com/c/dawn/+/150147 and https://chromium-review.googlesource.com/c/chromium/src/+/4859299

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
