### PR TITLE
Make Pass > Skip

### DIFF
--- a/src/common/internal/logging/result.ts
+++ b/src/common/internal/logging/result.ts
@@ -3,7 +3,7 @@ import { LogMessageWithStack } from './log_message.js';
 // MAINTENANCE_TODO: Add warn expectations
 export type Expectation = 'pass' | 'skip' | 'fail';
 
-export type Status = 'running' | 'warn' | Expectation;
+export type Status = 'notrun' | 'running' | 'warn' | Expectation;
 
 export interface TestCaseResult {
   status: Status;

--- a/src/common/internal/test_group.ts
+++ b/src/common/internal/test_group.ts
@@ -491,6 +491,7 @@ class RunCaseSpecific implements RunCase {
       try {
         await inst.init();
         await this.fn(inst as Fixture & { params: {} });
+        rec.passed();
       } finally {
         // Runs as long as constructor succeeded, even if initialization or the test failed.
         await inst.finalize();

--- a/src/unittests/logger.spec.ts
+++ b/src/unittests/logger.spec.ts
@@ -77,7 +77,7 @@ g.test('skip').fn(t => {
   t.expect(res.timems >= 0);
 });
 
-// Tests if there's some skips and at last one pass it's pass.
+// Tests if there's some skips and at least one pass it's pass.
 g.test('skip_pass').fn(t => {
   const mylog = new Logger({ overrideDebugMode: true });
   const [rec, res] = mylog.record('one');

--- a/src/unittests/logger.spec.ts
+++ b/src/unittests/logger.spec.ts
@@ -36,6 +36,18 @@ g.test('empty').fn(t => {
   t.expect(res.status === 'running');
   rec.finish();
 
+  t.expect(res.status === 'notrun');
+  t.expect(res.timems >= 0);
+});
+
+g.test('passed').fn(t => {
+  const mylog = new Logger({ overrideDebugMode: true });
+  const [rec, res] = mylog.record('one');
+
+  rec.start();
+  rec.passed();
+  rec.finish();
+
   t.expect(res.status === 'pass');
   t.expect(res.timems >= 0);
 });
@@ -59,10 +71,24 @@ g.test('skip').fn(t => {
 
   rec.start();
   rec.skipped(new SkipTestCase());
-  rec.debug(new Error('hello'));
   rec.finish();
 
   t.expect(res.status === 'skip');
+  t.expect(res.timems >= 0);
+});
+
+// Tests if there's some skips and at last one pass it's pass.
+g.test('skip_pass').fn(t => {
+  const mylog = new Logger({ overrideDebugMode: true });
+  const [rec, res] = mylog.record('one');
+
+  rec.start();
+  rec.skipped(new SkipTestCase());
+  rec.debug(new Error('hello'));
+  rec.skipped(new SkipTestCase());
+  rec.finish();
+
+  t.expect(res.status === 'pass');
   t.expect(res.timems >= 0);
 });
 

--- a/src/unittests/test_group.spec.ts
+++ b/src/unittests/test_group.spec.ts
@@ -262,6 +262,29 @@ g.test('subcases').fn(async t0 => {
   t0.expect(Array.from(result.values()).every(v => v.status === 'pass'));
 });
 
+g.test('subcases,skip')
+  .desc(
+    'If all tests are skipped then status is "skip". If at least one test passed, status is "pass"'
+  )
+  .params(u => u.combine('allSkip', [false, true]))
+  .fn(async t0 => {
+    const { allSkip } = t0.params;
+    const g = makeTestGroupForUnitTesting(UnitTest);
+    g.test('a')
+      .params(u => u.beginSubcases().combine('do', ['pass', 'skip', 'pass']))
+      .fn(t => {
+        t.skipIf(allSkip || t.params.do === 'skip');
+      });
+    const result = await t0.run(g);
+    const values = Array.from(result.values());
+    t0.expect(values.length === 1);
+    const expectedStatus = allSkip ? 'skip' : 'pass';
+    t0.expect(
+      values[0].status === expectedStatus,
+      `expect: ${values[0].status} === ${expectedStatus}}, allSkip: ${allSkip}`
+    );
+  });
+
 g.test('exceptions')
   .params(u =>
     u


### PR DESCRIPTION
As it is, the test recorder only keeps the "highest" status. It was Pass = 0, Skip = 1, that means if 1000 subcases passes but just one was skipped the entire case was marked as skip.

Making Skip less than Pass means they'll as long as one subcase runs the test will be marked as Pass unless there is higher a higher status subcase

Added tests, also tested locally via telemetry and it seems to work.

This is a fix for the revert: https://github.com/gpuweb/cts/pull/3043

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
