### PR TITLE
Compat: Refactor vertex_state tests for new limits

### DIFF
--- a/src/common/util/data_tables.ts
+++ b/src/common/util/data_tables.ts
@@ -51,3 +51,66 @@ export function makeTable<
   /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
   return result as any;
 }
+
+/**
+ * Creates an info lookup object from a more nicely-formatted table.
+ *
+ * Note: Using `as const` on the arguments to this function is necessary to infer the correct type.
+ *
+ * Example:
+ *
+ * ```
+ * const t = makeTableWithDefaults(
+ *   'c',                    // defaultName
+ *   ['a', 'default', 'd'],  // members
+ *   ['a', 'b', 'c', 'd'],   // dataMembers
+ *   [123, 456, 789, 1011],  // defaults
+ *   {                       // table
+ *     foo: [1, 2, 3, 4],
+ *     bar: [5,  ,  , 8],
+ *     moo: [ , 9,10,  ],
+ *   }
+ * );
+ *
+ * // t = {
+ * //   foo: { a:   1, default:   3, d:    4 },
+ * //   bar: { a:   5, default: 789, d:    8 },
+ * //   moo: { a: 123, default:  10, d: 1011 },
+ * // };
+ * ```
+ *
+ * @param defaultName the name of the column in the table that will be assigned to the 'default' property of each entry.
+ * @param members the names of properties you want in the generated lookup table. This must be a subset of the columns of the tables except for the name 'default' which is looked from the previous argument.
+ * @param dataMembers the names of the columns of the name
+ * @param defaults the default value by column for any element in a row of the table that is undefined
+ * @param table named table rows.
+ */
+export function makeTableWithDefaults<
+  Members extends readonly string[],
+  DataMembers extends readonly string[],
+  Defaults extends readonly unknown[],
+  Table extends { readonly [k: string]: readonly unknown[] }
+>(
+  defaultName: string,
+  members: Members,
+  dataMembers: DataMembers,
+  defaults: Defaults,
+  table: Table
+): {
+  readonly [k in keyof Table]: ResolveType<ZipKeysWithValues<Members, Table[k], Defaults>>;
+} {
+  const result: { [k: string]: { [m: string]: unknown } } = {};
+  const keyToIndex = new Map<string, number>(
+    members.map(name => [name, dataMembers.indexOf(name === 'default' ? defaultName : name)])
+  );
+  for (const [k, v] of Object.entries<readonly unknown[]>(table)) {
+    const item: { [m: string]: unknown } = {};
+    for (const member of members) {
+      const ndx = keyToIndex.get(member)!;
+      item[member] = v[ndx] ?? defaults[ndx];
+    }
+    result[k] = item;
+  }
+  /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+  return result as any;
+}

--- a/src/common/util/util.ts
+++ b/src/common/util/util.ts
@@ -428,7 +428,7 @@ export function memcpy(
  * Used to create a value that is specified by multiplying some runtime value
  * by a constant and then adding a constant to it.
  */
-export interface SpecValue {
+export interface ValueTestVariant {
   mult: number;
   add: number;
 }
@@ -436,8 +436,10 @@ export interface SpecValue {
 /**
  * Filters out SpecValues that are the same.
  */
-export function filterUniqueSpecValues(specValues: SpecValue[]) {
-  return new Map<string, SpecValue>(specValues.map(v => [`m:${v.mult},a:${v.add}`, v])).values();
+export function filterUniqueValueTestVariants(valueTestVariants: ValueTestVariant[]) {
+  return new Map<string, ValueTestVariant>(
+    valueTestVariants.map(v => [`m:${v.mult},a:${v.add}`, v])
+  ).values();
 }
 
 /**
@@ -446,6 +448,6 @@ export function filterUniqueSpecValues(specValues: SpecValue[]) {
  * with limits that can only be known at runtime and yet we need a way to
  * add parameters to a test and those parameters must be constants.
  */
-export function makeSpecValue(base: number, spec: SpecValue) {
-  return base * spec.mult + spec.add;
+export function makeValueTestVariant(base: number, variant: ValueTestVariant) {
+  return base * variant.mult + variant.add;
 }

--- a/src/common/util/util.ts
+++ b/src/common/util/util.ts
@@ -423,3 +423,29 @@ export function memcpy(
 ): void {
   subarrayAsU8(dst.dst, dst).set(subarrayAsU8(src.src, src));
 }
+
+/**
+ * Used to create a value that is specified by multiplying some runtime value
+ * by a constant and then adding a constant to it.
+ */
+export interface SpecValue {
+  mult: number;
+  add: number;
+}
+
+/**
+ * Filters out SpecValues that are the same.
+ */
+export function filterUniqueSpecValues(specValues: SpecValue[]) {
+  return new Map<string, SpecValue>(specValues.map(v => [`m:${v.mult},a:${v.add}`, v])).values();
+}
+
+/**
+ * Used to create a value that is specified by multiplied some runtime value
+ * by a constant and then adding a constant to it. This happens often in test
+ * with limits that can only be known at runtime and yet we need a way to
+ * add parameters to a test and those parameters must be constants.
+ */
+export function makeSpecValue(base: number, spec: SpecValue) {
+  return base * spec.mult + spec.add;
+}

--- a/src/webgpu/api/validation/render_pipeline/vertex_state.spec.ts
+++ b/src/webgpu/api/validation/render_pipeline/vertex_state.spec.ts
@@ -3,7 +3,10 @@ This test dedicatedly tests validation of GPUVertexState of createRenderPipeline
 `;
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
-import { filterUniqueSpecValues, makeSpecValue } from '../../../../common/util/util.js';
+import {
+  filterUniqueValueTestVariants,
+  makeValueTestVariant,
+} from '../../../../common/util/util.js';
 import { kVertexFormats, kVertexFormatInfo } from '../../../capability_info.js';
 import { ValidationTest } from '../validation_test.js';
 
@@ -144,7 +147,7 @@ g.test('max_vertex_buffer_limit')
   )
   .paramsSubcasesOnly(u =>
     u //
-      .combine('countSpec', [
+      .combine('countVariant', [
         { mult: 0, add: 0 },
         { mult: 0, add: 1 },
         { mult: 1, add: 0 },
@@ -153,8 +156,8 @@ g.test('max_vertex_buffer_limit')
       .combine('lastEmpty', [false, true])
   )
   .fn(t => {
-    const { countSpec, lastEmpty } = t.params;
-    const count = t.makeSpecValue('maxVertexBuffers', countSpec);
+    const { countVariant, lastEmpty } = t.params;
+    const count = t.makeLimitVariant('maxVertexBuffers', countVariant);
     const vertexBuffers = [];
     for (let i = 0; i < count; i++) {
       if (lastEmpty || i !== count - 1) {
@@ -179,7 +182,7 @@ g.test('max_vertex_attribute_limit')
   )
   .paramsSubcasesOnly(u =>
     u //
-      .combine('attribCountSpec', [
+      .combine('attribCountVariant', [
         { mult: 0, add: 0 },
         { mult: 0, add: 1 },
         { mult: 1, add: 0 },
@@ -188,8 +191,8 @@ g.test('max_vertex_attribute_limit')
       .combine('attribsPerBuffer', [0, 1, 4])
   )
   .fn(t => {
-    const { attribCountSpec, attribsPerBuffer } = t.params;
-    const attribCount = t.makeSpecValue('maxVertexAttributes', attribCountSpec);
+    const { attribCountVariant, attribsPerBuffer } = t.params;
+    const attribCount = t.makeLimitVariant('maxVertexAttributes', attribCountVariant);
 
     const vertexBuffers = [];
 
@@ -222,12 +225,12 @@ g.test('max_vertex_buffer_array_stride_limit')
   )
   .paramsSubcasesOnly(u =>
     u //
-      .combine('vertexBufferIndexSpec', [
+      .combine('vertexBufferIndexVariant', [
         { mult: 0, add: 0 },
         { mult: 0, add: 1 },
         { mult: 1, add: -1 },
       ])
-      .combine('arrayStrideSpec', [
+      .combine('arrayStrideVariant', [
         { mult: 0, add: 0 },
         { mult: 0, add: 4 },
         { mult: 0, add: 256 },
@@ -237,9 +240,9 @@ g.test('max_vertex_buffer_array_stride_limit')
       ])
   )
   .fn(t => {
-    const { vertexBufferIndexSpec, arrayStrideSpec } = t.params;
-    const vertexBufferIndex = t.makeSpecValue('maxVertexBuffers', vertexBufferIndexSpec);
-    const arrayStride = t.makeSpecValue('maxVertexBufferArrayStride', arrayStrideSpec);
+    const { vertexBufferIndexVariant, arrayStrideVariant } = t.params;
+    const vertexBufferIndex = t.makeLimitVariant('maxVertexBuffers', vertexBufferIndexVariant);
+    const arrayStride = t.makeLimitVariant('maxVertexBufferArrayStride', arrayStrideVariant);
     const vertexBuffers = [];
     vertexBuffers[vertexBufferIndex] = { arrayStride, attributes: [] };
 
@@ -255,12 +258,12 @@ g.test('vertex_buffer_array_stride_limit_alignment')
   )
   .paramsSubcasesOnly(u =>
     u //
-      .combine('vertexBufferIndexSpec', [
+      .combine('vertexBufferIndexVariant', [
         { mult: 0, add: 0 },
         { mult: 0, add: 1 },
         { mult: 1, add: -1 },
       ])
-      .combine('arrayStrideSpec', [
+      .combine('arrayStrideVariant', [
         { mult: 0, add: 0 },
         { mult: 0, add: 1 },
         { mult: 0, add: 2 },
@@ -271,9 +274,9 @@ g.test('vertex_buffer_array_stride_limit_alignment')
       ])
   )
   .fn(t => {
-    const { vertexBufferIndexSpec, arrayStrideSpec } = t.params;
-    const vertexBufferIndex = t.makeSpecValue('maxVertexBuffers', vertexBufferIndexSpec);
-    const arrayStride = t.makeSpecValue('maxVertexBufferArrayStride', arrayStrideSpec);
+    const { vertexBufferIndexVariant, arrayStrideVariant } = t.params;
+    const vertexBufferIndex = t.makeLimitVariant('maxVertexBuffers', vertexBufferIndexVariant);
+    const arrayStride = t.makeLimitVariant('maxVertexBufferArrayStride', arrayStrideVariant);
 
     const vertexBuffers = [];
     vertexBuffers[vertexBufferIndex] = { arrayStride, attributes: [] };
@@ -291,18 +294,18 @@ g.test('vertex_attribute_shaderLocation_limit')
   )
   .paramsSubcasesOnly(u =>
     u //
-      .combine('vertexBufferIndexSpec', [
+      .combine('vertexBufferIndexVariant', [
         { mult: 0, add: 0 },
         { mult: 0, add: 1 },
         { mult: 1, add: -1 },
       ])
-      .combine('extraAttributeCountSpec', [
+      .combine('extraAttributeCountVariant', [
         { mult: 0, add: 0 },
         { mult: 0, add: 1 },
         { mult: 1, add: -1 },
       ])
       .combine('testAttributeAtStart', [false, true])
-      .combine('testShaderLocationSpec', [
+      .combine('testShaderLocationVariant', [
         { mult: 0, add: 0 },
         { mult: 0, add: 1 },
         { mult: 1, add: -1 },
@@ -311,14 +314,17 @@ g.test('vertex_attribute_shaderLocation_limit')
   )
   .fn(t => {
     const {
-      vertexBufferIndexSpec,
-      extraAttributeCountSpec,
-      testShaderLocationSpec,
+      vertexBufferIndexVariant,
+      extraAttributeCountVariant,
+      testShaderLocationVariant,
       testAttributeAtStart,
     } = t.params;
-    const vertexBufferIndex = t.makeSpecValue('maxVertexBuffers', vertexBufferIndexSpec);
-    const extraAttributeCount = t.makeSpecValue('maxVertexAttributes', extraAttributeCountSpec);
-    const testShaderLocation = t.makeSpecValue('maxVertexAttributes', testShaderLocationSpec);
+    const vertexBufferIndex = t.makeLimitVariant('maxVertexBuffers', vertexBufferIndexVariant);
+    const extraAttributeCount = t.makeLimitVariant(
+      'maxVertexAttributes',
+      extraAttributeCountVariant
+    );
+    const testShaderLocation = t.makeLimitVariant('maxVertexAttributes', testShaderLocationVariant);
 
     const attributes: GPUVertexAttribute[] = [];
     addTestAttributes(attributes, {
@@ -344,25 +350,25 @@ g.test('vertex_attribute_shaderLocation_unique')
   )
   .paramsSubcasesOnly(u =>
     u //
-      .combine('vertexBufferIndexASpec', [
+      .combine('vertexBufferIndexAVariant', [
         { mult: 0, add: 0 },
         { mult: 0, add: 1 },
         { mult: 1, add: -1 },
       ])
-      .combine('vertexBufferIndexBSpec', [
+      .combine('vertexBufferIndexBVariant', [
         { mult: 0, add: 0 },
         { mult: 0, add: 1 },
         { mult: 1, add: -1 },
       ])
       .combine('testAttributeAtStartA', [false, true])
       .combine('testAttributeAtStartB', [false, true])
-      .combine('shaderLocationASpec', [
+      .combine('shaderLocationAVariant', [
         { mult: 0, add: 0 },
         { mult: 0, add: 1 },
         { mult: 0, add: 7 },
         { mult: 1, add: -1 },
       ])
-      .combine('shaderLocationBSpec', [
+      .combine('shaderLocationBVariant', [
         { mult: 0, add: 0 },
         { mult: 0, add: 1 },
         { mult: 0, add: 7 },
@@ -372,18 +378,18 @@ g.test('vertex_attribute_shaderLocation_unique')
   )
   .fn(t => {
     const {
-      vertexBufferIndexASpec,
-      vertexBufferIndexBSpec,
+      vertexBufferIndexAVariant,
+      vertexBufferIndexBVariant,
       testAttributeAtStartA,
       testAttributeAtStartB,
-      shaderLocationASpec,
-      shaderLocationBSpec,
+      shaderLocationAVariant,
+      shaderLocationBVariant,
       extraAttributeCount,
     } = t.params;
-    const vertexBufferIndexA = t.makeSpecValue('maxVertexBuffers', vertexBufferIndexASpec);
-    const vertexBufferIndexB = t.makeSpecValue('maxVertexBuffers', vertexBufferIndexBSpec);
-    const shaderLocationA = t.makeSpecValue('maxVertexAttributes', shaderLocationASpec);
-    const shaderLocationB = t.makeSpecValue('maxVertexAttributes', shaderLocationBSpec);
+    const vertexBufferIndexA = t.makeLimitVariant('maxVertexBuffers', vertexBufferIndexAVariant);
+    const vertexBufferIndexB = t.makeLimitVariant('maxVertexBuffers', vertexBufferIndexBVariant);
+    const shaderLocationA = t.makeLimitVariant('maxVertexAttributes', shaderLocationAVariant);
+    const shaderLocationB = t.makeLimitVariant('maxVertexAttributes', shaderLocationBVariant);
 
     // Depending on the params, the vertexBuffer for A and B can be the same or different. To support
     // both cases without code changes we treat `vertexBufferAttributes` as a map from indices to
@@ -429,7 +435,7 @@ g.test('vertex_shader_input_location_limit')
   )
   .paramsSubcasesOnly(u =>
     u //
-      .combine('testLocationSpec', [
+      .combine('testLocationVariant', [
         { mult: 0, add: 0 },
         { mult: 0, add: 1 },
         { mult: 1, add: -1 },
@@ -438,8 +444,8 @@ g.test('vertex_shader_input_location_limit')
       ])
   )
   .fn(t => {
-    const { testLocationSpec } = t.params;
-    const testLocation = t.makeSpecValue('maxVertexAttributes', testLocationSpec);
+    const { testLocationVariant } = t.params;
+    const testLocation = t.makeLimitVariant('maxVertexAttributes', testLocationVariant);
 
     const shader = t.generateTestVertexShader([
       {
@@ -473,18 +479,18 @@ g.test('vertex_shader_input_location_in_vertex_state')
   )
   .paramsSubcasesOnly(u =>
     u //
-      .combine('vertexBufferIndexSpec', [
+      .combine('vertexBufferIndexVariant', [
         { mult: 0, add: 0 },
         { mult: 0, add: 1 },
         { mult: 1, add: -1 },
       ])
-      .combine('extraAttributeCountSpec', [
+      .combine('extraAttributeCountVariant', [
         { mult: 0, add: 0 },
         { mult: 0, add: 1 },
         { mult: 1, add: -1 },
       ])
       .combine('testAttributeAtStart', [false, true])
-      .combine('testShaderLocationSpec', [
+      .combine('testShaderLocationVariant', [
         { mult: 0, add: 0 },
         { mult: 0, add: 1 },
         { mult: 0, add: 4 },
@@ -494,14 +500,17 @@ g.test('vertex_shader_input_location_in_vertex_state')
   )
   .fn(t => {
     const {
-      vertexBufferIndexSpec,
-      extraAttributeCountSpec,
+      vertexBufferIndexVariant,
+      extraAttributeCountVariant,
       testAttributeAtStart,
-      testShaderLocationSpec,
+      testShaderLocationVariant,
     } = t.params;
-    const vertexBufferIndex = t.makeSpecValue('maxVertexBuffers', vertexBufferIndexSpec);
-    const extraAttributeCount = t.makeSpecValue('maxVertexAttributes', extraAttributeCountSpec);
-    const testShaderLocation = t.makeSpecValue('maxVertexAttributes', testShaderLocationSpec);
+    const vertexBufferIndex = t.makeLimitVariant('maxVertexBuffers', vertexBufferIndexVariant);
+    const extraAttributeCount = t.makeLimitVariant(
+      'maxVertexAttributes',
+      extraAttributeCountVariant
+    );
+    const testShaderLocation = t.makeLimitVariant('maxVertexAttributes', testShaderLocationVariant);
     // We have a shader using `testShaderLocation`.
     const shader = t.generateTestVertexShader([
       {
@@ -591,14 +600,14 @@ g.test('vertex_attribute_offset_alignment')
   .params(u =>
     u
       .combine('format', kVertexFormats)
-      .combine('arrayStrideSpec', [
+      .combine('arrayStrideVariant', [
         { mult: 0, add: 256 },
         { mult: 1, add: 0 },
       ])
-      .expand('offsetSpec', p => {
+      .expand('offsetVariant', p => {
         const { bytesPerComponent, componentCount } = kVertexFormatInfo[p.format];
         const formatSize = bytesPerComponent * componentCount;
-        return filterUniqueSpecValues([
+        return filterUniqueValueTestVariants([
           { mult: 0, add: 0 },
           { mult: 0, add: Math.floor(formatSize / 2) },
           { mult: 0, add: formatSize },
@@ -611,12 +620,12 @@ g.test('vertex_attribute_offset_alignment')
         ]);
       })
       .beginSubcases()
-      .combine('vertexBufferIndexSpec', [
+      .combine('vertexBufferIndexVariant', [
         { mult: 0, add: 0 },
         { mult: 0, add: 1 },
         { mult: 1, add: -1 },
       ])
-      .combine('extraAttributeCountSpec', [
+      .combine('extraAttributeCountVariant', [
         { mult: 0, add: 0 },
         { mult: 0, add: 1 },
         { mult: 1, add: -1 },
@@ -626,16 +635,19 @@ g.test('vertex_attribute_offset_alignment')
   .fn(t => {
     const {
       format,
-      arrayStrideSpec,
-      offsetSpec,
-      vertexBufferIndexSpec,
-      extraAttributeCountSpec,
+      arrayStrideVariant,
+      offsetVariant,
+      vertexBufferIndexVariant,
+      extraAttributeCountVariant,
       testAttributeAtStart,
     } = t.params;
-    const arrayStride = t.makeSpecValue('maxVertexBufferArrayStride', arrayStrideSpec);
-    const vertexBufferIndex = t.makeSpecValue('maxVertexBuffers', vertexBufferIndexSpec);
-    const extraAttributeCount = t.makeSpecValue('maxVertexAttributes', extraAttributeCountSpec);
-    const offset = makeSpecValue(arrayStride, offsetSpec);
+    const arrayStride = t.makeLimitVariant('maxVertexBufferArrayStride', arrayStrideVariant);
+    const vertexBufferIndex = t.makeLimitVariant('maxVertexBuffers', vertexBufferIndexVariant);
+    const extraAttributeCount = t.makeLimitVariant(
+      'maxVertexAttributes',
+      extraAttributeCountVariant
+    );
+    const offset = makeValueTestVariant(arrayStride, offsetVariant);
 
     const attributes: GPUVertexAttribute[] = [];
     addTestAttributes(attributes, {
@@ -668,13 +680,13 @@ g.test('vertex_attribute_contained_in_stride')
     u
       .combine('format', kVertexFormats)
       .beginSubcases()
-      .combine('arrayStrideSpec', [
+      .combine('arrayStrideVariant', [
         { mult: 0, add: 0 },
         { mult: 0, add: 256 },
         { mult: 1, add: -4 },
         { mult: 1, add: 0 },
       ])
-      .expand('offsetSpec', function* (p) {
+      .expand('offsetVariant', function* (p) {
         // Compute a bunch of test offsets to test.
         const { bytesPerComponent, componentCount } = kVertexFormatInfo[p.format];
         const formatSize = bytesPerComponent * componentCount;
@@ -689,12 +701,12 @@ g.test('vertex_attribute_contained_in_stride')
           yield { mult: 1, add: 0 };
         }
       })
-      .combine('vertexBufferIndexSpec', [
+      .combine('vertexBufferIndexVariant', [
         { mult: 0, add: 0 },
         { mult: 0, add: 1 },
         { mult: 1, add: -1 },
       ])
-      .combine('extraAttributeCountSpec', [
+      .combine('extraAttributeCountVariant', [
         { mult: 0, add: 0 },
         { mult: 0, add: 1 },
         { mult: 1, add: -1 },
@@ -704,21 +716,24 @@ g.test('vertex_attribute_contained_in_stride')
   .fn(t => {
     const {
       format,
-      arrayStrideSpec,
-      offsetSpec,
-      vertexBufferIndexSpec,
-      extraAttributeCountSpec,
+      arrayStrideVariant,
+      offsetVariant,
+      vertexBufferIndexVariant,
+      extraAttributeCountVariant,
       testAttributeAtStart,
     } = t.params;
-    const arrayStride = t.makeSpecValue('maxVertexBufferArrayStride', arrayStrideSpec);
-    const vertexBufferIndex = t.makeSpecValue('maxVertexBuffers', vertexBufferIndexSpec);
-    const extraAttributeCount = t.makeSpecValue('maxVertexAttributes', extraAttributeCountSpec);
+    const arrayStride = t.makeLimitVariant('maxVertexBufferArrayStride', arrayStrideVariant);
+    const vertexBufferIndex = t.makeLimitVariant('maxVertexBuffers', vertexBufferIndexVariant);
+    const extraAttributeCount = t.makeLimitVariant(
+      'maxVertexAttributes',
+      extraAttributeCountVariant
+    );
     // arrayStride = 0 is a special case because for the offset validation it acts the same
     // as arrayStride = device.limits.maxVertexBufferArrayStride. We special case here so as to avoid adding
     // negative offsets that would cause an IDL exception to be thrown instead of a validation
     // error.
     const stride = arrayStride !== 0 ? arrayStride : t.device.limits.maxVertexBufferArrayStride;
-    const offset = makeSpecValue(stride, offsetSpec);
+    const offset = makeValueTestVariant(stride, offsetVariant);
 
     const attributes: GPUVertexAttribute[] = [];
     addTestAttributes(attributes, {

--- a/src/webgpu/capability_info.ts
+++ b/src/webgpu/capability_info.ts
@@ -6,7 +6,7 @@
 import {
   keysOf,
   makeTable,
-  makeTableWithDefaults,
+  makeTableRenameAndFilter,
   numericKeysOf,
   valueof,
 } from '../common/util/data_tables.js';
@@ -694,21 +694,27 @@ const [
   'maxComputeWorkgroupsPerDimension':          [           ,     65535,           65535,                          ],
 } as const];
 
+/**
+ * Feature levels corresponding to core WebGPU and WebGPU
+ * in compatibility mode. They can be passed to
+ * getDefaultLimits though if you have access to an adapter
+ * it's preferred to use getDefaultLimitsForAdapter.
+ */
 export const kFeatureLevels = ['core', 'compatibility'] as const;
 export type FeatureLevel = typeof kFeatureLevels[number];
 
 const kLimitKeys = ['class', 'default', 'maximumValue'] as const;
 
-const kLimitInfoCore = makeTableWithDefaults(
-  'core',
+const kLimitInfoCore = makeTableRenameAndFilter(
+  { default: 'core' },
   kLimitKeys,
   kLimitInfoKeys,
   kLimitInfoDefaults,
   kLimitInfoData
 );
 
-const kLimitInfoCompatibility = makeTableWithDefaults(
-  'compatibility',
+const kLimitInfoCompatibility = makeTableRenameAndFilter(
+  { default: 'compatibility' },
   kLimitKeys,
   kLimitInfoKeys,
   kLimitInfoDefaults,

--- a/src/webgpu/capability_info.ts
+++ b/src/webgpu/capability_info.ts
@@ -3,7 +3,13 @@
 
 /* eslint-disable no-sparse-arrays */
 
-import { keysOf, makeTable, numericKeysOf, valueof } from '../common/util/data_tables.js';
+import {
+  keysOf,
+  makeTable,
+  makeTableWithDefaults,
+  numericKeysOf,
+  valueof,
+} from '../common/util/data_tables.js';
 import { assertTypeTrue, TypeEqual } from '../common/util/types.js';
 import { unreachable } from '../common/util/util.js';
 
@@ -347,6 +353,7 @@ assertTypeTrue<TypeEqual<BindableResource, typeof kBindableResources[number]>>()
 /** Dynamic buffer offsets require offset to be divisible by 256, by spec. */
 export const kMinDynamicBufferOffsetAlignment = 256;
 
+// MAINTENANCE_TODO: remove these as tests need to use different limits for compatibility mode
 /** Default `PerShaderStage` binding limits, by spec. */
 export const kPerStageBindingLimits: {
   readonly [k in PerStageBindingLimitClass]: {
@@ -642,50 +649,101 @@ export const kIndexFormat: readonly GPUIndexFormat[] = ['uint16', 'uint32'];
 assertTypeTrue<TypeEqual<GPUIndexFormat, typeof kIndexFormat[number]>>();
 
 /** Info for each entry of GPUSupportedLimits */
-export const kLimitInfo = /* prettier-ignore */ makeTable(
-                                               [    'class', 'default',            'maximumValue'] as const,
-                                               [  'maximum',          ,     kMaxUnsignedLongValue] as const, {
-  'maxTextureDimension1D':                     [           ,      8192,                          ],
-  'maxTextureDimension2D':                     [           ,      8192,                          ],
-  'maxTextureDimension3D':                     [           ,      2048,                          ],
-  'maxTextureArrayLayers':                     [           ,       256,                          ],
+const [
+  kLimitInfoKeys,
+  kLimitInfoDefaults,
+  kLimitInfoData,
+] = /* prettier-ignore */ [
+                                               [    'class',    'core', 'compatibility',            'maximumValue'] as const,
+                                               [  'maximum',          ,                ,     kMaxUnsignedLongValue] as const, {
+  'maxTextureDimension1D':                     [           ,      8192,            4096,                          ],
+  'maxTextureDimension2D':                     [           ,      8192,            4096,                          ],
+  'maxTextureDimension3D':                     [           ,      2048,            1024,                          ],
+  'maxTextureArrayLayers':                     [           ,       256,             256,                          ],
 
-  'maxBindGroups':                             [           ,         4,                          ],
-  'maxBindingsPerBindGroup':                   [           ,      1000,                          ],
-  'maxDynamicUniformBuffersPerPipelineLayout': [           ,         8,                          ],
-  'maxDynamicStorageBuffersPerPipelineLayout': [           ,         4,                          ],
-  'maxSampledTexturesPerShaderStage':          [           ,        16,                          ],
-  'maxSamplersPerShaderStage':                 [           ,        16,                          ],
-  'maxStorageBuffersPerShaderStage':           [           ,         8,                          ],
-  'maxStorageTexturesPerShaderStage':          [           ,         4,                          ],
-  'maxUniformBuffersPerShaderStage':           [           ,        12,                          ],
+  'maxBindGroups':                             [           ,         4,               4,                          ],
+  'maxBindingsPerBindGroup':                   [           ,      1000,            1000,                          ],
+  'maxDynamicUniformBuffersPerPipelineLayout': [           ,         8,               8,                          ],
+  'maxDynamicStorageBuffersPerPipelineLayout': [           ,         4,               4,                          ],
+  'maxSampledTexturesPerShaderStage':          [           ,        16,              16,                          ],
+  'maxSamplersPerShaderStage':                 [           ,        16,              16,                          ],
+  'maxStorageBuffersPerShaderStage':           [           ,         8,               4,                          ],
+  'maxStorageTexturesPerShaderStage':          [           ,         4,               4,                          ],
+  'maxUniformBuffersPerShaderStage':           [           ,        12,              12,                          ],
 
-  'maxUniformBufferBindingSize':               [           ,     65536, kMaxUnsignedLongLongValue],
-  'maxStorageBufferBindingSize':               [           , 134217728, kMaxUnsignedLongLongValue],
-  'minUniformBufferOffsetAlignment':           ['alignment',       256,                          ],
-  'minStorageBufferOffsetAlignment':           ['alignment',       256,                          ],
+  'maxUniformBufferBindingSize':               [           ,     65536,           16384, kMaxUnsignedLongLongValue],
+  'maxStorageBufferBindingSize':               [           , 134217728,       134217728, kMaxUnsignedLongLongValue],
+  'minUniformBufferOffsetAlignment':           ['alignment',       256,             256,                          ],
+  'minStorageBufferOffsetAlignment':           ['alignment',       256,             256,                          ],
 
-  'maxVertexBuffers':                          [           ,         8,                          ],
-  'maxBufferSize':                             [           , 268435456, kMaxUnsignedLongLongValue],
-  'maxVertexAttributes':                       [           ,        16,                          ],
-  'maxVertexBufferArrayStride':                [           ,      2048,                          ],
-  'maxInterStageShaderComponents':             [           ,        60,                          ],
-  'maxInterStageShaderVariables':              [           ,        16,                          ],
+  'maxVertexBuffers':                          [           ,         8,               8,                          ],
+  'maxBufferSize':                             [           , 268435456,       268435456, kMaxUnsignedLongLongValue],
+  'maxVertexAttributes':                       [           ,        16,              16,                          ],
+  'maxVertexBufferArrayStride':                [           ,      2048,            2048,                          ],
+  'maxInterStageShaderComponents':             [           ,        60,              60,                          ],
+  'maxInterStageShaderVariables':              [           ,        16,              16,                          ],
 
-  'maxColorAttachments':                       [           ,         8,                          ],
-  'maxColorAttachmentBytesPerSample':          [           ,        32,                          ],
+  'maxColorAttachments':                       [           ,         8,               4,                          ],
+  'maxColorAttachmentBytesPerSample':          [           ,        32,              32,                          ],
 
-  'maxComputeWorkgroupStorageSize':            [           ,     16384,                          ],
-  'maxComputeInvocationsPerWorkgroup':         [           ,       256,                          ],
-  'maxComputeWorkgroupSizeX':                  [           ,       256,                          ],
-  'maxComputeWorkgroupSizeY':                  [           ,       256,                          ],
-  'maxComputeWorkgroupSizeZ':                  [           ,        64,                          ],
-  'maxComputeWorkgroupsPerDimension':          [           ,     65535,                          ],
-} as const);
+  'maxComputeWorkgroupStorageSize':            [           ,     16384,           16384,                          ],
+  'maxComputeInvocationsPerWorkgroup':         [           ,       256,             128,                          ],
+  'maxComputeWorkgroupSizeX':                  [           ,       256,             128,                          ],
+  'maxComputeWorkgroupSizeY':                  [           ,       256,             128,                          ],
+  'maxComputeWorkgroupSizeZ':                  [           ,        64,              64,                          ],
+  'maxComputeWorkgroupsPerDimension':          [           ,     65535,           65535,                          ],
+} as const];
+
+export const kFeatureLevels = ['core', 'compatibility'] as const;
+export type FeatureLevel = typeof kFeatureLevels[number];
+
+const kLimitKeys = ['class', 'default', 'maximumValue'] as const;
+
+const kLimitInfoCore = makeTableWithDefaults(
+  'core',
+  kLimitKeys,
+  kLimitInfoKeys,
+  kLimitInfoDefaults,
+  kLimitInfoData
+);
+
+const kLimitInfoCompatibility = makeTableWithDefaults(
+  'compatibility',
+  kLimitKeys,
+  kLimitInfoKeys,
+  kLimitInfoDefaults,
+  kLimitInfoData
+);
+
+// MAINTENANCE_TODO: remove this as tests need to use different limits for compatibility mode
+export const kLimitInfo = kLimitInfoCore;
+
+const kLimitInfos = {
+  core: kLimitInfoCore,
+  compatibility: kLimitInfoCompatibility,
+} as const;
+
+export const kLimitClasses = Object.fromEntries(
+  Object.entries(kLimitInfoCore).map(([k, { class: c }]) => [k, c])
+);
+
+export function getDefaultLimits(featureLevel: FeatureLevel) {
+  return kLimitInfos[featureLevel];
+}
+
+export function getDefaultLimitsForAdapter(adapter: GPUAdapter) {
+  // MAINTENANCE_TODO: Remove casts when GPUAdapter IDL has isCompatibilityMode.
+  return getDefaultLimits(
+    ((adapter as unknown) as { isCompatibilityMode: boolean }).isCompatibilityMode
+      ? 'compatibility'
+      : 'core'
+  );
+}
 
 /** List of all entries of GPUSupportedLimits. */
-export const kLimits = keysOf(kLimitInfo);
+export const kLimits = keysOf(kLimitInfoCore);
 
+// MAINTENANCE_TODO: remove these as tests need to use different limits for compatibility mode
 // Pipeline limits
 
 /** Maximum number of color attachments to a render pass, by spec. */
@@ -696,6 +754,17 @@ export const kMaxVertexBuffers = kLimitInfo.maxVertexBuffers.default;
 export const kMaxVertexAttributes = kLimitInfo.maxVertexAttributes.default;
 /** `maxVertexBufferArrayStride` in a vertex buffer in a GPURenderPipeline, by spec. */
 export const kMaxVertexBufferArrayStride = kLimitInfo.maxVertexBufferArrayStride.default;
+/**
+ * The number of color attachments to test.
+ * The CTS needs to generate a consistent list of tests.
+ * We can't use any default limits since they different from core to compat mode
+ * So, tests should use this value and filter out any values that are out of
+ * range for the current device.
+ *
+ * The test in maxColorAttachments.spec.ts tests that kMaxColorAttachmentsToTest
+ * is large enough to cover all devices tested.
+ */
+export const kMaxColorAttachmentsToTest = 32;
 
 /** The size of indirect draw parameters in the indirectBuffer of drawIndirect */
 export const kDrawIndirectParametersSize = 4;

--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -11,14 +11,16 @@ import {
 import { globalTestConfig } from '../common/framework/test_config.js';
 import {
   assert,
+  makeSpecValue,
   memcpy,
   range,
+  SpecValue,
   TypedArrayBufferView,
   TypedArrayBufferViewConstructor,
   unreachable,
 } from '../common/util/util.js';
 
-import { kQueryTypeInfo } from './capability_info.js';
+import { getDefaultLimits, kLimits, kQueryTypeInfo } from './capability_info.js';
 import {
   kTextureFormatInfo,
   kEncodableTextureFormats,
@@ -117,6 +119,10 @@ export class GPUTestSubcaseBatchState extends SubcaseBatchState {
     return globalTestConfig.compatibility;
   }
 
+  getDefaultLimits() {
+    return getDefaultLimits(this.isCompatibility ? 'compatibility' : 'core');
+  }
+
   /**
    * Some tests or cases need particular feature flags or limits to be enabled.
    * Call this function with a descriptor or feature name (or `undefined`) to select a
@@ -200,6 +206,13 @@ export class GPUTestSubcaseBatchState extends SubcaseBatchState {
     throw new SkipTestCase(msg);
   }
 
+  /** Throws an exception making the subcase as skipped if condition is true */
+  skipIf(cond: boolean, msg: string = '') {
+    if (cond) {
+      this.skip(msg);
+    }
+  }
+
   /**
    * Skips test if any format is not supported.
    */
@@ -261,6 +274,18 @@ export class GPUTestBase extends Fixture<GPUTestSubcaseBatchState> {
 
   get isCompatibility() {
     return globalTestConfig.compatibility;
+  }
+
+  getDefaultLimits() {
+    return getDefaultLimits(this.isCompatibility ? 'compatibility' : 'core');
+  }
+
+  getDefaultLimit(limit: typeof kLimits[number]) {
+    return this.getDefaultLimits()[limit].default;
+  }
+
+  makeSpecValue(limit: typeof kLimits[number], spec: SpecValue) {
+    return makeSpecValue(this.device.limits[limit], spec);
   }
 
   canCallCopyTextureToBufferWithTextureFormat(format: GPUTextureFormat) {

--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -11,10 +11,10 @@ import {
 import { globalTestConfig } from '../common/framework/test_config.js';
 import {
   assert,
-  makeSpecValue,
+  makeValueTestVariant,
   memcpy,
   range,
-  SpecValue,
+  ValueTestVariant,
   TypedArrayBufferView,
   TypedArrayBufferViewConstructor,
   unreachable,
@@ -207,9 +207,9 @@ export class GPUTestSubcaseBatchState extends SubcaseBatchState {
   }
 
   /** Throws an exception making the subcase as skipped if condition is true */
-  skipIf(cond: boolean, msg: string = '') {
+  skipIf(cond: boolean, msg: string | (() => string) = '') {
     if (cond) {
-      this.skip(msg);
+      this.skip(typeof msg === 'function' ? msg() : msg);
     }
   }
 
@@ -284,8 +284,8 @@ export class GPUTestBase extends Fixture<GPUTestSubcaseBatchState> {
     return this.getDefaultLimits()[limit].default;
   }
 
-  makeSpecValue(limit: typeof kLimits[number], spec: SpecValue) {
-    return makeSpecValue(this.device.limits[limit], spec);
+  makeLimitVariant(limit: typeof kLimits[number], variant: ValueTestVariant) {
+    return makeValueTestVariant(this.device.limits[limit], variant);
   }
 
   canCallCopyTextureToBufferWithTextureFormat(format: GPUTextureFormat) {


### PR DESCRIPTION
Compat has different limits than non-Compat and tons of the CTS needs to be refactored from assuming the default limits are fixed.

Note: Locally I have `kLimitInfo` deleted as well as  `kMaxColorAttachments`, `kMaxVertexBuffers `, `kMaxVertexAttributes`, `kMaxVertexBufferArrayStride`

But, deleting those meant changing 35 files with 2500 lines of changes so this is just the first file to keep the PRs small.

I'll try upload one file at a time and then finally delete those constants.

Note 2: I couldn't come up with a better name for `SpecValue`. I'm happy to change it but it would be nice if whatever it becomes was short because the longer it gets the harder the code becomes to read as things get reformatted across multiple lines.

Note 3: Right now, kLimitInfoCore and kLimitInfoCompat are generated with 2 calls to `makeTableWithDefaults`. Theoretically both could be created with one call to something but it was taking too long for me to figure out the magic type incantation so to move forward I just did the simplested thing I could think of. It doesn't leak outside of capabilities_info.ts so I'm hoping that can be fixed later.

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
