### PR TITLE
Compat: Limit max attributes

### DIFF
--- a/src/webgpu/api/operation/vertex_state/correctness.spec.ts
+++ b/src/webgpu/api/operation/vertex_state/correctness.spec.ts
@@ -941,13 +941,15 @@ g.test('max_buffers_and_attribs')
   .params(u => u.combine('format', kVertexFormats))
   .fn(t => {
     const { format } = t.params;
-    const attributesPerBuffer = Math.ceil(kMaxVertexAttributes / kMaxVertexBuffers);
+    // In compat mode, @builtin(vertex_index) and @builtin(instance_index) each take an attribute
+    const maxVertexAttributes = t.isCompatibility ? kMaxVertexAttributes - 2 : kMaxVertexAttributes;
+    const attributesPerBuffer = Math.ceil(maxVertexAttributes / kMaxVertexBuffers);
     let attributesEmitted = 0;
 
     const state: VertexLayoutState<{}, {}> = [];
     for (let i = 0; i < kMaxVertexBuffers; i++) {
       const attributes: GPUVertexAttribute[] = [];
-      for (let j = 0; j < attributesPerBuffer && attributesEmitted < kMaxVertexAttributes; j++) {
+      for (let j = 0; j < attributesPerBuffer && attributesEmitted < maxVertexAttributes; j++) {
         attributes.push({ format, offset: 0, shaderLocation: attributesEmitted });
         attributesEmitted++;
       }
@@ -1080,8 +1082,10 @@ g.test('overlapping_attributes')
   .fn(t => {
     const { format } = t.params;
 
+    // In compat mode, @builtin(vertex_index) and @builtin(instance_index) each take an attribute
+    const maxVertexAttributes = t.isCompatibility ? kMaxVertexAttributes - 2 : kMaxVertexAttributes;
     const attributes: GPUVertexAttribute[] = [];
-    for (let i = 0; i < kMaxVertexAttributes; i++) {
+    for (let i = 0; i < maxVertexAttributes; i++) {
       attributes.push({ format, offset: 0, shaderLocation: i });
     }
 


### PR DESCRIPTION
In compat @builtin(vertex_index) and @builtin(instance_index) each take an attribute so account for that in this test.

It's possible we should refactor this test to not
use vertex_index, instance_instance. For example we could make each pair of data generate the correct pixel position.

For now it seemed best to get it to pass.
The test in webgpu/compat/api/validation/encoding/render_pipeline/vertex_state.spec.ts does a simple test that you can use maxVertexAttributes but it does not test all the combinations like this test. It only tests that creating a pipeline passes if you use maxVertexAttributes and fails if you use maxVertexAttributes + the builtins above



<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
