### PR TITLE
Move listing_meta docs to docs/, clarify a few things

### DIFF
--- a/docs/adding_timing_metadata.md
+++ b/docs/adding_timing_metadata.md
@@ -1,7 +1,32 @@
+# Adding Timing Metadata
+
+## listing_meta.json files
+
+`listing_meta.json` files are SEMI AUTO-GENERATED.
+
+The raw data may be edited manually, to add entries or change timing values.
+
+The **list** of tests must stay up to date, so it can be used by external
+tools. This is verified by presubmit checks.
+
+The `subcaseMS` values are estimates. They can be set to 0 if for some reason
+you can't estimate the time (or there's an existing test with a long name and
+slow subcases that would result in query strings that are too long), but this
+will produce a non-fatal warning. Avoid creating new warnings whenever
+possible. Any existing failures should be fixed (eventually).
+
+### Performance
+
+Note this data is typically captured by developers using higher-end
+computers, so typical test machines might execute more slowly. For this
+reason, the WPT chunking should be configured to generate chunks much shorter
+than 5 seconds (a typical default time limit in WPT test executors) so they
+should still execute in under 5 seconds on lower-end computers.
+
 ## Problem
 
 When adding new tests to the CTS you may occasionally see an error like this
-when running `npm test` or `npm run standalone`
+when running `npm test` or `npm run standalone`:
 
 ```
 ERROR: Tests missing from listing_meta.json. Please add the new tests (set subcaseMS to 0 if you cannot estimate it):
@@ -10,7 +35,7 @@ ERROR: Tests missing from listing_meta.json. Please add the new tests (set subca
 /home/runner/work/cts/cts/src/common/util/util.ts:38
     throw new Error(msg && (typeof msg === 'string' ? msg : msg()));
           ^
-Error: 
+Error:
     at assert (/home/runner/work/cts/cts/src/common/util/util.ts:38:11)
     at crawl (/home/runner/work/cts/cts/src/common/tools/crawl.ts:155:11)
 Warning: non-zero exit code 1
@@ -25,9 +50,10 @@ What this error message is trying to tell us, is that there is no entry for
 
 These entries are estimates for the amount of time that subcases take to run,
 and are used as inputs into the WPT tooling to attempt to portion out tests into
-approximately same sized chunks.
+approximately same-sized chunks.
 
-If a value has been defaulted to 0 by someone, you will see warnings like this
+If a value has been defaulted to 0 by someone, you will see warnings like this:
+
 ```
 ...
 WARNING: subcaseMS≤0 found in listing_meta.json (allowed, but try to avoid):
@@ -38,71 +64,98 @@ WARNING: subcaseMS≤0 found in listing_meta.json (allowed, but try to avoid):
 These messages should be resolved by adding appropriate entries to the JSON
 file.
 
-## Solution
+## Solution 1 (manual, best for simple tests)
+
+If you're developing new tests and need to update this file, it is sometimes
+easiest to do so manually. Run your tests under your usual development workflow
+and see how long they take. In the standalone web runner `npm start`, the total
+time for a test case is reported on the right-hand side when the case logs are
+expanded.
+
+Record the average time per *subcase* across all cases of the test (you may need
+to compute this) into the `listing_meta.json` file.
+
+## Solution 2 (semi-automated)
 
 There exists tooling in the CTS repo for generating appropriate estimates for
 these values, though they do require some manual intervention. The rest of this
 doc will be a walkthrough of running these tools.
 
-### Default Value
+Timing data can be captured in bulk and "merged" into this file using
+the `merge_listing_times` tool. This is useful when a large number of tests
+change or otherwise a lot of tests need to be updated, but it also automates the
+manual steps above.
 
-The first step is to add a default value for entry to 
-`src/webgpu/listing_meta.json`, since there is a chicken-and-egg problem for 
-updating these values.
+The tool can also be used without any inputs to reformat `listing_meta.json`.
+Please read the help message of `merge_listing_times` for more information.
+
+### Placeholder Value
+
+If your development workflow requires a clean build, the first step is to add a
+placeholder value for entry to `src/webgpu/listing_meta.json`, since there is a
+chicken-and-egg problem for updating these values.
 
 ```
   "webgpu:shader,execution,expression,binary,af_matrix_addition:matrix:*": { "subcaseMS": 0 },
 ```
 
 (It should have a value of 0, since later tooling updates the value if the newer
-value is higher)
+value is higher.)
 
 ### Websocket Logger
 
-The first tool that needs to be run is `websocket-logger`, which uses a side
-channel from WPT to report timing data when CTS is run via a websocket. This
+The first tool that needs to be run is `websocket-logger`, which receives data
+on a WebSocket channel to capture timing data when CTS is run. This
 should be run in a separate process/terminal, since it needs to stay running
 throughout the following steps.
 
-At `tools/websocket-logger/`
+In the `tools/websocket-logger/` directory:
+
 ```
 npm ci
 npm start
 ```
 
 The output from this command will indicate where the results are being logged,
-which will be needed later
+which will be needed later. For example:
+
 ```
 ...
-Writing to wslog-2023-09-11T18-57-34.txt
+Writing to wslog-2023-09-12T18-57-34.txt
 ...
 ```
 
 ### Running CTS
 
-Now we need to run the specific cases in CTS, which requires serving the CTS 
-locally.
+Now we need to run the specific cases in CTS that we need to time.
+This should be possible under any development workflow (as long as its runtime environment, like Node, supports WebSockets), but the most well-tested way is using the standalone web runner.
 
-At project root
+This requires serving the CTS locally. In the project root:
+
 ```
 npm run standalone
 npm start
 ```
 
 Once this is started you can then direct a WebGPU enabled browser to the
-specific CTS entry and run the tests, for example
+specific CTS entry and run the tests, for example:
+
 ```
-http://127.0.0.1:8080/standalone/q?webgpu:shader,execution,expression,binary,af_matrix_addition:matrix:*
+http://localhost:8080/standalone/?q=webgpu:shader,execution,expression,binary,af_matrix_addition:matrix:*
 ```
+
+If the tests have a high variance in runtime, you can run them multiple times.
+The longest recorded time will be used.
 
 ### Merging metadata
 
 The final step is to merge the new data that has been captured into the JSON
 file.
 
-This can be done using the following command
+This can be done using the following command:
+
 ```
-tools/merge_listing_times webgpu -- tools/websocket-logger/wslog-2023-09-11T18-57-34.txt
+tools/merge_listing_times webgpu -- tools/websocket-logger/wslog-2023-09-12T18-57-34.txt
 ```
 
 where the text file is the result file from websocket-logger.

--- a/src/common/tools/merge_listing_times.ts
+++ b/src/common/tools/merge_listing_times.ts
@@ -50,7 +50,7 @@ How to generate TIMING_LOG_FILES files:
 }
 
 const kHeader = `{
-  "_comment": "SEMI AUTO-GENERATED: Please read tools/merge_listing_times.",
+  "_comment": "SEMI AUTO-GENERATED: Please read docs/adding_timing_metadata.md.",
 `;
 const kFooter = `\
   "_end": ""

--- a/src/webgpu/listing_meta.json
+++ b/src/webgpu/listing_meta.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "SEMI AUTO-GENERATED: Please read tools/merge_listing_times.",
+  "_comment": "SEMI AUTO-GENERATED: Please read docs/adding_timing_metadata.md.",
   "webgpu:api,operation,adapter,requestAdapter:requestAdapter:*": { "subcaseMS": 152.083 },
   "webgpu:api,operation,adapter,requestAdapter:requestAdapter_no_parameters:*": { "subcaseMS": 384.601 },
   "webgpu:api,operation,adapter,requestAdapterInfo:adapter_info:*": { "subcaseMS": 136.601 },

--- a/tools/merge_listing_times
+++ b/tools/merge_listing_times
@@ -1,38 +1,9 @@
 #!/usr/bin/env node
 
+// See `docs/adding_timing_metadata.md` for an explanation of listing times, and
+// a walkthrough on adding entries for new tests.
+
 require('../src/common/tools/setup-ts-in-node.js');
 
-// See help message in this file for info on how to use the tool.
+// See the help message in this file for info on how to use the tool.
 require('../src/common/tools/merge_listing_times.ts');
-
-// See docs/adding_timing_metadata.md for a basic walkthrough on adding entries
-// for new tests
-//
-// ## listing_meta.json File Maintenance ##
-//
-// listing_meta.json files are SEMI AUTO-GENERATED.
-//
-// The raw data may be edited manually, to add entries or change timing values.
-// This is a complete listing of tests in the CTS, which can be used for other
-// scripting purposes too. Presubmit checks will fail when it gets out of sync.
-//
-// The subcaseMS values are estimates. They can be set to 0 if for some reason
-// you can't estimate the time (or there's an existing test with a long name and
-// slow subcases that would result in query strings that are too long).
-//
-// If you're developing new tests and need to update this file, it may be
-// easiest to do so manually. Run your tests in your development environment and
-// see how long they take. Record the average time per *subcase* into the
-// listing_meta.json file.
-//
-// Timing data can also be captured in bulk and "merged" into this file using
-// the 'merge_listing_times' tool. This is useful when a large number of tests
-// change or otherwise a lot of tests need to be updated. It can also be used
-// without any inputs to reformat the listing_meta.json file. Please read the
-// documentation of the tool (see above) for more information.
-//
-// Finally, note this data is typically captured by developers using higher-end
-// computers, so typical test machines might execute more slowly. For this
-// reason, the WPT chunking should be configured to generate chunks much shorter
-// than 5 seconds (a typical default time limit in WPT test executors) so they
-// should still execute in under 5 seconds on lower-end computers.


### PR DESCRIPTION
docs/ is a better place for this documentation. I was doing this kind of in a rush and forgot we had a better place for it.

Followup to https://github.com/gpuweb/cts/pull/2942 and https://github.com/gpuweb/cts/pull/2936#issuecomment-1756601807.

<hr>

**Requirements for PR author:**

- [x] ~All missing test coverage is tracked with "TODO" or `.unimplemented()`.~
- [x] ~New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.~
- [x] ~Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)~

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] ~Tests are properly located in the test tree.~
- [x] ~[Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.~
- [x] ~Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**~
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
