### PR TITLE
Fix Skip/Pass Issues

### DIFF
--- a/src/common/internal/test_group.ts
+++ b/src/common/internal/test_group.ts
@@ -500,9 +500,10 @@ class RunCaseSpecific implements RunCase {
       // An error from init or test may have been a SkipTestCase.
       // An error from finalize may have been an eventualAsyncExpectation failure
       // or unexpected validation/OOM error from the GPUDevice.
-      rec.threw(ex);
       if (throwSkip && ex instanceof SkipTestCase) {
         throw ex;
+      } else {
+        rec.threw(ex);
       }
     } finally {
       try {

--- a/src/unittests/test_group.spec.ts
+++ b/src/unittests/test_group.spec.ts
@@ -262,6 +262,29 @@ g.test('subcases').fn(async t0 => {
   t0.expect(Array.from(result.values()).every(v => v.status === 'pass'));
 });
 
+g.test('subcases,skip')
+  .desc(
+    'If all tests are skipped then status is "skip". If at least one test passed, status is "pass"'
+  )
+  .params(u => u.combine('allSkip', [false, true]))
+  .fn(async t0 => {
+    const { allSkip } = t0.params;
+    const g = makeTestGroupForUnitTesting(UnitTest);
+    g.test('a')
+      .params(u => u.beginSubcases().combine('do', ['pass', 'skip', 'pass']))
+      .fn(t => {
+        t.skipIf(allSkip || t.params.do === 'skip');
+      });
+    const result = await t0.run(g);
+    const values = Array.from(result.values());
+    t0.expect(values.length === 1);
+    const expectedStatus = allSkip ? 'skip' : 'pass';
+    t0.expect(
+      values[0].status === expectedStatus,
+      `expect: ${values[0].status} === ${expectedStatus}}, allSkip: ${allSkip}`
+    );
+  });
+
 g.test('exceptions')
   .params(u =>
     u


### PR DESCRIPTION
As it was, if several subcases were skipped but a few passed the case would be marked as "skip".

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
