### PR TITLE
Compat: make perStageLimit tests handle different limits

### DIFF
--- a/src/webgpu/api/operation/vertex_state/correctness.spec.ts
+++ b/src/webgpu/api/operation/vertex_state/correctness.spec.ts
@@ -97,9 +97,9 @@ class VertexStateTest extends GPUTest {
     // than maxVertexAttributes = 16.
     // However this might not work in the future for implementations that allow even more vertex
     // attributes so there will need to be larger changes when that happens.
-    const maxUniformBuffers = kPerStageBindingLimits['uniformBuf'].max;
+    const maxUniformBuffers = this.getDefaultLimit(kPerStageBindingLimits['uniformBuf'].maxLimit);
     assert(
-      maxUniformBuffers + kPerStageBindingLimits['storageBuf'].max >=
+      maxUniformBuffers + this.getDefaultLimit(kPerStageBindingLimits['storageBuf'].maxLimit) >=
         this.device.limits.maxVertexAttributes
     );
 

--- a/src/webgpu/api/validation/createBindGroupLayout.spec.ts
+++ b/src/webgpu/api/validation/createBindGroupLayout.spec.ts
@@ -232,7 +232,10 @@ g.test('max_dynamic_buffers')
     const { type, extraDynamicBuffers, staticBuffers } = t.params;
     const info = bufferBindingTypeInfo({ type });
 
-    const dynamicBufferCount = info.perPipelineLimitClass.maxDynamic + extraDynamicBuffers;
+    const limitName = info.perPipelineLimitClass.maxDynamicLimit;
+    const bufferCount = limitName ? t.getDefaultLimit(limitName) : 0;
+    const dynamicBufferCount = bufferCount + extraDynamicBuffers;
+    const perStageLimit = t.getDefaultLimit(info.perStageLimitClass.maxLimit);
 
     const entries = [];
     for (let i = 0; i < dynamicBufferCount; i++) {
@@ -257,7 +260,7 @@ g.test('max_dynamic_buffers')
 
     t.expectValidationError(() => {
       t.device.createBindGroupLayout(descriptor);
-    }, extraDynamicBuffers > 0);
+    }, extraDynamicBuffers > 0 || entries.length > perStageLimit);
   });
 
 /**
@@ -311,7 +314,7 @@ g.test('max_resources_per_stage,in_bind_group_layout')
   .fn(t => {
     const { maxedEntry, extraEntry, maxedVisibility, extraVisibility } = t.params;
     const maxedTypeInfo = bindingTypeInfo(maxedEntry);
-    const maxedCount = maxedTypeInfo.perStageLimitClass.max;
+    const maxedCount = t.getDefaultLimit(maxedTypeInfo.perStageLimitClass.maxLimit);
     const extraTypeInfo = bindingTypeInfo(extraEntry);
 
     const maxResourceBindings: GPUBindGroupLayoutEntry[] = [];
@@ -362,7 +365,7 @@ g.test('max_resources_per_stage,in_pipeline_layout')
   .fn(t => {
     const { maxedEntry, extraEntry, maxedVisibility, extraVisibility } = t.params;
     const maxedTypeInfo = bindingTypeInfo(maxedEntry);
-    const maxedCount = maxedTypeInfo.perStageLimitClass.max;
+    const maxedCount = t.getDefaultLimit(maxedTypeInfo.perStageLimitClass.maxLimit);
     const extraTypeInfo = bindingTypeInfo(extraEntry);
 
     const maxResourceBindings: GPUBindGroupLayoutEntry[] = [];

--- a/src/webgpu/api/validation/createPipelineLayout.spec.ts
+++ b/src/webgpu/api/validation/createPipelineLayout.spec.ts
@@ -33,7 +33,13 @@ g.test('number_of_dynamic_buffers_exceeds_the_maximum_value')
   )
   .fn(t => {
     const { type, visibility } = t.params;
-    const { maxDynamic } = bufferBindingTypeInfo({ type }).perPipelineLimitClass;
+    const info = bufferBindingTypeInfo({ type });
+    const { maxDynamicLimit } = info.perPipelineLimitClass;
+    const perStageLimit = t.getDefaultLimit(info.perStageLimitClass.maxLimit);
+    const maxDynamic = Math.min(
+      maxDynamicLimit ? t.getDefaultLimit(maxDynamicLimit) : 0,
+      perStageLimit
+    );
 
     const maxDynamicBufferBindings: GPUBindGroupLayoutEntry[] = [];
     for (let binding = 0; binding < maxDynamic; binding++) {
@@ -52,15 +58,17 @@ g.test('number_of_dynamic_buffers_exceeds_the_maximum_value')
       entries: [{ binding: 0, visibility, buffer: { type, hasDynamicOffset: false } }],
     };
 
-    const goodPipelineLayoutDescriptor = {
-      bindGroupLayouts: [
-        maxDynamicBufferBindGroupLayout,
-        t.device.createBindGroupLayout(goodDescriptor),
-      ],
-    };
+    if (perStageLimit > maxDynamic) {
+      const goodPipelineLayoutDescriptor = {
+        bindGroupLayouts: [
+          maxDynamicBufferBindGroupLayout,
+          t.device.createBindGroupLayout(goodDescriptor),
+        ],
+      };
 
-    // Control case
-    t.device.createPipelineLayout(goodPipelineLayoutDescriptor);
+      // Control case
+      t.device.createPipelineLayout(goodPipelineLayoutDescriptor);
+    }
 
     // Check dynamic buffers exceed maximum in pipeline layout.
     const badDescriptor = clone(goodDescriptor);

--- a/src/webgpu/capability_info.ts
+++ b/src/webgpu/capability_info.ts
@@ -360,15 +360,15 @@ export const kPerStageBindingLimits: {
     /** Which `PerShaderStage` binding limit class. */
     readonly class: k;
     /** Maximum number of allowed bindings in that class. */
-    readonly max: number;
+    readonly maxLimit: typeof kLimits[number];
     // Add fields as needed
   };
 } = /* prettier-ignore */ {
-  'uniformBuf': { class: 'uniformBuf', max: 12, },
-  'storageBuf': { class: 'storageBuf', max:  8, },
-  'sampler':    { class: 'sampler',    max: 16, },
-  'sampledTex': { class: 'sampledTex', max: 16, },
-  'storageTex': { class: 'storageTex', max:  4, },
+  'uniformBuf': { class: 'uniformBuf', maxLimit: 'maxUniformBuffersPerShaderStage', },
+  'storageBuf': { class: 'storageBuf', maxLimit: 'maxStorageBuffersPerShaderStage', },
+  'sampler':    { class: 'sampler',    maxLimit: 'maxSamplersPerShaderStage', },
+  'sampledTex': { class: 'sampledTex', maxLimit: 'maxSampledTexturesPerShaderStage', },
+  'storageTex': { class: 'storageTex', maxLimit: 'maxStorageTexturesPerShaderStage', },
 };
 
 /**
@@ -378,16 +378,18 @@ export const kPerPipelineBindingLimits: {
   readonly [k in PerPipelineBindingLimitClass]: {
     /** Which `PerPipelineLayout` binding limit class. */
     readonly class: k;
-    /** Maximum number of allowed bindings with `hasDynamicOffset: true` in that class. */
-    readonly maxDynamic: number;
+    /**
+     * The name of the limit for the maximum number of allowed bindings with `hasDynamicOffset: true` in that class.
+     */
+    readonly maxDynamicLimit: typeof kLimits[number] | '';
     // Add fields as needed
   };
 } = /* prettier-ignore */ {
-  'uniformBuf': { class: 'uniformBuf', maxDynamic: 8, },
-  'storageBuf': { class: 'storageBuf', maxDynamic: 4, },
-  'sampler':    { class: 'sampler',    maxDynamic: 0, },
-  'sampledTex': { class: 'sampledTex', maxDynamic: 0, },
-  'storageTex': { class: 'storageTex', maxDynamic: 0, },
+  'uniformBuf': { class: 'uniformBuf', maxDynamicLimit: 'maxDynamicUniformBuffersPerPipelineLayout', },
+  'storageBuf': { class: 'storageBuf', maxDynamicLimit: 'maxDynamicStorageBuffersPerPipelineLayout', },
+  'sampler':    { class: 'sampler',    maxDynamicLimit: '', },
+  'sampledTex': { class: 'sampledTex', maxDynamicLimit: '', },
+  'storageTex': { class: 'storageTex', maxDynamicLimit: '', },
 };
 
 interface BindingKindInfo {


### PR DESCRIPTION
<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
