### PR TITLE
Remove limit constants

### DIFF
--- a/src/webgpu/api/validation/capability_checks/limits/limit_utils.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/limit_utils.ts
@@ -2,7 +2,7 @@ import { kUnitCaseParamsBuilder } from '../../../../../common/framework/params_b
 import { makeTestGroup } from '../../../../../common/framework/test_group.js';
 import { getGPU } from '../../../../../common/util/navigator_gpu.js';
 import { assert, range, reorder, ReorderOrder } from '../../../../../common/util/util.js';
-import { kLimitInfo, getDefaultLimitsForAdapter } from '../../../../capability_info.js';
+import { getDefaultLimitsForAdapter } from '../../../../capability_info.js';
 import { GPUTestBase } from '../../../../gpu_test.js';
 
 type GPUSupportedLimit = keyof GPUSupportedLimits;
@@ -260,11 +260,6 @@ export type MinimumLimitValueTest = typeof kMinimumLimitValueTests[number];
 export function getDefaultLimitForAdapter(adapter: GPUAdapter, limit: GPUSupportedLimit): number {
   const limitInfo = getDefaultLimitsForAdapter(adapter);
   return limitInfo[limit as keyof typeof limitInfo].default;
-}
-
-// MAINTENANCE_TODO: remove as soon as compat refactor is done and this is no longer used.
-export function getDefaultLimit(limit: GPUSupportedLimit): number {
-  return (kLimitInfo as Record<string, { default: number }>)[limit].default;
 }
 
 export type DeviceAndLimits = {

--- a/src/webgpu/capability_info.ts
+++ b/src/webgpu/capability_info.ts
@@ -353,7 +353,6 @@ assertTypeTrue<TypeEqual<BindableResource, typeof kBindableResources[number]>>()
 /** Dynamic buffer offsets require offset to be divisible by 256, by spec. */
 export const kMinDynamicBufferOffsetAlignment = 256;
 
-// MAINTENANCE_TODO: remove these as tests need to use different limits for compatibility mode
 /** Default `PerShaderStage` binding limits, by spec. */
 export const kPerStageBindingLimits: {
   readonly [k in PerStageBindingLimitClass]: {
@@ -723,9 +722,6 @@ const kLimitInfoCompatibility = makeTableRenameAndFilter(
   kLimitInfoData
 );
 
-// MAINTENANCE_TODO: remove this as tests need to use different limits for compatibility mode
-export const kLimitInfo = kLimitInfoCore;
-
 const kLimitInfos = {
   core: kLimitInfoCore,
   compatibility: kLimitInfoCompatibility,
@@ -751,17 +747,6 @@ export function getDefaultLimitsForAdapter(adapter: GPUAdapter) {
 /** List of all entries of GPUSupportedLimits. */
 export const kLimits = keysOf(kLimitInfoCore);
 
-// MAINTENANCE_TODO: remove these as tests need to use different limits for compatibility mode
-// Pipeline limits
-
-/** Maximum number of color attachments to a render pass, by spec. */
-export const kMaxColorAttachments = kLimitInfo.maxColorAttachments.default;
-/** `maxVertexBuffers` per GPURenderPipeline, by spec. */
-export const kMaxVertexBuffers = kLimitInfo.maxVertexBuffers.default;
-/** `maxVertexAttributes` per GPURenderPipeline, by spec. */
-export const kMaxVertexAttributes = kLimitInfo.maxVertexAttributes.default;
-/** `maxVertexBufferArrayStride` in a vertex buffer in a GPURenderPipeline, by spec. */
-export const kMaxVertexBufferArrayStride = kLimitInfo.maxVertexBufferArrayStride.default;
 /**
  * The number of color attachments to test.
  * The CTS needs to generate a consistent list of tests.


### PR DESCRIPTION
All the other tests have stopped referencing these hard coded constants so it should be safe to remove them

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
