### PR TITLE
Speed up shader,execution,expression tests with async pipelines

### DIFF
--- a/src/webgpu/shader/execution/expression/expression.ts
+++ b/src/webgpu/shader/execution/expression/expression.ts
@@ -365,7 +365,7 @@ export async function run(
     );
     checkBatch();
     void t.queue.onSubmittedWorkDone().finally(batchFinishedCallback);
-  }
+  };
 
   for (let i = 0; i < cases.length; i += casesPerBatch) {
     const batchCases = cases.slice(i, Math.min(i + casesPerBatch, cases.length));
@@ -379,7 +379,7 @@ export async function run(
     }
     batchesInFlight += 1;
 
-    processBatch(batchCases);
+    void processBatch(batchCases);
   }
 }
 

--- a/src/webgpu/shader/execution/expression/expression.ts
+++ b/src/webgpu/shader/execution/expression/expression.ts
@@ -367,6 +367,8 @@ export async function run(
     void t.queue.onSubmittedWorkDone().finally(batchFinishedCallback);
   };
 
+  const pendingBatches = [];
+
   for (let i = 0; i < cases.length; i += casesPerBatch) {
     const batchCases = cases.slice(i, Math.min(i + casesPerBatch, cases.length));
 
@@ -379,8 +381,10 @@ export async function run(
     }
     batchesInFlight += 1;
 
-    void processBatch(batchCases);
+    pendingBatches.push(processBatch(batchCases));
   }
+
+  await Promise.all(pendingBatches);
 }
 
 /**

--- a/src/webgpu/shader/execution/robust_access.spec.ts
+++ b/src/webgpu/shader/execution/robust_access.spec.ts
@@ -23,14 +23,14 @@ const kMinI32 = -0x8000_0000;
  * Non-test bindings are in bind group 1, including:
  * - `constants.zero`: a dynamically-uniform `0u` value.
  */
-function runShaderTest(
+async function runShaderTest(
   t: GPUTest,
   stage: GPUShaderStageFlags,
   testSource: string,
   layout: GPUPipelineLayout,
   testBindings: GPUBindGroupEntry[],
   dynamicOffsets?: number[]
-): void {
+): Promise<void> {
   assert(stage === GPUShaderStage.COMPUTE, 'Only know how to deal with compute for now');
 
   // Contains just zero (for now).
@@ -62,7 +62,7 @@ fn main() {
 
   t.debug(source);
   const module = t.device.createShaderModule({ code: source });
-  const pipeline = t.device.createComputePipeline({
+  const pipeline = await t.device.createComputePipelineAsync({
     layout,
     compute: { module, entryPoint: 'main' },
   });
@@ -172,7 +172,7 @@ g.test('linear_memory')
       .expand('baseType', supportedScalarTypes)
       .expandWithParams(generateTypes)
   )
-  .fn(t => {
+  .fn(async t => {
     const {
       addressSpace,
       storageMode,
@@ -448,7 +448,7 @@ fn runTest() -> u32 {
       );
 
       // Run the shader, accessing the buffer.
-      runShaderTest(
+      await runShaderTest(
         t,
         GPUShaderStage.COMPUTE,
         testSource,
@@ -475,6 +475,6 @@ fn runTest() -> u32 {
         bufferBindingEnd
       );
     } else {
-      runShaderTest(t, GPUShaderStage.COMPUTE, testSource, layout, []);
+      await runShaderTest(t, GPUShaderStage.COMPUTE, testSource, layout, []);
     }
   });

--- a/src/webgpu/shader/execution/zero_init.spec.ts
+++ b/src/webgpu/shader/execution/zero_init.spec.ts
@@ -227,7 +227,7 @@ g.test('compute,zero_init')
       })
   )
   .batch(15)
-  .fn(t => {
+  .fn(async t => {
     const { workgroupSize } = t.params;
     const { maxComputeInvocationsPerWorkgroup } = t.device.limits;
     const numWorkgroupInvocations = workgroupSize.reduce((a, b) => a * b);
@@ -446,7 +446,7 @@ g.test('compute,zero_init')
         ],
       });
 
-      const fillPipeline = t.device.createComputePipeline({
+      const fillPipeline = await t.device.createComputePipelineAsync({
         layout: t.device.createPipelineLayout({ bindGroupLayouts: [fillLayout] }),
         label: 'Workgroup Fill Pipeline',
         compute: {
@@ -495,7 +495,7 @@ g.test('compute,zero_init')
       t.queue.submit([e.finish()]);
     }
 
-    const pipeline = t.device.createComputePipeline({
+    const pipeline = await t.device.createComputePipelineAsync({
       layout: 'auto',
       compute: {
         module: t.device.createShaderModule({


### PR DESCRIPTION
Some of these tests are among the longest running that we have, so hopefully this has a dramatic impact on runtimes. Profiling shows that almost all the time is being spent waiting for pipeline creation. By using createComputePipelineAsync, however, we ensure that multiple shaders in a batch can be compiling at once, which drops test run times significantly.

For example, the `webgpu:shader,execution,expression,binary,af_matrix_subtraction:matrix:inputSource="const";cols=4;rows=4` test, one of the longest running in the entire CTS, was taking 5 minutes to run on my Windows machine. With this patch it completes in ~~46 seconds~~ 80 seconds on the same device.

In general I'm seeing **speedups of ~~5x-6x~~** (sorry, it's only **4x**. See comments below) on the tests that I've tried.

To demonstrate why, we can look at this chunk of a trace from the shorter `webgpu:shader,execution,expression,binary,af_matrix_subtraction:matrix:inputSource="const";cols=2;rows=2` test, which was previously taking 8 seconds to run.

<img width="840" alt="Screenshot 2023-11-01 104727" src="https://github.com/gpuweb/cts/assets/805273/999ecfb0-15fc-4277-89ba-222ded69932d">

The blue chunks are all pipeline compiles, and you can see they dominate the runtime and are being performed serially. With this patch it completes in about 2 seconds and the tracing produces results like this:

<img width="553" alt="Screenshot 2023-11-01 105615" src="https://github.com/gpuweb/cts/assets/805273/aa18626c-3031-4331-adf8-99fe0e60fda1">

Same amount of blue, but now more parallel!

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
