### PR TITLE
Adjust fragment state blend factor and write mask validation

### DIFF
--- a/src/webgpu/api/validation/render_pipeline/fragment_state.spec.ts
+++ b/src/webgpu/api/validation/render_pipeline/fragment_state.spec.ts
@@ -384,12 +384,11 @@ g.test('pipeline_output_targets,blend')
       ] as const)
       .expand('writeMask', function* (p) {
         yield 0;
-        for (let i = 1; i <= p.componentCount; i++) {
-          yield (1 << i) - 1;
+        for (let i = 0; i < p.componentCount; i++) {
+          yield 1 << i;
         }
-        if (p.componentCount < 4) {
-          yield 0xf;
-        }
+        // default full mask
+        yield 0xf;
       })
   )
   .beforeAllSubcases(t => {

--- a/src/webgpu/api/validation/render_pipeline/fragment_state.spec.ts
+++ b/src/webgpu/api/validation/render_pipeline/fragment_state.spec.ts
@@ -366,7 +366,7 @@ g.test('pipeline_output_targets')
 g.test('pipeline_output_targets,blend')
   .desc(
     `On top of requirements from pipeline_output_targets, when blending is enabled and alpha channel is read indicated by any blend factor, an extra requirement is added:
-  - fragment output must be vec4.
+  - fragment output must have an alpha channel (i.e. it must be vec4), otherwise writeMask must be 0.
   `
   )
   .params(u =>
@@ -382,6 +382,15 @@ g.test('pipeline_output_targets,blend')
         ...u.combine('alphaSrcFactor', kBlendFactors),
         ...u.combine('alphaDstFactor', kBlendFactors),
       ] as const)
+      .expand('writeMask', function* (p) {
+        yield 0;
+        for (let i = 1; i <= p.componentCount; i++) {
+          yield (1 << i) - 1;
+        }
+        if (p.componentCount < 4) {
+          yield 0xf;
+        }
+      })
   )
   .beforeAllSubcases(t => {
     const { format } = t.params;
@@ -398,6 +407,7 @@ g.test('pipeline_output_targets,blend')
       colorDstFactor,
       alphaSrcFactor,
       alphaDstFactor,
+      writeMask,
     } = t.params;
     const info = kTextureFormatInfo[format];
 
@@ -409,6 +419,7 @@ g.test('pipeline_output_targets,blend')
             color: { srcFactor: colorSrcFactor, dstFactor: colorDstFactor },
             alpha: { srcFactor: alphaSrcFactor, dstFactor: alphaDstFactor },
           },
+          writeMask,
         },
       ],
       fragmentShaderCode: getFragmentShaderCodeWithOutput([
@@ -422,6 +433,6 @@ g.test('pipeline_output_targets,blend')
     const _success =
       info.color.type === sampleType &&
       componentCount >= kTexelRepresentationInfo[format].componentOrder.length &&
-      meetsExtraBlendingRequirement;
+      (meetsExtraBlendingRequirement || writeMask === 0);
     t.doCreateRenderPipelineTest(isAsync, _success, descriptor);
   });


### PR DESCRIPTION

Issue: https://crbug.com/dawn/2272

Validation in chrome impl needs adjustment: https://dawn-review.googlesource.com/c/dawn/+/164922

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
