### PR TITLE
Compat: Make setVertexBuffer test handle different limits

### DIFF
--- a/src/webgpu/api/validation/encoding/cmds/render/setVertexBuffer.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/render/setVertexBuffer.spec.ts
@@ -3,7 +3,7 @@ Validation tests for setVertexBuffer on render pass and render bundle.
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
-import { kLimitInfo } from '../../../../../capability_info.js';
+import { makeValueTestVariant } from '../../../../../../common/util/util.js';
 import { GPUConst } from '../../../../../constants.js';
 import { kResourceStates } from '../../../../../gpu_test.js';
 import { ValidationTest } from '../../../validation_test.js';
@@ -19,14 +19,17 @@ Tests slot must be less than the maxVertexBuffers in device limits.
   `
   )
   .paramsSubcasesOnly(
-    kRenderEncodeTypeParams.combine('slot', [
-      0,
-      kLimitInfo.maxVertexBuffers.default - 1,
-      kLimitInfo.maxVertexBuffers.default,
+    kRenderEncodeTypeParams.combine('slotVariant', [
+      { mult: 0, add: 0 },
+      { mult: 1, add: -1 },
+      { mult: 1, add: 0 },
     ] as const)
   )
   .fn(t => {
-    const { encoderType, slot } = t.params;
+    const { encoderType, slotVariant } = t.params;
+    const maxVertexBuffers = t.device.limits.maxVertexBuffers;
+    const slot = makeValueTestVariant(maxVertexBuffers, slotVariant);
+
     const vertexBuffer = t.createBufferWithState('valid', {
       size: 16,
       usage: GPUBufferUsage.VERTEX,
@@ -34,7 +37,7 @@ Tests slot must be less than the maxVertexBuffers in device limits.
 
     const { encoder, validateFinish } = t.createEncoder(encoderType);
     encoder.setVertexBuffer(slot, vertexBuffer);
-    validateFinish(slot < kLimitInfo.maxVertexBuffers.default);
+    validateFinish(slot < maxVertexBuffers);
   });
 
 g.test('vertex_buffer_state')


### PR DESCRIPTION


<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
