### PR TITLE
Fix use of deprecated window.name.

### DIFF
--- a/src/webgpu/api/operation/command_buffer/queries/occlusionQuery.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/queries/occlusionQuery.spec.ts
@@ -695,7 +695,7 @@ g.test('occlusion_query,scissor')
         const expectPassed = !occluded;
         t.expect(
           !!passed === expectPassed,
-          `queryIndex: ${queryIndex}, scissorCase: ${scissorCase}, was: ${!!passed}, expected: ${expectPassed}, ${name}`
+          `queryIndex: ${queryIndex}, scissorCase: ${scissorCase}, was: ${!!passed}, expected: ${expectPassed}`
         );
       }
     );
@@ -739,7 +739,7 @@ g.test('occlusion_query,depth')
         const expectPassed = queryIndex % 2 === 0;
         t.expect(
           !!passed === expectPassed,
-          `queryIndex: ${queryIndex}, was: ${!!passed}, expected: ${expectPassed}, ${name}`
+          `queryIndex: ${queryIndex}, was: ${!!passed}, expected: ${expectPassed}`
         );
       }
     );
@@ -783,7 +783,7 @@ g.test('occlusion_query,stencil')
         const expectPassed = queryIndex % 2 === 0;
         t.expect(
           !!passed === expectPassed,
-          `queryIndex: ${queryIndex}, was: ${!!passed}, expected: ${expectPassed}, ${name}`
+          `queryIndex: ${queryIndex}, was: ${!!passed}, expected: ${expectPassed}`
         );
       }
     );
@@ -851,7 +851,7 @@ g.test('occlusion_query,sample_mask')
         const expectPassed = !!(sampleMask & drawMask);
         t.expect(
           !!passed === expectPassed,
-          `queryIndex: ${queryIndex}, was: ${!!passed}, expected: ${expectPassed}, ${name}`
+          `queryIndex: ${queryIndex}, was: ${!!passed}, expected: ${expectPassed}`
         );
       }
     );


### PR DESCRIPTION
This doesn't work in non-browser JS runtimes.




Issue: Nope

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
