### PR TITLE
Fix a bad slice operation in image_copy stencil tests

### DIFF
--- a/src/webgpu/api/operation/command_buffer/image_copy.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/image_copy.spec.ts
@@ -1088,16 +1088,19 @@ class ImageCopyTest extends TextureTestMixin(GPUTest) {
 
       // Check the valid data in outputStagingBuffer once per row.
       for (let y = 0; y < copyFromOutputTextureLayout.mipSize[1]; ++y) {
+        const rowOffset = expectedStencilTextureDataBytesPerRow * y;
+        const dataStart = expectedStencilTextureDataOffset +
+                          expectedStencilTextureDataBytesPerRow *
+                            expectedStencilTextureDataRowsPerImage *
+                            stencilTextureLayer +
+                          rowOffset;
         this.expectGPUBufferValuesEqual(
           outputStagingBuffer,
           expectedStencilTextureData.slice(
-            expectedStencilTextureDataOffset +
-              expectedStencilTextureDataBytesPerRow *
-                expectedStencilTextureDataRowsPerImage *
-                stencilTextureLayer +
-              expectedStencilTextureDataBytesPerRow * y,
-            copyFromOutputTextureLayout.mipSize[0]
-          )
+            dataStart,
+            dataStart + copyFromOutputTextureLayout.mipSize[0]
+          ),
+          rowOffset
         );
       }
     }

--- a/src/webgpu/api/operation/command_buffer/image_copy.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/image_copy.spec.ts
@@ -1089,11 +1089,12 @@ class ImageCopyTest extends TextureTestMixin(GPUTest) {
       // Check the valid data in outputStagingBuffer once per row.
       for (let y = 0; y < copyFromOutputTextureLayout.mipSize[1]; ++y) {
         const rowOffset = expectedStencilTextureDataBytesPerRow * y;
-        const dataStart = expectedStencilTextureDataOffset +
-                          expectedStencilTextureDataBytesPerRow *
-                            expectedStencilTextureDataRowsPerImage *
-                            stencilTextureLayer +
-                          rowOffset;
+        const dataStart =
+          expectedStencilTextureDataOffset +
+          expectedStencilTextureDataBytesPerRow *
+            expectedStencilTextureDataRowsPerImage *
+            stencilTextureLayer +
+          rowOffset;
         this.expectGPUBufferValuesEqual(
           outputStagingBuffer,
           expectedStencilTextureData.slice(


### PR DESCRIPTION
Found that in the `checkStencilTextureContent()` method of the `image_copy` tests an `ArrayBuffer.slice()` is being used that was passing arguments as if they were `(offset, length)`, when in fact they must be `(start, end)`. This was causing any tests with a buffer offset other than 0 to pass even where there was an error because the arrays that were being compared were zero length.

After correcting this issue I also found that a separate buffer offset needed to be passed to the `expectGPUBufferValuesEqual()` method to account for the offset of the row being tested. This was preventing anything other than the first row from being compared properly, though that didn't cause an error due to the aforementioned `slice()` issue.

Once these two fixes are in place the test can now properly check all subcases. Confirmed passing on Chrome.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
