### PR TITLE
Compat: Fixes for format reinterpretation

### DIFF
--- a/src/webgpu/api/operation/texture_view/format_reinterpretation.spec.ts
+++ b/src/webgpu/api/operation/texture_view/format_reinterpretation.spec.ts
@@ -106,6 +106,8 @@ g.test('texture_binding')
   .beforeAllSubcases(t => {
     const { format, viewFormat } = t.params;
     t.skipIfTextureFormatNotSupported(format, viewFormat);
+    // Compatibility mode does not support format reinterpretation.
+    t.skipIf(t.isCompatibility);
   })
   .fn(t => {
     const { format, viewFormat } = t.params;
@@ -207,6 +209,8 @@ in view format and match in base format.`
   .beforeAllSubcases(t => {
     const { format, viewFormat } = t.params;
     t.skipIfTextureFormatNotSupported(format, viewFormat);
+    // Compatibility mode does not support format reinterpretation.
+    t.skipIf(t.isCompatibility);
   })
   .fn(t => {
     const { format, viewFormat, sampleCount } = t.params;

--- a/src/webgpu/api/validation/createView.spec.ts
+++ b/src/webgpu/api/validation/createView.spec.ts
@@ -55,6 +55,8 @@ g.test('format')
     const { blockWidth, blockHeight } = kTextureFormatInfo[textureFormat];
 
     t.skipIfTextureFormatNotSupported(textureFormat, viewFormat);
+    // Compatibility mode does not support format reinterpretation.
+    t.skipIf(t.isCompatibility && viewFormat !== undefined && viewFormat !== textureFormat);
 
     const compatible = viewFormat === undefined || viewCompatible(textureFormat, viewFormat);
 


### PR DESCRIPTION
format reinterpretation is not supported in compat mode. The format_reinterpretation tests already filter out every case where format == viewFormat so all that's left is cases that don't work in compat.

The createView tests test multiple combinations, some of which are valid and some are not.

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
