### PR TITLE
Add tools/server for server under ts-node, and update help

### DIFF
--- a/src/common/runtime/server.ts
+++ b/src/common/runtime/server.ts
@@ -21,7 +21,7 @@ import sys from './helper/sys.js';
 
 function usage(rc: number): never {
   console.log(`Usage:
-  tools/run_${sys.type} [OPTIONS...]
+  tools/server [OPTIONS...]
 Options:
   --colors                  Enable ANSI colors in output.
   --compat                  Run tests in compatibility mode.
@@ -33,8 +33,10 @@ Options:
   --u                       Flag to set on the gpu-provider as <flag>=<value>
 
 Provides an HTTP server used for running tests via an HTTP RPC interface
-To run a test, perform an HTTP GET or POST at the URL:
-  http://localhost:port/run?<test-name>
+First, load some tree or subtree of tests:
+  http://localhost:port/load?unittests:basic:*
+To run a single test case, perform an HTTP GET or POST at the URL:
+  http://localhost:port/run?unittests:basic:test,sync
 To shutdown the server perform an HTTP GET or POST at the URL:
   http://localhost:port/terminate
 `);

--- a/tools/server
+++ b/tools/server
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+
+// Launch a server that runs tests server-side on demand.
+
+require('../src/common/tools/setup-ts-in-node.js');
+require('../src/common/runtime/server.ts');


### PR DESCRIPTION
Tested locally with:
```sh
npx grunt clean
tools/server
```
```sh
curl 'http://localhost:54738/load?unittests:basic:*'
curl 'http://localhost:54738/run?unittests:basic:test,sync:'
```

Issue: None

<hr>

**Requirements for PR author:**

- [x] ~All missing test coverage is tracked with "TODO" or `.unimplemented()`.~
- [x] ~New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.~
- [x] ~Test~ behaves as expected ~in a WebGPU implementation. (If not passing, explain above.)~

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] ~Tests are properly located in the test tree.~
- [ ] ~[Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.~
- [ ] ~Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**~
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
