### PR TITLE
Update webgpu/types to add 'rgb10a2uint'

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@types/pngjs": "^6.0.1",
         "@types/serve-index": "^1.9.1",
         "@typescript-eslint/parser": "^4.33.0",
-        "@webgpu/types": "gpuweb/types#ca1a548178567e6021fd194380b97be1bf6b07b7",
+        "@webgpu/types": "gpuweb/types#d1d74def71a13a2318828139994afd1b9c3f987c",
         "ansi-colors": "4.1.1",
         "babel-plugin-add-header-comment": "^1.0.3",
         "babel-plugin-const-enum": "^1.2.0",
@@ -1262,9 +1262,9 @@
       }
     },
     "node_modules/@webgpu/types": {
-      "version": "0.1.34",
-      "resolved": "git+ssh://git@github.com/gpuweb/types.git#ca1a548178567e6021fd194380b97be1bf6b07b7",
-      "integrity": "sha512-L3q2iZPXqb5/qHupSV4G8tphM2GnCuaAf6SQWLqMNDgMwDk/Y4UWRxSIlY98ONKa1pDOuhIsXj6s1U3rU0wqhw==",
+      "version": "0.1.35",
+      "resolved": "git+ssh://git@github.com/gpuweb/types.git#d1d74def71a13a2318828139994afd1b9c3f987c",
+      "integrity": "sha512-6mh8zm/DDdtY6c+DXRmYc/7wJ1RQitFFmQiviwV8BK1XB75lXigN8AC8netNUO4XWTm7zEZevWgdMzXgThwOtA==",
       "dev": true,
       "license": "BSD-3-Clause"
     },
@@ -9884,10 +9884,10 @@
       }
     },
     "@webgpu/types": {
-      "version": "git+ssh://git@github.com/gpuweb/types.git#ca1a548178567e6021fd194380b97be1bf6b07b7",
-      "integrity": "sha512-L3q2iZPXqb5/qHupSV4G8tphM2GnCuaAf6SQWLqMNDgMwDk/Y4UWRxSIlY98ONKa1pDOuhIsXj6s1U3rU0wqhw==",
+      "version": "git+ssh://git@github.com/gpuweb/types.git#d1d74def71a13a2318828139994afd1b9c3f987c",
+      "integrity": "sha512-6mh8zm/DDdtY6c+DXRmYc/7wJ1RQitFFmQiviwV8BK1XB75lXigN8AC8netNUO4XWTm7zEZevWgdMzXgThwOtA==",
       "dev": true,
-      "from": "@webgpu/types@gpuweb/types#ca1a548178567e6021fd194380b97be1bf6b07b7"
+      "from": "@webgpu/types@gpuweb/types#d1d74def71a13a2318828139994afd1b9c3f987c"
     },
     "abbrev": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@types/pngjs": "^6.0.1",
     "@types/serve-index": "^1.9.1",
     "@typescript-eslint/parser": "^4.33.0",
-    "@webgpu/types": "gpuweb/types#ca1a548178567e6021fd194380b97be1bf6b07b7",
+    "@webgpu/types": "gpuweb/types#d1d74def71a13a2318828139994afd1b9c3f987c",
     "ansi-colors": "4.1.1",
     "babel-plugin-add-header-comment": "^1.0.3",
     "babel-plugin-const-enum": "^1.2.0",


### PR DESCRIPTION


Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
