### PR TITLE
Add rgb10a2uint GPUTextureFormat testing.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@types/pngjs": "^6.0.1",
         "@types/serve-index": "^1.9.1",
         "@typescript-eslint/parser": "^4.33.0",
-        "@webgpu/types": "gpuweb/types#ca1a548178567e6021fd194380b97be1bf6b07b7",
+        "@webgpu/types": "gpuweb/types#d1d74def71a13a2318828139994afd1b9c3f987c",
         "ansi-colors": "4.1.1",
         "babel-plugin-add-header-comment": "^1.0.3",
         "babel-plugin-const-enum": "^1.2.0",
@@ -1262,9 +1262,9 @@
       }
     },
     "node_modules/@webgpu/types": {
-      "version": "0.1.34",
-      "resolved": "git+ssh://git@github.com/gpuweb/types.git#ca1a548178567e6021fd194380b97be1bf6b07b7",
-      "integrity": "sha512-L3q2iZPXqb5/qHupSV4G8tphM2GnCuaAf6SQWLqMNDgMwDk/Y4UWRxSIlY98ONKa1pDOuhIsXj6s1U3rU0wqhw==",
+      "version": "0.1.35",
+      "resolved": "git+ssh://git@github.com/gpuweb/types.git#d1d74def71a13a2318828139994afd1b9c3f987c",
+      "integrity": "sha512-6mh8zm/DDdtY6c+DXRmYc/7wJ1RQitFFmQiviwV8BK1XB75lXigN8AC8netNUO4XWTm7zEZevWgdMzXgThwOtA==",
       "dev": true,
       "license": "BSD-3-Clause"
     },
@@ -9884,10 +9884,10 @@
       }
     },
     "@webgpu/types": {
-      "version": "git+ssh://git@github.com/gpuweb/types.git#ca1a548178567e6021fd194380b97be1bf6b07b7",
-      "integrity": "sha512-L3q2iZPXqb5/qHupSV4G8tphM2GnCuaAf6SQWLqMNDgMwDk/Y4UWRxSIlY98ONKa1pDOuhIsXj6s1U3rU0wqhw==",
+      "version": "git+ssh://git@github.com/gpuweb/types.git#d1d74def71a13a2318828139994afd1b9c3f987c",
+      "integrity": "sha512-6mh8zm/DDdtY6c+DXRmYc/7wJ1RQitFFmQiviwV8BK1XB75lXigN8AC8netNUO4XWTm7zEZevWgdMzXgThwOtA==",
       "dev": true,
-      "from": "@webgpu/types@gpuweb/types#ca1a548178567e6021fd194380b97be1bf6b07b7"
+      "from": "@webgpu/types@gpuweb/types#d1d74def71a13a2318828139994afd1b9c3f987c"
     },
     "abbrev": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@types/pngjs": "^6.0.1",
     "@types/serve-index": "^1.9.1",
     "@typescript-eslint/parser": "^4.33.0",
-    "@webgpu/types": "gpuweb/types#ca1a548178567e6021fd194380b97be1bf6b07b7",
+    "@webgpu/types": "gpuweb/types#d1d74def71a13a2318828139994afd1b9c3f987c",
     "ansi-colors": "4.1.1",
     "babel-plugin-add-header-comment": "^1.0.3",
     "babel-plugin-const-enum": "^1.2.0",

--- a/src/webgpu/api/operation/render_pipeline/pipeline_output_targets.spec.ts
+++ b/src/webgpu/api/operation/render_pipeline/pipeline_output_targets.spec.ts
@@ -30,11 +30,14 @@ export const g = makeTestGroup(TextureTestMixin(GPUTest));
 // Values to write into each attachment
 // We make values different for each attachment index and each channel
 // to make sure they didn't get mixed up
+
+// Clamp alpha to 3 to avoid comparing a large expected value with a max 3 value for rgb10a2uint
+// MAINTENANCE_TODO: Make TexelRepresentation.numericRange per-component and use that.
 const attachmentsIntWriteValues = [
-  { R: 1, G: 2, B: 3, A: 4 },
-  { R: 5, G: 6, B: 7, A: 8 },
-  { R: 9, G: 10, B: 11, A: 12 },
-  { R: 13, G: 14, B: 15, A: 16 },
+  { R: 1, G: 2, B: 3, A: 1 },
+  { R: 5, G: 6, B: 7, A: 2 },
+  { R: 9, G: 10, B: 11, A: 3 },
+  { R: 13, G: 14, B: 15, A: 0 },
 ];
 const attachmentsFloatWriteValues = [
   { R: 0.12, G: 0.34, B: 0.56, A: 0 },

--- a/src/webgpu/format_info.ts
+++ b/src/webgpu/format_info.ts
@@ -408,6 +408,16 @@ const kRegularTextureFormatInfo = formatTableWithDefaults({
 
     // plain, mixed component width, 32 bits per texel
 
+    rgb10a2uint: {
+      color: { type: 'uint', copySrc: true, copyDst: true, storage: false, bytes: 4 },
+      colorRender: { blend: false, resolve: false, byteCost: 8, alignment: 4 },
+      renderable: true,
+      /*prettier-ignore*/ get renderTargetComponentAlignment() { return this.colorRender.alignment; },
+      /*prettier-ignore*/ get renderTargetPixelByteCost() { return this.colorRender.byteCost; },
+      multisample: true,
+      /*prettier-ignore*/ get sampleType() { return this.color.type; },
+      /*prettier-ignore*/ get bytesPerBlock() { return this.color.bytes; },
+    },
     rgb10a2unorm: {
       color: { type: 'float', copySrc: true, copyDst: true, storage: false, bytes: 4 },
       colorRender: { blend: true, resolve: true, byteCost: 8, alignment: 4 },

--- a/src/webgpu/util/texture/texel_data.ts
+++ b/src/webgpu/util/texture/texel_data.ts
@@ -662,6 +662,58 @@ export const kTexelRepresentationInfo: {
     'rgba32float':           makeFloatInfo(     kRGBA, 32),
   },
   ...{
+    rgb10a2uint: {
+      componentOrder: kRGBA,
+      componentInfo: {
+        R: { dataType: 'uint', bitLength: 10 },
+        G: { dataType: 'uint', bitLength: 10 },
+        B: { dataType: 'uint', bitLength: 10 },
+        A: { dataType: 'uint', bitLength: 2 },
+      },
+      encode: components => {
+        assertInIntegerRange(components.R!, 10, false);
+        assertInIntegerRange(components.G!, 10, false);
+        assertInIntegerRange(components.B!, 10, false);
+        assertInIntegerRange(components.A!, 2, false);
+        return components;
+      },
+      decode: components => {
+        assertInIntegerRange(components.R!, 10, false);
+        assertInIntegerRange(components.G!, 10, false);
+        assertInIntegerRange(components.B!, 10, false);
+        assertInIntegerRange(components.A!, 2, false);
+        return components;
+      },
+      pack: components =>
+        packComponents(
+          kRGBA,
+          components,
+          {
+            R: 10,
+            G: 10,
+            B: 10,
+            A: 2,
+          },
+          'uint'
+        ),
+      unpackBits: (data: Uint8Array) =>
+        unpackComponentsBits(kRGBA, data, { R: 10, G: 10, B: 10, A: 2 }),
+      numberToBits: components => ({
+        R: components.R! & 0x3ff,
+        G: components.G! & 0x3ff,
+        B: components.B! & 0x3ff,
+        A: components.A! & 0x3,
+      }),
+      bitsToNumber: components => {
+        assertInIntegerRange(components.R!, 10, false);
+        assertInIntegerRange(components.G!, 10, false);
+        assertInIntegerRange(components.B!, 10, false);
+        assertInIntegerRange(components.A!, 2, false);
+        return components;
+      },
+      bitsToULPFromZero: components => components,
+      numericRange: null,
+    },
     rgb10a2unorm: {
       componentOrder: kRGBA,
       componentInfo: {


### PR DESCRIPTION


Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
