### PR TITLE
Show parseQuery error

### DIFF
--- a/src/common/runtime/standalone.ts
+++ b/src/common/runtime/standalone.ts
@@ -11,7 +11,7 @@ import { parseQuery } from '../internal/query/parseQuery.js';
 import { TestQueryLevel } from '../internal/query/query.js';
 import { TestTreeNode, TestSubtree, TestTreeLeaf, TestTree } from '../internal/tree.js';
 import { setDefaultRequestAdapterOptions } from '../util/navigator_gpu.js';
-import { assert, ErrorWithExtra, unreachable } from '../util/util.js';
+import { ErrorWithExtra, unreachable } from '../util/util.js';
 
 import {
   kCTSOptionsInfo,
@@ -543,6 +543,14 @@ function createSearchQuery(queries: string[], params?: string) {
   return `?${params}${params ? '&' : ''}${queries.map(q => 'q=' + q).join('&')}`;
 }
 
+/**
+ * Show an info message on the page.
+ * @param msg Message to show
+ */
+function showInfo(msg: string) {
+  $('#info')[0].textContent = msg;
+}
+
 void (async () => {
   const loader = new DefaultTestFileLoader();
 
@@ -609,26 +617,37 @@ void (async () => {
   };
   addOptionsToPage(options, kStandaloneOptionsInfos);
 
-  assert(qs.length === 1, 'currently, there must be exactly one ?q=');
-  const rootQuery = parseQuery(qs[0]);
+  if (qs.length !== 1) {
+    showInfo('currently, there must be exactly one ?q=');
+    return;
+  }
+
+  let rootQuery;
+  try {
+    rootQuery = parseQuery(qs[0]);
+  } catch (e) {
+    showInfo((e as Error).toString());
+    return;
+  }
+
   if (rootQuery.level > lastQueryLevelToExpand) {
     lastQueryLevelToExpand = rootQuery.level;
   }
   loader.addEventListener('import', ev => {
-    $('#info')[0].textContent = `loading: ${ev.data.url}`;
+    showInfo(`loading: ${ev.data.url}`);
   });
   loader.addEventListener('imported', ev => {
-    $('#info')[0].textContent = `imported: ${ev.data.url}`;
+    showInfo(`imported: ${ev.data.url}`);
   });
   loader.addEventListener('finish', () => {
-    $('#info')[0].textContent = '';
+    showInfo('');
   });
 
   let tree;
   try {
     tree = await loader.loadTree(rootQuery);
   } catch (err) {
-    $('#info')[0].textContent = (err as Error).toString();
+    showInfo((err as Error).toString());
     return;
   }
 


### PR DESCRIPTION
Some errors in parsing the query string were only showing in the JavaScript console so that a bad query the test page would just show nothing. This is an attempt to try to surface those errors to the page.

