### PR TITLE
Compat: copyTextureToTexture validation

### DIFF
--- a/src/webgpu/compat/api/validation/encoding/cmds/copyTextureToTexture.spec.ts
+++ b/src/webgpu/compat/api/validation/encoding/cmds/copyTextureToTexture.spec.ts
@@ -32,7 +32,7 @@ g.test('compressed')
     const dstTexture = t.device.createTexture({
       size: [blockWidth, blockHeight, 1],
       format,
-      usage: GPUTextureUsage.COPY_SRC,
+      usage: GPUTextureUsage.COPY_DST,
     });
     t.trackForCleanup(dstTexture);
 

--- a/src/webgpu/compat/api/validation/encoding/cmds/copyTextureToTexture.spec.ts
+++ b/src/webgpu/compat/api/validation/encoding/cmds/copyTextureToTexture.spec.ts
@@ -1,0 +1,48 @@
+export const description = `
+Tests limitations of copyTextureToTextures in compat mode.
+`;
+
+import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
+import { kCompressedTextureFormats, kTextureFormatInfo } from '../../../../../format_info.js';
+import { CompatibilityTest } from '../../../../compatibility_test.js';
+
+export const g = makeTestGroup(CompatibilityTest);
+
+g.test('compressed')
+  .desc(
+    `Tests that you can not call copyTextureToTextures with compressed textures in compat mode.`
+  )
+  .params(u => u.combine('format', kCompressedTextureFormats))
+  .beforeAllSubcases(t => {
+    const { format } = t.params;
+    t.selectDeviceOrSkipTestCase([kTextureFormatInfo[format].feature]);
+  })
+  .fn(t => {
+    const { format } = t.params;
+
+    const { blockWidth, blockHeight } = kTextureFormatInfo[format];
+
+    const srcTexture = t.device.createTexture({
+      size: [blockWidth, blockHeight, 1],
+      format,
+      usage: GPUTextureUsage.COPY_SRC,
+    });
+    t.trackForCleanup(srcTexture);
+
+    const dstTexture = t.device.createTexture({
+      size: [blockWidth, blockHeight, 1],
+      format,
+      usage: GPUTextureUsage.COPY_SRC,
+    });
+    t.trackForCleanup(dstTexture);
+
+    const encoder = t.device.createCommandEncoder();
+    encoder.copyTextureToTexture({ texture: srcTexture }, { texture: dstTexture }, [
+      blockWidth,
+      blockHeight,
+      1,
+    ]);
+    t.expectGPUError('validation', () => {
+      encoder.finish();
+    });
+  });

--- a/src/webgpu/listing_meta.json
+++ b/src/webgpu/listing_meta.json
@@ -830,6 +830,7 @@
   "webgpu:api,validation,texture,rg11b10ufloat_renderable:create_texture:*": { "subcaseMS": 12.700 },
   "webgpu:compat,api,validation,createBindGroup:viewDimension_matches_textureBindingViewDimension:*": { "subcaseMS": 6.523 },
   "webgpu:compat,api,validation,encoding,cmds,copyTextureToBuffer:compressed:*": { "subcaseMS": 202.929 },
+  "webgpu:compat,api,validation,encoding,cmds,copyTextureToTexture:compressed:*": { "subcaseMS": 0.600 },
   "webgpu:compat,api,validation,encoding,programmable,pipeline_bind_group_compat:twoDifferentTextureViews,compute_pass,unused:*": { "subcaseMS": 1.501 },
   "webgpu:compat,api,validation,encoding,programmable,pipeline_bind_group_compat:twoDifferentTextureViews,compute_pass,used:*": { "subcaseMS": 49.405 },
   "webgpu:compat,api,validation,encoding,programmable,pipeline_bind_group_compat:twoDifferentTextureViews,render_pass,unused:*": { "subcaseMS": 16.002 },


### PR DESCRIPTION
Checks that you get a validation error of trying to copyT2T compressed textures in compat


<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
