### PR TITLE
wgsl: add f16 execution test for builtin fma

### DIFF
--- a/src/unittests/floating_point.spec.ts
+++ b/src/unittests/floating_point.spec.ts
@@ -5059,52 +5059,74 @@ g.test('clampMinMaxInterval')
     );
   });
 
-g.test('fmaInterval_f32')
-  .paramsSubcasesOnly<ScalarTripleToIntervalCase>(
-    // prettier-ignore
-    [
-      // Normals
-      { input: [0, 0, 0], expected: 0 },
-      { input: [1, 0, 0], expected: 0 },
-      { input: [0, 1, 0], expected: 0 },
-      { input: [0, 0, 1], expected: 1 },
-      { input: [1, 0, 1], expected: 1 },
-      { input: [1, 1, 0], expected: 1 },
-      { input: [0, 1, 1], expected: 1 },
-      { input: [1, 1, 1], expected: 2 },
-      { input: [1, 10, 100], expected: 110 },
-      { input: [10, 1, 100], expected: 110 },
-      { input: [100, 1, 10], expected: 110 },
-      { input: [-10, 1, 100], expected: 90 },
-      { input: [10, 1, -100], expected: -90 },
-      { input: [-10, 1, -100], expected: -110 },
-      { input: [-10, -10, -10], expected: 90 },
+g.test('fmaInterval')
+  .params(u =>
+    u
+      .combine('trait', ['f32', 'f16'] as const)
+      .beginSubcases()
+      .expandWithParams<ScalarTripleToIntervalCase>(p => {
+        const trait = FP[p.trait];
+        const constants = trait.constants();
+        // prettier-ignore
+        return [
+          // Normals
+          { input: [0, 0, 0], expected: 0 },
+          { input: [1, 0, 0], expected: 0 },
+          { input: [0, 1, 0], expected: 0 },
+          { input: [0, 0, 1], expected: 1 },
+          { input: [1, 0, 1], expected: 1 },
+          { input: [1, 1, 0], expected: 1 },
+          { input: [0, 1, 1], expected: 1 },
+          { input: [1, 1, 1], expected: 2 },
+          { input: [1, 10, 100], expected: 110 },
+          { input: [10, 1, 100], expected: 110 },
+          { input: [100, 1, 10], expected: 110 },
+          { input: [-10, 1, 100], expected: 90 },
+          { input: [10, 1, -100], expected: -90 },
+          { input: [-10, 1, -100], expected: -110 },
+          { input: [-10, -10, -10], expected: 90 },
 
-      // Subnormals
-      { input: [kValue.f32.subnormal.positive.max, 0, 0], expected: 0 },
-      { input: [0, kValue.f32.subnormal.positive.max, 0], expected: 0 },
-      { input: [0, 0, kValue.f32.subnormal.positive.max], expected: [0, kValue.f32.subnormal.positive.max] },
-      { input: [kValue.f32.subnormal.positive.max, 0, kValue.f32.subnormal.positive.max], expected: [0, kValue.f32.subnormal.positive.max] },
-      { input: [kValue.f32.subnormal.positive.max, kValue.f32.subnormal.positive.max, 0], expected: [0, kValue.f32.subnormal.positive.min] },
-      { input: [0, kValue.f32.subnormal.positive.max, kValue.f32.subnormal.positive.max], expected: [0, kValue.f32.subnormal.positive.max] },
-      { input: [kValue.f32.subnormal.positive.max, kValue.f32.subnormal.positive.max, kValue.f32.subnormal.positive.max], expected: [0, kValue.f32.positive.min] },
-      { input: [kValue.f32.subnormal.positive.max, kValue.f32.subnormal.positive.min, kValue.f32.subnormal.negative.max], expected: [kValue.f32.subnormal.negative.max, kValue.f32.subnormal.positive.min] },
-      { input: [kValue.f32.subnormal.positive.max, kValue.f32.subnormal.negative.min, kValue.f32.subnormal.negative.max], expected: [reinterpretU32AsF32(0x80000002), 0] },
+          // Subnormals
+          { input: [constants.positive.subnormal.max, 0, 0], expected: 0 },
+          { input: [0, constants.positive.subnormal.max, 0], expected: 0 },
+          { input: [0, 0, constants.positive.subnormal.max], expected: [0, constants.positive.subnormal.max] },
+          { input: [constants.positive.subnormal.max, 0, constants.positive.subnormal.max], expected: [0, constants.positive.subnormal.max] },
+          // positive.subnormal.max * positive.subnormal.max is much smaller than positive.subnormal.min but larger than 0, rounded to [0, positive.subnormal.min]
+          { input: [constants.positive.subnormal.max, constants.positive.subnormal.max, 0], expected: [0, constants.positive.subnormal.min] },
+          { input: [0, constants.positive.subnormal.max, constants.positive.subnormal.max], expected: [0, constants.positive.subnormal.max] },
+          // positive.subnormal.max * positive.subnormal.max rounded to 0 or positive.subnormal.min,
+          // 0 + constants.positive.subnormal.max rounded to [0, constants.positive.subnormal.max],
+          // positive.subnormal.min + constants.positive.subnormal.max = constants.positive.min.
+          { input: [constants.positive.subnormal.max, constants.positive.subnormal.max, constants.positive.subnormal.max], expected: [0, constants.positive.min] },
+          // positive.subnormal.max * positive.subnormal.max rounded to 0 or positive.subnormal.min,
+          // negative.subnormal.max may flushed to 0,
+          // minimum case: 0 + negative.subnormal.max rounded to [negative.subnormal.max, 0],
+          // maximum case: positive.subnormal.min + 0 rounded to [0, positive.subnormal.min].
+          { input: [constants.positive.subnormal.max, constants.positive.subnormal.min, constants.negative.subnormal.max], expected: [constants.negative.subnormal.max, constants.positive.subnormal.min] },
+          // positive.subnormal.max * negative.subnormal.min rounded to -0.0 or negative.subnormal.max = -1 * [subnormal ulp],
+          // negative.subnormal.max = -1 * [subnormal ulp] may flushed to -0.0,
+          // minimum case: -1 * [subnormal ulp] + -1 * [subnormal ulp] rounded to [-2 * [subnormal ulp], 0],
+          // maximum case: -0.0 + -0.0 = 0.
+          { input: [constants.positive.subnormal.max, constants.negative.subnormal.min, constants.negative.subnormal.max], expected: [-2 * FP[p.trait].oneULP(0, 'no-flush'), 0] },
 
-      // Infinities
-      { input: [0, 1, kValue.f32.infinity.positive], expected: kUnboundedBounds },
-      { input: [0, kValue.f32.infinity.positive, kValue.f32.infinity.positive], expected: kUnboundedBounds },
-      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive, kValue.f32.infinity.positive], expected: kUnboundedBounds },
-      { input: [kValue.f32.infinity.negative, kValue.f32.infinity.positive, kValue.f32.infinity.negative], expected: kUnboundedBounds },
-      { input: [kValue.f32.positive.max, kValue.f32.positive.max, kValue.f32.subnormal.positive.min], expected: kUnboundedBounds },
-    ]
+          // Infinities
+          { input: [0, 1, constants.positive.infinity], expected: kUnboundedBounds },
+          { input: [0, constants.positive.infinity, constants.positive.infinity], expected: kUnboundedBounds },
+          { input: [constants.negative.infinity, constants.positive.infinity, constants.positive.infinity], expected: kUnboundedBounds },
+          { input: [constants.negative.infinity, constants.positive.infinity, constants.negative.infinity], expected: kUnboundedBounds },
+          { input: [constants.positive.max, constants.positive.max, constants.positive.subnormal.min], expected: kUnboundedBounds },
+        ];
+      })
   )
   .fn(t => {
-    const expected = FP.f32.toInterval(t.params.expected);
-    const got = FP.f32.fmaInterval(...t.params.input);
+    const trait = FP[t.params.trait];
+    const expected = trait.toInterval(t.params.expected);
+    const got = trait.fmaInterval(...t.params.input);
     t.expect(
       objectEquals(expected, got),
-      `f32.fmaInterval(${t.params.input.join(',')}) returned ${got}. Expected ${expected}`
+      `${t.params.trait}.fmaInterval(${t.params.input.join(
+        ','
+      )}) returned ${got}. Expected ${expected}`
     );
   });
 

--- a/src/webgpu/listing_meta.json
+++ b/src/webgpu/listing_meta.json
@@ -1206,7 +1206,7 @@
   "webgpu:shader,execution,expression,call,builtin,floor:f16:*": { "subcaseMS": 30.708 },
   "webgpu:shader,execution,expression,call,builtin,floor:f32:*": { "subcaseMS": 10.119 },
   "webgpu:shader,execution,expression,call,builtin,fma:abstract_float:*": { "subcaseMS": 18.208 },
-  "webgpu:shader,execution,expression,call,builtin,fma:f16:*": { "subcaseMS": 27.805 },
+  "webgpu:shader,execution,expression,call,builtin,fma:f16:*": { "subcaseMS": 485.857 },
   "webgpu:shader,execution,expression,call,builtin,fma:f32:*": { "subcaseMS": 80.388 },
   "webgpu:shader,execution,expression,call,builtin,fract:abstract_float:*": { "subcaseMS": 17.408 },
   "webgpu:shader,execution,expression,call,builtin,fract:f16:*": { "subcaseMS": 17.106 },

--- a/src/webgpu/shader/execution/expression/call/builtin/fma.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/fma.spec.ts
@@ -9,9 +9,9 @@ Returns e1 * e2 + e3. Component-wise when T is a vector.
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
-import { TypeF32 } from '../../../../../util/conversion.js';
+import { TypeF32, TypeF16 } from '../../../../../util/conversion.js';
 import { FP } from '../../../../../util/floating_point.js';
-import { sparseF32Range } from '../../../../../util/math.js';
+import { sparseF32Range, sparseF16Range } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
 import { allInputSources, run } from '../../expression.js';
 
@@ -36,6 +36,24 @@ export const d = makeCaseCache('fma', {
       sparseF32Range(),
       'unfiltered',
       FP.f32.fmaInterval
+    );
+  },
+  f16_const: () => {
+    return FP.f16.generateScalarTripleToIntervalCases(
+      sparseF16Range(),
+      sparseF16Range(),
+      sparseF16Range(),
+      'finite',
+      FP.f16.fmaInterval
+    );
+  },
+  f16_non_const: () => {
+    return FP.f16.generateScalarTripleToIntervalCases(
+      sparseF16Range(),
+      sparseF16Range(),
+      sparseF16Range(),
+      'unfiltered',
+      FP.f16.fmaInterval
     );
   },
 });
@@ -65,4 +83,10 @@ g.test('f16')
   .params(u =>
     u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
-  .unimplemented();
+  .beforeAllSubcases(t => {
+    t.selectDeviceOrSkipTestCase({ requiredFeatures: ['shader-f16'] });
+  })
+  .fn(async t => {
+    const cases = await d.get(t.params.inputSource === 'const' ? 'f16_const' : 'f16_non_const');
+    await run(t, builtin('fma'), [TypeF16, TypeF16, TypeF16], TypeF16, t.params, cases);
+  });

--- a/src/webgpu/util/floating_point.ts
+++ b/src/webgpu/util/floating_point.ts
@@ -5218,7 +5218,7 @@ class F16Traits extends FPTraits {
   public readonly exp2Interval = this.exp2IntervalImpl.bind(this);
   public readonly faceForwardIntervals = this.unimplementedFaceForward.bind(this);
   public readonly floorInterval = this.floorIntervalImpl.bind(this);
-  public readonly fmaInterval = this.unimplementedScalarTripleToInterval.bind(this, 'fmaInterval');
+  public readonly fmaInterval = this.fmaIntervalImpl.bind(this);
   public readonly fractInterval = this.unimplementedScalarToInterval.bind(this, 'fractInterval');
   public readonly inverseSqrtInterval = this.inverseSqrtIntervalImpl.bind(this);
   public readonly ldexpInterval = this.unimplementedScalarPairToInterval.bind(


### PR DESCRIPTION
This PR add execution test for f16 built-in fma.

Issue: #1248, #2549

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
