### PR TITLE
Compat: make createRenderBundleEncoder test handle different limits

### DIFF
--- a/src/webgpu/api/validation/encoding/createRenderBundleEncoder.spec.ts
+++ b/src/webgpu/api/validation/encoding/createRenderBundleEncoder.spec.ts
@@ -4,8 +4,9 @@ createRenderBundleEncoder validation tests.
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { range } from '../../../../common/util/util.js';
-import { kMaxColorAttachments } from '../../../capability_info.js';
+import { kMaxColorAttachmentsToTest } from '../../../capability_info.js';
 import {
+  computeBytesPerSampleFromFormats,
   kAllTextureFormats,
   kDepthStencilFormats,
   kTextureFormatInfo,
@@ -20,11 +21,16 @@ g.test('attachment_state,limits,maxColorAttachments')
   .params(u =>
     u.beginSubcases().combine(
       'colorFormatCount',
-      range(kMaxColorAttachments + 1, i => i + 1) // 1-9
+      range(kMaxColorAttachmentsToTest, i => i + 1)
     )
   )
   .fn(t => {
     const { colorFormatCount } = t.params;
+    const maxColorAttachments = t.device.limits.maxColorAttachments;
+    t.skipIf(
+      colorFormatCount > maxColorAttachments,
+      `${colorFormatCount} > maxColorAttachments: ${maxColorAttachments}`
+    );
     t.expectValidationError(() => {
       t.device.createRenderBundleEncoder({
         colorFormats: Array(colorFormatCount).fill('r8unorm'),
@@ -46,7 +52,7 @@ g.test('attachment_state,limits,maxColorAttachmentBytesPerSample,aligned')
       .beginSubcases()
       .combine(
         'colorFormatCount',
-        range(kMaxColorAttachments, i => i + 1)
+        range(kMaxColorAttachmentsToTest, i => i + 1)
       )
   )
   .beforeAllSubcases(t => {
@@ -54,6 +60,11 @@ g.test('attachment_state,limits,maxColorAttachmentBytesPerSample,aligned')
   })
   .fn(t => {
     const { format, colorFormatCount } = t.params;
+    const maxColorAttachments = t.device.limits.maxColorAttachments;
+    t.skipIf(
+      colorFormatCount > maxColorAttachments,
+      `${colorFormatCount} > maxColorAttachments: ${maxColorAttachments}`
+    );
     const info = kTextureFormatInfo[format];
     const shouldError =
       !info.colorRender ||
@@ -89,7 +100,6 @@ g.test('attachment_state,limits,maxColorAttachmentBytesPerSample,unaligned')
           'rgba32float',
           'r8unorm',
         ] as GPUTextureFormat[],
-        _shouldError: true,
       },
       {
         formats: [
@@ -99,18 +109,25 @@ g.test('attachment_state,limits,maxColorAttachmentBytesPerSample,unaligned')
           'r8unorm',
           'r8unorm',
         ] as GPUTextureFormat[],
-        _shouldError: false,
       },
     ])
   )
   .fn(t => {
-    const { formats, _shouldError } = t.params;
+    const { formats } = t.params;
+
+    t.skipIf(
+      formats.length > t.device.limits.maxColorAttachments,
+      `numColorAttachments: ${formats.length} > maxColorAttachments: ${t.device.limits.maxColorAttachments}`
+    );
+
+    const shouldError =
+      computeBytesPerSampleFromFormats(formats) > t.device.limits.maxColorAttachmentBytesPerSample;
 
     t.expectValidationError(() => {
       t.device.createRenderBundleEncoder({
         colorFormats: formats,
       });
-    }, _shouldError);
+    }, shouldError);
   });
 
 g.test('attachment_state,empty_color_formats')


### PR DESCRIPTION
Note: some of these tests may be duplicated: see #3022

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
