### PR TITLE
Compat: Make setBindGroup tests handle different limits

### DIFF
--- a/src/webgpu/api/validation/encoding/cmds/setBindGroup.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/setBindGroup.spec.ts
@@ -11,11 +11,10 @@ TODO: merge these notes and implement.
 `;
 
 import { makeTestGroup } from '../../../../../common/framework/test_group.js';
-import { range, unreachable } from '../../../../../common/util/util.js';
+import { makeValueTestVariant, range, unreachable } from '../../../../../common/util/util.js';
 import {
   kBufferBindingTypes,
   kMinDynamicBufferOffsetAlignment,
-  kLimitInfo,
 } from '../../../../capability_info.js';
 import { kResourceStates, ResourceState } from '../../../../gpu_test.js';
 import {
@@ -389,27 +388,23 @@ g.test('buffer_dynamic_offsets')
       .combine('type', kBufferBindingTypes)
       .combine('encoderType', kProgrammableEncoderTypes)
       .beginSubcases()
-      .expand('dynamicOffset', ({ type }) =>
-        type === 'uniform'
-          ? [
-              kLimitInfo.minUniformBufferOffsetAlignment.default,
-              kLimitInfo.minUniformBufferOffsetAlignment.default * 0.5,
-              kLimitInfo.minUniformBufferOffsetAlignment.default * 1.5,
-              kLimitInfo.minUniformBufferOffsetAlignment.default * 2,
-              kLimitInfo.minUniformBufferOffsetAlignment.default + 2,
-            ]
-          : [
-              kLimitInfo.minStorageBufferOffsetAlignment.default,
-              kLimitInfo.minStorageBufferOffsetAlignment.default * 0.5,
-              kLimitInfo.minStorageBufferOffsetAlignment.default * 1.5,
-              kLimitInfo.minStorageBufferOffsetAlignment.default * 2,
-              kLimitInfo.minStorageBufferOffsetAlignment.default + 2,
-            ]
-      )
+      .combine('dynamicOffsetVariant', [
+        { mult: 1, add: 0 },
+        { mult: 0.5, add: 0 },
+        { mult: 1.5, add: 0 },
+        { mult: 2, add: 0 },
+        { mult: 1, add: 2 },
+      ])
   )
   .fn(t => {
-    const { type, dynamicOffset, encoderType } = t.params;
+    const { type, dynamicOffsetVariant, encoderType } = t.params;
     const kBindingSize = 12;
+
+    const minAlignment =
+      t.device.limits[
+        type === 'uniform' ? 'minUniformBufferOffsetAlignment' : 'minStorageBufferOffsetAlignment'
+      ];
+    const dynamicOffset = makeValueTestVariant(minAlignment, dynamicOffsetVariant);
 
     const bindGroupLayout = t.device.createBindGroupLayout({
       entries: [
@@ -421,14 +416,8 @@ g.test('buffer_dynamic_offsets')
       ],
     });
 
-    let usage, isValid;
-    if (type === 'uniform') {
-      usage = GPUBufferUsage.UNIFORM;
-      isValid = dynamicOffset % kLimitInfo.minUniformBufferOffsetAlignment.default === 0;
-    } else {
-      usage = GPUBufferUsage.STORAGE;
-      isValid = dynamicOffset % kLimitInfo.minStorageBufferOffsetAlignment.default === 0;
-    }
+    const usage = type === 'uniform' ? GPUBufferUsage.UNIFORM : GPUBufferUsage.STORAGE;
+    const isValid = dynamicOffset % minAlignment === 0;
 
     const buffer = t.device.createBuffer({
       size: 3 * kMinDynamicBufferOffsetAlignment,


### PR DESCRIPTION

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
