### PR TITLE
Compat: make maxComputeInvocationsPerWorkgroup test handle different limits

### DIFF
--- a/src/webgpu/api/validation/capability_checks/limits/maxComputeInvocationsPerWorkgroup.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxComputeInvocationsPerWorkgroup.spec.ts
@@ -1,6 +1,7 @@
+import { GPUTestBase } from '../../../../gpu_test.js';
+
 import {
   kMaximumLimitBaseParams,
-  getDefaultLimit,
   MaximumLimitValueTest,
   MaximumTestValue,
   makeLimitTestGroup,
@@ -75,11 +76,15 @@ function getDeviceLimitToRequest(
   }
 }
 
-function getTestWorkgroupSize(testValueName: MaximumTestValue, requestedLimit: number) {
+function getTestWorkgroupSize(
+  t: GPUTestBase,
+  testValueName: MaximumTestValue,
+  requestedLimit: number
+) {
   const maxDimensions = [
-    getDefaultLimit('maxComputeWorkgroupSizeX'),
-    getDefaultLimit('maxComputeWorkgroupSizeY'),
-    getDefaultLimit('maxComputeWorkgroupSizeZ'),
+    t.getDefaultLimit('maxComputeWorkgroupSizeX'),
+    t.getDefaultLimit('maxComputeWorkgroupSizeY'),
+    t.getDefaultLimit('maxComputeWorkgroupSizeZ'),
   ];
 
   switch (testValueName) {
@@ -91,13 +96,14 @@ function getTestWorkgroupSize(testValueName: MaximumTestValue, requestedLimit: n
 }
 
 function getDeviceLimitToRequestAndValueToTest(
+  t: GPUTestBase,
   limitValueTest: MaximumLimitValueTest,
   testValueName: MaximumTestValue,
   defaultLimit: number,
   maximumLimit: number
 ) {
   const requestedLimit = getDeviceLimitToRequest(limitValueTest, defaultLimit, maximumLimit);
-  const workgroupSize = getTestWorkgroupSize(testValueName, requestedLimit);
+  const workgroupSize = getTestWorkgroupSize(t, testValueName, requestedLimit);
   return {
     requestedLimit,
     workgroupSize,
@@ -115,6 +121,7 @@ g.test('createComputePipeline,at_over')
     const { defaultLimit, adapterLimit: maximumLimit } = t;
 
     const { requestedLimit, workgroupSize } = getDeviceLimitToRequestAndValueToTest(
+      t,
       limitTest,
       testValueName,
       defaultLimit,


### PR DESCRIPTION

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
