### PR TITLE
Compat: Skip copyTextureToTexture for compressed textures

### DIFF
--- a/src/webgpu/api/validation/encoding/cmds/copyTextureToTexture.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/copyTextureToTexture.spec.ts
@@ -779,6 +779,7 @@ TODO: Express the offsets in "block size" so as to be able to test non-4x4 compr
   .beforeAllSubcases(t => {
     const { format } = t.params;
     t.selectDeviceOrSkipTestCase(kTextureFormatInfo[format].feature);
+    t.skipIfCopyTextureToTextureNotSupportedForFormat(format);
   })
   .fn(t => {
     const { format, dimension, copyBoxOffsets, srcCopyLevel, dstCopyLevel } = t.params;


### PR DESCRIPTION

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
