### PR TITLE
wgsl: Correctly invoke multiplicationInterval instead impl directly

### DIFF
--- a/src/unittests/floating_point.spec.ts
+++ b/src/unittests/floating_point.spec.ts
@@ -7574,135 +7574,171 @@ interface MatrixScalarToMatrixCase {
   expected: (number | IntervalBounds)[][];
 }
 
+const kMultiplicationMatrixScalarIntervalCases = {
+  f32: [
+    // From https://github.com/gpuweb/cts/issues/3044
+    {
+      matrix: [
+        [kValue.f32.negative.min, 0],
+        [0, 0],
+      ],
+      scalar: kValue.f32.negative.subnormal.min,
+      expected: [
+        [[0, reinterpretU32AsF32(0x407ffffe)], 0], // [[0, 3.9999995...], 0],
+        [0, 0],
+      ],
+    },
+  ] as MatrixScalarToMatrixCase[],
+  f16: [
+    // From https://github.com/gpuweb/cts/issues/3044
+    {
+      matrix: [
+        [kValue.f16.negative.min, 0],
+        [0, 0],
+      ],
+      scalar: kValue.f16.negative.subnormal.min,
+      expected: [
+        [[0, reinterpretU16AsF16(0x43fe)], 0], // [[0, 3.99609375], 0]
+        [0, 0],
+      ],
+    },
+  ] as MatrixScalarToMatrixCase[],
+} as const;
+
 g.test('multiplicationMatrixScalarInterval')
   .params(u =>
     u
       .combine('trait', ['f32', 'f16'] as const)
       .beginSubcases()
-      .combineWithParams<MatrixScalarToMatrixCase>([
-        // Only testing that different shapes of matrices are handled correctly
-        // here, to reduce test duplication.
-        // multiplicationMatrixScalarInterval uses MultiplicationIntervalOp for calculating intervals,
-        // so the testing for multiplcationInterval covers the actual interval
+      .expandWithParams<MatrixScalarToMatrixCase>(p => {
+        // Primarily testing that different shapes of matrices are handled correctly
+        // here, to reduce test duplication. Additional testing for edge case
+        // discovered in https://github.com/gpuweb/cts/issues/3044.
+        //
+        // multiplicationMatrixScalarInterval uses for calculating intervals,
+        // so the testing for multiplicationInterval covers the actual interval
         // calculations.
-        {
-          matrix: [
-            [1, 2],
-            [3, 4],
-          ],
-          scalar: 10,
-          expected: [
-            [10, 20],
-            [30, 40],
-          ],
-        },
-        {
-          matrix: [
-            [1, 2],
-            [3, 4],
-            [5, 6],
-          ],
-          scalar: 10,
-          expected: [
-            [10, 20],
-            [30, 40],
-            [50, 60],
-          ],
-        },
-        {
-          matrix: [
-            [1, 2],
-            [3, 4],
-            [5, 6],
-            [7, 8],
-          ],
-          scalar: 10,
-          expected: [
-            [10, 20],
-            [30, 40],
-            [50, 60],
-            [70, 80],
-          ],
-        },
-        {
-          matrix: [
-            [1, 2, 3],
-            [4, 5, 6],
-          ],
-          scalar: 10,
-          expected: [
-            [10, 20, 30],
-            [40, 50, 60],
-          ],
-        },
-        {
-          matrix: [
-            [1, 2, 3],
-            [4, 5, 6],
-            [7, 8, 9],
-          ],
-          scalar: 10,
-          expected: [
-            [10, 20, 30],
-            [40, 50, 60],
-            [70, 80, 90],
-          ],
-        },
-        {
-          matrix: [
-            [1, 2, 3],
-            [4, 5, 6],
-            [7, 8, 9],
-            [10, 11, 12],
-          ],
-          scalar: 10,
-          expected: [
-            [10, 20, 30],
-            [40, 50, 60],
-            [70, 80, 90],
-            [100, 110, 120],
-          ],
-        },
-        {
-          matrix: [
-            [1, 2, 3, 4],
-            [5, 6, 7, 8],
-          ],
-          scalar: 10,
-          expected: [
-            [10, 20, 30, 40],
-            [50, 60, 70, 80],
-          ],
-        },
-        {
-          matrix: [
-            [1, 2, 3, 4],
-            [5, 6, 7, 8],
-            [9, 10, 11, 12],
-          ],
-          scalar: 10,
-          expected: [
-            [10, 20, 30, 40],
-            [50, 60, 70, 80],
-            [90, 100, 110, 120],
-          ],
-        },
-        {
-          matrix: [
-            [1, 2, 3, 4],
-            [5, 6, 7, 8],
-            [9, 10, 11, 12],
-            [13, 14, 15, 16],
-          ],
-          scalar: 10,
-          expected: [
-            [10, 20, 30, 40],
-            [50, 60, 70, 80],
-            [90, 100, 110, 120],
-            [130, 140, 150, 160],
-          ],
-        },
-      ])
+        return [
+          {
+            matrix: [
+              [1, 2],
+              [3, 4],
+            ],
+            scalar: 10,
+            expected: [
+              [10, 20],
+              [30, 40],
+            ],
+          },
+          {
+            matrix: [
+              [1, 2],
+              [3, 4],
+              [5, 6],
+            ],
+            scalar: 10,
+            expected: [
+              [10, 20],
+              [30, 40],
+              [50, 60],
+            ],
+          },
+          {
+            matrix: [
+              [1, 2],
+              [3, 4],
+              [5, 6],
+              [7, 8],
+            ],
+            scalar: 10,
+            expected: [
+              [10, 20],
+              [30, 40],
+              [50, 60],
+              [70, 80],
+            ],
+          },
+          {
+            matrix: [
+              [1, 2, 3],
+              [4, 5, 6],
+            ],
+            scalar: 10,
+            expected: [
+              [10, 20, 30],
+              [40, 50, 60],
+            ],
+          },
+          {
+            matrix: [
+              [1, 2, 3],
+              [4, 5, 6],
+              [7, 8, 9],
+            ],
+            scalar: 10,
+            expected: [
+              [10, 20, 30],
+              [40, 50, 60],
+              [70, 80, 90],
+            ],
+          },
+          {
+            matrix: [
+              [1, 2, 3],
+              [4, 5, 6],
+              [7, 8, 9],
+              [10, 11, 12],
+            ],
+            scalar: 10,
+            expected: [
+              [10, 20, 30],
+              [40, 50, 60],
+              [70, 80, 90],
+              [100, 110, 120],
+            ],
+          },
+          {
+            matrix: [
+              [1, 2, 3, 4],
+              [5, 6, 7, 8],
+            ],
+            scalar: 10,
+            expected: [
+              [10, 20, 30, 40],
+              [50, 60, 70, 80],
+            ],
+          },
+          {
+            matrix: [
+              [1, 2, 3, 4],
+              [5, 6, 7, 8],
+              [9, 10, 11, 12],
+            ],
+            scalar: 10,
+            expected: [
+              [10, 20, 30, 40],
+              [50, 60, 70, 80],
+              [90, 100, 110, 120],
+            ],
+          },
+          {
+            matrix: [
+              [1, 2, 3, 4],
+              [5, 6, 7, 8],
+              [9, 10, 11, 12],
+              [13, 14, 15, 16],
+            ],
+            scalar: 10,
+            expected: [
+              [10, 20, 30, 40],
+              [50, 60, 70, 80],
+              [90, 100, 110, 120],
+              [130, 140, 150, 160],
+            ],
+          },
+          ...kMultiplicationMatrixScalarIntervalCases[p.trait],
+        ];
+      })
   )
   .fn(t => {
     const matrix = t.params.matrix;

--- a/src/webgpu/util/floating_point.ts
+++ b/src/webgpu/util/floating_point.ts
@@ -3748,7 +3748,7 @@ export abstract class FPTraits {
     const rows = mat[0].length;
     return this.toMatrix(
       unflatten2DArray(
-        flatten2DArray(mat).map(e => this.MultiplicationIntervalOp.impl(e, scalar)),
+        flatten2DArray(mat).map(e => this.multiplicationInterval(e, scalar)),
         cols,
         rows
       )


### PR DESCRIPTION
This corrects issues with missing possible FTZ

Fixes #3044

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
