### PR TITLE
Change generate-cache to validate-cache

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -26,6 +26,10 @@ module.exports = function (grunt) {
         cmd: 'node',
         args: ['tools/validate', 'src/webgpu', 'src/stress', 'src/manual', 'src/unittests', 'src/demo'],
       },
+      'validate-cache': {
+        cmd: 'node',
+        args: ['tools/gen_cache', 'out', 'src/webgpu', '--validate'],
+      },
       'generate-wpt-cts-html': {
         cmd: 'node',
         args: ['tools/gen_wpt_cts_html', 'tools/gen_wpt_cfg_unchunked.json'],
@@ -33,10 +37,6 @@ module.exports = function (grunt) {
       'generate-wpt-cts-html-chunked2sec': {
         cmd: 'node',
         args: ['tools/gen_wpt_cts_html', 'tools/gen_wpt_cfg_chunked2sec.json'],
-      },
-      'generate-cache': {
-        cmd: 'node',
-        args: ['tools/gen_cache', 'out', 'src/webgpu'],
       },
       unittest: {
         cmd: 'node',
@@ -194,11 +194,11 @@ module.exports = function (grunt) {
   registerTaskAndAddToHelp('pre', 'Run all presubmit checks: standalone+wpt+typecheck+unittest+lint', [
     'clean',
     'run:validate',
+    'run:validate-cache',
     'build-standalone',
     'run:generate-listings',
     'build-wpt',
     'run:build-out-node',
-    'run:generate-cache',
     'build-done-message',
     'ts:check',
     'run:presubmit',

--- a/src/common/tools/.eslintrc.json
+++ b/src/common/tools/.eslintrc.json
@@ -1,4 +1,6 @@
 {
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": { "project": "../../../tsconfig.json" },
   "rules": {
     "no-console": "off",
     "no-process-exit": "off",

--- a/src/common/tools/gen_cache.ts
+++ b/src/common/tools/gen_cache.ts
@@ -14,12 +14,13 @@ DataCache will load this instead of building the expensive data at CTS runtime.
 Options:
   --help          Print this message and exit.
   --list          Print the list of output files without writing them.
+  --validate      Check that cache should build (Tests for collisions).
   --verbose       Print each action taken.
 `);
   process.exit(rc);
 }
 
-let mode: 'emit' | 'list' = 'emit';
+let mode: 'emit' | 'list' | 'validate' = 'emit';
 let verbose = false;
 
 const nonFlagsArgs: string[] = [];
@@ -34,6 +35,9 @@ for (const a of process.argv) {
         break;
       case '--verbose':
         verbose = true;
+        break;
+      case '--validate':
+        mode = 'validate';
         break;
       default:
         console.log('unrecognized flag: ', a);
@@ -146,6 +150,10 @@ and
           }
           case 'list': {
             console.log(outPath);
+            break;
+          }
+          case 'validate': {
+            // Only check currently performed is the collision detection above
             break;
           }
         }


### PR DESCRIPTION
For `npm test` only check that the cache validates (don't build it) since building it is relatively expensive compared to other checks performed.

Issue #2980

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
