### PR TITLE
Compat: make maxColorAttachments test handle different limits

### DIFF
--- a/src/webgpu/api/validation/capability_checks/limits/limit_utils.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/limit_utils.ts
@@ -2,10 +2,8 @@ import { kUnitCaseParamsBuilder } from '../../../../../common/framework/params_b
 import { makeTestGroup } from '../../../../../common/framework/test_group.js';
 import { getGPU } from '../../../../../common/util/navigator_gpu.js';
 import { assert, range, reorder, ReorderOrder } from '../../../../../common/util/util.js';
-import { kLimitInfo } from '../../../../capability_info.js';
-import { kTextureFormatInfo } from '../../../../format_info.js';
+import { kLimitInfo, getDefaultLimitsForAdapter } from '../../../../capability_info.js';
 import { GPUTestBase } from '../../../../gpu_test.js';
-import { align } from '../../../../util/math.js';
 
 type GPUSupportedLimit = keyof GPUSupportedLimits;
 
@@ -74,19 +72,6 @@ function getWGSLBindings(
         )}) @binding(${i}) ${storageDefinitionWGSLSnippetFn(i, id)};`
     )
   ).join('\n        ');
-}
-
-/**
- * Given an array of GPUColorTargetState return the number of bytes per sample
- */
-export function computeBytesPerSample(targets: GPUColorTargetState[]) {
-  let bytesPerSample = 0;
-  for (const { format } of targets) {
-    const info = kTextureFormatInfo[format];
-    const alignedBytesPerSample = align(bytesPerSample, info.colorRender!.alignment);
-    bytesPerSample = alignedBytesPerSample + info.colorRender!.byteCost;
-  }
-  return bytesPerSample;
 }
 
 export function getPerStageWGSLForBindingCombinationImpl(
@@ -272,6 +257,12 @@ export const kMinimumLimitValueTests = [
 ] as const;
 export type MinimumLimitValueTest = typeof kMinimumLimitValueTests[number];
 
+export function getDefaultLimitForAdapter(adapter: GPUAdapter, limit: GPUSupportedLimit): number {
+  const limitInfo = getDefaultLimitsForAdapter(adapter);
+  return limitInfo[limit as keyof typeof limitInfo].default;
+}
+
+// MAINTENANCE_TODO: remove as soon as compat refactor is done and this is no longer used.
 export function getDefaultLimit(limit: GPUSupportedLimit): number {
   return (kLimitInfo as Record<string, { default: number }>)[limit].default;
 }
@@ -321,7 +312,7 @@ export class LimitTestsImpl extends GPUTestBase {
     const gpu = getGPU(this.rec);
     this._adapter = await gpu.requestAdapter();
     const limit = this.limit;
-    this.defaultLimit = getDefaultLimit(limit);
+    this.defaultLimit = getDefaultLimitForAdapter(this.adapter, limit);
     this.adapterLimit = this.adapter.limits[limit] as number;
     assert(!Number.isNaN(this.defaultLimit));
     assert(!Number.isNaN(this.adapterLimit));
@@ -354,7 +345,7 @@ export class LimitTestsImpl extends GPUTestBase {
   getDefaultOrAdapterLimit(limit: GPUSupportedLimit, limitMode: LimitMode) {
     switch (limitMode) {
       case 'defaultLimit':
-        return getDefaultLimit(limit);
+        return getDefaultLimitForAdapter(this.adapter, limit);
       case 'adapterLimit':
         return this.adapter.limits[limit];
     }
@@ -380,7 +371,7 @@ export class LimitTestsImpl extends GPUTestBase {
         const extraLimit = extraLimitStr as GPUSupportedLimit;
         requiredLimits[extraLimit] =
           limitMode === 'defaultLimit'
-            ? getDefaultLimit(extraLimit)
+            ? getDefaultLimitForAdapter(adapter, extraLimit)
             : (adapter.limits[extraLimit] as number);
       }
     }

--- a/src/webgpu/api/validation/capability_checks/limits/maxColorAttachments.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxColorAttachments.spec.ts
@@ -1,6 +1,7 @@
 import { range } from '../../../../../common/util/util.js';
+import { kMaxColorAttachmentsToTest } from '../../../../capability_info.js';
 
-import { kMaximumLimitBaseParams, getDefaultLimit, makeLimitTestGroup } from './limit_utils.js';
+import { kMaximumLimitBaseParams, makeLimitTestGroup } from './limit_utils.js';
 
 function getPipelineDescriptor(device: GPUDevice, testValue: number): GPURenderPipelineDescriptor {
   const code = `
@@ -105,9 +106,19 @@ g.test('validate,maxColorAttachmentBytesPerSample')
   .desc(`Test ${limit} against maxColorAttachmentBytesPerSample`)
   .fn(t => {
     const { adapter, defaultLimit, adapterLimit: maximumLimit } = t;
-    const minColorAttachmentBytesPerSample = getDefaultLimit('maxColorAttachmentBytesPerSample');
+    const minColorAttachmentBytesPerSample = t.getDefaultLimit('maxColorAttachmentBytesPerSample');
     // The smallest attachment is 1 byte
     // so make sure maxColorAttachments < maxColorAttachmentBytesPerSample
     t.expect(defaultLimit <= minColorAttachmentBytesPerSample);
     t.expect(maximumLimit <= adapter.limits.maxColorAttachmentBytesPerSample);
+  });
+
+g.test('validate,kMaxColorAttachmentsToTest')
+  .desc(
+    `
+    Tests that kMaxColorAttachmentsToTest is large enough to test the limits of this device
+  `
+  )
+  .fn(t => {
+    t.expect(t.adapter.limits.maxColorAttachments <= kMaxColorAttachmentsToTest);
   });

--- a/src/webgpu/listing_meta.json
+++ b/src/webgpu/listing_meta.json
@@ -286,6 +286,7 @@
   "webgpu:api,validation,capability_checks,limits,maxColorAttachments:createRenderBundle,at_over:*": { "subcaseMS": 12.681 },
   "webgpu:api,validation,capability_checks,limits,maxColorAttachments:createRenderPipeline,at_over:*": { "subcaseMS": 10.450 },
   "webgpu:api,validation,capability_checks,limits,maxColorAttachments:validate,maxColorAttachmentBytesPerSample:*": { "subcaseMS": 1.101 },
+  "webgpu:api,validation,capability_checks,limits,maxColorAttachments:validate,kMaxColorAttachmentsToTest:*": { "subcaseMS": 1.101 },
   "webgpu:api,validation,capability_checks,limits,maxComputeInvocationsPerWorkgroup:createComputePipeline,at_over:*": { "subcaseMS": 13.735 },
   "webgpu:api,validation,capability_checks,limits,maxComputeWorkgroupSizeX:createComputePipeline,at_over:*": { "subcaseMS": 14.465 },
   "webgpu:api,validation,capability_checks,limits,maxComputeWorkgroupSizeY:createComputePipeline,at_over:*": { "subcaseMS": 14.131 },


### PR DESCRIPTION
<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
