### PR TITLE
wgsl: Implement validation test for parsing f16 literal

### DIFF
--- a/src/webgpu/shader/validation/parse/literal.spec.ts
+++ b/src/webgpu/shader/validation/parse/literal.spec.ts
@@ -287,10 +287,16 @@ const kAbstractFloat = new Set([
     .desc(
       `
 Test that valid half floats are accepted, and invalid half floats are rejected
-
-TODO: Need to inject the 'enable fp16' into the shader to enable the parsing.
 `
     )
     .params(u => u.combine('val', new Set([...kValidF16, ...kInvalidF16])).beginSubcases())
-    .unimplemented();
+    .beforeAllSubcases(t => {
+      t.selectDeviceOrSkipTestCase('shader-f16');
+    })
+    .fn(t => {
+      const { val } = t.params;
+      const code = `var test: f16 = ${val};`;
+      const extensionList = ['f16'];
+      t.expectCompileResult(kValidF16.has(val), t.wrapInEntryPoint(code, extensionList));
+    });
 }


### PR DESCRIPTION
This PR add missing validation test for parsing f16 literal.

Issue: #1192

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
