### PR TITLE
depthCompare is not required for depth attachments if not used

### DIFF
--- a/src/webgpu/api/validation/render_pipeline/depth_stencil_state.spec.ts
+++ b/src/webgpu/api/validation/render_pipeline/depth_stencil_state.spec.ts
@@ -73,21 +73,20 @@ g.test('depthCompare_optional')
       },
     });
 
-    const areDepthFailOpKeep =
+    const depthFailOpsAreKeep =
       stencilFrontDepthFailOp === 'keep' && stencilBackDepthFailOp === 'keep';
-
-    let success = false;
-    if (!info.depth) {
-      // depthCompare is optional for stencil-only formats.
-      if (!depthWriteEnabled) success = true;
-    } else {
-      // depthCompare is optional for formats with a depth if it's not used for anything.
-      if (depthWriteEnabled === false && areDepthFailOpKeep) success = true;
-      if (depthCompare) {
-        // validation will succeed normally for formats with depth aspect.
-        if (depthWriteEnabled && areDepthFailOpKeep) success = true;
-        // validation will succeed as well for formats with stencil and depth aspect.
-        if (info.stencil && depthWriteEnabled !== undefined) success = true;
+    const stencilStateIsDefault = depthFailOpsAreKeep;
+    let success = true;
+    if (depthWriteEnabled || (depthCompare && depthCompare !== 'always')) {
+      if (!info.depth) success = false;
+    }
+    if (!stencilStateIsDefault) {
+      if (!info.stencil) success = false;
+    }
+    if (info.depth) {
+      if (depthWriteEnabled === undefined) success = false;
+      if (depthWriteEnabled || !depthFailOpsAreKeep) {
+        if (depthCompare === undefined) success = false;
       }
     }
 

--- a/src/webgpu/api/validation/render_pipeline/depth_stencil_state.spec.ts
+++ b/src/webgpu/api/validation/render_pipeline/depth_stencil_state.spec.ts
@@ -75,15 +75,21 @@ g.test('depthCompare_optional')
 
     const areDepthFailOpKeep =
       stencilFrontDepthFailOp === 'keep' && stencilBackDepthFailOp === 'keep';
-    const success =
+
+    let success = false;
+    if (!info.depth) {
       // depthCompare is optional for stencil-only formats.
-      (!info.depth && depthWriteEnabled !== true) ||
-      // depthCompare is optional for formats with a depth if it is not used for anything.
-      (!!info.depth &&
-        ((depthWriteEnabled === false && areDepthFailOpKeep) ||
-          (!!depthCompare &&
-            ((!!info.stencil && depthWriteEnabled !== undefined) ||
-              (!!depthWriteEnabled && areDepthFailOpKeep)))));
+      if (!depthWriteEnabled) success = true;
+    } else {
+      // depthCompare is optional for formats with a depth if it's not used for anything.
+      if (depthWriteEnabled === false && areDepthFailOpKeep) success = true;
+      if (depthCompare) {
+        // validation will succeed normally for formats with depth aspect.
+        if (depthWriteEnabled && areDepthFailOpKeep) success = true;
+        // validation will succeed as well for formats with stencil and depth aspect.
+        if (info.stencil && depthWriteEnabled !== undefined) success = true;
+      }
+    }
 
     t.doCreateRenderPipelineTest(isAsync, success, descriptor);
   });


### PR DESCRIPTION
Following https://github.com/gpuweb/cts/pull/3066, this PR adds tests that check that depthCompare is not required for formats with depth if it's not used. See https://github.com/gpuweb/gpuweb/pull/4336/

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.) They pass in my Chromium build patched with https://dawn-review.googlesource.com/c/dawn/+/155703

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.

@Kangz Please have a look
