### PR TITLE
Add back generate-cache grunt command

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -38,6 +38,10 @@ module.exports = function (grunt) {
         cmd: 'node',
         args: ['tools/gen_wpt_cts_html', 'tools/gen_wpt_cfg_chunked2sec.json'],
       },
+      'generate-cache': {
+        cmd: 'node',
+        args: ['tools/gen_cache', 'out', 'src/webgpu'],
+      },
       unittest: {
         cmd: 'node',
         args: ['tools/run_node', 'unittests:*'],


### PR DESCRIPTION
This was accidentally removed in
https://github.com/gpuweb/cts/commit/30c129e2ed4a61149eeb697d8abd6cb155b3e70f

Issue: #2980 

