### PR TITLE
memory_model: Add f16 to barrier tests

### DIFF
--- a/src/webgpu/shader/execution/memory_model/barrier.spec.ts
+++ b/src/webgpu/shader/execution/memory_model/barrier.spec.ts
@@ -7,6 +7,7 @@ import { GPUTest } from '../../../gpu_test.js';
 import {
   MemoryModelTestParams,
   MemoryModelTester,
+  kAccessValueTypes,
   buildTestShader,
   MemoryType,
   TestType,
@@ -42,19 +43,73 @@ const memoryModelTestParams: MemoryModelTestParams = {
   numBehaviors: 2,
 };
 
+// The two kinds of non-atomic accesses tested.
+//  rw: read -> barrier -> write
+//  wr: write -> barrier -> read
+//  ww: write -> barrier -> write
+type AccessPair = 'rw' | 'wr' | 'ww';
+
+// Test the non-atomic memory types.
+const kMemTypes = [MemoryType.NonAtomicStorageClass, MemoryType.NonAtomicWorkgroupClass] as const;
+
 const storageMemoryBarrierStoreLoadTestCode = `
-  test_locations.value[x_0] = 1u;
+  test_locations.value[x_0] = 1;
   workgroupBarrier();
-  let r0 = test_locations.value[x_1];
+  let r0 = u32(test_locations.value[x_1]);
   atomicStore(&results.value[shuffled_workgroup * workgroupXSize + id_1].r0, r0);
 `;
 
 const workgroupMemoryBarrierStoreLoadTestCode = `
-  wg_test_locations[x_0] = 1u;
+  wg_test_locations[x_0] = 1;
   workgroupBarrier();
-  let r0 = wg_test_locations[x_1];
+  let r0 = u32(wg_test_locations[x_1]);
   atomicStore(&results.value[shuffled_workgroup * workgroupXSize + id_1].r0, r0);
 `;
+
+const storageMemoryBarrierLoadStoreTestCode = `
+  let r0 = u32(test_locations.value[x_0]);
+  workgroupBarrier();
+  test_locations.value[x_1] = 1;
+  atomicStore(&results.value[shuffled_workgroup * workgroupXSize + id_0].r0, r0);
+`;
+
+const workgroupMemoryBarrierLoadStoreTestCode = `
+  let r0 = u32(wg_test_locations[x_0]);
+  workgroupBarrier();
+  wg_test_locations[x_1] = 1;
+  atomicStore(&results.value[shuffled_workgroup * workgroupXSize + id_0].r0, r0);
+`;
+
+const storageMemoryBarrierStoreStoreTestCode = `
+  test_locations.value[x_0] = 1;
+  storageBarrier();
+  test_locations.value[x_1] = 2;
+`;
+
+const workgroupMemoryBarrierStoreStoreTestCode = `
+  wg_test_locations[x_0] = 1;
+  workgroupBarrier();
+  wg_test_locations[x_1] = 2;
+  workgroupBarrier();
+  test_locations.value[shuffled_workgroup * workgroupXSize * stress_params.mem_stride * 2u + x_1] = wg_test_locations[x_1];
+`;
+
+function getTestCode(p: { memType: MemoryType; accessPair: AccessPair }): string {
+  switch (p.accessPair) {
+    case 'rw':
+      return p.memType === MemoryType.NonAtomicStorageClass
+        ? storageMemoryBarrierLoadStoreTestCode
+        : workgroupMemoryBarrierLoadStoreTestCode;
+    case 'wr':
+      return p.memType === MemoryType.NonAtomicStorageClass
+        ? storageMemoryBarrierStoreLoadTestCode
+        : workgroupMemoryBarrierStoreLoadTestCode;
+    case 'ww':
+      return p.memType === MemoryType.NonAtomicStorageClass
+        ? storageMemoryBarrierStoreStoreTestCode
+        : workgroupMemoryBarrierStoreStoreTestCode;
+  }
+}
 
 g.test('workgroup_barrier_store_load')
   .desc(
@@ -63,13 +118,17 @@ g.test('workgroup_barrier_store_load')
     after the barrier to read a write from an invocation before the barrier.
     `
   )
-  .paramsSimple([
-    { memType: MemoryType.NonAtomicStorageClass, _testCode: storageMemoryBarrierStoreLoadTestCode },
-    {
-      memType: MemoryType.NonAtomicWorkgroupClass,
-      _testCode: workgroupMemoryBarrierStoreLoadTestCode,
-    },
-  ])
+  .params(u =>
+    u
+      .combine('accessValueType', kAccessValueTypes)
+      .combine('memType', kMemTypes)
+      .combine('accessPair', ['wr'] as const)
+  )
+  .beforeAllSubcases(t => {
+    if (t.params.accessValueType === 'f16') {
+      t.selectDeviceOrSkipTestCase('shader-f16');
+    }
+  })
   .fn(async t => {
     const resultCode = `
       if (r0 == 1u) {
@@ -79,7 +138,7 @@ g.test('workgroup_barrier_store_load')
       }
     `;
     const testShader = buildTestShader(
-      t.params._testCode,
+      getTestCode(t.params),
       t.params.memType,
       TestType.IntraWorkgroup
     );
@@ -92,24 +151,11 @@ g.test('workgroup_barrier_store_load')
       t,
       memoryModelTestParams,
       testShader,
-      resultShader
+      resultShader,
+      t.params.accessValueType
     );
     await memModelTester.run(15, 1);
   });
-
-const storageMemoryBarrierLoadStoreTestCode = `
-  let r0 = test_locations.value[x_0];
-  workgroupBarrier();
-  test_locations.value[x_1] = 1u;
-  atomicStore(&results.value[shuffled_workgroup * workgroupXSize + id_0].r0, r0);
-`;
-
-const workgroupMemoryBarrierLoadStoreTestCode = `
-  let r0 = wg_test_locations[x_0];
-  workgroupBarrier();
-  wg_test_locations[x_1] = 1u;
-  atomicStore(&results.value[shuffled_workgroup * workgroupXSize + id_0].r0, r0);
-`;
 
 g.test('workgroup_barrier_load_store')
   .desc(
@@ -118,13 +164,17 @@ g.test('workgroup_barrier_load_store')
     before the barrier to not read the write from an invocation after the barrier.
     `
   )
-  .paramsSimple([
-    { memType: MemoryType.NonAtomicStorageClass, _testCode: storageMemoryBarrierLoadStoreTestCode },
-    {
-      memType: MemoryType.NonAtomicWorkgroupClass,
-      _testCode: workgroupMemoryBarrierLoadStoreTestCode,
-    },
-  ])
+  .params(u =>
+    u
+      .combine('accessValueType', kAccessValueTypes)
+      .combine('memType', kMemTypes)
+      .combine('accessPair', ['rw'] as const)
+  )
+  .beforeAllSubcases(t => {
+    if (t.params.accessValueType === 'f16') {
+      t.selectDeviceOrSkipTestCase('shader-f16');
+    }
+  })
   .fn(async t => {
     const resultCode = `
       if (r0 == 0u) {
@@ -134,7 +184,7 @@ g.test('workgroup_barrier_load_store')
       }
     `;
     const testShader = buildTestShader(
-      t.params._testCode,
+      getTestCode(t.params),
       t.params.memType,
       TestType.IntraWorkgroup
     );
@@ -147,24 +197,11 @@ g.test('workgroup_barrier_load_store')
       t,
       memoryModelTestParams,
       testShader,
-      resultShader
+      resultShader,
+      t.params.accessValueType
     );
     await memModelTester.run(12, 1);
   });
-
-const storageMemoryBarrierStoreStoreTestCode = `
-  test_locations.value[x_0] = 1u;
-  storageBarrier();
-  test_locations.value[x_1] = 2u;
-`;
-
-const workgroupMemoryBarrierStoreStoreTestCode = `
-  wg_test_locations[x_0] = 1u;
-  workgroupBarrier();
-  wg_test_locations[x_1] = 2u;
-  workgroupBarrier();
-  test_locations.value[shuffled_workgroup * workgroupXSize * stress_params.mem_stride * 2u + x_1] = wg_test_locations[x_1];
-`;
 
 g.test('workgroup_barrier_store_store')
   .desc(
@@ -173,16 +210,17 @@ g.test('workgroup_barrier_store_store')
     to be the result of the write after the barrier, not the write before.
     `
   )
-  .paramsSimple([
-    {
-      memType: MemoryType.NonAtomicStorageClass,
-      _testCode: storageMemoryBarrierStoreStoreTestCode,
-    },
-    {
-      memType: MemoryType.NonAtomicWorkgroupClass,
-      _testCode: workgroupMemoryBarrierStoreStoreTestCode,
-    },
-  ])
+  .params(u =>
+    u
+      .combine('accessValueType', kAccessValueTypes)
+      .combine('memType', kMemTypes)
+      .combine('accessPair', ['ww'] as const)
+  )
+  .beforeAllSubcases(t => {
+    if (t.params.accessValueType === 'f16') {
+      t.selectDeviceOrSkipTestCase('shader-f16');
+    }
+  })
   .fn(async t => {
     const resultCode = `
       if (mem_x_0 == 2u) {
@@ -192,7 +230,7 @@ g.test('workgroup_barrier_store_store')
       }
     `;
     const testShader = buildTestShader(
-      t.params._testCode,
+      getTestCode(t.params),
       t.params.memType,
       TestType.IntraWorkgroup
     );
@@ -205,7 +243,8 @@ g.test('workgroup_barrier_store_store')
       t,
       memoryModelTestParams,
       testShader,
-      resultShader
+      resultShader,
+      t.params.accessValueType
     );
     await memModelTester.run(10, 1);
   });

--- a/src/webgpu/shader/execution/memory_model/memory_model_setup.ts
+++ b/src/webgpu/shader/execution/memory_model/memory_model_setup.ts
@@ -1010,7 +1010,7 @@ const resultShaderCommonCode = [
   shaderEntryPoint,
 ].join('\n');
 
-/*
+/**
  * Defines the types of possible memory a test is operating on. Used as part of the process of building shader code from
  * its composite parts.
  */

--- a/src/webgpu/shader/execution/memory_model/memory_model_setup.ts
+++ b/src/webgpu/shader/execution/memory_model/memory_model_setup.ts
@@ -3,6 +3,18 @@ import { checkElementsPassPredicate } from '../../../util/check_contents.js';
 
 /* All buffer sizes are counted in units of 4-byte words. */
 
+/**
+ * The value type loaded and stored from memory.
+ * This is what the WGSL spec calls 'store type' for the locations being accessed.
+ * The GPU buffers are sized assuming this type is at most 4 bytes.
+ *
+ * 'u32' is the default case; it can be atomically loaded and stored.
+ * 'f16' is interesting because it is not 32-bits, and can't be the store type
+ * for atomic accesses.
+ */
+export type AccessValueType = 'f16' | 'u32';
+export const kAccessValueTypes = ['f16', 'u32'] as const;
+
 /* Parameter values are set heuristically, typically by a time-intensive search. */
 export type MemoryModelTestParams = {
   /* Number of invocations per workgroup. The workgroups are 1-dimensional. */
@@ -112,13 +124,52 @@ const memLocationOffsetIndex = 11;
 const bytesPerWord = 4;
 
 /**
+ * Returns the shader preamble based on the access value type:
+ *  - enable directives, if necessary
+ *  - the type alias for AccessValueType
+ */
+function shaderPreamble(accessValueType: AccessValueType): string {
+  if (accessValueType === 'f16') {
+    return 'enable f16;\nalias AccessValueTy = f16;\n';
+  }
+  return `alias AccessValueTy = ${accessValueType};\n`;
+}
+
+/**
  * Implements setup code necessary to run a memory model test. A test consists of two parts:
  *  1.) A test shader that runs a specified memory model litmus test and attempts to reveal a weak (disallowed) behavior.
  *      At a high level, a test shader consists of a set of testing workgroups where every invocation executes the litmus test
  *      on a set of test locations, and a set of stressing workgroups where every invocation accesses a specified memory location
  *      in a random pattern.
+ *
+ *      The main buffer variables are:
+ *
+ *        `test_locations`: invocations access entries in this array, trying to
+ *          evoke weak behaviours.
+ *
+ *          This is array<AccessValueTy> or array<atomic<u32>>.
+ *          AccessValueTy is either f16 or u32.
+ *          Note that atomic<u32> is only used when AccessValueTy is u32.
+ *
+ *        `results`: holds the observed values, which is where we can see
+ *          whether a weak behaviour was observed.
+ *
+ *          This is an array<atomic<u32>>.
+ *
+ *      The others are used to parameterize and stress the main activity.
+ *
  *  2.) A result shader that takes the output of the test shader, which consists of the memory locations accessed during the test
  *      and the results of any reads made during the test, and aggregate the results based on the possible behaviors of the test.
+ *
+ *      The first two buffer variables are the same buffers as for the test shader:
+ *
+ *        `test_locations` is the same as `test_locations` from the test shader,
+ *        but is mapped as array<AccessValueTy>.
+ *
+ *        `read_results` is the same buffer as `results` from the test shader.
+ *
+ *      The other variables are used to accumulate a summary that counts the weak behaviours stimulated and recorded by the
+ *      test shader.
  */
 export class MemoryModelTester {
   protected test: GPUTest;
@@ -130,9 +181,18 @@ export class MemoryModelTester {
   protected resultBindGroup: GPUBindGroup;
 
   /** Sets up a memory model test by initializing buffers and pipeline layouts. */
-  constructor(t: GPUTest, params: MemoryModelTestParams, testShader: string, resultShader: string) {
+  constructor(
+    t: GPUTest,
+    params: MemoryModelTestParams,
+    testShader: string,
+    resultShader: string,
+    accessValueType: AccessValueType = 'u32'
+  ) {
     this.test = t;
     this.params = params;
+
+    testShader = shaderPreamble(accessValueType) + testShader;
+    resultShader = shaderPreamble(accessValueType) + resultShader;
 
     // set up buffers
     const testingThreads = this.params.workgroupSize * this.params.testingWorkgroups;
@@ -558,11 +618,15 @@ export class MemoryModelTester {
 /** Defines common data structures used in memory model test shaders. */
 const shaderMemStructures = `
   struct Memory {
-    value: array<u32>
+    value: array<AccessValueTy>
   };
 
   struct AtomicMemory {
     value: array<atomic<u32>>
+  };
+
+  struct IndexMemory {
+    value: array<u32>
   };
 
   struct ReadResult {
@@ -622,10 +686,10 @@ const twoBehaviorTestResultStructure = `
 /** Common bindings used in the test shader phase of a test. */
 const commonTestShaderBindings = `
   @group(0) @binding(1) var<storage, read_write> results : ReadResults;
-  @group(0) @binding(2) var<storage, read> shuffled_workgroups : Memory;
+  @group(0) @binding(2) var<storage, read> shuffled_workgroups : IndexMemory;
   @group(0) @binding(3) var<storage, read_write> barrier : AtomicMemory;
-  @group(0) @binding(4) var<storage, read_write> scratchpad : Memory;
-  @group(0) @binding(5) var<storage, read_write> scratch_locations : Memory;
+  @group(0) @binding(4) var<storage, read_write> scratchpad : IndexMemory;
+  @group(0) @binding(5) var<storage, read_write> scratch_locations : IndexMemory;
   @group(0) @binding(6) var<uniform> stress_params : StressParamsMemory;
 `;
 
@@ -647,7 +711,7 @@ const nonAtomicTestShaderBindings = [
 
 /** Bindings used in the result aggregation phase of the test. */
 const resultShaderBindings = `
-  @group(0) @binding(0) var<storage, read_write> test_locations : AtomicMemory;
+  @group(0) @binding(0) var<storage, read_write> test_locations : Memory;
   @group(0) @binding(1) var<storage, read_write> read_results : ReadResults;
   @group(0) @binding(2) var<storage, read_write> test_results : TestResults;
   @group(0) @binding(3) var<uniform> stress_params : StressParamsMemory;
@@ -668,7 +732,7 @@ const atomicWorkgroupMemory = `
  * is large enough to accommodate the maximum memory size needed per workgroup for testing.
  */
 const nonAtomicWorkgroupMemory = `
-  var<workgroup> wg_test_locations: array<u32, 3584>;
+  var<workgroup> wg_test_locations: array<AccessValueTy, 3584>;
 `;
 
 /**
@@ -857,11 +921,16 @@ const testShaderCommonFooter = `
 /**
  * All result shaders must calculate memory locations used in the test. Not all these locations are
  * used in every result shader, but no result shader uses more than these locations.
+ *
+ * Each value read from test_locations is converted from AccessValueTy to u32
+ * before storing it in the read result.  This assumes u32(AccessValueTy)
+ * is either an identity function u32(u32) or a value-converting overload such
+ * as u32(f16).
  */
 const resultShaderCommonCalculations = `
   let id_0 = workgroup_id[0] * workgroupXSize + local_invocation_id[0];
   let x_0 = id_0 * stress_params.mem_stride * 2u;
-  let mem_x_0 = atomicLoad(&test_locations.value[x_0]);
+  let mem_x_0 = u32(test_locations.value[x_0]);
   let r0 = atomicLoad(&read_results.value[id_0].r0);
   let r1 = atomicLoad(&read_results.value[id_0].r1);
 `;
@@ -872,7 +941,7 @@ const interWorkgroupResultShaderCode = [
   `
   let total_ids = workgroupXSize * stress_params.testing_workgroups;
   let y_0 = permute_id(id_0, stress_params.permute_second, total_ids) * stress_params.mem_stride * 2u + stress_params.location_offset;
-  let mem_y_0 = atomicLoad(&test_locations.value[y_0]);
+  let mem_y_0 = u32(test_locations.value[y_0]);
 `,
 ].join('\n');
 
@@ -882,7 +951,7 @@ const intraWorkgroupResultShaderCode = [
   `
   let total_ids = workgroupXSize;
   let y_0 = (workgroup_id[0] * workgroupXSize + permute_id(local_invocation_id[0], stress_params.permute_second, total_ids)) * stress_params.mem_stride * 2u + stress_params.location_offset;
-  let mem_y_0 = atomicLoad(&test_locations.value[y_0]);
+  let mem_y_0 = u32(test_locations.value[y_0]);
 `,
 ].join('\n');
 
@@ -941,7 +1010,7 @@ const resultShaderCommonCode = [
   shaderEntryPoint,
 ].join('\n');
 
-/**
+/*
  * Defines the types of possible memory a test is operating on. Used as part of the process of building shader code from
  * its composite parts.
  */


### PR DESCRIPTION
memory_model_setup.ts: Generalize access value type

- Describe the test_locations and results buffers in more detail
- Use new type alias AccessValueType as the element type in test_locations.  It is set up to be switched easily between f16 and u32.
- In the results shader, use the Memory type for test_locations instead of AtomicMemory.
- In test shaders, use 1 and 2 instead of 1u and 2u.  Take advantage of the flexibility of AbstractInt literals.

barrier.spec.ts: Add f16 to barrier test

- Rework parameterization of the barrier tests.

Fixes: #3053




Issue: #3053
Passes on Macbook Pro with 2017

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
