### PR TITLE
wgsl: make expectation id strats from 1 in flow_control exec tests

### DIFF
--- a/src/webgpu/shader/execution/flow_control/harness.ts
+++ b/src/webgpu/shader/execution/flow_control/harness.ts
@@ -119,14 +119,16 @@ export function runFlowControlTest(
         values: expected,
         counter: 0,
       });
-      return `push_output(${expectations.length - 1});`;
+      // Expectation id starts from 1 to distinguish from initialization 0.
+      return `push_output(${expectations.length}); // expect_order(${expected.join(', ')})`;
     },
     expect_not_reached: () => {
       expectations.push({
         kind: 'not-reached',
         stack: Error().stack,
       });
-      return `push_output(${expectations.length - 1});`;
+      // Expectation id starts from 1 to distinguish from initialization 0.
+      return `push_output(${expectations.length}); // expect_not_reached()`;
     },
   });
 
@@ -247,7 +249,14 @@ ${main_wgsl.extra}
         // Each of the outputted values represents an event
         // Check that each event is as expected
         for (let event = 0; event < outputCount; event++) {
-          const expectationIndex = outputs.data[1 + event]; // 0 is count
+          const eventValue = outputs.data[1 + event]; // outputs.data[0] is count
+          // Expectation id starts from 1, and 0 is invalid value.
+          if (eventValue === 0) {
+            return fail(
+              `outputs.data[${event}] is initial value 0, doesn't refer to any valid expectations)\n${print_output_value()}`
+            );
+          }
+          const expectationIndex = eventValue - 1;
           if (expectationIndex >= expectations.length) {
             return fail(
               `outputs.data[${event}] value (${expectationIndex}) exceeds number of expectations (${


### PR DESCRIPTION
This PR make expectation id starts from 1 instead of 0 to be distinguishable from initialized 0 value in output buffer. And also improve the generated WGSL shaders' readability by adding expectation details in comments next to push_output.

Issue: #2312

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
