### PR TITLE
Compat: Check viewFormats match format

### DIFF
--- a/src/webgpu/compat/api/validation/texture/createTexture.spec.ts
+++ b/src/webgpu/compat/api/validation/texture/createTexture.spec.ts
@@ -6,6 +6,7 @@ Tests that textureBindingViewDimension must compatible with texture dimension
 
 import { makeTestGroup } from '../../../../../common/framework/test_group.js';
 import { kTextureDimensions, kTextureViewDimensions } from '../../../../capability_info.js';
+import { kColorTextureFormats, kTextureFormatInfo } from '../../../../format_info.js';
 import { getTextureDimensionFromView } from '../../../../util/texture/base.js';
 import { CompatibilityTest } from '../../../compatibility_test.js';
 
@@ -105,3 +106,50 @@ g.test('depthOrArrayLayers_incompatible_with_textureBindingViewDimension')
     );
   });
 
+g.test('format_reinterpretation')
+  .desc(
+    `
+    Tests that you can not request different view formats when creating a texture.
+    For example, rgba8unorm can not be viewed as rgba8unorm-srgb
+  `
+  )
+  .params(u =>
+    u //
+      .combine('format', kColorTextureFormats as GPUTextureFormat[])
+      .filter(
+        ({ format }) =>
+          !!kTextureFormatInfo[format].baseFormat &&
+          kTextureFormatInfo[format].baseFormat !== format
+      )
+  )
+  .beforeAllSubcases(t => {
+    const info = kTextureFormatInfo[t.params.format];
+    t.skipIfTextureFormatNotSupported(t.params.format);
+    t.selectDeviceOrSkipTestCase(info.feature);
+  })
+  .fn(t => {
+    const { format } = t.params;
+    const info = kTextureFormatInfo[t.params.format];
+
+    const formatPairs = [
+      { format, viewFormats: [info.baseFormat!] },
+      { format: info.baseFormat!, viewFormats: [format] },
+      { format, viewFormats: [format, info.baseFormat!] },
+      { format: info.baseFormat!, viewFormats: [format, info.baseFormat!] },
+    ];
+    for (const { format, viewFormats } of formatPairs) {
+      t.expectGPUError(
+        'validation',
+        () => {
+          const texture = t.device.createTexture({
+            size: [info.blockWidth, info.blockHeight],
+            format,
+            viewFormats,
+            usage: GPUTextureUsage.TEXTURE_BINDING,
+          });
+          t.trackForCleanup(texture);
+        },
+        true
+      );
+    }
+  });

--- a/src/webgpu/listing_meta.json
+++ b/src/webgpu/listing_meta.json
@@ -842,6 +842,7 @@
   "webgpu:compat,api,validation,render_pipeline,shader_module:sample_mask:*": { "subcaseMS": 14.801 },
   "webgpu:compat,api,validation,render_pipeline,vertex_state:maxVertexAttributesVertexIndexInstanceIndex:*": { "subcaseMS": 3.700 },
   "webgpu:compat,api,validation,texture,createTexture:depthOrArrayLayers_incompatible_with_textureBindingViewDimension:*": { "subcaseMS": 12.712 },
+  "webgpu:compat,api,validation,texture,createTexture:format_reinterpretation:*": { "subcaseMS": 7.012 },
   "webgpu:compat,api,validation,texture,createTexture:invalidTextureBindingViewDimension:*": { "subcaseMS": 6.022 },
   "webgpu:compat,api,validation,texture,createTexture:unsupportedTextureFormats:*": { "subcaseMS": 0.700 },
   "webgpu:compat,api,validation,texture,createTexture:unsupportedTextureViewFormats:*": { "subcaseMS": 0.601 },


### PR DESCRIPTION

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
