### PR TITLE
Fix cache files being padded with trailing 0's

### DIFF
--- a/src/unittests/serialization.spec.ts
+++ b/src/unittests/serialization.spec.ts
@@ -209,7 +209,7 @@ g.test('value').fn(t => {
   ]) {
     const s = new BinaryStream(new Uint8Array(1024).buffer);
     serializeValue(s, value);
-    const d = new BinaryStream(s.buffer());
+    const d = new BinaryStream(s.buffer().buffer);
     const deserialized = deserializeValue(d);
     t.expect(
       objectEquals(value, deserialized),
@@ -246,7 +246,7 @@ g.test('fpinterval_f32').fn(t => {
   ]) {
     const s = new BinaryStream(new Uint8Array(1024).buffer);
     serializeFPInterval(s, interval);
-    const d = new BinaryStream(s.buffer());
+    const d = new BinaryStream(s.buffer().buffer);
     const deserialized = deserializeFPInterval(d);
     t.expect(
       objectEquals(interval, deserialized),
@@ -282,7 +282,7 @@ g.test('fpinterval_f16').fn(t => {
   ]) {
     const s = new BinaryStream(new Uint8Array(1024).buffer);
     serializeFPInterval(s, interval);
-    const d = new BinaryStream(s.buffer());
+    const d = new BinaryStream(s.buffer().buffer);
     const deserialized = deserializeFPInterval(d);
     t.expect(
       objectEquals(interval, deserialized),
@@ -318,7 +318,7 @@ g.test('fpinterval_abstract').fn(t => {
   ]) {
     const s = new BinaryStream(new Uint8Array(1024).buffer);
     serializeFPInterval(s, interval);
-    const d = new BinaryStream(s.buffer());
+    const d = new BinaryStream(s.buffer().buffer);
     const deserialized = deserializeFPInterval(d);
     t.expect(
       objectEquals(interval, deserialized),
@@ -340,7 +340,7 @@ g.test('expression_expectation').fn(t => {
   ]) {
     const s = new BinaryStream(new Uint8Array(1024).buffer);
     serializeExpectation(s, expectation);
-    const d = new BinaryStream(s.buffer());
+    const d = new BinaryStream(s.buffer().buffer);
     const deserialized = deserializeExpectation(d);
     t.expect(
       objectEquals(expectation, deserialized),
@@ -370,7 +370,7 @@ g.test('anyOf').fn(t => {
     ]) {
       const s = new BinaryStream(new Uint8Array(1024).buffer);
       serializeComparator(s, c.comparator);
-      const d = new BinaryStream(s.buffer());
+      const d = new BinaryStream(s.buffer().buffer);
       const deserialized = deserializeComparator(d);
       for (const val of c.testCases) {
         const got = deserialized.compare(val);
@@ -398,7 +398,7 @@ g.test('skipUndefined').fn(t => {
     ]) {
       const s = new BinaryStream(new Uint8Array(1024).buffer);
       serializeComparator(s, c.comparator);
-      const d = new BinaryStream(s.buffer());
+      const d = new BinaryStream(s.buffer().buffer);
       const deserialized = deserializeComparator(d);
       for (const val of c.testCases) {
         const got = deserialized.compare(val);

--- a/src/webgpu/shader/execution/expression/case_cache.ts
+++ b/src/webgpu/shader/execution/expression/case_cache.ts
@@ -166,13 +166,13 @@ export class CaseCache implements Cacheable<Record<string, CaseList>> {
    */
   serialize(data: Record<string, CaseList>): Uint8Array {
     const maxSize = 32 << 20; // 32MB - max size for a file
-    const s = new BinaryStream(new Uint8Array(maxSize).buffer);
-    s.writeU32(Object.keys(data).length);
+    const stream = new BinaryStream(new ArrayBuffer(maxSize));
+    stream.writeU32(Object.keys(data).length);
     for (const name in data) {
-      s.writeString(name);
-      s.writeArray(data[name], serializeCase);
+      stream.writeString(name);
+      stream.writeArray(data[name], serializeCase);
     }
-    return new Uint8Array(s.buffer());
+    return stream.buffer();
   }
 
   /**

--- a/src/webgpu/util/binary_stream.ts
+++ b/src/webgpu/util/binary_stream.ts
@@ -19,8 +19,8 @@ export default class BinaryStream {
   }
 
   /** buffer() returns the stream's buffer sliced to the 8-byte rounded read or write offset */
-  buffer(): ArrayBufferLike {
-    return new Uint8Array(this.view.buffer, align(this.offset, 8)).buffer;
+  buffer(): Uint8Array {
+    return new Uint8Array(this.view.buffer, 0, align(this.offset, 8));
   }
 
   /** writeBool() writes a boolean as 255 or 0 to the buffer at the next byte offset */


### PR DESCRIPTION
`buffer()` was offsetting the array instead of truncating the returned array.



<hr>

**Requirements for PR author:**

- [ ] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [ ] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
