### PR TITLE
Comapt: Fix createTexture:'viewFormats' test for compat

### DIFF
--- a/src/webgpu/api/validation/createTexture.spec.ts
+++ b/src/webgpu/api/validation/createTexture.spec.ts
@@ -1096,7 +1096,9 @@ g.test('viewFormats')
 
     t.skipIfTextureFormatNotSupported(format, viewFormat);
 
-    const compatible = viewCompatible(format, viewFormat);
+    const compatible = t.isCompatibility
+      ? viewFormat === format
+      : viewCompatible(format, viewFormat);
 
     // Test the viewFormat in the list.
     t.expectValidationError(() => {


### PR DESCRIPTION


<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
