### PR TITLE
Compat: Fix compat tests for depthOrArrayLayers restrictions

### DIFF
--- a/src/webgpu/compat/api/validation/createBindGroup.spec.ts
+++ b/src/webgpu/compat/api/validation/createBindGroup.spec.ts
@@ -68,6 +68,8 @@ function isValidViewDimensionForDepthOrArrayLayers(
   depthOrArrayLayers: number
 ) {
   switch (viewDimension) {
+    case '2d':
+      return depthOrArrayLayers === 1;
     case 'cube':
       return depthOrArrayLayers === 6;
     case 'cube-array':

--- a/src/webgpu/compat/api/validation/texture/createTexture.spec.ts
+++ b/src/webgpu/compat/api/validation/texture/createTexture.spec.ts
@@ -55,12 +55,13 @@ g.test('invalidTextureBindingViewDimension')
   )
   .fn(t => {
     const { dimension, textureBindingViewDimension } = t.params;
+    const depthOrArrayLayers = textureBindingViewDimension === '1d' || textureBindingViewDimension === '2d' ? 1 : 6;
     const shouldError = getTextureDimensionFromView(textureBindingViewDimension) !== dimension;
     t.expectGPUError(
       'validation',
       () => {
         const texture = t.device.createTexture({
-          size: [1, 1, dimension === '1d' ? 1 : 6],
+          size: [1, 1, depthOrArrayLayers],
           format: 'rgba8unorm',
           usage: GPUTextureUsage.TEXTURE_BINDING,
           dimension,


### PR DESCRIPTION
textureBindingViewDimension = '2d' must have depthOrArrayLayers = 1 textureBindingViewDimension = 'cube' must have depthOrArrayLayers = 6

For the `createBindGroup` test we just needed to skip when it's `'2d'` and not `depthOrArrayLayers === 1`

For the `createTexture` test we just need to pass in the correct `depthOrArrayLayers` for the given `textureBindingViewDimension` so we can test what we really want to test (`textureBindingViewDimension` vs `dimension`). The test below that tests `depthOrArrayLayers` vs `textureBindingViewDimension`

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
