### PR TITLE
Update websocket-logger instructions to use `npm ci`

### DIFF
--- a/docs/adding_timing_metadata.md
+++ b/docs/adding_timing_metadata.md
@@ -66,8 +66,8 @@ throughout the following steps.
 
 At `tools/websocket-logger/`
 ```
-npm install
-npm run
+npm ci
+npm start
 ```
 
 The output from this command will indicate where the results are being logged,

--- a/tools/websocket-logger/README.md
+++ b/tools/websocket-logger/README.md
@@ -5,5 +5,5 @@ It can be used to receive logs from CTS in a way that's resistant to test crashe
 independent of which runtime is being used (e.g. standalone, WPT, Node).
 It's used in particular to capture timing results for predefining "chunking" of the CTS for WPT.
 
-To set up, use `npm install`.
+To set up, use `npm ci`.
 To launch, use `npm start`.


### PR DESCRIPTION
Changing to using `npm ci` instead of `npm install` to avoid potentially pulling in unvetted dependencies.

Fixes #2945

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
