### PR TITLE
Use `findFailedPixels` in `copyTextureToTexture`

### DIFF
--- a/src/webgpu/api/operation/command_buffer/copyTextureToTexture.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/copyTextureToTexture.spec.ts
@@ -361,15 +361,9 @@ class F extends TextureTestMixin(GPUTest) {
     const checkByTextureFormat = (actual: Uint8Array) => {
       const zero = { x: 0, y: 0, z: 0 };
 
-      const dataLayout = {
-        offset: 0,
+      const actTexelView = TexelView.fromTextureDataByReference(dstFormat, actual, {
         bytesPerRow: bytesInRow,
         rowsPerImage: dstBlockRowsPerImage,
-      };
-
-      const actTexelView = TexelView.fromTextureDataByReference(dstFormat, actual, {
-        bytesPerRow: dataLayout.bytesPerRow,
-        rowsPerImage: dataLayout.rowsPerImage,
         subrectOrigin: zero,
         subrectSize: dstTextureSizeAtLevel,
       });
@@ -377,8 +371,8 @@ class F extends TextureTestMixin(GPUTest) {
         dstFormat,
         expectedUint8DataWithPadding,
         {
-          bytesPerRow: dataLayout.bytesPerRow,
-          rowsPerImage: dataLayout.rowsPerImage,
+          bytesPerRow: bytesInRow,
+          rowsPerImage: dstBlockRowsPerImage,
           subrectOrigin: zero,
           subrectSize: dstTextureSizeAtLevel,
         }

--- a/src/webgpu/format_info.ts
+++ b/src/webgpu/format_info.ts
@@ -1250,6 +1250,10 @@ export function isCompressedTextureFormat(format: GPUTextureFormat) {
   return format in kCompressedTextureFormatInfo;
 }
 
+export function isEncodableTextureformat(format: GPUTextureFormat) {
+  return format in kEncodableTextureFormatInfo;
+}
+
 export const kFeaturesForFormats = getFeaturesForFormats(kTextureFormats);
 
 /**


### PR DESCRIPTION


Issue: #937 #2081

Use `findFailedPixels` in `copyTextureToTexture` like that in `image_copy`. So that formats with multiple issues (rgb9e5ufloat) can pass.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
