### PR TITLE
Make the CTS debuggable again

### DIFF
--- a/src/common/runtime/helper/options.ts
+++ b/src/common/runtime/helper/options.ts
@@ -29,6 +29,7 @@ export interface CTSOptions {
   debug: boolean;
   compatibility: boolean;
   unrollConstEvalLoops: boolean;
+  noRaceWithRejectOnTimeout: boolean;
   powerPreference?: GPUPowerPreference | '';
 }
 
@@ -37,6 +38,7 @@ export const kDefaultCTSOptions: CTSOptions = {
   debug: true,
   compatibility: false,
   unrollConstEvalLoops: false,
+  noRaceWithRejectOnTimeout: false,
   powerPreference: '',
 };
 
@@ -63,6 +65,7 @@ export const kCTSOptionsInfo: OptionsInfos<CTSOptions> = {
   debug: { description: 'show more info' },
   compatibility: { description: 'run in compatibility mode' },
   unrollConstEvalLoops: { description: 'unroll const eval loops in WGSL' },
+  noRaceWithRejectOnTimeout: { description: 'turn off race timeout' },
   powerPreference: {
     description: 'set default powerPreference for some tests',
     parser: optionString,

--- a/src/common/runtime/standalone.ts
+++ b/src/common/runtime/standalone.ts
@@ -47,9 +47,17 @@ const { queries: qs, options } = parseSearchParamLikeWithOptions(
   kStandaloneOptionsInfos,
   window.location.search || rootQuerySpec
 );
-const { runnow, debug, unrollConstEvalLoops, powerPreference, compatibility } = options;
+const {
+  runnow,
+  debug,
+  unrollConstEvalLoops,
+  powerPreference,
+  compatibility,
+  noRaceWithRejectOnTimeout,
+} = options;
 globalTestConfig.unrollConstEvalLoops = unrollConstEvalLoops;
 globalTestConfig.compatibility = compatibility;
+globalTestConfig.noRaceWithRejectOnTimeout = noRaceWithRejectOnTimeout;
 
 Logger.globalDebugMode = debug;
 const logger = new Logger();


### PR DESCRIPTION
with the timeouts added you can't step through the code without it timing out so add an option to disable them.