### PR TITLE
Compat: Limit draw test attributes in compat

### DIFF
--- a/src/webgpu/api/operation/rendering/draw.spec.ts
+++ b/src/webgpu/api/operation/rendering/draw.spec.ts
@@ -430,9 +430,10 @@ g.test('vertex_attributes,basic')
     const vertexCount = 4;
     const instanceCount = 4;
 
-    const attributesPerVertexBuffer =
-      t.params.vertex_attribute_count / t.params.vertex_buffer_count;
-    assert(Math.round(attributesPerVertexBuffer) === attributesPerVertexBuffer);
+    // In compat mode, @builtin(vertex_index) and @builtin(instance_index) each take an attribute.
+    const maxAttributes = t.device.limits.maxVertexAttributes - (t.isCompatibility ? 2 : 0);
+    const numAttributes = Math.min(maxAttributes, t.params.vertex_attribute_count);
+    const maxAttributesPerVertexBuffer = Math.ceil(numAttributes / t.params.vertex_buffer_count);
 
     let shaderLocation = 0;
     let attributeValue = 0;
@@ -477,7 +478,12 @@ g.test('vertex_attributes,basic')
       }
 
       const attributes: GPUVertexAttribute[] = [];
-      for (let a = 0; a < attributesPerVertexBuffer; ++a) {
+      const numAttributesForBuffer = Math.min(
+        maxAttributesPerVertexBuffer,
+        maxAttributes - b * maxAttributesPerVertexBuffer
+      );
+
+      for (let a = 0; a < numAttributesForBuffer; ++a) {
         const attribute: GPUVertexAttribute = {
           format: t.params.vertex_format,
           shaderLocation,
@@ -490,7 +496,7 @@ g.test('vertex_attributes,basic')
       }
 
       for (let v = 0; v < vertexOrInstanceCount; ++v) {
-        for (let a = 0; a < attributesPerVertexBuffer; ++a) {
+        for (let a = 0; a < numAttributesForBuffer; ++a) {
           vertexBufferValues.push(attributeValue);
           attributeValue += 1.234; // Values will get rounded later if we make a Uint32Array.
         }
@@ -570,7 +576,7 @@ g.test('vertex_attributes,basic')
     let accumulateVariableDeclarationsInFragmentShader = '';
     let accumulateVariableAssignmentsInFragmentShader = '';
     // The remaining 3 vertex attributes
-    if (t.params.vertex_attribute_count === 16) {
+    if (numAttributes === 16) {
       accumulateVariableDeclarationsInVertexShader = `
         @location(13) @interpolate(flat) outAttrib13 : vec4<${wgslFormat}>,
       `;
@@ -586,6 +592,21 @@ g.test('vertex_attributes,basic')
       outBuffer.primitives[input.primitiveId].attrib13 = input.attrib13.y;
       outBuffer.primitives[input.primitiveId].attrib14 = input.attrib13.z;
       outBuffer.primitives[input.primitiveId].attrib15 = input.attrib13.w;
+      `;
+    } else if (numAttributes === 14) {
+      accumulateVariableDeclarationsInVertexShader = `
+        @location(13) @interpolate(flat) outAttrib13 : vec4<${wgslFormat}>,
+      `;
+      accumulateVariableAssignmentsInVertexShader = `
+      output.outAttrib13 =
+          vec4<${wgslFormat}>(input.attrib12, input.attrib13, 0, 0);
+      `;
+      accumulateVariableDeclarationsInFragmentShader = `
+      @location(13) @interpolate(flat) attrib13 : vec4<${wgslFormat}>,
+      `;
+      accumulateVariableAssignmentsInFragmentShader = `
+      outBuffer.primitives[input.primitiveId].attrib12 = input.attrib13.x;
+      outBuffer.primitives[input.primitiveId].attrib13 = input.attrib13.y;
       `;
     }
 


### PR DESCRIPTION
In compat mode, @builtin(vertex_index) and @builtin(instance_index) each take an attribute so adjust this test to account for that.

I don't know if this test should be refactored to make sure 16 attributes are tested (So without using the builtins). My feeling is this is probably fine?

The test in
webgpu/compat/api/validation/encoding/render_pipeline/vertex_state.spec.ts does a simple test that you can create a pipeline with maxVertexAttributes but it does not actually draw with that pipeline.

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
