### PR TITLE
Compat: fix in-render-misc.spec.ts for compat

### DIFF
--- a/src/webgpu/api/validation/resource_usages/texture/in_render_misc.spec.ts
+++ b/src/webgpu/api/validation/resource_usages/texture/in_render_misc.spec.ts
@@ -155,6 +155,9 @@ g.test('subresources,set_bind_group_on_same_index_depth_stencil_texture')
       format: 'depth24plus-stencil8',
       usage: GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.RENDER_ATTACHMENT,
       size: [kTextureSize, kTextureSize, 1],
+      ...(t.isCompatibility && {
+        textureBindingViewDimension: '2d-array',
+      }),
     });
 
     const conflictedToNonReadOnlyAttachmentBindGroup = t.createBindGroupForTest(
@@ -170,6 +173,9 @@ g.test('subresources,set_bind_group_on_same_index_depth_stencil_texture')
       format: 'rgba8unorm',
       usage: GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.STORAGE_BINDING,
       size: [kTextureSize, kTextureSize, 1],
+      ...(t.isCompatibility && {
+        textureBindingViewDimension: '2d-array',
+      }),
     });
     const validBindGroup = t.createBindGroupForTest(
       colorTexture.createView({


### PR DESCRIPTION
In compat, have a '2d-array' view of a texture the texture must have 'textureBindingViewDimension: '2d-array' at creation time.

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
