### PR TITLE
Compat: make attachment compatibility test handle different limits

### DIFF
--- a/src/common/framework/fixture.ts
+++ b/src/common/framework/fixture.ts
@@ -166,6 +166,13 @@ export class Fixture<S extends SubcaseBatchState = SubcaseBatchState> {
     throw new SkipTestCase(msg);
   }
 
+  /** Throws an exception marking the subcase as skipped if condition is true */
+  skipIf(cond: boolean, msg: string | (() => string) = '') {
+    if (cond) {
+      this.skip(typeof msg === 'function' ? msg() : msg);
+    }
+  }
+
   /** Log a warning and increase the result status to "Warn". */
   warn(msg?: string): void {
     this.rec.warn(new Error(msg));

--- a/src/webgpu/api/validation/render_pass/attachment_compatibility.spec.ts
+++ b/src/webgpu/api/validation/render_pass/attachment_compatibility.spec.ts
@@ -4,7 +4,7 @@ Validation for attachment compatibility between render passes, bundles, and pipe
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { range } from '../../../../common/util/util.js';
-import { kTextureSampleCounts, kMaxColorAttachments } from '../../../capability_info.js';
+import { kMaxColorAttachmentsToTest, kTextureSampleCounts } from '../../../capability_info.js';
 import {
   kRegularTextureFormats,
   kSizedDepthStencilFormats,
@@ -15,7 +15,7 @@ import {
 } from '../../../format_info.js';
 import { ValidationTest } from '../validation_test.js';
 
-const kColorAttachmentCounts = range(kMaxColorAttachments, i => i + 1);
+const kColorAttachmentCounts = range(kMaxColorAttachmentsToTest, i => i + 1);
 const kColorAttachments = kColorAttachmentCounts
   .map(count => {
     // generate cases with 0..1 null attachments at different location
@@ -241,6 +241,17 @@ g.test('render_pass_and_bundle,color_sparse')
   )
   .fn(t => {
     const { passAttachments, bundleAttachments } = t.params;
+
+    const maxColorAttachments = t.device.limits.maxColorAttachments;
+    t.skipIf(
+      passAttachments.length > maxColorAttachments,
+      `num passAttachments: ${passAttachments.length} > maxColorAttachments for device: ${maxColorAttachments}`
+    );
+    t.skipIf(
+      bundleAttachments.length > maxColorAttachments,
+      `num bundleAttachments: ${bundleAttachments.length} > maxColorAttachments for device: ${maxColorAttachments}`
+    );
+
     const colorFormats = bundleAttachments.map(i => (i ? 'rgba8uint' : null));
     const bundleEncoder = t.device.createRenderBundleEncoder({
       colorFormats,
@@ -424,6 +435,15 @@ Test that each of color attachments in render passes or bundles match that of th
   )
   .fn(t => {
     const { encoderType, encoderAttachments, pipelineAttachments } = t.params;
+    const maxColorAttachments = t.device.limits.maxColorAttachments;
+    t.skipIf(
+      encoderAttachments.length > maxColorAttachments,
+      `num encoderAttachments: ${encoderAttachments.length} > maxColorAttachments for device: ${maxColorAttachments}`
+    );
+    t.skipIf(
+      pipelineAttachments.length > maxColorAttachments,
+      `num pipelineAttachments: ${pipelineAttachments.length} > maxColorAttachments for device: ${maxColorAttachments}`
+    );
 
     const colorTargets = pipelineAttachments.map(i =>
       i ? ({ format: 'rgba8uint', writeMask: 0 } as GPUColorTargetState) : null


### PR DESCRIPTION


<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
