### PR TITLE
wgsl: Add AbstractFloat `clamp` execution tests

### DIFF
--- a/src/unittests/floating_point.spec.ts
+++ b/src/unittests/floating_point.spec.ts
@@ -4906,7 +4906,7 @@ interface ScalarTripleToIntervalCase {
 g.test('clampMedianInterval')
   .params(u =>
     u
-      .combine('trait', ['f32', 'f16'] as const)
+      .combine('trait', ['f32', 'f16', 'abstract'] as const)
       .beginSubcases()
       .expandWithParams<ScalarTripleToIntervalCase>(p => {
         const trait = FP[p.trait];
@@ -4964,7 +4964,7 @@ g.test('clampMedianInterval')
 g.test('clampMinMaxInterval')
   .params(u =>
     u
-      .combine('trait', ['f32', 'f16'] as const)
+      .combine('trait', ['f32', 'f16', 'abstract'] as const)
       .beginSubcases()
       .expandWithParams<ScalarTripleToIntervalCase>(p => {
         const trait = FP[p.trait];

--- a/src/webgpu/listing_meta.json
+++ b/src/webgpu/listing_meta.json
@@ -1133,7 +1133,7 @@
   "webgpu:shader,execution,expression,call,builtin,ceil:abstract_float:*": { "subcaseMS": 23.611 },
   "webgpu:shader,execution,expression,call,builtin,ceil:f16:*": { "subcaseMS": 29.209 },
   "webgpu:shader,execution,expression,call,builtin,ceil:f32:*": { "subcaseMS": 11.132 },
-  "webgpu:shader,execution,expression,call,builtin,clamp:abstract_float:*": { "subcaseMS": 28.706 },
+  "webgpu:shader,execution,expression,call,builtin,clamp:abstract_float:*": { "subcaseMS": 11800.350 },
   "webgpu:shader,execution,expression,call,builtin,clamp:abstract_int:*": { "subcaseMS": 18.104 },
   "webgpu:shader,execution,expression,call,builtin,clamp:f16:*": { "subcaseMS": 32.809 },
   "webgpu:shader,execution,expression,call,builtin,clamp:f32:*": { "subcaseMS": 159.926 },

--- a/src/webgpu/shader/execution/expression/call/builtin/clamp.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/clamp.spec.ts
@@ -16,13 +16,20 @@ Component-wise when T is a vector.
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
 import { kValue } from '../../../../../util/constants.js';
-import { ScalarType, TypeF32, TypeF16, TypeI32, TypeU32 } from '../../../../../util/conversion.js';
+import {
+  ScalarType,
+  TypeF32,
+  TypeF16,
+  TypeI32,
+  TypeU32,
+  TypeAbstractFloat,
+} from '../../../../../util/conversion.js';
 import { FP } from '../../../../../util/floating_point.js';
-import { sparseF32Range, sparseF16Range } from '../../../../../util/math.js';
+import { sparseF32Range, sparseF16Range, sparseF64Range } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
-import { allInputSources, Case, run } from '../../expression.js';
+import { allInputSources, Case, onlyConstInputSource, run } from '../../expression.js';
 
-import { builtin } from './builtin.js';
+import { abstractBuiltin, builtin } from './builtin.js';
 
 export const g = makeTestGroup(GPUTest);
 
@@ -66,6 +73,9 @@ export const d = makeCaseCache('clamp', {
   f16_non_const: () => {
     return generateFloatTestCases(sparseF16Range(), 'f16', 'non-const');
   },
+  abstract: () => {
+    return generateFloatTestCases(sparseF64Range(), 'abstract', 'const');
+  },
 });
 
 /** @returns a set of clamp test cases from an ascending list of integer values */
@@ -88,7 +98,7 @@ function generateIntegerTestCases(
 
 function generateFloatTestCases(
   test_values: Array<number>,
-  trait: 'f32' | 'f16',
+  trait: 'f32' | 'f16' | 'abstract',
   stage: 'const' | 'non-const'
 ): Array<Case> {
   return test_values.flatMap(low =>
@@ -143,9 +153,21 @@ g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`abstract float tests`)
   .params(u =>
-    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
+    u
+      .combine('inputSource', onlyConstInputSource)
+      .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
-  .unimplemented();
+  .fn(async t => {
+    const cases = await d.get('abstract');
+    await run(
+      t,
+      abstractBuiltin('clamp'),
+      [TypeAbstractFloat, TypeAbstractFloat, TypeAbstractFloat],
+      TypeAbstractFloat,
+      t.params,
+      cases
+    );
+  });
 
 g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')

--- a/src/webgpu/util/floating_point.ts
+++ b/src/webgpu/util/floating_point.ts
@@ -4869,14 +4869,8 @@ class FPAbstractTraits extends FPTraits {
   );
   public readonly atanhInterval = this.unimplementedScalarToInterval.bind(this, 'atanhInterval');
   public readonly ceilInterval = this.unimplementedScalarToInterval.bind(this, 'ceilInterval');
-  public readonly clampMedianInterval = this.unimplementedScalarTripleToInterval.bind(
-    this,
-    'clampMedianInterval'
-  );
-  public readonly clampMinMaxInterval = this.unimplementedScalarTripleToInterval.bind(
-    this,
-    'clampMinMaxInterval'
-  );
+  public readonly clampMedianInterval = this.clampMedianIntervalImpl.bind(this);
+  public readonly clampMinMaxInterval = this.clampMinMaxIntervalImpl.bind(this);
   public readonly clampIntervals = [this.clampMedianInterval, this.clampMinMaxInterval];
   public readonly cosInterval = this.unimplementedScalarToInterval.bind(this, 'cosInterval');
   public readonly coshInterval = this.unimplementedScalarToInterval.bind(this, 'coshInterval');


### PR DESCRIPTION

Fixes #2970

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
