### PR TITLE
Require depthWriteEnabled and depthCompare only for formats with depth

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@types/pngjs": "^6.0.1",
         "@types/serve-index": "^1.9.1",
         "@typescript-eslint/parser": "^4.33.0",
-        "@webgpu/types": "^0.1.37",
+        "@webgpu/types": "^0.1.38",
         "ansi-colors": "4.1.1",
         "babel-plugin-add-header-comment": "^1.0.3",
         "babel-plugin-const-enum": "^1.2.0",
@@ -1262,9 +1262,9 @@
       }
     },
     "node_modules/@webgpu/types": {
-      "version": "0.1.37",
-      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.37.tgz",
-      "integrity": "sha512-hfndFDYk5AlZUE/qZ1kSuZHLobxzsbn7/jdJEJfmn4kg3rTM0+A+5TC/+z7lg3L74tSNEtZUVk7ojXw31wzeFw==",
+      "version": "0.1.38",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.38.tgz",
+      "integrity": "sha512-7LrhVKz2PRh+DD7+S+PVaFd5HxaWQvoMqBbsV9fNJO1pjUs1P8bM2vQVNfk+3URTqbuTI7gkXi0rfsN0IadoBA==",
       "dev": true
     },
     "node_modules/abbrev": {
@@ -9883,9 +9883,9 @@
       }
     },
     "@webgpu/types": {
-      "version": "0.1.37",
-      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.37.tgz",
-      "integrity": "sha512-hfndFDYk5AlZUE/qZ1kSuZHLobxzsbn7/jdJEJfmn4kg3rTM0+A+5TC/+z7lg3L74tSNEtZUVk7ojXw31wzeFw==",
+      "version": "0.1.38",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.38.tgz",
+      "integrity": "sha512-7LrhVKz2PRh+DD7+S+PVaFd5HxaWQvoMqBbsV9fNJO1pjUs1P8bM2vQVNfk+3URTqbuTI7gkXi0rfsN0IadoBA==",
       "dev": true
     },
     "abbrev": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@types/pngjs": "^6.0.1",
     "@types/serve-index": "^1.9.1",
     "@typescript-eslint/parser": "^4.33.0",
-    "@webgpu/types": "^0.1.37",
+    "@webgpu/types": "^0.1.38",
     "ansi-colors": "4.1.1",
     "babel-plugin-add-header-comment": "^1.0.3",
     "babel-plugin-const-enum": "^1.2.0",

--- a/src/webgpu/api/validation/render_pipeline/depth_stencil_state.spec.ts
+++ b/src/webgpu/api/validation/render_pipeline/depth_stencil_state.spec.ts
@@ -32,6 +32,45 @@ g.test('format')
     t.doCreateRenderPipelineTest(isAsync, !!info.depth || !!info.stencil, descriptor);
   });
 
+g.test('depthCompare')
+  .desc(`The depthCompare in depthStencilState is optional for stencil-only formats.`)
+  .params(u => u.combine('isAsync', [false, true]).combine('format', kTextureFormats))
+  .beforeAllSubcases(t => {
+    const { format } = t.params;
+    const info = kTextureFormatInfo[format];
+    t.skipIfTextureFormatNotSupported(format);
+    t.selectDeviceOrSkipTestCase(info.feature);
+  })
+  .fn(t => {
+    const { isAsync, format } = t.params;
+    const info = kTextureFormatInfo[format];
+    const depthWriteEnabled = !!info.depth;
+    const descriptor = t.getDescriptor({
+      depthStencil: { format, depthWriteEnabled },
+    });
+
+    t.doCreateRenderPipelineTest(isAsync, !info.depth && !!info.stencil, descriptor);
+  });
+
+g.test('depthWriteEnabled')
+  .desc(`The depthWriteEnabled in depthStencilState is optional for stencil-only formats.`)
+  .params(u => u.combine('isAsync', [false, true]).combine('format', kTextureFormats))
+  .beforeAllSubcases(t => {
+    const { format } = t.params;
+    const info = kTextureFormatInfo[format];
+    t.skipIfTextureFormatNotSupported(format);
+    t.selectDeviceOrSkipTestCase(info.feature);
+  })
+  .fn(t => {
+    const { isAsync, format } = t.params;
+    const info = kTextureFormatInfo[format];
+    const descriptor = t.getDescriptor({
+      depthStencil: { format, depthCompare: 'always' },
+    });
+
+    t.doCreateRenderPipelineTest(isAsync, !info.depth && !!info.stencil, descriptor);
+  });
+
 g.test('depth_test')
   .desc(
     `Depth aspect must be contained in the format if depth test is enabled in depthStencilState.`

--- a/src/webgpu/api/validation/render_pipeline/depth_stencil_state.spec.ts
+++ b/src/webgpu/api/validation/render_pipeline/depth_stencil_state.spec.ts
@@ -40,7 +40,7 @@ g.test('depthCompare_optional')
     u
       .combine('isAsync', [false, true])
       .combine('format', kDepthStencilFormats)
-      .combine('depthCompare', ['always' as GPUCompareFunction, undefined])
+      .combine('depthCompare', ['always', undefined] as const)
   )
   .beforeAllSubcases(t => {
     const { format } = t.params;
@@ -73,7 +73,7 @@ g.test('depthWriteEnabled_optional')
     const { isAsync, format } = t.params;
     const info = kTextureFormatInfo[format];
     const descriptor = t.getDescriptor({
-      depthStencil: { format, depthCompare: 'always' },
+      depthStencil: { format, depthCompare: 'always', depthWriteEnabled: undefined },
     });
 
     t.doCreateRenderPipelineTest(isAsync, !info.depth, descriptor);

--- a/src/webgpu/api/validation/render_pipeline/depth_stencil_state.spec.ts
+++ b/src/webgpu/api/validation/render_pipeline/depth_stencil_state.spec.ts
@@ -40,6 +40,7 @@ g.test('depthCompare_optional')
     u
       .combine('isAsync', [false, true])
       .combine('format', kDepthStencilFormats)
+      .beginSubcases()
       .combine('depthCompare', ['always', undefined] as const)
   )
   .beforeAllSubcases(t => {

--- a/src/webgpu/api/validation/render_pipeline/depth_stencil_state.spec.ts
+++ b/src/webgpu/api/validation/render_pipeline/depth_stencil_state.spec.ts
@@ -32,9 +32,16 @@ g.test('format')
     t.doCreateRenderPipelineTest(isAsync, !!info.depth || !!info.stencil, descriptor);
   });
 
-g.test('depthCompare')
-  .desc(`The depthCompare in depthStencilState is optional for stencil-only formats.`)
-  .params(u => u.combine('isAsync', [false, true]).combine('format', kTextureFormats))
+g.test('depthCompare_optional')
+  .desc(
+    `The depthCompare in depthStencilState is optional for stencil-only formats but required for formats with a depth.`
+  )
+  .params(u =>
+    u
+      .combine('isAsync', [false, true])
+      .combine('format', kDepthStencilFormats)
+      .combine('depthCompare', ['always' as GPUCompareFunction, undefined])
+  )
   .beforeAllSubcases(t => {
     const { format } = t.params;
     const info = kTextureFormatInfo[format];
@@ -42,19 +49,20 @@ g.test('depthCompare')
     t.selectDeviceOrSkipTestCase(info.feature);
   })
   .fn(t => {
-    const { isAsync, format } = t.params;
+    const { isAsync, format, depthCompare } = t.params;
     const info = kTextureFormatInfo[format];
-    const depthWriteEnabled = !!info.depth;
     const descriptor = t.getDescriptor({
-      depthStencil: { format, depthWriteEnabled },
+      depthStencil: { format, depthCompare, depthWriteEnabled: false },
     });
 
-    t.doCreateRenderPipelineTest(isAsync, !info.depth && !!info.stencil, descriptor);
+    t.doCreateRenderPipelineTest(isAsync, !(info.depth && depthCompare === undefined), descriptor);
   });
 
-g.test('depthWriteEnabled')
-  .desc(`The depthWriteEnabled in depthStencilState is optional for stencil-only formats.`)
-  .params(u => u.combine('isAsync', [false, true]).combine('format', kTextureFormats))
+g.test('depthWriteEnabled_optional')
+  .desc(
+    `The depthWriteEnabled in depthStencilState is optional for stencil-only formats but required for formats with a depth.`
+  )
+  .params(u => u.combine('isAsync', [false, true]).combine('format', kDepthStencilFormats))
   .beforeAllSubcases(t => {
     const { format } = t.params;
     const info = kTextureFormatInfo[format];
@@ -68,7 +76,7 @@ g.test('depthWriteEnabled')
       depthStencil: { format, depthCompare: 'always' },
     });
 
-    t.doCreateRenderPipelineTest(isAsync, !info.depth && !!info.stencil, descriptor);
+    t.doCreateRenderPipelineTest(isAsync, !info.depth, descriptor);
   });
 
 g.test('depth_test')

--- a/src/webgpu/listing_meta.json
+++ b/src/webgpu/listing_meta.json
@@ -676,6 +676,8 @@
   "webgpu:api,validation,render_pass,render_pass_descriptor:timestampWrite,query_index:*": { "subcaseMS": 0.200 },
   "webgpu:api,validation,render_pass,render_pass_descriptor:timestampWrites,query_set_type:*": { "subcaseMS": 0.501 },
   "webgpu:api,validation,render_pass,resolve:resolve_attachment:*": { "subcaseMS": 6.205 },
+  "webgpu:api,validation,render_pipeline,depth_stencil_state:depthCompare_optional:*": { "subcaseMS": 21.401 },
+  "webgpu:api,validation,render_pipeline,depth_stencil_state:depthWriteEnabled_optional:*": { "subcaseMS": 16.950 },
   "webgpu:api,validation,render_pipeline,depth_stencil_state:depth_test:*": { "subcaseMS": 3.407 },
   "webgpu:api,validation,render_pipeline,depth_stencil_state:depth_write,frag_depth:*": { "subcaseMS": 6.465 },
   "webgpu:api,validation,render_pipeline,depth_stencil_state:depth_write:*": { "subcaseMS": 4.113 },


### PR DESCRIPTION
This PR adds tests that check that depthWriteEnabled and depthCompare are required only for formats with depth following https://github.com/gpuweb/gpuweb/pull/4318.

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.) They pass in my Chromium build patched with https://chromium-review.googlesource.com/c/chromium/src/+/4931470 and https://dawn-review.googlesource.com/c/dawn/+/155720

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.

FYI @Kangz 