### PR TITLE
wgsl: Filter `atan2` tests based on if const-eval or not

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/atan2.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atan2.spec.ts
@@ -9,7 +9,6 @@ Returns the arc tangent of e1 over e2. Component-wise when T is a vector.
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
-import { kValue } from '../../../../../util/constants.js';
 import { TypeF32, TypeF16 } from '../../../../../util/conversion.js';
 import { FP } from '../../../../../util/floating_point.js';
 import { linearRange, sparseF32Range, sparseF16Range } from '../../../../../util/math.js';
@@ -20,36 +19,29 @@ import { builtin } from './builtin.js';
 
 export const g = makeTestGroup(GPUTest);
 
-export const d = makeCaseCache('atan2', {
-  f32: () => {
-    // Using sparse range since there are N^2 cases being generated, and also including extra values
-    // around 0, where there is a discontinuity that implementations may behave badly at.
-    const numeric_range = [
-      ...sparseF32Range(),
-      ...linearRange(kValue.f32.negative.max, kValue.f32.positive.min, 10),
-    ];
-    return FP.f32.generateScalarPairToIntervalCases(
-      numeric_range,
-      numeric_range,
-      'unfiltered',
-      FP.f32.atan2Interval
-    );
-  },
-  f16: () => {
-    // Using sparse range since there are N^2 cases being generated, and also including extra values
-    // around 0, where there is a discontinuity that implementations may behave badly at.
-    const numeric_range = [
-      ...sparseF16Range(),
-      ...linearRange(kValue.f16.negative.max, kValue.f16.positive.min, 10),
-    ];
-    return FP.f16.generateScalarPairToIntervalCases(
-      numeric_range,
-      numeric_range,
-      'unfiltered',
-      FP.f16.atan2Interval
-    );
-  },
-});
+const cases = (['f32', 'f16'] as const)
+  .flatMap(kind =>
+    ([true, false] as const).map(nonConst => ({
+      [`${kind}_${nonConst ? 'non_const' : 'const'}`]: () => {
+        const fp = FP[kind];
+        // Using sparse range since there are N^2 cases being generated, and also including extra values
+        // around 0, where there is a discontinuity that implementations may behave badly at.
+        const numeric_range = [
+          ...(kind === 'f32' ? sparseF32Range() : sparseF16Range()),
+          ...linearRange(fp.constants().negative.max, fp.constants().positive.min, 10),
+        ];
+        return fp.generateScalarPairToIntervalCases(
+          numeric_range,
+          numeric_range,
+          nonConst ? 'unfiltered' : 'finite',
+          fp.atan2Interval
+        );
+      },
+    }))
+  )
+  .reduce((a, b) => ({ ...a, ...b }), {});
+
+export const d = makeCaseCache('atan2', cases);
 
 g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
@@ -72,7 +64,7 @@ TODO(#792): Decide what the ground-truth is for these tests. [1]
     u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
-    const cases = await d.get('f32');
+    const cases = await d.get(`f32_${t.params.inputSource === 'const' ? 'const' : 'non_const'}`);
     await run(t, builtin('atan2'), [TypeF32, TypeF32], TypeF32, t.params, cases);
   });
 
@@ -86,6 +78,6 @@ g.test('f16')
     t.selectDeviceOrSkipTestCase('shader-f16');
   })
   .fn(async t => {
-    const cases = await d.get('f16');
+    const cases = await d.get(`f16_${t.params.inputSource === 'const' ? 'const' : 'non_const'}`);
     await run(t, builtin('atan2'), [TypeF16, TypeF16], TypeF16, t.params, cases);
   });


### PR DESCRIPTION
Rewrites how test cases are generated for atan2, so that if running in const-eval unbounded results will not be generated, since those will cause compilation errors.

Fixes #3088

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
