### PR TITLE
Compat: Make compute pass tests handle different limits

### DIFF
--- a/src/webgpu/api/validation/encoding/cmds/compute_pass.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/compute_pass.spec.ts
@@ -5,7 +5,8 @@ Does **not** test usage scopes (resource_usages/) or programmable pass stuff (pr
 `;
 
 import { makeTestGroup } from '../../../../../common/framework/test_group.js';
-import { kBufferUsages, kLimitInfo } from '../../../../capability_info.js';
+import { makeValueTestVariant } from '../../../../../common/util/util.js';
+import { kBufferUsages } from '../../../../capability_info.js';
 import { GPUConst } from '../../../../constants.js';
 import { kResourceStates, ResourceState } from '../../../../gpu_test.js';
 import { ValidationTest } from '../../validation_test.js';
@@ -88,7 +89,6 @@ g.test('pipeline,device_mismatch')
     validateFinish(!mismatched);
   });
 
-const kMaxDispatch = kLimitInfo.maxComputeWorkgroupsPerDimension.default;
 g.test('dispatch_sizes')
   .desc(
     `Test 'direct' and 'indirect' dispatch with various sizes.
@@ -104,13 +104,22 @@ g.test('dispatch_sizes')
   .params(u =>
     u
       .combine('dispatchType', ['direct', 'indirect'] as const)
-      .combine('largeDimValue', [0, 1, kMaxDispatch, kMaxDispatch + 1, 0x7fff_ffff, 0xffff_ffff])
+      .combine('largeDimValueVariant', [
+        { mult: 0, add: 0 },
+        { mult: 0, add: 1 },
+        { mult: 1, add: 0 },
+        { mult: 1, add: 1 },
+        { mult: 0, add: 0x7fff_ffff },
+        { mult: 0, add: 0xffff_ffff },
+      ])
       .beginSubcases()
       .combine('largeDimIndex', [0, 1, 2] as const)
       .combine('smallDimValue', [0, 1])
   )
   .fn(t => {
-    const { dispatchType, largeDimIndex, smallDimValue, largeDimValue } = t.params;
+    const { dispatchType, largeDimIndex, smallDimValue, largeDimValueVariant } = t.params;
+    const maxDispatch = t.device.limits.maxComputeWorkgroupsPerDimension;
+    const largeDimValue = makeValueTestVariant(maxDispatch, largeDimValueVariant);
 
     const pipeline = t.createNoOpComputePipeline();
 
@@ -131,7 +140,7 @@ g.test('dispatch_sizes')
 
     const shouldError =
       dispatchType === 'direct' &&
-      (workSizes[0] > kMaxDispatch || workSizes[1] > kMaxDispatch || workSizes[2] > kMaxDispatch);
+      (workSizes[0] > maxDispatch || workSizes[1] > maxDispatch || workSizes[2] > maxDispatch);
 
     validateFinishAndSubmit(!shouldError, true);
   });


### PR DESCRIPTION
<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
