### PR TITLE
Revert "Skip compressed image_copy tests in Compatibility mode."

### DIFF
--- a/src/webgpu/api/operation/command_buffer/image_copy.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/image_copy.spec.ts
@@ -1413,7 +1413,6 @@ bytes in copy works for every format.
   .beforeAllSubcases(t => {
     const info = kTextureFormatInfo[t.params.format];
     t.skipIfTextureFormatNotSupported(t.params.format);
-    t.skipIfCopyTextureToTextureNotSupportedForFormat(t.params.format);
     t.selectDeviceOrSkipTestCase(info.feature);
   })
   .fn(t => {
@@ -1511,7 +1510,6 @@ works for every format with 2d and 2d-array textures.
   .beforeAllSubcases(t => {
     const info = kTextureFormatInfo[t.params.format];
     t.skipIfTextureFormatNotSupported(t.params.format);
-    t.skipIfCopyTextureToTextureNotSupportedForFormat(t.params.format);
     t.selectDeviceOrSkipTestCase(info.feature);
   })
   .fn(t => {
@@ -1592,7 +1590,6 @@ for all formats. We pass origin and copyExtent as [number, number, number].`
   .beforeAllSubcases(t => {
     const info = kTextureFormatInfo[t.params.format];
     t.skipIfTextureFormatNotSupported(t.params.format);
-    t.skipIfCopyTextureToTextureNotSupportedForFormat(t.params.format);
     t.selectDeviceOrSkipTestCase(info.feature);
   })
   .fn(t => {
@@ -1793,7 +1790,6 @@ TODO: Make a variant for depth-stencil formats.
   .beforeAllSubcases(t => {
     const info = kTextureFormatInfo[t.params.format];
     t.skipIfTextureFormatNotSupported(t.params.format);
-    t.skipIfCopyTextureToTextureNotSupportedForFormat(t.params.format);
     t.selectDeviceOrSkipTestCase(info.feature);
   })
   .fn(t => {


### PR DESCRIPTION
Reverts gpuweb/cts#3140

this is an invalid change isn't it? Suppressions shouldn't happen in the CTS