### PR TITLE
Fix atan and tan validation tests

### DIFF
--- a/src/webgpu/shader/validation/expression/call/builtin/atan.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/atan.spec.ts
@@ -12,7 +12,6 @@ import {
   kAllFloatScalarsAndVectors,
   kAllIntegerScalarsAndVectors,
 } from '../../../../../util/conversion.js';
-import { fpTraitsFor } from '../../../../../util/floating_point.js';
 import { ShaderValidationTest } from '../../../shader_validation_test.js';
 
 import {
@@ -49,8 +48,7 @@ Validates that constant evaluation and override evaluation of ${builtin}() rejec
   })
   .fn(t => {
     const type = kValuesTypes[t.params.type];
-    const smallestPositive = fpTraitsFor(elementType(type)).constants().positive.min;
-    const expectedResult = Math.abs(Math.cos(t.params.value)) > smallestPositive;
+    const expectedResult = true;
     validateConstOrOverrideBuiltinEval(
       t,
       builtin,

--- a/src/webgpu/shader/validation/expression/call/builtin/tan.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/tan.spec.ts
@@ -49,8 +49,10 @@ Validates that constant evaluation and override evaluation of ${builtin}() rejec
   })
   .fn(t => {
     const type = kValuesTypes[t.params.type];
-    const smallestPositive = fpTraitsFor(elementType(type)).constants().positive.min;
-    const expectedResult = Math.abs(Math.cos(t.params.value)) > smallestPositive;
+    const fp = fpTraitsFor(elementType(type));
+    const smallestPositive = fp.constants().positive.min;
+    const v = fp.quantize(t.params.value);
+    const expectedResult = Math.abs(Math.cos(v)) > smallestPositive;
     validateConstOrOverrideBuiltinEval(
       t,
       builtin,


### PR DESCRIPTION
The atan validation code was copied from tan, and did not apply. It should always succeed. For tan, was failing for f16 values because the value was not first being quantized to f16 before its cosine was computed.

Fixes https://crbug.com/tint/2035

Issue: #2740
Issue: #2806

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
