### PR TITLE
tsdoc: Remove @p with backticks

### DIFF
--- a/src/common/framework/data_cache.ts
+++ b/src/common/framework/data_cache.ts
@@ -23,7 +23,7 @@ class DataCacheNode {
     this.data = data;
   }
 
-  /** insertAfter() re-inserts this node in the doubly-linked list after @p prev */
+  /** insertAfter() re-inserts this node in the doubly-linked list after `prev` */
   public insertAfter(prev: DataCacheNode) {
     this.unlink();
     this.next = prev.next;
@@ -114,7 +114,7 @@ export class DataCache {
   }
 
   /**
-   * addToCache() creates a new node for @p path and @p data, inserting the new node at the front of
+   * addToCache() creates a new node for `path` and `data`, inserting the new node at the front of
    * the doubly-linked list. If the number of entries in the cache exceeds this.maxCount, then the
    * least recently used entry is evicted
    * @param path the file path for the data

--- a/src/common/util/data_tables.ts
+++ b/src/common/util/data_tables.ts
@@ -11,7 +11,7 @@ export function numericKeysOf<T>(obj: object): readonly T[] {
 }
 
 /**
- * @returns a new Record from @p objects, using the string returned by Object.toString() as the keys
+ * @returns a new Record from `objects`, using the string returned by Object.toString() as the keys
  * and the objects as the values.
  */
 export function objectsToRecord<T extends Object>(objects: readonly T[]): Record<string, T> {

--- a/src/webgpu/shader/execution/expression/expression.ts
+++ b/src/webgpu/shader/execution/expression/expression.ts
@@ -261,7 +261,7 @@ type PipelineCache = Map<String, GPUComputePipeline>;
 
 /**
  * Searches for an entry with the given key, adding and returning the result of calling
- * @p create if the entry was not found.
+ * `create` if the entry was not found.
  * @param map the cache map
  * @param key the entry's key
  * @param create the function used to construct a value, if not found in the cache
@@ -468,9 +468,9 @@ function submitBatch(
 }
 
 /**
- * map is a helper for returning a new array with each element of @p v
- * transformed with @p fn.
- * If @p v is not an array, then @p fn is called with (v, 0).
+ * map is a helper for returning a new array with each element of `v`
+ * transformed with `fn`.
+ * If `v` is not an array, then `fn` is called with (v, 0).
  */
 function map<T, U>(v: T | readonly T[], fn: (value: T, index?: number) => U): U[] {
   if (v instanceof Array) {
@@ -992,7 +992,7 @@ ${body}
 /**
  * Constructs and returns a GPUComputePipeline and GPUBindGroup for running a
  * batch of test cases. If a pre-created pipeline can be found in
- * @p pipelineCache, then this may be returned instead of creating a new
+ * `pipelineCache`, then this may be returned instead of creating a new
  * pipeline.
  * @param t the GPUTest
  * @param shaderBuilder the shader builder

--- a/src/webgpu/shader/execution/flow_control/harness.ts
+++ b/src/webgpu/shader/execution/flow_control/harness.ts
@@ -49,7 +49,7 @@ interface FlowControlTestBuilder {
 /**
  * Builds, runs then checks the output of a flow control shader test.
  *
- * @p build_wgsl is a function that's called to build the WGSL shader.
+ * `build_wgsl` is a function that's called to build the WGSL shader.
  * This function takes a FlowControlTestBuilder as the single argument, and
  * returns either a string which is embedded into the WGSL entrypoint function,
  * or an object of the signature `{ entrypoint: string; extra: string }` which

--- a/src/webgpu/shader/validation/decl/util.ts
+++ b/src/webgpu/shader/validation/decl/util.ts
@@ -14,7 +14,7 @@ export const kShaderStages = ['vertex', 'fragment', 'compute'] as const;
 
 /**
  * declareEntrypoint emits the WGSL to declare an entry point with the name, stage and body.
- * The generated function will have an appropriate return type and return statement, so that @p body
+ * The generated function will have an appropriate return type and return statement, so that `body`
  * does not have to change between stage.
  * @param arg - arg specifies the
  * optional entry point function name, the shader stage, and the body of the

--- a/src/webgpu/shader/validation/expression/call/builtin/const_override_validation.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/const_override_validation.ts
@@ -92,7 +92,7 @@ export const kConstantAndOverrideStages = ['constant', 'override'] as const;
 export type ConstantOrOverrideStage = 'constant' | 'override';
 
 /**
- * @returns true if evaluation stage @p stage supports expressions of type @p.
+ * @returns true if evaluation stage `stage` supports expressions of type @p.
  */
 export function stageSupportsType(stage: ConstantOrOverrideStage, type: Type) {
   if (stage === 'override' && isAbstractType(elementType(type)!)) {
@@ -103,7 +103,7 @@ export function stageSupportsType(stage: ConstantOrOverrideStage, type: Type) {
 }
 
 /**
- * Runs a validation test to check that evaluation of @p builtin either evaluates with or without
+ * Runs a validation test to check that evaluation of `builtin` either evaluates with or without
  * error at shader creation time or pipeline creation time.
  * @param t the ShaderValidationTest
  * @param builtin the name of the builtin
@@ -159,7 +159,7 @@ var<private> v = ${builtin}(${callArgs.join(', ')});`,
   }
 }
 
-/** @returns a sweep of the representable values for element type of @p type */
+/** @returns a sweep of the representable values for element type of `type` */
 export function fullRangeForType(type: Type, count?: number) {
   if (count === undefined) {
     count = 25;

--- a/src/webgpu/shader/validation/expression/call/builtin/length.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/length.spec.ts
@@ -30,7 +30,7 @@ export const g = makeTestGroup(ShaderValidationTest);
 
 /**
  * Evaluates the result and information about a call to length(), with a vector
- * formed from @p vec of the element type @p type.
+ * formed from `vec` of the element type `type`.
  */
 function calculate(
   vec: number[],

--- a/src/webgpu/shader/validation/shader_io/util.ts
+++ b/src/webgpu/shader/validation/shader_io/util.ts
@@ -167,7 +167,7 @@ export type ShaderStage = 'vertex' | 'fragment' | 'compute';
 
 /**
  * declareEntrypoint emits the WGSL to declare an entry point with the given name, stage and body.
- * The generated function will have an appropriate return type and return statement, so that @p body
+ * The generated function will have an appropriate return type and return statement, so that `body`
  * does not have to change between stage.
  * @param name the entry point function name
  * @param stage the entry point stage

--- a/src/webgpu/util/binary_stream.ts
+++ b/src/webgpu/util/binary_stream.ts
@@ -236,8 +236,8 @@ export default class BinaryStream {
   }
 
   /**
-   * writeCond() writes the boolean condition @p cond to the buffer, then either calls if_true if
-   * @p cond is true, otherwise if_false
+   * writeCond() writes the boolean condition `cond` to the buffer, then either calls if_true if
+   * `cond` is true, otherwise if_false
    */
   writeCond<T, F>(cond: boolean, fns: { if_true: () => T; if_false: () => F }) {
     this.writeBool(cond);
@@ -261,8 +261,8 @@ export default class BinaryStream {
   }
 
   /**
-   * bumpWord() increments this.offset by @p bytes, after first aligning this.offset to @p bytes.
-   * @returns the old offset aligned to the next multiple of @p bytes, divided by @p bytes.
+   * bumpWord() increments this.offset by `bytes`, after first aligning this.offset to `bytes`.
+   * @returns the old offset aligned to the next multiple of `bytes`, divided by `bytes`.
    */
   private bumpWord(bytes: number) {
     const multiple = Math.floor((this.offset + bytes - 1) / bytes);

--- a/src/webgpu/util/conversion.ts
+++ b/src/webgpu/util/conversion.ts
@@ -609,7 +609,7 @@ export class ScalarType {
     return this._size;
   }
 
-  /** Constructs a Scalar of this type with @p value */
+  /** Constructs a Scalar of this type with `value` */
   public create(value: number): Scalar {
     switch (this.kind) {
       case 'abstract-float':
@@ -891,7 +891,7 @@ export class Scalar {
   /**
    * Copies the scalar value to the buffer at the provided byte offset.
    * @param buffer the destination buffer
-   * @param offset the offset in buffer, in units of @p buffer
+   * @param offset the offset in buffer, in units of `buffer`
    */
   public copyTo(buffer: TypedArrayBufferView, offset: number) {
     assert(this.type.kind !== 'f64', `Copying f64 values to/from buffers is not defined`);
@@ -1527,7 +1527,7 @@ export function isFloatValue(v: Value): boolean {
 }
 
 /**
- * @returns if @p ty is an abstract numeric type.
+ * @returns if `ty` is an abstract numeric type.
  * @note this does not consider composite types.
  * Use elementType() if you want to test the element type.
  */
@@ -1539,7 +1539,7 @@ export function isAbstractType(ty: Type): boolean {
 }
 
 /**
- * @returns if @p ty is a floating point type.
+ * @returns if `ty` is a floating point type.
  * @note this does not consider composite types.
  * Use elementType() if you want to test the element type.
  */

--- a/src/webgpu/util/floating_point.ts
+++ b/src/webgpu/util/floating_point.ts
@@ -5426,7 +5426,7 @@ export const FP = {
   abstract: new FPAbstractTraits(),
 };
 
-/** @returns the floating-point traits for @p type */
+/** @returns the floating-point traits for `type` */
 export function fpTraitsFor(type: ScalarType): FPTraits {
   switch (type.kind) {
     case 'abstract-float':
@@ -5440,7 +5440,7 @@ export function fpTraitsFor(type: ScalarType): FPTraits {
   }
 }
 
-/** @returns true if the value @p value is representable with @p type */
+/** @returns true if the value `value` is representable with `type` */
 export function isRepresentable(value: number, type: ScalarType) {
   if (!Number.isFinite(value)) {
     return false;


### PR DESCRIPTION
Unlike doxygen, TSDoc doesn't support `@p` to link to a parameter. Use code backticks instead.
