### PR TITLE
wgsl: Convert `quantizeToF16` to used `hfround`

### DIFF
--- a/src/webgpu/util/math.ts
+++ b/src/webgpu/util/math.ts
@@ -3,6 +3,7 @@ import { assert } from '../../common/util/util.js';
 import {
   Float16Array,
   getFloat16,
+  hfround,
   setFloat16,
 } from '../../external/petamoriken/float16/float16.js';
 
@@ -2021,13 +2022,9 @@ export function quantizeToF32(num: number): number {
   return quantizeToF32Data[0];
 }
 
-/** Statically allocate working data, so it doesn't need per-call creation */
-const quantizeToF16Data = new Float16Array(new ArrayBuffer(2));
-
 /** @returns the closest 16-bit floating point value to the input */
 export function quantizeToF16(num: number): number {
-  quantizeToF16Data[0] = num;
-  return quantizeToF16Data[0];
+  return hfround(num);
 }
 
 /** Statically allocate working data, so it doesn't need per-call creation */


### PR DESCRIPTION
Instead of passing the input through a F16Array, use the library provided function hfround. hfround is a fast look up table based rounding function for f16.

Benchmarking locally this provides a ~20% improvement to fma interval calculations, which are particularly sensitive to quantization cost. Overall I was seeing more on the order of ~10% improvement.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
