### PR TITLE
wgsl: Add f16 `trunc` execution tests

### DIFF
--- a/src/unittests/floating_point.spec.ts
+++ b/src/unittests/floating_point.spec.ts
@@ -3611,7 +3611,7 @@ g.test('tanhInterval_f32')
 g.test('truncInterval')
   .params(u =>
     u
-      .combine('trait', ['f32', 'abstract'] as const)
+      .combine('trait', ['f32', 'f16', 'abstract'] as const)
       .beginSubcases()
       .expandWithParams<ScalarToIntervalCase>(p => {
         const trait = FP[p.trait];

--- a/src/webgpu/listing_meta.json
+++ b/src/webgpu/listing_meta.json
@@ -1403,7 +1403,7 @@
   "webgpu:shader,execution,expression,call,builtin,transpose:f16:*": { "subcaseMS": 33.311 },
   "webgpu:shader,execution,expression,call,builtin,transpose:f32:*": { "subcaseMS": 8.184 },
   "webgpu:shader,execution,expression,call,builtin,trunc:abstract_float:*": { "subcaseMS": 455.726 },
-  "webgpu:shader,execution,expression,call,builtin,trunc:f16:*": { "subcaseMS": 81.305 },
+  "webgpu:shader,execution,expression,call,builtin,trunc:f16:*": { "subcaseMS": 120.204 },
   "webgpu:shader,execution,expression,call,builtin,trunc:f32:*": { "subcaseMS": 48.544 },
   "webgpu:shader,execution,expression,call,builtin,unpack2x16float:unpack:*": { "subcaseMS": 11.651 },
   "webgpu:shader,execution,expression,call,builtin,unpack2x16snorm:unpack:*": { "subcaseMS": 9.275 },

--- a/src/webgpu/shader/execution/expression/call/builtin/trunc.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/trunc.spec.ts
@@ -10,7 +10,7 @@ Component-wise when T is a vector.
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
-import { TypeAbstractFloat, TypeF32 } from '../../../../../util/conversion.js';
+import { TypeAbstractFloat, TypeF16, TypeF32 } from '../../../../../util/conversion.js';
 import { FP } from '../../../../../util/floating_point.js';
 import { fullF32Range, fullF64Range } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
@@ -23,6 +23,9 @@ export const g = makeTestGroup(GPUTest);
 export const d = makeCaseCache('trunc', {
   f32: () => {
     return FP.f32.generateScalarToIntervalCases(fullF32Range(), 'unfiltered', FP.f32.truncInterval);
+  },
+  f16: () => {
+    return FP.f16.generateScalarToIntervalCases(fullF32Range(), 'unfiltered', FP.f16.truncInterval);
   },
   abstract: () => {
     return FP.abstract.generateScalarToIntervalCases(
@@ -63,4 +66,10 @@ g.test('f16')
   .params(u =>
     u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
-  .unimplemented();
+  .beforeAllSubcases(t => {
+    t.selectDeviceOrSkipTestCase('shader-f16');
+  })
+  .fn(async t => {
+    const cases = await d.get('f16');
+    await run(t, builtin('trunc'), [TypeF16], TypeF16, t.params, cases);
+  });

--- a/src/webgpu/util/floating_point.ts
+++ b/src/webgpu/util/floating_point.ts
@@ -5194,7 +5194,7 @@ class F16Traits extends FPTraits {
   public readonly tanInterval = this.unimplementedScalarToInterval.bind(this);
   public readonly tanhInterval = this.unimplementedScalarToInterval.bind(this);
   public readonly transposeInterval = this.unimplementedMatrixToMatrix.bind(this);
-  public readonly truncInterval = this.unimplementedScalarToInterval.bind(this);
+  public readonly truncInterval = this.truncIntervalImpl.bind(this);
 
   /** quantizeToF16 has no f16 overload. */
   private quantizeToF16IntervalNotAvailable(n: number): FPInterval {


### PR DESCRIPTION
Fixes https://github.com/gpuweb/cts/issues/2524

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
