### PR TITLE
Compat: make vertex state correctness tests handle different limits

### DIFF
--- a/src/webgpu/api/operation/vertex_state/correctness.spec.ts
+++ b/src/webgpu/api/operation/vertex_state/correctness.spec.ts
@@ -4,11 +4,14 @@ float tolerance.
 `;
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
-import { assert, memcpy, unreachable } from '../../../../common/util/util.js';
 import {
-  kMaxVertexAttributes,
-  kMaxVertexBufferArrayStride,
-  kMaxVertexBuffers,
+  assert,
+  filterUniqueValueTestVariants,
+  makeValueTestVariant,
+  memcpy,
+  unreachable,
+} from '../../../../common/util/util.js';
+import {
   kPerStageBindingLimits,
   kVertexFormatInfo,
   kVertexFormats,
@@ -95,7 +98,10 @@ class VertexStateTest extends GPUTest {
     // However this might not work in the future for implementations that allow even more vertex
     // attributes so there will need to be larger changes when that happens.
     const maxUniformBuffers = kPerStageBindingLimits['uniformBuf'].max;
-    assert(maxUniformBuffers + kPerStageBindingLimits['storageBuf'].max >= kMaxVertexAttributes);
+    assert(
+      maxUniformBuffers + kPerStageBindingLimits['storageBuf'].max >=
+        this.device.limits.maxVertexAttributes
+    );
 
     let vsInputs = '';
     let vsChecks = '';
@@ -600,11 +606,21 @@ g.test('vertex_format_to_shader_format_conversion')
       .combine('format', kVertexFormats)
       .combine('shaderComponentCount', [1, 2, 3, 4])
       .beginSubcases()
-      .combine('slot', [0, 1, kMaxVertexBuffers - 1])
-      .combine('shaderLocation', [0, 1, kMaxVertexAttributes - 1])
+      .combine('slotVariant', [
+        { mult: 0, add: 0 },
+        { mult: 0, add: 1 },
+        { mult: 1, add: -1 },
+      ])
+      .combine('shaderLocationVariant', [
+        { mult: 0, add: 0 },
+        { mult: 0, add: 1 },
+        { mult: 1, add: -1 },
+      ])
   )
   .fn(t => {
-    const { format, shaderComponentCount, slot, shaderLocation } = t.params;
+    const { format, shaderComponentCount, slotVariant, shaderLocationVariant } = t.params;
+    const slot = t.makeLimitVariant('maxVertexBuffers', slotVariant);
+    const shaderLocation = t.makeLimitVariant('maxVertexAttributes', shaderLocationVariant);
     t.runTest([
       {
         slot,
@@ -683,30 +699,40 @@ g.test('non_zero_array_stride_and_attribute_offset')
     u //
       .combine('format', kVertexFormats)
       .beginSubcases()
-      .expand('arrayStride', p => {
+      .expand('arrayStrideVariant', p => {
         const formatInfo = kVertexFormatInfo[p.format];
         const formatSize = formatInfo.bytesPerComponent * formatInfo.componentCount;
 
-        return [align(formatSize, 4), align(formatSize, 4) + 4, kMaxVertexBufferArrayStride];
+        return [
+          { mult: 0, add: align(formatSize, 4) },
+          { mult: 0, add: align(formatSize, 4) + 4 },
+          { mult: 1, add: 0 },
+        ];
       })
-      .expand('offset', p => {
+      .expand('offsetVariant', p => {
         const formatInfo = kVertexFormatInfo[p.format];
         const formatSize = formatInfo.bytesPerComponent * formatInfo.componentCount;
-        return new Set(
-          [
-            0,
-            formatSize,
-            4,
-            p.arrayStride / 2,
-            p.arrayStride - formatSize * 2,
-            p.arrayStride - formatSize - 4,
-            p.arrayStride - formatSize,
-          ].map(offset => clamp(offset, { min: 0, max: p.arrayStride - formatSize }))
-        );
+        return [
+          { mult: 0, add: 0 },
+          { mult: 0, add: formatSize },
+          { mult: 0, add: 4 },
+          { mult: 0.5, add: 0 },
+          { mult: 1, add: -formatSize * 2 },
+          { mult: 1, add: -formatSize - 4 },
+          { mult: 1, add: -formatSize },
+        ];
       })
   )
   .fn(t => {
-    const { format, arrayStride, offset } = t.params;
+    const { format, arrayStrideVariant, offsetVariant } = t.params;
+    const arrayStride = t.makeLimitVariant('maxVertexBufferArrayStride', arrayStrideVariant);
+    const formatInfo = kVertexFormatInfo[format];
+    const formatSize = formatInfo.bytesPerComponent * formatInfo.componentCount;
+    const offset = clamp(makeValueTestVariant(arrayStride, offsetVariant), {
+      min: 0,
+      max: arrayStride - formatSize,
+    });
+
     t.runTest([
       {
         slot: 0,
@@ -764,11 +790,16 @@ g.test('vertex_buffer_used_multiple_times_overlapped')
     u //
       .combine('format', kVertexFormats)
       .beginSubcases()
-      .combine('vbCount', [2, 3, kMaxVertexBuffers])
+      .combine('vbCountVariant', [
+        { mult: 0, add: 2 },
+        { mult: 0, add: 3 },
+        { mult: 1, add: 0 },
+      ])
       .combine('additionalVBOffset', [0, 4, 120])
   )
   .fn(t => {
-    const { format, vbCount, additionalVBOffset } = t.params;
+    const { format, vbCountVariant, additionalVBOffset } = t.params;
+    const vbCount = t.makeLimitVariant('maxVertexBuffers', vbCountVariant);
     const kVertexCount = 20;
     const kInstanceCount = 1;
     const formatInfo = kVertexFormatInfo[format];
@@ -863,11 +894,16 @@ g.test('vertex_buffer_used_multiple_times_interleaved')
     u //
       .combine('format', kVertexFormats)
       .beginSubcases()
-      .combine('vbCount', [2, 3, kMaxVertexBuffers])
+      .combine('vbCountVariant', [
+        { mult: 0, add: 2 },
+        { mult: 0, add: 3 },
+        { mult: 1, add: 0 },
+      ])
       .combine('additionalVBOffset', [0, 4, 120])
   )
   .fn(t => {
-    const { format, vbCount, additionalVBOffset } = t.params;
+    const { format, vbCountVariant, additionalVBOffset } = t.params;
+    const vbCount = t.makeLimitVariant('maxVertexBuffers', vbCountVariant);
     const kVertexCount = 20;
     const kInstanceCount = 1;
     const formatInfo = kVertexFormatInfo[format];
@@ -942,12 +978,14 @@ g.test('max_buffers_and_attribs')
   .fn(t => {
     const { format } = t.params;
     // In compat mode, @builtin(vertex_index) and @builtin(instance_index) each take an attribute
-    const maxVertexAttributes = t.isCompatibility ? kMaxVertexAttributes - 2 : kMaxVertexAttributes;
-    const attributesPerBuffer = Math.ceil(maxVertexAttributes / kMaxVertexBuffers);
+    const maxVertexBuffers = t.device.limits.maxVertexBuffers;
+    const deviceMaxVertexAttributes = t.device.limits.maxVertexAttributes;
+    const maxVertexAttributes = deviceMaxVertexAttributes - (t.isCompatibility ? 2 : 0);
+    const attributesPerBuffer = Math.ceil(maxVertexAttributes / maxVertexBuffers);
     let attributesEmitted = 0;
 
     const state: VertexLayoutState<{}, {}> = [];
-    for (let i = 0; i < kMaxVertexBuffers; i++) {
+    for (let i = 0; i < maxVertexBuffers; i++) {
       const attributes: GPUVertexAttribute[] = [];
       for (let j = 0; j < attributesPerBuffer && attributesEmitted < maxVertexAttributes; j++) {
         attributes.push({ format, offset: 0, shaderLocation: attributesEmitted });
@@ -974,25 +1012,26 @@ g.test('array_stride_zero')
       .combine('format', kVertexFormats)
       .beginSubcases()
       .combine('stepMode', ['vertex', 'instance'] as const)
-      .expand('offset', p => {
+      .expand('offsetVariant', p => {
         const formatInfo = kVertexFormatInfo[p.format];
         const formatSize = formatInfo.bytesPerComponent * formatInfo.componentCount;
-        return new Set([
-          0,
-          4,
-          8,
-          formatSize,
-          formatSize * 2,
-          kMaxVertexBufferArrayStride / 2,
-          kMaxVertexBufferArrayStride - formatSize - 4,
-          kMaxVertexBufferArrayStride - formatSize - 8,
-          kMaxVertexBufferArrayStride - formatSize,
-          kMaxVertexBufferArrayStride - formatSize * 2,
+        return filterUniqueValueTestVariants([
+          { mult: 0, add: 0 },
+          { mult: 0, add: 4 },
+          { mult: 0, add: 8 },
+          { mult: 0, add: formatSize },
+          { mult: 0, add: formatSize * 2 },
+          { mult: 0.5, add: 0 },
+          { mult: 1, add: -formatSize - 4 },
+          { mult: 1, add: -formatSize - 8 },
+          { mult: 1, add: -formatSize },
+          { mult: 1, add: -formatSize * 2 },
         ]);
       })
   )
   .fn(t => {
-    const { format, stepMode, offset } = t.params;
+    const { format, stepMode, offsetVariant } = t.params;
+    const offset = t.makeLimitVariant('maxVertexBufferArrayStride', offsetVariant);
     const kCount = 10;
 
     // Create the stride 0 part of the test, first by faking a single vertex being drawn and
@@ -1055,7 +1094,7 @@ g.test('discontiguous_location_and_attribs')
   .fn(t => {
     t.runTest([
       {
-        slot: kMaxVertexBuffers - 1,
+        slot: t.device.limits.maxVertexBuffers - 1,
         arrayStride: 4,
         stepMode: 'vertex',
         attributes: [
@@ -1068,7 +1107,13 @@ g.test('discontiguous_location_and_attribs')
         arrayStride: 16,
         stepMode: 'instance',
         vbOffset: 1000,
-        attributes: [{ format: 'uint32x4', offset: 0, shaderLocation: kMaxVertexAttributes - 1 }],
+        attributes: [
+          {
+            format: 'uint32x4',
+            offset: 0,
+            shaderLocation: t.device.limits.maxVertexAttributes - 1,
+          },
+        ],
       },
     ]);
   });
@@ -1083,7 +1128,7 @@ g.test('overlapping_attributes')
     const { format } = t.params;
 
     // In compat mode, @builtin(vertex_index) and @builtin(instance_index) each take an attribute
-    const maxVertexAttributes = t.isCompatibility ? kMaxVertexAttributes - 2 : kMaxVertexAttributes;
+    const maxVertexAttributes = t.device.limits.maxVertexAttributes - (t.isCompatibility ? 2 : 0);
     const attributes: GPUVertexAttribute[] = [];
     for (let i = 0; i < maxVertexAttributes; i++) {
       attributes.push({ format, offset: 0, shaderLocation: i });


### PR DESCRIPTION


<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
