### PR TITLE
Use largest maxInterStageShaderVariables in maxInterStageShaderCompon…

### DIFF
--- a/src/webgpu/api/validation/capability_checks/limits/maxInterStageShaderComponents.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxInterStageShaderComponents.spec.ts
@@ -1,6 +1,6 @@
-import { assert, range } from '../../../../../common/util/util.js';
+import { range } from '../../../../../common/util/util.js';
 
-import { kMaximumLimitBaseParams, makeLimitTestGroup } from './limit_utils.js';
+import { kMaximumLimitBaseParams, LimitsRequest, makeLimitTestGroup } from './limit_utils.js';
 
 function getTypeForNumComponents(numComponents: number) {
   return numComponents > 1 ? `vec${numComponents}f` : 'f32';
@@ -21,7 +21,6 @@ function getPipelineDescriptor(
 
   const maxInterStageVariables = device.limits.maxInterStageShaderVariables;
   const numComponents = Math.min(maxVertexShaderOutputComponents, maxFragmentShaderInputComponents);
-  assert(Math.ceil(numComponents / 4) <= maxInterStageVariables);
 
   const num4ComponentVaryings = Math.floor(numComponents / 4);
   const lastVaryingNumComponents = numComponents % 4;
@@ -127,6 +126,10 @@ g.test('createRenderPipeline,at_over')
       sampleMaskIn,
       sampleMaskOut,
     } = t.params;
+    // Request the largest value of maxInterStageShaderVariables to allow the test using as many
+    // inter-stage shader components as possible without being limited by
+    // maxInterStageShaderVariables.
+    const extraLimits: LimitsRequest = { maxInterStageShaderVariables: 'adapterLimit' };
     await t.testDeviceWithRequestedMaximumLimits(
       limitTest,
       testValueName,
@@ -142,6 +145,7 @@ g.test('createRenderPipeline,at_over')
         );
 
         await t.testCreateRenderPipeline(pipelineDescriptor, async, shouldError, code);
-      }
+      },
+      extraLimits
     );
   });


### PR DESCRIPTION
…ents tests

This patch uses the largest value of maxInterStageShaderVariables supported on current adapter in the tests about maxInterStageShaderComponents when creating devices so that when the value we use as maxInterStageShaderComponents is larger than the default one, we won't be limited by the default value of maxInterStageShaderVariables.

This patch also removes the assertion that the value of maxInterStageShaderVariables must be larger than a quarter of maxInterStageShaderComponents as on many backends the largest value of maxInterStageShaderComponents is equal to 4x maxInterStageShaderVaraibles, so in "overLimit" tests the value of maxInterStageShaderComponents can be greater than 4x device.limits.maxInterStageShaderVaraibles.




Issue: #2195

<hr>

**Requirements for PR author:**

- [*] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [*] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [*] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
