### PR TITLE
Compat: make maxXXXBufferBindingSize tests handle different limits

### DIFF
--- a/src/webgpu/api/validation/capability_checks/limits/maxStorageBufferBindingSize.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxStorageBufferBindingSize.spec.ts
@@ -4,7 +4,6 @@ import {
   kMaximumLimitBaseParams,
   makeLimitTestGroup,
   LimitMode,
-  getDefaultLimit,
   MaximumLimitValueTest,
   MaximumTestValue,
 } from './limit_utils.js';
@@ -149,6 +148,6 @@ g.test('validate,maxBufferSize')
   .desc(`Test that ${limit} <= maxBufferSize`)
   .fn(t => {
     const { adapter, defaultLimit, adapterLimit } = t;
-    t.expect(defaultLimit <= getDefaultLimit('maxBufferSize'));
+    t.expect(defaultLimit <= t.getDefaultLimit('maxBufferSize'));
     t.expect(adapterLimit <= adapter.limits.maxBufferSize);
   });

--- a/src/webgpu/api/validation/capability_checks/limits/maxUniformBufferBindingSize.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxUniformBufferBindingSize.spec.ts
@@ -1,9 +1,4 @@
-import {
-  LimitMode,
-  getDefaultLimit,
-  kMaximumLimitBaseParams,
-  makeLimitTestGroup,
-} from './limit_utils.js';
+import { LimitMode, kMaximumLimitBaseParams, makeLimitTestGroup } from './limit_utils.js';
 
 const kBufferParts = ['wholeBuffer', 'biggerBufferWithOffset'] as const;
 type BufferPart = typeof kBufferParts[number];
@@ -90,6 +85,6 @@ g.test('validate,maxBufferSize')
   .desc(`Test that ${limit} <= maxBufferSize`)
   .fn(t => {
     const { adapter, defaultLimit, adapterLimit } = t;
-    t.expect(defaultLimit <= getDefaultLimit('maxBufferSize'));
+    t.expect(defaultLimit <= t.getDefaultLimit('maxBufferSize'));
     t.expect(adapterLimit <= adapter.limits.maxBufferSize);
   });


### PR DESCRIPTION
<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
