### PR TITLE
Compat fix image copy

### DIFF
--- a/src/webgpu/api/operation/command_buffer/image_copy.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/image_copy.spec.ts
@@ -1413,7 +1413,6 @@ bytes in copy works for every format.
   .beforeAllSubcases(t => {
     const info = kTextureFormatInfo[t.params.format];
     t.skipIfTextureFormatNotSupported(t.params.format);
-    t.skipIfCopyTextureToTextureNotSupportedForFormat(t.params.format);
     t.selectDeviceOrSkipTestCase(info.feature);
   })
   .fn(t => {
@@ -1511,7 +1510,6 @@ works for every format with 2d and 2d-array textures.
   .beforeAllSubcases(t => {
     const info = kTextureFormatInfo[t.params.format];
     t.skipIfTextureFormatNotSupported(t.params.format);
-    t.skipIfCopyTextureToTextureNotSupportedForFormat(t.params.format);
     t.selectDeviceOrSkipTestCase(info.feature);
   })
   .fn(t => {
@@ -1592,7 +1590,6 @@ for all formats. We pass origin and copyExtent as [number, number, number].`
   .beforeAllSubcases(t => {
     const info = kTextureFormatInfo[t.params.format];
     t.skipIfTextureFormatNotSupported(t.params.format);
-    t.skipIfCopyTextureToTextureNotSupportedForFormat(t.params.format);
     t.selectDeviceOrSkipTestCase(info.feature);
   })
   .fn(t => {
@@ -1793,7 +1790,6 @@ TODO: Make a variant for depth-stencil formats.
   .beforeAllSubcases(t => {
     const info = kTextureFormatInfo[t.params.format];
     t.skipIfTextureFormatNotSupported(t.params.format);
-    t.skipIfCopyTextureToTextureNotSupportedForFormat(t.params.format);
     t.selectDeviceOrSkipTestCase(info.feature);
   })
   .fn(t => {

--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -1260,7 +1260,7 @@ function getPipelineToRenderTextureToRGB8UnormTexture(
   }
 
   const { pipelineByPipelineType } = s_deviceToResourcesMap.get(device)!;
-  const pipelineType = isCompatibility && texture.depthOrArrayLayers > 1 ? '2d-array' : '2d';
+  const pipelineType: PipelineType = isCompatibility && texture.depthOrArrayLayers > 1 ? '2d-array' : '2d';
   if (!pipelineByPipelineType.get(pipelineType)) {
     const [textureType, layerCode] =
       pipelineType === '2d' ? ['texture_2d', ''] : ['texture_2d_array', ', uni.baseArrayLayer'];

--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -1504,7 +1504,7 @@ export function TextureTestMixin<F extends FixtureClass<GPUTest>>(
                       baseArrayLayer: layer,
                       arrayLayerCount: 1,
                     }),
-                    dimension: pipelineType as GPUTextureViewDimension,
+                    dimension: pipelineType,
                   }),
                 },
                 ...(pipelineType === '2d-array'


### PR DESCRIPTION
Use comapt compatible pipelines for checking results.

Kai suggested not changing anything in core so it only uses the compat versions in compat mode.

Issue: #3143

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
