### PR TITLE
Compat: make buffer create test handle different limits

### DIFF
--- a/src/webgpu/api/validation/buffer/create.spec.ts
+++ b/src/webgpu/api/validation/buffer/create.spec.ts
@@ -48,7 +48,7 @@ g.test('limit')
   .params(u => u.beginSubcases().combine('sizeAddition', [-1, 0, +1]))
   .fn(t => {
     const { sizeAddition } = t.params;
-    const size = t.device.limits.maxBufferSize + sizeAddition;
+    const size = t.makeLimitVariant('maxBufferSize', { mult: 1, add: sizeAddition });
     const isValid = size <= t.device.limits.maxBufferSize;
     const usage = BufferUsage.COPY_SRC;
     t.expectGPUError('validation', () => t.device.createBuffer({ size, usage }), !isValid);

--- a/src/webgpu/api/validation/buffer/create.spec.ts
+++ b/src/webgpu/api/validation/buffer/create.spec.ts
@@ -8,7 +8,6 @@ import {
   kAllBufferUsageBits,
   kBufferSizeAlignment,
   kBufferUsages,
-  kLimitInfo,
 } from '../../../capability_info.js';
 import { GPUConst } from '../../../constants.js';
 import { kMaxSafeMultipleOf8 } from '../../../util/math.js';
@@ -46,18 +45,11 @@ g.test('size')
 
 g.test('limit')
   .desc('Test buffer size is validated against maxBufferSize.')
-  .params(u =>
-    u
-      .beginSubcases()
-      .combine('size', [
-        kLimitInfo.maxBufferSize.default - 1,
-        kLimitInfo.maxBufferSize.default,
-        kLimitInfo.maxBufferSize.default + 1,
-      ])
-  )
+  .params(u => u.beginSubcases().combine('sizeAddition', [-1, 0, +1]))
   .fn(t => {
-    const { size } = t.params;
-    const isValid = size <= kLimitInfo.maxBufferSize.default;
+    const { sizeAddition } = t.params;
+    const size = t.device.limits.maxBufferSize + sizeAddition;
+    const isValid = size <= t.device.limits.maxBufferSize;
     const usage = BufferUsage.COPY_SRC;
     t.expectGPUError('validation', () => t.device.createBuffer({ size, usage }), !isValid);
   });


### PR DESCRIPTION
<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
