### PR TITLE
wgsl: Add AbstractFloat `sign` execution tests

### DIFF
--- a/src/unittests/floating_point.spec.ts
+++ b/src/unittests/floating_point.spec.ts
@@ -3647,7 +3647,7 @@ g.test('saturateInterval')
 g.test('signInterval')
   .params(u =>
     u
-      .combine('trait', ['f32', 'f16'] as const)
+      .combine('trait', ['f32', 'f16', 'abstract'] as const)
       .beginSubcases()
       .expandWithParams<ScalarToIntervalCase>(p => {
         const constants = FP[p.trait].constants();

--- a/src/webgpu/listing_meta.json
+++ b/src/webgpu/listing_meta.json
@@ -1356,7 +1356,7 @@
   "webgpu:shader,execution,expression,call,builtin,saturate:f32:*": { "subcaseMS": 116.275 },
   "webgpu:shader,execution,expression,call,builtin,select:scalar:*": { "subcaseMS": 6.882 },
   "webgpu:shader,execution,expression,call,builtin,select:vector:*": { "subcaseMS": 7.096 },
-  "webgpu:shader,execution,expression,call,builtin,sign:abstract_float:*": { "subcaseMS": 31.708 },
+  "webgpu:shader,execution,expression,call,builtin,sign:abstract_float:*": { "subcaseMS": 412.925 },
   "webgpu:shader,execution,expression,call,builtin,sign:abstract_int:*": { "subcaseMS": 25.806 },
   "webgpu:shader,execution,expression,call,builtin,sign:f16:*": { "subcaseMS": 25.103 },
   "webgpu:shader,execution,expression,call,builtin,sign:f32:*": { "subcaseMS": 8.188 },

--- a/src/webgpu/util/floating_point.ts
+++ b/src/webgpu/util/floating_point.ts
@@ -5070,7 +5070,7 @@ class FPAbstractTraits extends FPTraits {
   };
   public readonly roundInterval = this.unimplementedScalarToInterval.bind(this, 'roundInterval');
   public readonly saturateInterval = this.saturateIntervalImpl.bind(this);
-  public readonly signInterval = this.unimplementedScalarToInterval.bind(this, 'signInterval');
+  public readonly signInterval = this.signIntervalImpl.bind(this);
   public readonly sinInterval = this.unimplementedScalarToInterval.bind(this, 'sinInterval');
   public readonly sinhInterval = this.unimplementedScalarToInterval.bind(this, 'sinhInterval');
   public readonly smoothStepInterval = this.unimplementedScalarTripleToInterval.bind(


### PR DESCRIPTION
Fixes #2582

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
