### PR TITLE
Compat: Make createBindGroupLayout tests handle different limits

### DIFF
--- a/src/webgpu/api/validation/createBindGroupLayout.spec.ts
+++ b/src/webgpu/api/validation/createBindGroupLayout.spec.ts
@@ -7,7 +7,6 @@ TODO: make sure tests are complete.
 import { kUnitCaseParamsBuilder } from '../../../common/framework/params_builder.js';
 import { makeTestGroup } from '../../../common/framework/test_group.js';
 import {
-  kLimitInfo,
   kShaderStages,
   kShaderStageCombinations,
   kStorageTextureAccessValues,
@@ -63,19 +62,18 @@ g.test('maximum_binding_limit')
   `
   )
   .paramsSubcasesOnly(u =>
-    u //
-      .combine('binding', [
-        1,
-        4,
-        8,
-        256,
-        kLimitInfo.maxBindingsPerBindGroup.default - 1,
-        kLimitInfo.maxBindingsPerBindGroup.default,
-      ])
+    u.combine('bindingVariant', [1, 4, 8, 256, 'default', 'default-minus-one'])
   )
   .fn(t => {
-    const { binding } = t.params;
+    const { bindingVariant } = t.params;
     const entries: Array<GPUBindGroupLayoutEntry> = [];
+
+    const binding =
+      bindingVariant === 'default'
+        ? t.device.limits.maxBindingsPerBindGroup
+        : bindingVariant === 'default-minus-one'
+        ? t.device.limits.maxBindingsPerBindGroup - 1
+        : (bindingVariant as number);
 
     entries.push({
       binding,
@@ -83,7 +81,7 @@ g.test('maximum_binding_limit')
       buffer: { type: 'storage' as const },
     });
 
-    const success = binding < kLimitInfo.maxBindingsPerBindGroup.default;
+    const success = binding < t.device.limits.maxBindingsPerBindGroup;
 
     t.expectValidationError(() => {
       t.device.createBindGroupLayout({
@@ -297,7 +295,7 @@ const kMaxResourcesCases = kUnitCaseParamsBuilder
   .combine('extraVisibility', kShaderStages)
   .filter(p => (bindingTypeInfo(p.extraEntry).validStages & p.extraVisibility) !== 0);
 
-// Should never fail unless kLimitInfo.maxBindingsPerBindGroup.default is exceeded, because the validation for
+// Should never fail unless limitInfo.maxBindingsPerBindGroup.default is exceeded, because the validation for
 // resources-of-type-per-stage is in pipeline layout creation.
 g.test('max_resources_per_stage,in_bind_group_layout')
   .desc(

--- a/src/webgpu/api/validation/createBindGroupLayout.spec.ts
+++ b/src/webgpu/api/validation/createBindGroupLayout.spec.ts
@@ -62,7 +62,7 @@ g.test('maximum_binding_limit')
   `
   )
   .paramsSubcasesOnly(u =>
-    u.combine('bindingVariant', [1, 4, 8, 256, 'default', 'default-minus-one'])
+    u.combine('bindingVariant', [1, 4, 8, 256, 'default', 'default-minus-one'] as const)
   )
   .fn(t => {
     const { bindingVariant } = t.params;
@@ -73,7 +73,7 @@ g.test('maximum_binding_limit')
         ? t.device.limits.maxBindingsPerBindGroup
         : bindingVariant === 'default-minus-one'
         ? t.device.limits.maxBindingsPerBindGroup - 1
-        : (bindingVariant as number);
+        : bindingVariant;
 
     entries.push({
       binding,


### PR DESCRIPTION

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
