### PR TITLE
wgsl: show output values in flow_control exec tests error messages

### DIFF
--- a/src/webgpu/shader/execution/flow_control/harness.ts
+++ b/src/webgpu/shader/execution/flow_control/harness.ts
@@ -217,6 +217,13 @@ ${main_wgsl.extra}
         // returns an Error with the given message and WGSL source
         const fail = (err: string) => Error(`${err}\nWGSL:\n${Colors.dim(Colors.blue(wgsl))}`);
 
+        // returns a string that shows the outputted values to help understand the whole trace.
+        const print_output_value = () => {
+          return `Output values (length: ${outputCount}): ${outputs.data
+            .slice(1, outputCount + 1)
+            .join(', ')}`;
+        };
+
         // returns a colorized string of the expect_order() call, highlighting
         // the event number that caused an error.
         const expect_order_err = (expectation: ExpectedEvents, err_idx: number) => {
@@ -243,27 +250,35 @@ ${main_wgsl.extra}
           const expectationIndex = outputs.data[1 + event]; // 0 is count
           if (expectationIndex >= expectations.length) {
             return fail(
-              `outputs.data[${event}] value (${expectationIndex}) exceeds number of expectations (${expectations.length})`
+              `outputs.data[${event}] value (${expectationIndex}) exceeds number of expectations (${
+                expectations.length
+              })\n${print_output_value()}`
             );
           }
           const expectation = expectations[expectationIndex];
           switch (expectation.kind) {
             case 'not-reached':
-              return fail(`expect_not_reached() reached at event ${event}\n${expectation.stack}`);
+              return fail(
+                `expect_not_reached() reached at event ${event}\n${print_output_value()}\n${
+                  expectation.stack
+                }`
+              );
             case 'events':
               if (expectation.counter >= expectation.values.length) {
                 return fail(
                   `${expect_order_err(
                     expectation,
                     expectation.counter
-                  )}) unexpectedly reached at event ${Colors.red(`${event}`)}\n${expectation.stack}`
+                  )}) unexpectedly reached at event ${Colors.red(
+                    `${event}`
+                  )}\n${print_output_value()}\n${expectation.stack}`
                 );
               }
               if (event !== expectation.values[expectation.counter]) {
                 return fail(
                   `${expect_order_err(expectation, expectation.counter)} expected event ${
                     expectation.values[expectation.counter]
-                  }, got ${event}\n${expectation.stack}`
+                  }, got ${event}\n${print_output_value()}\n${expectation.stack}`
                 );
               }
 
@@ -278,7 +293,7 @@ ${main_wgsl.extra}
             return fail(
               `${expect_order_err(expectation, expectation.counter)} event ${
                 expectation.values[expectation.counter]
-              } was not reached\n${expectation.stack}`
+              } was not reached\n${expectation.stack}\n${print_output_value()}`
             );
           }
         }


### PR DESCRIPTION
This PR make error messages in WGSL flow_control execution tests contains full output values, in order to help seeing the whole execution trace.

Issue: #2312

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
