### PR TITLE
Prevent Double Runs and make run clearer.

### DIFF
--- a/src/common/runtime/standalone.ts
+++ b/src/common/runtime/standalone.ts
@@ -427,11 +427,20 @@ function makeTreeNodeHeaderHTML(
     .attr('alt', runtext)
     .attr('title', runtext)
     .on('click', async () => {
+      if (runDepth > 0) {
+        showInfo('tests are already running');
+        return;
+      }
+      showInfo('');
       console.log(`Starting run for ${n.query}`);
+      // turn off all run buttons
+      $('#resultsVis').addClass('disable-run');
       const startTime = performance.now();
       await runSubtree();
       const dt = performance.now() - startTime;
       const dtMinutes = dt / 1000 / 60;
+      // turn on all run buttons
+      $('#resultsVis').removeClass('disable-run');
       console.log(`Finished run: ${dt.toFixed(1)} ms = ${dtMinutes.toFixed(1)} min`);
     })
     .appendTo(header);

--- a/standalone/index.html
+++ b/standalone/index.html
@@ -148,7 +148,7 @@
         width: 100%;
         left: 0;
         top: 0;
-        background-color: #000;
+        background-color: #068;
         color: #fff;
         align-items: center;
       }
@@ -168,6 +168,13 @@
 
       #resultsVis {
         border-right: 1px solid var(--results-fg-color);
+      }
+
+      /* PS: this does not disable using the keyboard to click */
+      #resultsVis.disable-run button.leafrun,
+      #resultsVis.disable-run button.subtreerun {
+         pointer-events: none;
+         opacity: 25%;
       }
 
       /* tree nodes */


### PR DESCRIPTION
Prevents clicking a run button while tests are running. I seem to do this once in a while and get errors about DevicePool acquire device in use 😅

Also made the progress bar have a background color so it's slightly clearer that tests are running.

