### PR TITLE
dev_server: Serve on localhost by default

### DIFF
--- a/src/common/tools/dev_server.ts
+++ b/src/common/tools/dev_server.ts
@@ -123,7 +123,7 @@ app.use('/out-wpt', express.static(path.resolve(srcDir, '../out-wpt')));
 app.use('/docs/tsdoc', express.static(path.resolve(srcDir, '../docs/tsdoc')));
 
 // Serve a suite's listing.js file by crawling the filesystem for all tests.
-app.get('/out/:suite/listing.js', async (req, res, next) => {
+app.get('/out/:suite([a-zA-Z0-9_-]+)/listing.js', async (req, res, next) => {
   const suite = req.params['suite'];
 
   if (listingCache.has(suite)) {

--- a/src/common/tools/dev_server.ts
+++ b/src/common/tools/dev_server.ts
@@ -179,10 +179,10 @@ app.get('/out/**/*.js', async (req, res, next) => {
 app.use('/out', serveIndex(path.resolve(srcDir, '../src')));
 app.use('/out', express.static(path.resolve(srcDir, '../src')));
 
-(async () => {
+void (async () => {
   let host = '127.0.0.1';
   if (process.argv.length >= 3) {
-    if (process.argv.length != 3) usage(1);
+    if (process.argv.length !== 3) usage(1);
     if (process.argv[2] === '0.0.0.0') {
       host = '0.0.0.0';
     } else {

--- a/src/common/tools/dev_server.ts
+++ b/src/common/tools/dev_server.ts
@@ -14,6 +14,19 @@ import { makeListing } from './crawl.js';
 // Make sure that makeListing doesn't cache imported spec files. See crawl().
 process.env.STANDALONE_DEV_SERVER = '1';
 
+function usage(rc: number): void {
+  console.error(`\
+Usage:
+  tools/dev_server
+  tools/dev_server 0.0.0.0
+  npm start
+  npm start 0.0.0.0
+
+By default, serves on localhost only. If the argument 0.0.0.0 is passed, serves on all interfaces.
+`);
+  process.exit(rc);
+}
+
 const srcDir = path.resolve(__dirname, '../../');
 
 // Import the project's babel.config.js. We'll use the same config for the runtime compiler.
@@ -162,28 +175,40 @@ app.get('/out/**/*.js', async (req, res, next) => {
   }
 });
 
-const host = '0.0.0.0';
-const port = 8080;
-// Find an available port, starting at 8080.
-portfinder.getPort({ host, port }, (err, port) => {
-  if (err) {
-    throw err;
+// Serve everything else (not .js) as static, and directories as directory listings.
+app.use('/out', serveIndex(path.resolve(srcDir, '../src')));
+app.use('/out', express.static(path.resolve(srcDir, '../src')));
+
+(async () => {
+  let host = '127.0.0.1';
+  if (process.argv.length >= 3) {
+    if (process.argv.length != 3) usage(1);
+    if (process.argv[2] === '0.0.0.0') {
+      host = '0.0.0.0';
+    } else {
+      usage(1);
+    }
   }
+
+  console.log(`Finding an available port on ${host}...`);
+  const kPortFinderStart = 8080;
+  const port = await portfinder.getPortPromise({ host, port: kPortFinderStart });
+
   watcher.on('ready', () => {
     // Listen on the available port.
     app.listen(port, host, () => {
       console.log('Standalone test runner running at:');
-      for (const iface of Object.values(os.networkInterfaces())) {
-        for (const details of iface || []) {
-          if (details.family === 'IPv4') {
-            console.log(`  http://${details.address}:${port}/standalone/`);
+      if (host === '0.0.0.0') {
+        for (const iface of Object.values(os.networkInterfaces())) {
+          for (const details of iface || []) {
+            if (details.family === 'IPv4') {
+              console.log(`  http://${details.address}:${port}/standalone/`);
+            }
           }
         }
+      } else {
+        console.log(`  http://${host}:${port}/standalone/`);
       }
     });
   });
-});
-
-// Serve everything else (not .js) as static, and directories as directory listings.
-app.use('/out', serveIndex(path.resolve(srcDir, '../src')));
-app.use('/out', express.static(path.resolve(srcDir, '../src')));
+})();


### PR DESCRIPTION
Binding 127.0.0.1 avoids unexpectedly exposing the dev server over the network when the port is not protected by a firewall.

Issue: None

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] ~Tests are properly located in the test tree.~
- [x] ~[Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.~
- [x] ~Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**~
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
