### PR TITLE
Compat: skip unsupported formats in filter mode tests

### DIFF
--- a/src/webgpu/api/operation/sampling/filter_mode.spec.ts
+++ b/src/webgpu/api/operation/sampling/filter_mode.spec.ts
@@ -480,6 +480,7 @@ g.test('magFilter,nearest')
       .combine('addressModeV', kAddressModes)
   )
   .beforeAllSubcases(t => {
+    t.skipIfTextureFormatNotSupported(t.params.format);
     if (kTextureFormatInfo[t.params.format].color.type === 'unfilterable-float') {
       t.selectDeviceOrSkipTestCase('float32-filterable');
     }
@@ -602,6 +603,7 @@ g.test('magFilter,linear')
       .combine('addressModeV', kAddressModes)
   )
   .beforeAllSubcases(t => {
+    t.skipIfTextureFormatNotSupported(t.params.format);
     if (kTextureFormatInfo[t.params.format].color.type === 'unfilterable-float') {
       t.selectDeviceOrSkipTestCase('float32-filterable');
     }
@@ -736,6 +738,7 @@ g.test('minFilter,nearest')
       .combine('addressModeV', kAddressModes)
   )
   .beforeAllSubcases(t => {
+    t.skipIfTextureFormatNotSupported(t.params.format);
     if (kTextureFormatInfo[t.params.format].color.type === 'unfilterable-float') {
       t.selectDeviceOrSkipTestCase('float32-filterable');
     }
@@ -868,6 +871,7 @@ g.test('minFilter,linear')
       .combine('addressModeV', kAddressModes)
   )
   .beforeAllSubcases(t => {
+    t.skipIfTextureFormatNotSupported(t.params.format);
     if (kTextureFormatInfo[t.params.format].color.type === 'unfilterable-float') {
       t.selectDeviceOrSkipTestCase('float32-filterable');
     }
@@ -963,6 +967,7 @@ g.test('mipmapFilter')
       .combine('filterMode', kMipmapFilterModes)
   )
   .beforeAllSubcases(t => {
+    t.skipIfTextureFormatNotSupported(t.params.format);
     if (kTextureFormatInfo[t.params.format].color.type === 'unfilterable-float') {
       t.selectDeviceOrSkipTestCase('float32-filterable');
     }


### PR DESCRIPTION
<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
