### PR TITLE
Fix a minor issue introduced in previous stencil test fix

### DIFF
--- a/src/webgpu/api/operation/command_buffer/image_copy.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/image_copy.spec.ts
@@ -1088,20 +1088,19 @@ class ImageCopyTest extends TextureTestMixin(GPUTest) {
 
       // Check the valid data in outputStagingBuffer once per row.
       for (let y = 0; y < copyFromOutputTextureLayout.mipSize[1]; ++y) {
-        const rowOffset = expectedStencilTextureDataBytesPerRow * y;
         const dataStart =
           expectedStencilTextureDataOffset +
           expectedStencilTextureDataBytesPerRow *
             expectedStencilTextureDataRowsPerImage *
             stencilTextureLayer +
-          rowOffset;
+          expectedStencilTextureDataBytesPerRow * y;
         this.expectGPUBufferValuesEqual(
           outputStagingBuffer,
           expectedStencilTextureData.slice(
             dataStart,
             dataStart + copyFromOutputTextureLayout.mipSize[0]
           ),
-          rowOffset
+          copyFromOutputTextureLayout.bytesPerRow * y
         );
       }
     }


### PR DESCRIPTION
I flubbed one line in #3083, not realizing that the row stride needed to be computed differently for the source data and readback data. Previous code worked fine for the `offsets_and_sizes_copy_depth_stencil` tests, but failed for the `rowsPerImage_and_bytesPerRow_depth_stencil` tests. This fix allows both to work as expected.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
