### PR TITLE
Reapply "Skip compressed image_copy tests in Compatibility mode. (#31…

### DIFF
--- a/src/webgpu/api/operation/command_buffer/image_copy.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/image_copy.spec.ts
@@ -1413,6 +1413,7 @@ bytes in copy works for every format.
   .beforeAllSubcases(t => {
     const info = kTextureFormatInfo[t.params.format];
     t.skipIfTextureFormatNotSupported(t.params.format);
+    t.skipIfCopyTextureToTextureNotSupportedForFormat(t.params.format);
     t.selectDeviceOrSkipTestCase(info.feature);
   })
   .fn(t => {
@@ -1510,6 +1511,7 @@ works for every format with 2d and 2d-array textures.
   .beforeAllSubcases(t => {
     const info = kTextureFormatInfo[t.params.format];
     t.skipIfTextureFormatNotSupported(t.params.format);
+    t.skipIfCopyTextureToTextureNotSupportedForFormat(t.params.format);
     t.selectDeviceOrSkipTestCase(info.feature);
   })
   .fn(t => {
@@ -1590,6 +1592,7 @@ for all formats. We pass origin and copyExtent as [number, number, number].`
   .beforeAllSubcases(t => {
     const info = kTextureFormatInfo[t.params.format];
     t.skipIfTextureFormatNotSupported(t.params.format);
+    t.skipIfCopyTextureToTextureNotSupportedForFormat(t.params.format);
     t.selectDeviceOrSkipTestCase(info.feature);
   })
   .fn(t => {
@@ -1790,6 +1793,7 @@ TODO: Make a variant for depth-stencil formats.
   .beforeAllSubcases(t => {
     const info = kTextureFormatInfo[t.params.format];
     t.skipIfTextureFormatNotSupported(t.params.format);
+    t.skipIfCopyTextureToTextureNotSupportedForFormat(t.params.format);
     t.selectDeviceOrSkipTestCase(info.feature);
   })
   .fn(t => {


### PR DESCRIPTION
This reverts commit d30a01d17c7aa9be3880bef2744fbe2130f1e11d.

<hr>

**Requirements for PR author:**

- [ ] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [ ] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.