### PR TITLE
BinaryStream: Use little endian for f64

### DIFF
--- a/src/webgpu/util/binary_stream.ts
+++ b/src/webgpu/util/binary_stream.ts
@@ -117,12 +117,12 @@ export default class BinaryStream {
 
   /** writeF64() writes a float64 to the buffer at the next 64-bit aligned offset */
   writeF64(value: number) {
-    this.view.setFloat64(this.alignedOffset(8), value);
+    this.view.setFloat64(this.alignedOffset(8), value, /* littleEndian */ true);
   }
 
   /** readF64() reads a float64 from the buffer at the next 64-bit aligned offset */
   readF64(): number {
-    return this.view.getFloat64(this.alignedOffset(8));
+    return this.view.getFloat64(this.alignedOffset(8), /* littleEndian */ true);
   }
 
   /**


### PR DESCRIPTION
To match all the other data types

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
