### PR TITLE
Compat: make requestDevice tests handle different limits

### DIFF
--- a/src/webgpu/api/operation/adapter/requestDevice.spec.ts
+++ b/src/webgpu/api/operation/adapter/requestDevice.spec.ts
@@ -9,7 +9,12 @@ import { Fixture } from '../../../../common/framework/fixture.js';
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { getGPU } from '../../../../common/util/navigator_gpu.js';
 import { assert, assertReject, raceWithRejectOnTimeout } from '../../../../common/util/util.js';
-import { kFeatureNames, kLimitInfo, kLimits } from '../../../capability_info.js';
+import {
+  getDefaultLimitsForAdapter,
+  kFeatureNames,
+  kLimits,
+  kLimitClasses,
+} from '../../../capability_info.js';
 import { clamp, isPowerOfTwo } from '../../../util/math.js';
 
 export const g = makeTestGroup(Fixture);
@@ -40,10 +45,11 @@ g.test('default')
     // Default device should have no features.
     t.expect(device.features.size === 0, 'Default device should not have any features');
     // All limits should be defaults.
+    const limitInfo = getDefaultLimitsForAdapter(adapter);
     for (const limit of kLimits) {
       t.expect(
-        device.limits[limit] === kLimitInfo[limit].default,
-        `Expected ${limit} == default: ${device.limits[limit]} != ${kLimitInfo[limit].default}`
+        device.limits[limit] === limitInfo[limit].default,
+        `Expected ${limit} == default: ${device.limits[limit]} != ${limitInfo[limit].default}`
       );
     }
 
@@ -239,10 +245,11 @@ g.test('limits,supported')
     const adapter = await gpu.requestAdapter();
     assert(adapter !== null);
 
+    const limitInfo = getDefaultLimitsForAdapter(adapter);
     let value: number = -1;
     switch (limitValue) {
       case 'default':
-        value = kLimitInfo[limit].default;
+        value = limitInfo[limit].default;
         break;
       case 'adapter':
         value = adapter.limits[limit];
@@ -271,7 +278,7 @@ g.test('limit,better_than_supported')
       .combine('limit', kLimits)
       .beginSubcases()
       .expandWithParams(p => {
-        switch (kLimitInfo[p.limit].class) {
+        switch (kLimitClasses[p.limit]) {
           case 'maximum':
             return [
               { mul: 1, add: 1 },
@@ -293,9 +300,10 @@ g.test('limit,better_than_supported')
     const adapter = await gpu.requestAdapter();
     assert(adapter !== null);
 
+    const limitInfo = getDefaultLimitsForAdapter(adapter);
     const value = adapter.limits[limit] * mul + add;
     const requiredLimits = {
-      [limit]: clamp(value, { min: 0, max: kLimitInfo[limit].maximumValue }),
+      [limit]: clamp(value, { min: 0, max: limitInfo[limit].maximumValue }),
     };
 
     t.shouldReject('OperationError', adapter.requestDevice({ requiredLimits }));
@@ -314,7 +322,7 @@ g.test('limit,worse_than_default')
       .combine('limit', kLimits)
       .beginSubcases()
       .expandWithParams(p => {
-        switch (kLimitInfo[p.limit].class) {
+        switch (kLimitClasses[p.limit]) {
           case 'maximum':
             return [
               { mul: 1, add: -1 },
@@ -336,13 +344,14 @@ g.test('limit,worse_than_default')
     const adapter = await gpu.requestAdapter();
     assert(adapter !== null);
 
-    const value = kLimitInfo[limit].default * mul + add;
+    const limitInfo = getDefaultLimitsForAdapter(adapter);
+    const value = limitInfo[limit].default * mul + add;
     const requiredLimits = {
-      [limit]: clamp(value, { min: 0, max: kLimitInfo[limit].maximumValue }),
+      [limit]: clamp(value, { min: 0, max: limitInfo[limit].maximumValue }),
     };
 
     let success;
-    switch (kLimitInfo[limit].class) {
+    switch (limitInfo[limit].class) {
       case 'alignment':
         success = isPowerOfTwo(value);
         break;
@@ -355,7 +364,7 @@ g.test('limit,worse_than_default')
       const device = await adapter.requestDevice({ requiredLimits });
       assert(device !== null);
       t.expect(
-        device.limits[limit] === kLimitInfo[limit].default,
+        device.limits[limit] === limitInfo[limit].default,
         'Devices reported limit should match the default limit'
       );
       device.destroy();


### PR DESCRIPTION


<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
