### PR TITLE
Compat: Make createTexture tests handle different limits

### DIFF
--- a/src/webgpu/api/validation/createTexture.spec.ts
+++ b/src/webgpu/api/validation/createTexture.spec.ts
@@ -2,8 +2,8 @@ export const description = `createTexture validation tests.`;
 
 import { SkipTestCase } from '../../../common/framework/fixture.js';
 import { makeTestGroup } from '../../../common/framework/test_group.js';
-import { assert } from '../../../common/util/util.js';
-import { kTextureDimensions, kTextureUsages, kLimitInfo } from '../../capability_info.js';
+import { assert, makeValueTestVariant } from '../../../common/util/util.js';
+import { kTextureDimensions, kTextureUsages } from '../../capability_info.js';
 import { GPUConst } from '../../constants.js';
 import {
   kTextureFormats,
@@ -495,10 +495,10 @@ g.test('texture_size,1d_texture')
       // Compressed and depth-stencil textures are invalid for 1D.
       .combine('format', kRegularTextureFormats)
       .beginSubcases()
-      .combine('width', [
-        kLimitInfo.maxTextureDimension1D.default - 1,
-        kLimitInfo.maxTextureDimension1D.default,
-        kLimitInfo.maxTextureDimension1D.default + 1,
+      .combine('widthVariant', [
+        { mult: 1, add: -1 },
+        { mult: 1, add: 0 },
+        { mult: 1, add: 1 },
       ])
       .combine('height', [1, 2])
       .combine('depthOrArrayLayers', [1, 2])
@@ -510,7 +510,8 @@ g.test('texture_size,1d_texture')
     t.selectDeviceOrSkipTestCase(info.feature);
   })
   .fn(t => {
-    const { format, width, height, depthOrArrayLayers } = t.params;
+    const { format, widthVariant, height, depthOrArrayLayers } = t.params;
+    const width = t.makeLimitVariant('maxTextureDimension1D', widthVariant);
 
     const descriptor: GPUTextureDescriptor = {
       size: [width, height, depthOrArrayLayers],
@@ -520,7 +521,7 @@ g.test('texture_size,1d_texture')
     };
 
     const success =
-      width <= kLimitInfo.maxTextureDimension1D.default && height === 1 && depthOrArrayLayers === 1;
+      width <= t.device.limits.maxTextureDimension1D && height === 1 && depthOrArrayLayers === 1;
 
     t.expectValidationError(() => {
       t.device.createTexture(descriptor);
@@ -533,20 +534,23 @@ g.test('texture_size,2d_texture,uncompressed_format')
     u
       .combine('dimension', [undefined, '2d'] as const)
       .combine('format', kUncompressedTextureFormats)
-      .combine('size', [
-        // Test the bound of width
-        [kLimitInfo.maxTextureDimension2D.default - 1, 1, 1],
-        [kLimitInfo.maxTextureDimension2D.default, 1, 1],
-        [kLimitInfo.maxTextureDimension2D.default + 1, 1, 1],
-        // Test the bound of height
-        [1, kLimitInfo.maxTextureDimension2D.default - 1, 1],
-        [1, kLimitInfo.maxTextureDimension2D.default, 1],
-        [1, kLimitInfo.maxTextureDimension2D.default + 1, 1],
-        // Test the bound of array layers
-        [1, 1, kLimitInfo.maxTextureArrayLayers.default - 1],
-        [1, 1, kLimitInfo.maxTextureArrayLayers.default],
-        [1, 1, kLimitInfo.maxTextureArrayLayers.default + 1],
-      ])
+      .combine(
+        'sizeVariant',
+        /* prettier-ignore */ [
+          // Test the bound of width
+          [{ mult: 1, add: -1, }, { mult: 0, add: 1 }, { mult: 0, add: 1 }],
+          [{ mult: 1, add:  0, }, { mult: 0, add: 1 }, { mult: 0, add: 1 }],
+          [{ mult: 1, add:  1, }, { mult: 0, add: 1 }, { mult: 0, add: 1 }],
+          // Test the bound of height
+          [{ mult: 0, add:  1, }, { mult: 1, add: -1 }, { mult: 0, add: 1 }],
+          [{ mult: 0, add:  1, }, { mult: 1, add:  0 }, { mult: 0, add: 1 }],
+          [{ mult: 0, add:  1, }, { mult: 1, add:  1 }, { mult: 0, add: 1 }],
+          // Test the bound of array layers
+          [{ mult: 0, add:  1, }, { mult: 0, add: 1 }, { mult: 1, add: -1 }],
+          [{ mult: 0, add:  1, }, { mult: 0, add: 1 }, { mult: 1, add:  0 }],
+          [{ mult: 0, add:  1, }, { mult: 0, add: 1 }, { mult: 1, add:  1 }],
+        ]
+      )
   )
   .beforeAllSubcases(t => {
     const { format } = t.params;
@@ -555,7 +559,12 @@ g.test('texture_size,2d_texture,uncompressed_format')
     t.selectDeviceOrSkipTestCase(info.feature);
   })
   .fn(t => {
-    const { dimension, format, size } = t.params;
+    const { dimension, format, sizeVariant } = t.params;
+    const size = [
+      t.device.limits.maxTextureDimension2D,
+      t.device.limits.maxTextureDimension2D,
+      t.device.limits.maxTextureArrayLayers,
+    ].map((limit, ndx) => makeValueTestVariant(limit, sizeVariant[ndx]));
 
     const descriptor: GPUTextureDescriptor = {
       size,
@@ -565,9 +574,9 @@ g.test('texture_size,2d_texture,uncompressed_format')
     };
 
     const success =
-      size[0] <= kLimitInfo.maxTextureDimension2D.default &&
-      size[1] <= kLimitInfo.maxTextureDimension2D.default &&
-      size[2] <= kLimitInfo.maxTextureArrayLayers.default;
+      size[0] <= t.device.limits.maxTextureDimension2D &&
+      size[1] <= t.device.limits.maxTextureDimension2D &&
+      size[2] <= t.device.limits.maxTextureArrayLayers;
 
     t.expectValidationError(() => {
       t.device.createTexture(descriptor);
@@ -580,40 +589,152 @@ g.test('texture_size,2d_texture,compressed_format')
     u
       .combine('dimension', [undefined, '2d'] as const)
       .combine('format', kCompressedTextureFormats)
-      .expand('size', p => {
+      .expand('sizeVariant', p => {
         const { blockWidth, blockHeight } = kTextureFormatInfo[p.format];
         return [
           // Test the bound of width
-          [kLimitInfo.maxTextureDimension2D.default - 1, 1, 1],
-          [kLimitInfo.maxTextureDimension2D.default - blockWidth, 1, 1],
-          [kLimitInfo.maxTextureDimension2D.default - blockWidth, blockHeight, 1],
-          [kLimitInfo.maxTextureDimension2D.default, 1, 1],
-          [kLimitInfo.maxTextureDimension2D.default, blockHeight, 1],
-          [kLimitInfo.maxTextureDimension2D.default + 1, 1, 1],
-          [kLimitInfo.maxTextureDimension2D.default + blockWidth, 1, 1],
-          [kLimitInfo.maxTextureDimension2D.default + blockWidth, blockHeight, 1],
+          [
+            { mult: 1, add: -1 },
+            { mult: 0, add: 1 },
+            { mult: 0, add: 1 },
+          ],
+          [
+            { mult: 1, add: -blockWidth },
+            { mult: 0, add: 1 },
+            { mult: 0, add: 1 },
+          ],
+          [
+            { mult: 1, add: -blockWidth },
+            { mult: 0, add: blockHeight },
+            { mult: 0, add: 1 },
+          ],
+          [
+            { mult: 1, add: 0 },
+            { mult: 0, add: 1 },
+            { mult: 0, add: 1 },
+          ],
+          [
+            { mult: 1, add: 0 },
+            { mult: 0, add: blockHeight },
+            { mult: 0, add: 1 },
+          ],
+          [
+            { mult: 1, add: 1 },
+            { mult: 0, add: 1 },
+            { mult: 0, add: 1 },
+          ],
+          [
+            { mult: 1, add: blockWidth },
+            { mult: 0, add: 1 },
+            { mult: 0, add: 1 },
+          ],
+          [
+            { mult: 1, add: blockWidth },
+            { mult: 0, add: blockHeight },
+            { mult: 0, add: 1 },
+          ],
           // Test the bound of height
-          [1, kLimitInfo.maxTextureDimension2D.default - 1, 1],
-          [1, kLimitInfo.maxTextureDimension2D.default - blockHeight, 1],
-          [blockWidth, kLimitInfo.maxTextureDimension2D.default - blockHeight, 1],
-          [1, kLimitInfo.maxTextureDimension2D.default, 1],
-          [blockWidth, kLimitInfo.maxTextureDimension2D.default, 1],
-          [1, kLimitInfo.maxTextureDimension2D.default + 1, 1],
-          [1, kLimitInfo.maxTextureDimension2D.default + blockWidth, 1],
-          [blockWidth, kLimitInfo.maxTextureDimension2D.default + blockHeight, 1],
+          [
+            { mult: 0, add: 1 },
+            { mult: 1, add: -1 },
+            { mult: 0, add: 1 },
+          ],
+          [
+            { mult: 0, add: 1 },
+            { mult: 1, add: -blockHeight },
+            { mult: 0, add: 1 },
+          ],
+          [
+            { mult: 0, add: blockWidth },
+            { mult: 1, add: -blockHeight },
+            { mult: 0, add: 1 },
+          ],
+          [
+            { mult: 0, add: 1 },
+            { mult: 1, add: 0 },
+            { mult: 0, add: 1 },
+          ],
+          [
+            { mult: 0, add: blockWidth },
+            { mult: 1, add: 0 },
+            { mult: 0, add: 1 },
+          ],
+          [
+            { mult: 0, add: 1 },
+            { mult: 1, add: +1 },
+            { mult: 0, add: 1 },
+          ],
+          [
+            { mult: 0, add: 1 },
+            { mult: 1, add: +blockWidth },
+            { mult: 0, add: 1 },
+          ],
+          [
+            { mult: 0, add: blockWidth },
+            { mult: 1, add: +blockHeight },
+            { mult: 0, add: 1 },
+          ],
           // Test the bound of array layers
-          [1, 1, kLimitInfo.maxTextureArrayLayers.default - 1],
-          [blockWidth, 1, kLimitInfo.maxTextureArrayLayers.default - 1],
-          [1, blockHeight, kLimitInfo.maxTextureArrayLayers.default - 1],
-          [blockWidth, blockHeight, kLimitInfo.maxTextureArrayLayers.default - 1],
-          [1, 1, kLimitInfo.maxTextureArrayLayers.default],
-          [blockWidth, 1, kLimitInfo.maxTextureArrayLayers.default],
-          [1, blockHeight, kLimitInfo.maxTextureArrayLayers.default],
-          [blockWidth, blockHeight, kLimitInfo.maxTextureArrayLayers.default],
-          [1, 1, kLimitInfo.maxTextureArrayLayers.default + 1],
-          [blockWidth, 1, kLimitInfo.maxTextureArrayLayers.default + 1],
-          [1, blockHeight, kLimitInfo.maxTextureArrayLayers.default + 1],
-          [blockWidth, blockHeight, kLimitInfo.maxTextureArrayLayers.default + 1],
+          [
+            { mult: 0, add: 1 },
+            { mult: 0, add: 1 },
+            { mult: 1, add: -1 },
+          ],
+          [
+            { mult: 0, add: blockWidth },
+            { mult: 0, add: 1 },
+            { mult: 1, add: -1 },
+          ],
+          [
+            { mult: 0, add: 1 },
+            { mult: 0, add: blockHeight },
+            { mult: 1, add: -1 },
+          ],
+          [
+            { mult: 0, add: blockWidth },
+            { mult: 0, add: blockHeight },
+            { mult: 1, add: -1 },
+          ],
+          [
+            { mult: 0, add: 1 },
+            { mult: 0, add: 1 },
+            { mult: 1, add: 0 },
+          ],
+          [
+            { mult: 0, add: blockWidth },
+            { mult: 0, add: 1 },
+            { mult: 1, add: 0 },
+          ],
+          [
+            { mult: 0, add: 1 },
+            { mult: 0, add: blockHeight },
+            { mult: 1, add: 0 },
+          ],
+          [
+            { mult: 0, add: blockWidth },
+            { mult: 0, add: blockHeight },
+            { mult: 1, add: 0 },
+          ],
+          [
+            { mult: 0, add: 1 },
+            { mult: 0, add: 1 },
+            { mult: 1, add: +1 },
+          ],
+          [
+            { mult: 0, add: blockWidth },
+            { mult: 0, add: 1 },
+            { mult: 1, add: +1 },
+          ],
+          [
+            { mult: 0, add: 1 },
+            { mult: 0, add: blockHeight },
+            { mult: 1, add: +1 },
+          ],
+          [
+            { mult: 0, add: blockWidth },
+            { mult: 0, add: blockHeight },
+            { mult: 1, add: +1 },
+          ],
         ];
       })
   )
@@ -623,8 +744,13 @@ g.test('texture_size,2d_texture,compressed_format')
     t.selectDeviceOrSkipTestCase(info.feature);
   })
   .fn(t => {
-    const { dimension, format, size } = t.params;
+    const { dimension, format, sizeVariant } = t.params;
     const info = kTextureFormatInfo[format];
+    const size = [
+      t.device.limits.maxTextureDimension2D,
+      t.device.limits.maxTextureDimension2D,
+      t.device.limits.maxTextureArrayLayers,
+    ].map((limit, ndx) => makeValueTestVariant(limit, sizeVariant[ndx]));
 
     const descriptor: GPUTextureDescriptor = {
       size,
@@ -636,9 +762,9 @@ g.test('texture_size,2d_texture,compressed_format')
     const success =
       size[0] % info.blockWidth === 0 &&
       size[1] % info.blockHeight === 0 &&
-      size[0] <= kLimitInfo.maxTextureDimension2D.default &&
-      size[1] <= kLimitInfo.maxTextureDimension2D.default &&
-      size[2] <= kLimitInfo.maxTextureArrayLayers.default;
+      size[0] <= t.device.limits.maxTextureDimension2D &&
+      size[1] <= t.device.limits.maxTextureDimension2D &&
+      size[2] <= t.device.limits.maxTextureArrayLayers;
 
     t.expectValidationError(() => {
       t.device.createTexture(descriptor);
@@ -653,20 +779,23 @@ g.test('texture_size,3d_texture,uncompressed_format')
     u //
       .combine('format', kRegularTextureFormats)
       .beginSubcases()
-      .combine('size', [
+      .combine(
+        'sizeVariant',
+        /* prettier-ignore */ [
         // Test the bound of width
-        [kLimitInfo.maxTextureDimension3D.default - 1, 1, 1],
-        [kLimitInfo.maxTextureDimension3D.default, 1, 1],
-        [kLimitInfo.maxTextureDimension3D.default + 1, 1, 1],
+        [{mult: 1, add: -1}, {mult: 0, add: 1}, {mult: 0, add: 1}],
+        [{mult: 1, add:  0}, {mult: 0, add: 1}, {mult: 0, add: 1}],
+        [{mult: 1, add: +1}, {mult: 0, add: 1}, {mult: 0, add: 1}],
         // Test the bound of height
-        [1, kLimitInfo.maxTextureDimension3D.default - 1, 1],
-        [1, kLimitInfo.maxTextureDimension3D.default, 1],
-        [1, kLimitInfo.maxTextureDimension3D.default + 1, 1],
+        [{mult: 0, add: 1}, {mult: 1, add: -1}, {mult: 0, add: 1}],
+        [{mult: 0, add: 1}, {mult: 1, add:  0}, {mult: 0, add: 1}],
+        [{mult: 0, add: 1}, {mult: 1, add: +1}, {mult: 0, add: 1}],
         // Test the bound of depth
-        [1, 1, kLimitInfo.maxTextureDimension3D.default - 1],
-        [1, 1, kLimitInfo.maxTextureDimension3D.default],
-        [1, 1, kLimitInfo.maxTextureDimension3D.default + 1],
-      ])
+        [{mult: 0, add: 1}, {mult: 0, add: 1}, {mult: 1, add: -1}],
+        [{mult: 0, add: 1}, {mult: 0, add: 1}, {mult: 1, add:  0}],
+        [{mult: 0, add: 1}, {mult: 0, add: 1}, {mult: 1, add: +1}],
+      ]
+      )
   )
   .beforeAllSubcases(t => {
     const { format } = t.params;
@@ -675,7 +804,9 @@ g.test('texture_size,3d_texture,uncompressed_format')
     t.selectDeviceOrSkipTestCase(info.feature);
   })
   .fn(t => {
-    const { format, size } = t.params;
+    const { format, sizeVariant } = t.params;
+    const maxTextureDimension3D = t.device.limits.maxTextureDimension3D;
+    const size = sizeVariant.map(variant => t.makeLimitVariant('maxTextureDimension3D', variant));
 
     const descriptor: GPUTextureDescriptor = {
       size,
@@ -685,9 +816,9 @@ g.test('texture_size,3d_texture,uncompressed_format')
     };
 
     const success =
-      size[0] <= kLimitInfo.maxTextureDimension3D.default &&
-      size[1] <= kLimitInfo.maxTextureDimension3D.default &&
-      size[2] <= kLimitInfo.maxTextureDimension3D.default;
+      size[0] <= maxTextureDimension3D &&
+      size[1] <= maxTextureDimension3D &&
+      size[2] <= maxTextureDimension3D;
 
     t.expectValidationError(() => {
       t.device.createTexture(descriptor);
@@ -700,40 +831,152 @@ g.test('texture_size,3d_texture,compressed_format')
     u //
       .combine('format', kCompressedTextureFormats)
       .beginSubcases()
-      .expand('size', p => {
+      .expand('sizeVariant', p => {
         const { blockWidth, blockHeight } = kTextureFormatInfo[p.format];
         return [
           // Test the bound of width
-          [kLimitInfo.maxTextureDimension3D.default - 1, 1, 1],
-          [kLimitInfo.maxTextureDimension3D.default - blockWidth, 1, 1],
-          [kLimitInfo.maxTextureDimension3D.default - blockWidth, blockHeight, 1],
-          [kLimitInfo.maxTextureDimension3D.default, 1, 1],
-          [kLimitInfo.maxTextureDimension3D.default, blockHeight, 1],
-          [kLimitInfo.maxTextureDimension3D.default + 1, 1, 1],
-          [kLimitInfo.maxTextureDimension3D.default + blockWidth, 1, 1],
-          [kLimitInfo.maxTextureDimension3D.default + blockWidth, blockHeight, 1],
+          [
+            { mult: 1, add: -1 },
+            { mult: 0, add: 1 },
+            { mult: 0, add: 1 },
+          ],
+          [
+            { mult: 1, add: -blockWidth },
+            { mult: 0, add: 1 },
+            { mult: 0, add: 1 },
+          ],
+          [
+            { mult: 1, add: -blockWidth },
+            { mult: 0, add: blockHeight },
+            { mult: 0, add: 1 },
+          ],
+          [
+            { mult: 1, add: 0 },
+            { mult: 0, add: 1 },
+            { mult: 0, add: 1 },
+          ],
+          [
+            { mult: 1, add: 0 },
+            { mult: 0, add: blockHeight },
+            { mult: 0, add: 1 },
+          ],
+          [
+            { mult: 1, add: +1 },
+            { mult: 0, add: 1 },
+            { mult: 0, add: 1 },
+          ],
+          [
+            { mult: 1, add: +blockWidth },
+            { mult: 0, add: 1 },
+            { mult: 0, add: 1 },
+          ],
+          [
+            { mult: 1, add: +blockWidth },
+            { mult: 0, add: blockHeight },
+            { mult: 0, add: 1 },
+          ],
           // Test the bound of height
-          [1, kLimitInfo.maxTextureDimension3D.default - 1, 1],
-          [1, kLimitInfo.maxTextureDimension3D.default - blockHeight, 1],
-          [blockWidth, kLimitInfo.maxTextureDimension3D.default - blockHeight, 1],
-          [1, kLimitInfo.maxTextureDimension3D.default, 1],
-          [blockWidth, kLimitInfo.maxTextureDimension3D.default, 1],
-          [1, kLimitInfo.maxTextureDimension3D.default + 1, 1],
-          [1, kLimitInfo.maxTextureDimension3D.default + blockWidth, 1],
-          [blockWidth, kLimitInfo.maxTextureDimension3D.default + blockHeight, 1],
+          [
+            { mult: 0, add: 1 },
+            { mult: 1, add: -1 },
+            { mult: 0, add: 1 },
+          ],
+          [
+            { mult: 0, add: 1 },
+            { mult: 1, add: -blockHeight },
+            { mult: 0, add: 1 },
+          ],
+          [
+            { mult: 0, add: blockWidth },
+            { mult: 1, add: -blockHeight },
+            { mult: 0, add: 1 },
+          ],
+          [
+            { mult: 0, add: 1 },
+            { mult: 1, add: 0 },
+            { mult: 0, add: 1 },
+          ],
+          [
+            { mult: 0, add: blockWidth },
+            { mult: 1, add: 0 },
+            { mult: 0, add: 1 },
+          ],
+          [
+            { mult: 0, add: 1 },
+            { mult: 1, add: +1 },
+            { mult: 0, add: 1 },
+          ],
+          [
+            { mult: 0, add: 1 },
+            { mult: 1, add: +blockWidth },
+            { mult: 0, add: 1 },
+          ],
+          [
+            { mult: 0, add: blockWidth },
+            { mult: 1, add: +blockHeight },
+            { mult: 0, add: 1 },
+          ],
           // Test the bound of depth
-          [1, 1, kLimitInfo.maxTextureDimension3D.default - 1],
-          [blockWidth, 1, kLimitInfo.maxTextureDimension3D.default - 1],
-          [1, blockHeight, kLimitInfo.maxTextureDimension3D.default - 1],
-          [blockWidth, blockHeight, kLimitInfo.maxTextureDimension3D.default - 1],
-          [1, 1, kLimitInfo.maxTextureDimension3D.default],
-          [blockWidth, 1, kLimitInfo.maxTextureDimension3D.default],
-          [1, blockHeight, kLimitInfo.maxTextureDimension3D.default],
-          [blockWidth, blockHeight, kLimitInfo.maxTextureDimension3D.default],
-          [1, 1, kLimitInfo.maxTextureDimension3D.default + 1],
-          [blockWidth, 1, kLimitInfo.maxTextureDimension3D.default + 1],
-          [1, blockHeight, kLimitInfo.maxTextureDimension3D.default + 1],
-          [blockWidth, blockHeight, kLimitInfo.maxTextureDimension3D.default + 1],
+          [
+            { mult: 0, add: 1 },
+            { mult: 0, add: 1 },
+            { mult: 1, add: -1 },
+          ],
+          [
+            { mult: 0, add: blockWidth },
+            { mult: 0, add: 1 },
+            { mult: 1, add: -1 },
+          ],
+          [
+            { mult: 0, add: 1 },
+            { mult: 0, add: blockHeight },
+            { mult: 1, add: -1 },
+          ],
+          [
+            { mult: 0, add: blockWidth },
+            { mult: 0, add: blockHeight },
+            { mult: 1, add: -1 },
+          ],
+          [
+            { mult: 0, add: 1 },
+            { mult: 0, add: 1 },
+            { mult: 1, add: 0 },
+          ],
+          [
+            { mult: 0, add: blockWidth },
+            { mult: 0, add: 1 },
+            { mult: 1, add: 0 },
+          ],
+          [
+            { mult: 0, add: 1 },
+            { mult: 0, add: blockHeight },
+            { mult: 1, add: 0 },
+          ],
+          [
+            { mult: 0, add: blockWidth },
+            { mult: 0, add: blockHeight },
+            { mult: 1, add: 0 },
+          ],
+          [
+            { mult: 0, add: 1 },
+            { mult: 0, add: 1 },
+            { mult: 1, add: +1 },
+          ],
+          [
+            { mult: 0, add: blockWidth },
+            { mult: 0, add: 1 },
+            { mult: 1, add: +1 },
+          ],
+          [
+            { mult: 0, add: 1 },
+            { mult: 0, add: blockHeight },
+            { mult: 1, add: +1 },
+          ],
+          [
+            { mult: 0, add: blockWidth },
+            { mult: 0, add: blockHeight },
+            { mult: 1, add: +1 },
+          ],
         ];
       })
   )
@@ -746,12 +989,15 @@ g.test('texture_size,3d_texture,compressed_format')
     t.selectDeviceOrSkipTestCase(info.feature);
   })
   .fn(t => {
-    const { format, size } = t.params;
+    const { format, sizeVariant } = t.params;
     const info = kTextureFormatInfo[format];
 
+    const maxTextureDimension3D = t.device.limits.maxTextureDimension3D;
+    const size = sizeVariant.map(variant => t.makeLimitVariant('maxTextureDimension3D', variant));
+
     assert(
-      kLimitInfo.maxTextureDimension3D.default % info.blockWidth === 0 &&
-        kLimitInfo.maxTextureDimension3D.default % info.blockHeight === 0
+      maxTextureDimension3D % info.blockWidth === 0 &&
+        maxTextureDimension3D % info.blockHeight === 0
     );
 
     const descriptor: GPUTextureDescriptor = {
@@ -764,9 +1010,9 @@ g.test('texture_size,3d_texture,compressed_format')
     const success =
       size[0] % info.blockWidth === 0 &&
       size[1] % info.blockHeight === 0 &&
-      size[0] <= kLimitInfo.maxTextureDimension3D.default &&
-      size[1] <= kLimitInfo.maxTextureDimension3D.default &&
-      size[2] <= kLimitInfo.maxTextureDimension3D.default;
+      size[0] <= maxTextureDimension3D &&
+      size[1] <= maxTextureDimension3D &&
+      size[2] <= maxTextureDimension3D;
 
     t.expectValidationError(() => {
       t.device.createTexture(descriptor);


### PR DESCRIPTION

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
