### PR TITLE
More cache deserialization micro-optimisations

### DIFF
--- a/src/unittests/serialization.spec.ts
+++ b/src/unittests/serialization.spec.ts
@@ -207,7 +207,7 @@ g.test('value').fn(t => {
       f32
     ),
   ]) {
-    const s = new BinaryStream(new Uint8Array(1024));
+    const s = new BinaryStream(new Uint8Array(1024).buffer);
     serializeValue(s, value);
     const d = new BinaryStream(s.buffer());
     const deserialized = deserializeValue(d);
@@ -244,7 +244,7 @@ g.test('fpinterval_f32').fn(t => {
     FP.f32.toInterval([kValue.f32.negative.subnormal.min, kValue.f32.negative.subnormal.max]),
     FP.f32.toInterval([kValue.f32.negative.infinity, kValue.f32.positive.infinity]),
   ]) {
-    const s = new BinaryStream(new Uint8Array(1024));
+    const s = new BinaryStream(new Uint8Array(1024).buffer);
     serializeFPInterval(s, interval);
     const d = new BinaryStream(s.buffer());
     const deserialized = deserializeFPInterval(d);
@@ -280,7 +280,7 @@ g.test('fpinterval_f16').fn(t => {
     FP.f16.toInterval([kValue.f16.negative.subnormal.min, kValue.f16.negative.subnormal.max]),
     FP.f16.toInterval([kValue.f16.negative.infinity, kValue.f16.positive.infinity]),
   ]) {
-    const s = new BinaryStream(new Uint8Array(1024));
+    const s = new BinaryStream(new Uint8Array(1024).buffer);
     serializeFPInterval(s, interval);
     const d = new BinaryStream(s.buffer());
     const deserialized = deserializeFPInterval(d);
@@ -316,7 +316,7 @@ g.test('fpinterval_abstract').fn(t => {
     FP.abstract.toInterval([kValue.f64.negative.subnormal.min, kValue.f64.negative.subnormal.max]),
     FP.abstract.toInterval([kValue.f64.negative.infinity, kValue.f64.positive.infinity]),
   ]) {
-    const s = new BinaryStream(new Uint8Array(1024));
+    const s = new BinaryStream(new Uint8Array(1024).buffer);
     serializeFPInterval(s, interval);
     const d = new BinaryStream(s.buffer());
     const deserialized = deserializeFPInterval(d);
@@ -338,7 +338,7 @@ g.test('expression_expectation').fn(t => {
     // Intervals
     [FP.f32.toInterval([-8.0, 0.5]), FP.f32.toInterval([2.0, 4.0])],
   ]) {
-    const s = new BinaryStream(new Uint8Array(1024));
+    const s = new BinaryStream(new Uint8Array(1024).buffer);
     serializeExpectation(s, expectation);
     const d = new BinaryStream(s.buffer());
     const deserialized = deserializeExpectation(d);
@@ -368,7 +368,7 @@ g.test('anyOf').fn(t => {
         testCases: [f32(0), f32(10), f32(122), f32(123), f32(124), f32(200)],
       },
     ]) {
-      const s = new BinaryStream(new Uint8Array(1024));
+      const s = new BinaryStream(new Uint8Array(1024).buffer);
       serializeComparator(s, c.comparator);
       const d = new BinaryStream(s.buffer());
       const deserialized = deserializeComparator(d);
@@ -396,7 +396,7 @@ g.test('skipUndefined').fn(t => {
         testCases: [f32(0), f32(10), f32(122), f32(123), f32(124), f32(200)],
       },
     ]) {
-      const s = new BinaryStream(new Uint8Array(1024));
+      const s = new BinaryStream(new Uint8Array(1024).buffer);
       serializeComparator(s, c.comparator);
       const d = new BinaryStream(s.buffer());
       const deserialized = deserializeComparator(d);

--- a/src/webgpu/shader/execution/expression/case_cache.ts
+++ b/src/webgpu/shader/execution/expression/case_cache.ts
@@ -166,21 +166,21 @@ export class CaseCache implements Cacheable<Record<string, CaseList>> {
    */
   serialize(data: Record<string, CaseList>): Uint8Array {
     const maxSize = 32 << 20; // 32MB - max size for a file
-    const s = new BinaryStream(new Uint8Array(maxSize));
+    const s = new BinaryStream(new Uint8Array(maxSize).buffer);
     s.writeU32(Object.keys(data).length);
     for (const name in data) {
       s.writeString(name);
       s.writeArray(data[name], serializeCase);
     }
-    return s.buffer();
+    return new Uint8Array(s.buffer());
   }
 
   /**
    * deserialize() implements the Cacheable.deserialize interface.
    * @returns the deserialize data.
    */
-  deserialize(buffer: Uint8Array): Record<string, CaseList> {
-    const s = new BinaryStream(buffer);
+  deserialize(array: Uint8Array): Record<string, CaseList> {
+    const s = new BinaryStream(array.buffer);
     const casesByName: Record<string, CaseList> = {};
     const numRecords = s.readU32();
     for (let i = 0; i < numRecords; i++) {

--- a/src/webgpu/util/floating_point.ts
+++ b/src/webgpu/util/floating_point.ts
@@ -107,7 +107,8 @@ export class FPInterval {
   public constructor(kind: FPKind, ...bounds: IntervalBounds) {
     this.kind = kind;
 
-    const [begin, end] = bounds.length === 2 ? bounds : [bounds[0], bounds[0]];
+    const begin = bounds[0];
+    const end = bounds.length === 2 ? bounds[1] : bounds[0];
     assert(!Number.isNaN(begin) && !Number.isNaN(end), `bounds need to be non-NaN`);
     assert(begin <= end, `bounds[0] (${begin}) must be less than or equal to bounds[1]  (${end})`);
 
@@ -206,11 +207,11 @@ export function deserializeFPInterval(s: BinaryStream): FPInterval {
       // Bounded
       switch (kind) {
         case 'abstract':
-          return traits.toInterval([s.readF64(), s.readF64()]);
+          return new FPInterval(traits.kind, s.readF64(), s.readF64());
         case 'f32':
-          return traits.toInterval([s.readF32(), s.readF32()]);
+          return new FPInterval(traits.kind, s.readF32(), s.readF32());
         case 'f16':
-          return traits.toInterval([s.readF16(), s.readF16()]);
+          return new FPInterval(traits.kind, s.readF16(), s.readF16());
       }
       unreachable(`Unable to deserialize FPInterval with kind ${kind}`);
     },


### PR DESCRIPTION
* Use `DataView` instead of a bunch of separate typed arrays.
* Avoid small allocations where it's trivial to do so.

Speeds up deserialization around ~10% based on profiling in Chrome.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
