### PR TITLE
wgsl: Revert changes to `round` execution tests

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/round.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/round.spec.ts
@@ -12,13 +12,13 @@ Component-wise when T is a vector.
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
-import { TypeF32, TypeF16, TypeAbstractFloat } from '../../../../../util/conversion.js';
+import { TypeF32, TypeF16 } from '../../../../../util/conversion.js';
 import { FP } from '../../../../../util/floating_point.js';
-import { fullF32Range, fullF16Range, fullF64Range } from '../../../../../util/math.js';
+import { fullF32Range, fullF16Range } from '../../../../../util/math.js';
 import { makeCaseCache } from '../../case_cache.js';
-import { allInputSources, onlyConstInputSource, run } from '../../expression.js';
+import { allInputSources, run } from '../../expression.js';
 
-import { abstractBuiltin, builtin } from './builtin.js';
+import { builtin } from './builtin.js';
 
 export const g = makeTestGroup(GPUTest);
 
@@ -43,30 +43,15 @@ export const d = makeCaseCache('round', {
       FP.f16.roundInterval
     );
   },
-  abstract: () => {
-    return FP.abstract.generateScalarToIntervalCases(
-      [
-        0x8000_0000_0000_0000, // https://github.com/gpuweb/cts/issues/2766
-        ...fullF64Range(),
-      ],
-      'unfiltered',
-      FP.abstract.roundInterval
-    );
-  },
 });
 
 g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
   .desc(`abstract float tests`)
   .params(u =>
-    u
-      .combine('inputSource', onlyConstInputSource)
-      .combine('vectorize', [undefined, 2, 3, 4] as const)
+    u.combine('inputSource', allInputSources).combine('vectorize', [undefined, 2, 3, 4] as const)
   )
-  .fn(async t => {
-    const cases = await d.get('abstract');
-    await run(t, abstractBuiltin('round'), [TypeAbstractFloat], TypeAbstractFloat, t.params, cases);
-  });
+  .unimplemented();
 
 g.test('f32')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')


### PR DESCRIPTION
These were landed on the wrong branch, and are causing tests to fail to build, because some of the code that they depend on is implemented in a PR that hasn't landed yet.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
