### PR TITLE
wgsl: Convert `quantizeToI32/U32` to use `Math.trunc`

### DIFF
--- a/src/webgpu/util/math.ts
+++ b/src/webgpu/util/math.ts
@@ -2023,22 +2023,32 @@ export function quantizeToF16(num: number): number {
   return hfround(num);
 }
 
-/** Statically allocate working data, so it doesn't need per-call creation */
-const quantizeToI32Data = new Int32Array(new ArrayBuffer(4));
-
-/** @returns the closest 32-bit signed integer value to the input */
+/**
+ * @returns the closest 32-bit signed integer value to the input, rounding
+ * towards 0, if not already an integer
+ */
 export function quantizeToI32(num: number): number {
-  quantizeToI32Data[0] = num;
-  return quantizeToI32Data[0];
+  if (num >= kValue.i32.positive.max) {
+    return kValue.i32.positive.max;
+  }
+  if (num <= kValue.i32.negative.min) {
+    return kValue.i32.negative.min;
+  }
+  return Math.trunc(num);
 }
 
-/** Statically allocate working data, so it doesn't need per-call creation */
-const quantizeToU32Data = new Uint32Array(new ArrayBuffer(4));
-
-/** @returns the closest 32-bit signed integer value to the input */
+/**
+ * @returns the closest 32-bit unsigned integer value to the input, rounding
+ * towards 0, if not already an integer
+ */
 export function quantizeToU32(num: number): number {
-  quantizeToU32Data[0] = num;
-  return quantizeToU32Data[0];
+  if (num >= kValue.u32.max) {
+    return kValue.u32.max;
+  }
+  if (num <= 0) {
+    return 0;
+  }
+  return Math.trunc(num);
 }
 
 /** @returns whether the number is an integer and a power of two */


### PR DESCRIPTION
Another small bump (~5%) to be gained through using a builtin instead of trampolining through a TypedArray.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
