### PR TITLE
wgsl: Convert `quantizeToF32` to used `Math.fround`

### DIFF
--- a/src/webgpu/util/math.ts
+++ b/src/webgpu/util/math.ts
@@ -2013,13 +2013,9 @@ export interface QuantizeFunc {
   (num: number): number;
 }
 
-/** Statically allocate working data, so it doesn't need per-call creation */
-const quantizeToF32Data = new Float32Array(new ArrayBuffer(4));
-
 /** @returns the closest 32-bit floating point value to the input */
 export function quantizeToF32(num: number): number {
-  quantizeToF32Data[0] = num;
-  return quantizeToF32Data[0];
+  return Math.fround(num);
 }
 
 /** @returns the closest 16-bit floating point value to the input */


### PR DESCRIPTION
Instead of passing the input through a F32Array, use the builtin Math.fround.

This leads to a ~5% improvement benchmarking locally. This is less than the equivalent f16 change, because F32Array is provided by the runtime, whereas F16Array is being polyfilled, so is probably more efficient to begin with.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
