### PR TITLE
Compat: make fragment_state test handle different limits

### DIFF
--- a/src/webgpu/api/validation/render_pipeline/fragment_state.spec.ts
+++ b/src/webgpu/api/validation/render_pipeline/fragment_state.spec.ts
@@ -4,11 +4,16 @@ This test dedicatedly tests validation of GPUFragmentState of createRenderPipeli
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { range } from '../../../../common/util/util.js';
-import { kBlendFactors, kBlendOperations, kMaxColorAttachments } from '../../../capability_info.js';
+import {
+  kBlendFactors,
+  kBlendOperations,
+  kMaxColorAttachmentsToTest,
+} from '../../../capability_info.js';
 import {
   kTextureFormats,
   kRenderableColorTextureFormats,
   kTextureFormatInfo,
+  computeBytesPerSampleFromFormats,
 } from '../../../format_info.js';
 import {
   getFragmentShaderCodeWithOutput,
@@ -66,9 +71,15 @@ g.test('limits,maxColorAttachments')
   .desc(
     `Tests that color state targets length must not be larger than device.limits.maxColorAttachments.`
   )
-  .params(u => u.combine('isAsync', [false, true]).combine('targetsLength', [8, 9]))
+  .params(u =>
+    u.combine('isAsync', [false, true]).combine('targetsLengthVariant', [
+      { mult: 1, add: 0 },
+      { mult: 1, add: 1 },
+    ])
+  )
   .fn(t => {
-    const { isAsync, targetsLength } = t.params;
+    const { isAsync, targetsLengthVariant } = t.params;
+    const targetsLength = t.makeLimitVariant('maxColorAttachments', targetsLengthVariant);
 
     const descriptor = t.getDescriptor({
       targets: range(targetsLength, i => {
@@ -103,7 +114,7 @@ g.test('limits,maxColorAttachmentBytesPerSample,aligned')
       .beginSubcases()
       .combine(
         'attachmentCount',
-        range(kMaxColorAttachments, i => i + 1)
+        range(kMaxColorAttachmentsToTest, i => i + 1)
       )
       .combine('isAsync', [false, true])
   )
@@ -113,6 +124,11 @@ g.test('limits,maxColorAttachmentBytesPerSample,aligned')
   .fn(t => {
     const { format, attachmentCount, isAsync } = t.params;
     const info = kTextureFormatInfo[format];
+
+    t.skipIf(
+      attachmentCount > t.device.limits.maxColorAttachments,
+      `attachmentCount: ${attachmentCount} > maxColorAttachments: ${t.device.limits.maxColorAttachments}`
+    );
 
     const descriptor = t.getDescriptor({
       targets: range(attachmentCount, () => {
@@ -149,7 +165,6 @@ g.test('limits,maxColorAttachmentBytesPerSample,unaligned')
             'rgba32float',
             'r8unorm',
           ] as GPUTextureFormat[],
-          _success: false,
         },
         {
           formats: [
@@ -159,14 +174,21 @@ g.test('limits,maxColorAttachmentBytesPerSample,unaligned')
             'r8unorm',
             'r8unorm',
           ] as GPUTextureFormat[],
-          _success: true,
         },
       ])
       .beginSubcases()
       .combine('isAsync', [false, true])
   )
   .fn(t => {
-    const { formats, _success, isAsync } = t.params;
+    const { formats, isAsync } = t.params;
+
+    t.skipIf(
+      formats.length > t.device.limits.maxColorAttachments,
+      `numColorAttachments: ${formats.length} > maxColorAttachments: ${t.device.limits.maxColorAttachments}`
+    );
+
+    const success =
+      computeBytesPerSampleFromFormats(formats) <= t.device.limits.maxColorAttachmentBytesPerSample;
 
     const descriptor = t.getDescriptor({
       targets: formats.map(f => {
@@ -174,7 +196,7 @@ g.test('limits,maxColorAttachmentBytesPerSample,unaligned')
       }),
     });
 
-    t.doCreateRenderPipelineTest(isAsync, _success, descriptor);
+    t.doCreateRenderPipelineTest(isAsync, success, descriptor);
   });
 
 g.test('targets_format_filterable')


### PR DESCRIPTION
<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
