### PR TITLE
binary_stream: Simplify away a no-op TypedArray

### DIFF
--- a/src/webgpu/shader/execution/expression/case_cache.ts
+++ b/src/webgpu/shader/execution/expression/case_cache.ts
@@ -166,7 +166,7 @@ export class CaseCache implements Cacheable<Record<string, CaseList>> {
    */
   serialize(data: Record<string, CaseList>): Uint8Array {
     const maxSize = 32 << 20; // 32MB - max size for a file
-    const s = new BinaryStream(new Uint8Array(maxSize).buffer);
+    const s = new BinaryStream(new ArrayBuffer(maxSize));
     s.writeU32(Object.keys(data).length);
     for (const name in data) {
       s.writeString(name);

--- a/src/webgpu/util/binary_stream.ts
+++ b/src/webgpu/util/binary_stream.ts
@@ -18,9 +18,9 @@ export default class BinaryStream {
     this.view = new DataView(buffer);
   }
 
-  /** buffer() returns the stream's buffer sliced to the 8-byte rounded read or write offset */
+  /** buffer() returns the stream's whole buffer */
   buffer(): ArrayBufferLike {
-    return new Uint8Array(this.view.buffer, align(this.offset, 8)).buffer;
+    return this.view.buffer;
   }
 
   /** writeBool() writes a boolean as 255 or 0 to the buffer at the next byte offset */


### PR DESCRIPTION
I just noticed this while looking around for TypedArray allocations that could be cleaned up. The code here didn't match the intent. This change is a no-op, but maybe there is a bug to be fixed instead.

I only verified the unittests pass, so far, since I figured I should send this to you first.

Issue: None

<hr>

**Requirements for PR author:**

- [ ] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
