### PR TITLE
Reduce draw validation test parameterization

### DIFF
--- a/src/webgpu/api/validation/encoding/cmds/render/draw.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/render/draw.spec.ts
@@ -426,7 +426,6 @@ success/error as expected. Such set of buffer parameters should include cases li
               { firstVertex: 0, vertexCount: 1 },
               { firstVertex: 0, vertexCount: 10000 },
               { firstVertex: 10000, vertexCount: 0 },
-              { firstVertex: 10000, vertexCount: 1 },
               { firstVertex: 10000, vertexCount: 10000 },
             ]
       )
@@ -437,7 +436,6 @@ success/error as expected. Such set of buffer parameters should include cases li
               { firstInstance: 0, instanceCount: 1 },
               { firstInstance: 0, instanceCount: 10000 },
               { firstInstance: 10000, instanceCount: 0 },
-              { firstInstance: 10000, instanceCount: 1 },
               { firstInstance: 10000, instanceCount: 10000 },
             ]
       )

--- a/src/webgpu/api/validation/encoding/cmds/render/draw.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/render/draw.spec.ts
@@ -419,12 +419,28 @@ success/error as expected. Such set of buffer parameters should include cases li
       .beginSubcases()
       .combine('setBufferOffset', [0, 200]) // must be a multiple of 4
       .combine('attributeFormat', ['snorm8x2', 'float32', 'float16x4'] as GPUVertexFormat[])
-      .combine('vertexCount', [0, 1, 10000])
-      .combine('firstVertex', [0, 10000])
-      .filter(p => p.VStride0 === (p.firstVertex + p.vertexCount === 0))
-      .combine('instanceCount', [0, 1, 10000])
-      .combine('firstInstance', [0, 10000])
-      .filter(p => p.IStride0 === (p.firstInstance + p.instanceCount === 0))
+      .expandWithParams(p =>
+        p.VStride0
+          ? [{ firstVertex: 0, vertexCount: 0 }]
+          : [
+              { firstVertex: 0, vertexCount: 1 },
+              { firstVertex: 0, vertexCount: 10000 },
+              { firstVertex: 10000, vertexCount: 0 },
+              { firstVertex: 10000, vertexCount: 1 },
+              { firstVertex: 10000, vertexCount: 10000 },
+            ]
+      )
+      .expandWithParams(p =>
+        p.IStride0
+          ? [{ firstInstance: 0, instanceCount: 0 }]
+          : [
+              { firstInstance: 0, instanceCount: 1 },
+              { firstInstance: 0, instanceCount: 10000 },
+              { firstInstance: 10000, instanceCount: 0 },
+              { firstInstance: 10000, instanceCount: 1 },
+              { firstInstance: 10000, instanceCount: 10000 },
+            ]
+      )
       .unless(p => p.vertexCount === 10000 && p.instanceCount === 10000)
   )
   .fn(t => {

--- a/src/webgpu/api/validation/encoding/cmds/render/draw.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/render/draw.spec.ts
@@ -592,17 +592,34 @@ buffer slot and index buffer will cause no validation error, with completely/par
     u //
       .combine('drawType', ['draw', 'drawIndexed', 'drawIndirect', 'drawIndexedIndirect'] as const)
       .beginSubcases()
-      .combine('vertexBoundOffestFactor', [0, 0.5, 1, 1.5, 2])
-      .combine('instanceBoundOffestFactor', [0, 0.5, 1, 1.5, 2])
-      .combine('indexBoundOffestFactor', [0, 0.5, 1, 1.5, 2])
       .combine('arrayStrideState', ['zero', 'exact', 'oversize'] as const)
+      .combineWithParams([
+        { vertexOffsetFactor: 0.0, instanceOffsetFactor: 0.0, indexOffsetFactor: 0.0 },
+        { vertexOffsetFactor: 1.0, instanceOffsetFactor: 1.0, indexOffsetFactor: 1.0 },
+        //
+        { vertexOffsetFactor: 0.0, instanceOffsetFactor: 1.0, indexOffsetFactor: 2.0 },
+        { vertexOffsetFactor: 1.0, instanceOffsetFactor: 2.0, indexOffsetFactor: 0.0 },
+        { vertexOffsetFactor: 2.0, instanceOffsetFactor: 0.0, indexOffsetFactor: 1.0 },
+        //
+        { vertexOffsetFactor: 0.5, instanceOffsetFactor: 0.0, indexOffsetFactor: 0.0 },
+        { vertexOffsetFactor: 1.5, instanceOffsetFactor: 0.0, indexOffsetFactor: 0.0 },
+        { vertexOffsetFactor: 2.0, instanceOffsetFactor: 0.0, indexOffsetFactor: 0.0 },
+        //
+        { vertexOffsetFactor: 0.0, instanceOffsetFactor: 0.5, indexOffsetFactor: 0.0 },
+        { vertexOffsetFactor: 0.0, instanceOffsetFactor: 1.5, indexOffsetFactor: 0.0 },
+        { vertexOffsetFactor: 0.0, instanceOffsetFactor: 2.0, indexOffsetFactor: 0.0 },
+        //
+        { vertexOffsetFactor: 0.0, instanceOffsetFactor: 0.0, indexOffsetFactor: 0.5 },
+        { vertexOffsetFactor: 0.0, instanceOffsetFactor: 0.0, indexOffsetFactor: 1.5 },
+        { vertexOffsetFactor: 0.0, instanceOffsetFactor: 0.0, indexOffsetFactor: 2.0 },
+      ])
   )
   .fn(t => {
     const {
       drawType,
-      vertexBoundOffestFactor,
-      instanceBoundOffestFactor,
-      indexBoundOffestFactor,
+      vertexOffsetFactor,
+      instanceOffsetFactor,
+      indexOffsetFactor,
       arrayStrideState,
     } = t.params;
 
@@ -644,7 +661,7 @@ buffer slot and index buffer will cause no validation error, with completely/par
     const { vertexCount, firstVertex } = kDefaultParameterForNonIndexedDraw;
     const strideCountForVertexBuffer = firstVertex + vertexCount;
     const setVertexBufferSize = calcAttributeBufferSize(strideCountForVertexBuffer);
-    const setVertexBufferOffset = calcSetBufferOffset(setVertexBufferSize, vertexBoundOffestFactor);
+    const setVertexBufferOffset = calcSetBufferOffset(setVertexBufferSize, vertexOffsetFactor);
     let requiredBufferSize = setVertexBufferOffset + setVertexBufferSize;
 
     const { instanceCount, firstInstance } = kDefaultParameterForDraw;
@@ -652,7 +669,7 @@ buffer slot and index buffer will cause no validation error, with completely/par
     const setInstanceBufferSize = calcAttributeBufferSize(strideCountForInstanceBuffer);
     const setInstanceBufferOffset = calcSetBufferOffset(
       setInstanceBufferSize,
-      instanceBoundOffestFactor
+      instanceOffsetFactor
     );
     requiredBufferSize = Math.max(
       requiredBufferSize,
@@ -660,7 +677,7 @@ buffer slot and index buffer will cause no validation error, with completely/par
     );
 
     const { indexBufferSize: setIndexBufferSize, indexFormat } = kDefaultParameterForIndexedDraw;
-    const setIndexBufferOffset = calcSetBufferOffset(setIndexBufferSize, indexBoundOffestFactor);
+    const setIndexBufferOffset = calcSetBufferOffset(setIndexBufferSize, indexOffsetFactor);
     requiredBufferSize = Math.max(requiredBufferSize, setIndexBufferOffset + setIndexBufferSize);
 
     // Create the shared GPU buffer with both vertetx and index usage

--- a/src/webgpu/api/validation/encoding/cmds/render/draw.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/render/draw.spec.ts
@@ -408,15 +408,15 @@ success/error as expected. Such set of buffer parameters should include cases li
       .combine('VBSize', ['zero', 'exile', 'enough'] as const)
       // the state of instance step mode vertex buffer bound size
       .combine('IBSize', ['zero', 'exile', 'enough'] as const)
+      // the state of array stride
+      .combine('AStride', ['zero', 'exact', 'oversize'] as const)
+      .beginSubcases()
       // should the vertex stride count be zero
       .combine('VStride0', [false, true] as const)
       // should the instance stride count be zero
       .combine('IStride0', [false, true] as const)
-      // the state of array stride
-      .combine('AStride', ['zero', 'exact', 'oversize'] as const)
       // the factor for offset of attributes in vertex layout
       .combine('offset', [0, 1, 2, 7]) // the offset of attribute will be factor * MIN(4, sizeof(vertexFormat))
-      .beginSubcases()
       .combine('setBufferOffset', [200]) // must be a multiple of 4
       .combine('attributeFormat', ['snorm8x2', 'float32', 'float16x4'] as GPUVertexFormat[])
       .expandWithParams(p =>

--- a/src/webgpu/api/validation/encoding/cmds/render/draw.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/render/draw.spec.ts
@@ -609,6 +609,7 @@ buffer slot and index buffer will cause no validation error, with completely/par
     TODO: The "Factor" parameters don't necessarily guarantee that we test all configurations
     of buffers overlapping or not. This test should be refactored to test specific overlap cases,
     and have fewer total parameterizations.
+    See https://github.com/gpuweb/cts/pull/3122#discussion_r1378623214
 `
   )
   .params(u =>

--- a/src/webgpu/api/validation/encoding/cmds/render/draw.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/render/draw.spec.ts
@@ -417,7 +417,7 @@ success/error as expected. Such set of buffer parameters should include cases li
       // the factor for offset of attributes in vertex layout
       .combine('offset', [0, 1, 2, 7]) // the offset of attribute will be factor * MIN(4, sizeof(vertexFormat))
       .beginSubcases()
-      .combine('setBufferOffset', [0, 200]) // must be a multiple of 4
+      .combine('setBufferOffset', [200]) // must be a multiple of 4
       .combine('attributeFormat', ['snorm8x2', 'float32', 'float16x4'] as GPUVertexFormat[])
       .expandWithParams(p =>
         p.VStride0


### PR DESCRIPTION
Draw validation tests were taking a huge chunk (maybe 25%) of the time of the whole api,validation suite. This should reduce their time by roughly 80-90%.

It may be useful to look at each commit separately to have a good sense of how much they're reducing the test coverage by. My estimate is that we still probably have all of the coverage we need.

cc @jzm-intel in case you have opinions about these tests.

Issue: None

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
