### PR TITLE
Compat: Fix attachment_compatibility color_count tests for limits

### DIFF
--- a/src/webgpu/api/validation/render_pass/attachment_compatibility.spec.ts
+++ b/src/webgpu/api/validation/render_pass/attachment_compatibility.spec.ts
@@ -206,6 +206,17 @@ g.test('render_pass_and_bundle,color_count')
   )
   .fn(t => {
     const { passCount, bundleCount } = t.params;
+
+    const { maxColorAttachments } = t.device.limits;
+    t.skipIf(
+      passCount > maxColorAttachments,
+      `passCount: ${passCount} > maxColorAttachments for device: ${maxColorAttachments}`
+    );
+    t.skipIf(
+      bundleCount > maxColorAttachments,
+      `bundleCount: ${bundleCount} > maxColorAttachments for device: ${maxColorAttachments}`
+    );
+
     const bundleEncoder = t.device.createRenderBundleEncoder({
       colorFormats: range(bundleCount, () => 'rgba8uint'),
     });
@@ -242,7 +253,7 @@ g.test('render_pass_and_bundle,color_sparse')
   .fn(t => {
     const { passAttachments, bundleAttachments } = t.params;
 
-    const maxColorAttachments = t.device.limits.maxColorAttachments;
+    const { maxColorAttachments } = t.device.limits;
     t.skipIf(
       passAttachments.length > maxColorAttachments,
       `num passAttachments: ${passAttachments.length} > maxColorAttachments for device: ${maxColorAttachments}`
@@ -402,6 +413,17 @@ count.
   )
   .fn(t => {
     const { encoderType, encoderCount, pipelineCount } = t.params;
+
+    const { maxColorAttachments } = t.device.limits;
+    t.skipIf(
+      pipelineCount > maxColorAttachments,
+      `pipelineCount: ${pipelineCount} > maxColorAttachments for device: ${maxColorAttachments}`
+    );
+    t.skipIf(
+      encoderCount > maxColorAttachments,
+      `encoderCount: ${encoderCount} > maxColorAttachments for device: ${maxColorAttachments}`
+    );
+
     const pipeline = t.createRenderPipeline(
       range(pipelineCount, () => ({ format: 'rgba8uint', writeMask: 0 }))
     );
@@ -435,7 +457,7 @@ Test that each of color attachments in render passes or bundles match that of th
   )
   .fn(t => {
     const { encoderType, encoderAttachments, pipelineAttachments } = t.params;
-    const maxColorAttachments = t.device.limits.maxColorAttachments;
+    const { maxColorAttachments } = t.device.limits;
     t.skipIf(
       encoderAttachments.length > maxColorAttachments,
       `num encoderAttachments: ${encoderAttachments.length} > maxColorAttachments for device: ${maxColorAttachments}`


### PR DESCRIPTION
also a little cleanup 

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
