### PR TITLE
Compat: make pipline-output-targets tests handle different limits

### DIFF
--- a/src/common/framework/fixture.ts
+++ b/src/common/framework/fixture.ts
@@ -166,6 +166,13 @@ export class Fixture<S extends SubcaseBatchState = SubcaseBatchState> {
     throw new SkipTestCase(msg);
   }
 
+  /** Throws an exception marking the subcase as skipped if condition is true */
+  skipIf(cond: boolean, msg: string | (() => string) = '') {
+    if (cond) {
+      this.skip(typeof msg === 'function' ? msg() : msg);
+    }
+  }
+
   /** Log a warning and increase the result status to "Warn". */
   warn(msg?: string): void {
     this.rec.warn(new Error(msg));

--- a/src/webgpu/api/operation/render_pipeline/pipeline_output_targets.spec.ts
+++ b/src/webgpu/api/operation/render_pipeline/pipeline_output_targets.spec.ts
@@ -4,8 +4,11 @@ export const description = `
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { range } from '../../../../common/util/util.js';
-import { kLimitInfo } from '../../../capability_info.js';
-import { kRenderableColorTextureFormats, kTextureFormatInfo } from '../../../format_info.js';
+import {
+  computeBytesPerSampleFromFormats,
+  kRenderableColorTextureFormats,
+  kTextureFormatInfo,
+} from '../../../format_info.js';
 import { GPUTest, TextureTestMixin } from '../../../gpu_test.js';
 import { getFragmentShaderCodeWithOutput, getPlainTypeInfo } from '../../../util/shader.js';
 import { kTexelRepresentationInfo } from '../../../util/texture/texel_data.js';
@@ -47,14 +50,6 @@ g.test('color,attachments')
       .combine('format', kRenderableColorTextureFormats)
       .beginSubcases()
       .combine('attachmentCount', [2, 3, 4])
-      .filter(t => {
-        // We only need to test formats that have a valid color attachment bytes per sample.
-        const pixelByteCost = kTextureFormatInfo[t.format].colorRender?.byteCost;
-        return (
-          pixelByteCost !== undefined &&
-          pixelByteCost * t.attachmentCount <= kLimitInfo.maxColorAttachmentBytesPerSample.default
-        );
-      })
       .expand('emptyAttachmentId', p => range(p.attachmentCount, i => i))
   )
   .beforeAllSubcases(t => {
@@ -66,6 +61,14 @@ g.test('color,attachments')
     const { format, attachmentCount, emptyAttachmentId } = t.params;
     const componentCount = kTexelRepresentationInfo[format].componentOrder.length;
     const info = kTextureFormatInfo[format];
+
+    // We only need to test formats that have a valid color attachment bytes per sample.
+    const pixelByteCost = kTextureFormatInfo[format].colorRender?.byteCost;
+    t.skipIf(
+      pixelByteCost === undefined ||
+        computeBytesPerSampleFromFormats(range(attachmentCount, () => format)) >
+          t.device.limits.maxColorAttachmentBytesPerSample
+    );
 
     const writeValues =
       info.color.type === 'sint' || info.color.type === 'uint'

--- a/src/webgpu/format_info.ts
+++ b/src/webgpu/format_info.ts
@@ -1,6 +1,7 @@
 import { keysOf } from '../common/util/data_tables.js';
 import { assert } from '../common/util/util.js';
 
+import { align } from './util/math.js';
 import { ImageCopyType } from './util/texture/layout.js';
 
 //
@@ -1240,3 +1241,23 @@ export function isCompressedTextureFormat(format: GPUTextureFormat) {
 }
 
 export const kFeaturesForFormats = getFeaturesForFormats(kTextureFormats);
+
+/**
+ * Given an array of texture formats return the number of bytes per sample.
+ */
+export function computeBytesPerSampleFromFormats(formats: GPUTextureFormat[]) {
+  let bytesPerSample = 0;
+  for (const format of formats) {
+    const info = kTextureFormatInfo[format];
+    const alignedBytesPerSample = align(bytesPerSample, info.colorRender!.alignment);
+    bytesPerSample = alignedBytesPerSample + info.colorRender!.byteCost;
+  }
+  return bytesPerSample;
+}
+
+/**
+ * Given an array of GPUColorTargetState return the number of bytes per sample
+ */
+export function computeBytesPerSample(targets: GPUColorTargetState[]) {
+  return computeBytesPerSampleFromFormats(targets.map(({ format }) => format));
+}


### PR DESCRIPTION

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
