### PR TITLE
Compat: test depthOrArrayLayers vs textureBindingViewFormat

### DIFF
--- a/src/webgpu/compat/api/validation/texture/createTexture.spec.ts
+++ b/src/webgpu/compat/api/validation/texture/createTexture.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable prettier/prettier */
 export const description = `
 Tests that you can not use bgra8unorm-srgb in compat mode.
 Tests that textureBindingViewDimension must compatible with texture dimension
@@ -70,3 +71,36 @@ g.test('invalidTextureBindingViewDimension')
       shouldError
     );
   });
+
+g.test('depthOrArrayLayers_incompatible_with_textureBindingViewDimension')
+  .desc(
+    `Tests
+    * if textureBindingViewDimension is '2d' then depthOrArrayLayers must be 1
+    * if textureBindingViewDimension is 'cube' then depthOrArrayLayers must be 6
+    `
+  )
+  .params(u =>
+    u //
+      .combine('textureBindingViewDimension', ['2d', 'cube'])
+      .combine('depthOrArrayLayers', [1, 3, 6, 12])
+  )
+  .fn(t => {
+    const { textureBindingViewDimension, depthOrArrayLayers } = t.params;
+    const shouldError =
+      (textureBindingViewDimension === '2d' && depthOrArrayLayers !== 1) ||
+      (textureBindingViewDimension === 'cube' && depthOrArrayLayers !== 6);
+    t.expectGPUError(
+      'validation',
+      () => {
+        const texture = t.device.createTexture({
+          size: [1, 1, depthOrArrayLayers],
+          format: 'rgba8unorm',
+          usage: GPUTextureUsage.TEXTURE_BINDING,
+          textureBindingViewDimension,
+        } as GPUTextureDescriptor); // MAINTENANCE_TODO: remove cast once textureBindingViewDimension is added to IDL
+        t.trackForCleanup(texture);
+      },
+      shouldError
+    );
+  });
+

--- a/src/webgpu/listing_meta.json
+++ b/src/webgpu/listing_meta.json
@@ -841,6 +841,7 @@
   "webgpu:compat,api,validation,render_pipeline,fragment_state:colorState:*": { "subcaseMS": 32.604 },
   "webgpu:compat,api,validation,render_pipeline,shader_module:sample_mask:*": { "subcaseMS": 14.801 },
   "webgpu:compat,api,validation,render_pipeline,vertex_state:maxVertexAttributesVertexIndexInstanceIndex:*": { "subcaseMS": 3.700 },
+  "webgpu:compat,api,validation,texture,createTexture:depthOrArrayLayers_incompatible_with_textureBindingViewDimension:*": { "subcaseMS": 12.712 },
   "webgpu:compat,api,validation,texture,createTexture:invalidTextureBindingViewDimension:*": { "subcaseMS": 6.022 },
   "webgpu:compat,api,validation,texture,createTexture:unsupportedTextureFormats:*": { "subcaseMS": 0.700 },
   "webgpu:compat,api,validation,texture,createTexture:unsupportedTextureViewFormats:*": { "subcaseMS": 0.601 },


### PR DESCRIPTION
A texture with textureBindingViewFormat = '2d' should generate a validation error if depthOrArrayLayers is not 1

A texture with textureBindingViewFormat = 'cube' should generate a validation error if depthOrArrayLayers is not 6


<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
