### PR TITLE
wgsl: Add AbstractFloat `saturate` execution tests

### DIFF
--- a/src/unittests/floating_point.spec.ts
+++ b/src/unittests/floating_point.spec.ts
@@ -3484,12 +3484,18 @@ const kSaturateIntervalCases = {
       ],
     }, // ~0.1
   ] as ScalarToIntervalCase[],
+  abstract: [
+    {
+      input: 0.1,
+      expected: 0.1,
+    }, // ~0.1
+  ] as ScalarToIntervalCase[],
 } as const;
 
 g.test('saturateInterval')
   .params(u =>
     u
-      .combine('trait', ['f32', 'f16'] as const)
+      .combine('trait', ['f32', 'f16', 'abstract'] as const)
       .beginSubcases()
       .expandWithParams<ScalarToIntervalCase>(p => {
         const constants = FP[p.trait].constants();

--- a/src/webgpu/listing_meta.json
+++ b/src/webgpu/listing_meta.json
@@ -1312,7 +1312,7 @@
   "webgpu:shader,execution,expression,call,builtin,round:abstract_float:*": { "subcaseMS": 19.408 },
   "webgpu:shader,execution,expression,call,builtin,round:f16:*": { "subcaseMS": 30.509 },
   "webgpu:shader,execution,expression,call,builtin,round:f32:*": { "subcaseMS": 12.407 },
-  "webgpu:shader,execution,expression,call,builtin,saturate:abstract_float:*": { "subcaseMS": 227.607 },
+  "webgpu:shader,execution,expression,call,builtin,saturate:abstract_float:*": { "subcaseMS": 527.425 },
   "webgpu:shader,execution,expression,call,builtin,saturate:f16:*": { "subcaseMS": 23.407 },
   "webgpu:shader,execution,expression,call,builtin,saturate:f32:*": { "subcaseMS": 116.275 },
   "webgpu:shader,execution,expression,call,builtin,select:scalar:*": { "subcaseMS": 6.882 },

--- a/src/webgpu/shader/execution/expression/call/builtin/saturate.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/saturate.spec.ts
@@ -9,13 +9,13 @@ Returns clamp(e, 0.0, 1.0). Component-wise when T is a vector.
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
-import { TypeF16, TypeF32 } from '../../../../../util/conversion.js';
+import { TypeAbstractFloat, TypeF16, TypeF32 } from '../../../../../util/conversion.js';
 import { FP } from '../../../../../util/floating_point.js';
-import { fullF16Range, fullF32Range, linearRange } from '../../../../../util/math.js';
+import { fullF16Range, fullF32Range, fullF64Range, linearRange } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
-import { allInputSources, run } from '../../expression.js';
+import { allInputSources, onlyConstInputSource, run } from '../../expression.js';
 
-import { builtin } from './builtin.js';
+import { abstractBuiltin, builtin } from './builtin.js';
 
 export const g = makeTestGroup(GPUTest);
 
@@ -42,16 +42,38 @@ export const d = makeCaseCache('saturate', {
       FP.f16.saturateInterval
     );
   },
+  abstract: () => {
+    return FP.abstract.generateScalarToIntervalCases(
+      [
+        // Non-clamped values
+        ...linearRange(0.0, 1.0, 20),
+        ...fullF64Range(),
+      ],
+      'unfiltered',
+      FP.abstract.saturateInterval
+    );
+  },
 });
 
 g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`abstract float tests`)
   .params(u =>
-    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
+    u
+      .combine('inputSource', onlyConstInputSource)
+      .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
-  .unimplemented();
-
+  .fn(async t => {
+    const cases = await d.get('abstract');
+    await run(
+      t,
+      abstractBuiltin('saturate'),
+      [TypeAbstractFloat],
+      TypeAbstractFloat,
+      t.params,
+      cases
+    );
+  });
 g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`f32 tests`)

--- a/src/webgpu/util/floating_point.ts
+++ b/src/webgpu/util/floating_point.ts
@@ -4957,10 +4957,7 @@ class FPAbstractTraits extends FPTraits {
     'remainderInterval'
   );
   public readonly roundInterval = this.unimplementedScalarToInterval.bind(this, 'roundInterval');
-  public readonly saturateInterval = this.unimplementedScalarToInterval.bind(
-    this,
-    'saturateInterval'
-  );
+  public readonly saturateInterval = this.saturateIntervalImpl.bind(this);
   public readonly signInterval = this.unimplementedScalarToInterval.bind(this, 'signInterval');
   public readonly sinInterval = this.unimplementedScalarToInterval.bind(this, 'sinInterval');
   public readonly sinhInterval = this.unimplementedScalarToInterval.bind(this, 'sinhInterval');


### PR DESCRIPTION
Fixes #1635

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
