### PR TITLE
Compat: Fix texture_zero init tests for compat

### DIFF
--- a/src/webgpu/api/operation/resource_init/check_texture/by_sampling.ts
+++ b/src/webgpu/api/operation/resource_init/check_texture/by_sampling.ts
@@ -41,14 +41,20 @@ export const checkContentsBySampling: CheckContents = (
         ? componentOrder[0].toLowerCase()
         : componentOrder.map(c => c.toLowerCase()).join('') + '[i]';
 
-    const _xd = '_' + params.dimension;
+    const viewDimension =
+      t.isCompatibility && params.dimension === '2d' && texture.depthOrArrayLayers > 1
+        ? '2d-array'
+        : params.dimension;
+    const _xd = `_${viewDimension.replace('-', '_')}`;
     const _multisampled = params.sampleCount > 1 ? '_multisampled' : '';
     const texelIndexExpression =
-      params.dimension === '2d'
+      viewDimension === '2d'
         ? 'vec2<i32>(GlobalInvocationID.xy)'
-        : params.dimension === '3d'
+        : viewDimension === '2d-array'
+        ? 'vec2<i32>(GlobalInvocationID.xy), constants.layer'
+        : viewDimension === '3d'
         ? 'vec3<i32>(GlobalInvocationID.xyz)'
-        : params.dimension === '1d'
+        : viewDimension === '1d'
         ? 'i32(GlobalInvocationID.x)'
         : unreachable();
     const computePipeline = t.device.createComputePipeline({
@@ -58,7 +64,8 @@ export const checkContentsBySampling: CheckContents = (
         module: t.device.createShaderModule({
           code: `
             struct Constants {
-              level : i32
+              level : i32,
+              layer : i32,
             };
 
             @group(0) @binding(0) var<uniform> constants : Constants;
@@ -90,10 +97,10 @@ export const checkContentsBySampling: CheckContents = (
     for (const layer of layers) {
       const ubo = t.device.createBuffer({
         mappedAtCreation: true,
-        size: 4,
+        size: 8,
         usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
       });
-      new Int32Array(ubo.getMappedRange(), 0, 1)[0] = level;
+      new Int32Array(ubo.getMappedRange()).set([level, layer]);
       ubo.unmap();
 
       const byteLength =
@@ -104,6 +111,14 @@ export const checkContentsBySampling: CheckContents = (
       });
       t.trackForCleanup(resultBuffer);
 
+      const viewDescriptor: GPUTextureViewDescriptor = {
+        ...(!t.isCompatibility && {
+          baseArrayLayer: layer,
+          arrayLayerCount: 1,
+        }),
+        dimension: viewDimension,
+      };
+
       const bindGroup = t.device.createBindGroup({
         layout: computePipeline.getBindGroupLayout(0),
         entries: [
@@ -113,11 +128,7 @@ export const checkContentsBySampling: CheckContents = (
           },
           {
             binding: 1,
-            resource: texture.createView({
-              baseArrayLayer: layer,
-              arrayLayerCount: 1,
-              dimension: params.dimension,
-            }),
+            resource: texture.createView(viewDescriptor),
           },
           {
             binding: 3,


### PR DESCRIPTION
Fixes for texture_zero init tests in compat mode.

Issue: #3145

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
