### PR TITLE
wgsl: Use sparse version of kMinus3PiTo3Pi for atan2 validation tests

### DIFF
--- a/src/webgpu/shader/validation/expression/call/builtin/atan2.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/atan2.spec.ts
@@ -20,7 +20,7 @@ import { ShaderValidationTest } from '../../../shader_validation_test.js';
 import {
   fullRangeForType,
   kConstantAndOverrideStages,
-  kMinus3PiTo3Pi,
+  kSparseMinus3PiTo3Pi,
   stageSupportsType,
   unique,
   validateConstOrOverrideBuiltinEval,
@@ -42,8 +42,8 @@ Validates that constant evaluation and override evaluation of ${builtin}() rejec
       .combine('type', keysOf(kValuesTypes))
       .filter(u => stageSupportsType(u.stage, kValuesTypes[u.type]))
       .beginSubcases()
-      .expand('y', u => unique(kMinus3PiTo3Pi, fullRangeForType(kValuesTypes[u.type], 4)))
-      .expand('x', u => unique(kMinus3PiTo3Pi, fullRangeForType(kValuesTypes[u.type], 4)))
+      .expand('y', u => unique(kSparseMinus3PiTo3Pi, fullRangeForType(kValuesTypes[u.type], 4)))
+      .expand('x', u => unique(kSparseMinus3PiTo3Pi, fullRangeForType(kValuesTypes[u.type], 4)))
   )
   .beforeAllSubcases(t => {
     if (elementType(kValuesTypes[t.params.type]) === TypeF16) {

--- a/src/webgpu/shader/validation/expression/call/builtin/const_override_validation.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/const_override_validation.ts
@@ -67,6 +67,25 @@ export const kMinus3PiTo3Pi = [
   3 * Math.PI,
 ] as const;
 
+/// A minimal array of values ranging from -3π to 3π, with a focus on multiples
+/// of π. Used when multiple parameters are being passed in, so the number of
+/// cases becomes the square or more of this list.
+export const kSparseMinus3PiTo3Pi = [
+  -3 * Math.PI,
+  -2.5 * Math.PI,
+  -2.0 * Math.PI,
+  -1.5 * Math.PI,
+  -1.0 * Math.PI,
+  -0.5 * Math.PI,
+  0,
+  0.5 * Math.PI,
+  Math.PI,
+  1.5 * Math.PI,
+  2.0 * Math.PI,
+  2.5 * Math.PI,
+  3 * Math.PI,
+] as const;
+
 /// The evaluation stages to test
 export const kConstantAndOverrideStages = ['constant', 'override'] as const;
 


### PR DESCRIPTION
Reduces run time for these tests to ~1/3 of original

Fixes #3071

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
