### PR TITLE
wgsl: Add AF `select` execution tests

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/select.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/select.spec.ts
@@ -30,10 +30,12 @@ import {
   vec2,
   vec3,
   vec4,
+  abstractFloat,
+  TypeAbstractFloat,
 } from '../../../../../util/conversion.js';
 import { run, CaseList, allInputSources } from '../../expression.js';
 
-import { builtin } from './builtin.js';
+import { abstractBuiltin, builtin } from './builtin.js';
 
 export const g = makeTestGroup(GPUTest);
 
@@ -41,12 +43,16 @@ function makeBool(n: number) {
   return bool((n & 1) === 1);
 }
 
-type scalarKind = 'b' | 'f' | 'h' | 'i' | 'u';
+type scalarKind = 'b' | 'af' | 'f' | 'h' | 'i' | 'u';
 
 const dataType = {
   b: {
     type: TypeBool,
     constructor: makeBool,
+  },
+  af: {
+    type: TypeAbstractFloat,
+    constructor: abstractFloat,
   },
   f: {
     type: TypeF32,
@@ -72,13 +78,14 @@ g.test('scalar')
   .params(u =>
     u
       .combine('inputSource', allInputSources)
-      .combine('component', ['b', 'f', 'h', 'i', 'u'] as const)
+      .combine('component', ['b', 'af', 'f', 'h', 'i', 'u'] as const)
       .combine('overload', ['scalar', 'vec2', 'vec3', 'vec4'] as const)
   )
   .beforeAllSubcases(t => {
     if (t.params.component === 'h') {
       t.selectDeviceOrSkipTestCase({ requiredFeatures: ['shader-f16'] });
     }
+    t.skipIf(t.params.component === 'af' && t.params.inputSource !== 'const');
   })
   .fn(async t => {
     const componentType = dataType[t.params.component as scalarKind].type;
@@ -133,7 +140,7 @@ g.test('scalar')
 
     await run(
       t,
-      builtin('select'),
+      t.params.component === 'af' ? abstractBuiltin('select') : builtin('select'),
       [overload.type, overload.type, TypeBool],
       overload.type,
       t.params,
@@ -147,13 +154,14 @@ g.test('vector')
   .params(u =>
     u
       .combine('inputSource', allInputSources)
-      .combine('component', ['b', 'f', 'h', 'i', 'u'] as const)
+      .combine('component', ['b', 'af', 'f', 'h', 'i', 'u'] as const)
       .combine('overload', ['vec2', 'vec3', 'vec4'] as const)
   )
   .beforeAllSubcases(t => {
     if (t.params.component === 'h') {
       t.selectDeviceOrSkipTestCase({ requiredFeatures: ['shader-f16'] });
     }
+    t.skipIf(t.params.component === 'af' && t.params.inputSource !== 'const');
   })
   .fn(async t => {
     const componentType = dataType[t.params.component as scalarKind].type;
@@ -236,7 +244,7 @@ g.test('vector')
 
     await run(
       t,
-      builtin('select'),
+      t.params.component === 'af' ? abstractBuiltin('select') : builtin('select'),
       [tests.dataType, tests.dataType, tests.boolType],
       tests.dataType,
       t.params,


### PR DESCRIPTION
Fixes #3076

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
