### PR TITLE
Compat: Skip or expect error for rg32xxx texture formats

### DIFF
--- a/src/webgpu/api/validation/createBindGroup.spec.ts
+++ b/src/webgpu/api/validation/createBindGroup.spec.ts
@@ -815,6 +815,10 @@ g.test('storage_texture,format')
       .combine('storageTextureFormat', kStorageTextureFormats)
       .combine('resourceFormat', kStorageTextureFormats)
   )
+  .beforeAllSubcases(t => {
+    const { resourceFormat } = t.params;
+    t.skipIfTextureFormatNotUsableAsStorageTexture(resourceFormat);
+  })
   .fn(t => {
     const { storageTextureFormat, resourceFormat } = t.params;
 

--- a/src/webgpu/api/validation/createBindGroupLayout.spec.ts
+++ b/src/webgpu/api/validation/createBindGroupLayout.spec.ts
@@ -450,6 +450,7 @@ g.test('storage_texture,formats')
   )
   .beforeAllSubcases(t => {
     t.selectDeviceForTextureFormatOrSkipTestCase(t.params.format);
+    t.skipIfTextureFormatNotUsableAsStorageTexture(t.params.format);
   })
   .fn(t => {
     const { format, access } = t.params;

--- a/src/webgpu/api/validation/createTexture.spec.ts
+++ b/src/webgpu/api/validation/createTexture.spec.ts
@@ -373,20 +373,19 @@ g.test('sampleCount,valid_sampleCount_with_other_parameter_varies')
       usage,
     };
 
-    const usableWithStorageUsage =
+    const satisfyWithStorageUsageRequirement =
       (usage & GPUConst.TextureUsage.STORAGE_BINDING) === 0 ||
       isTextureFormatUsableAsStorageFormat(format, t.isCompatibility);
 
     const success =
-      usableWithStorageUsage &&
-      (sampleCount === 1 ||
-        (sampleCount === 4 &&
-          (dimension === '2d' || dimension === undefined) &&
-          kTextureFormatInfo[format].multisample &&
-          mipLevelCount === 1 &&
-          arrayLayerCount === 1 &&
-          (usage & GPUConst.TextureUsage.RENDER_ATTACHMENT) !== 0 &&
-          (usage & GPUConst.TextureUsage.STORAGE_BINDING) === 0));
+      (sampleCount === 1 && satisfyWithStorageUsageRequirement) ||
+      (sampleCount === 4 &&
+        (dimension === '2d' || dimension === undefined) &&
+        kTextureFormatInfo[format].multisample &&
+        mipLevelCount === 1 &&
+        arrayLayerCount === 1 &&
+        (usage & GPUConst.TextureUsage.RENDER_ATTACHMENT) !== 0 &&
+        (usage & GPUConst.TextureUsage.STORAGE_BINDING) === 0);
 
     t.expectValidationError(() => {
       t.device.createTexture(descriptor);

--- a/src/webgpu/api/validation/createTexture.spec.ts
+++ b/src/webgpu/api/validation/createTexture.spec.ts
@@ -15,6 +15,7 @@ import {
   filterFormatsByFeature,
   viewCompatible,
   textureDimensionAndFormatCompatible,
+  isTextureFormatUsableAsStorageFormat,
 } from '../../format_info.js';
 import { maxMipLevelCount } from '../../util/texture/base.js';
 
@@ -372,15 +373,20 @@ g.test('sampleCount,valid_sampleCount_with_other_parameter_varies')
       usage,
     };
 
+    const usableWithStorageUsage =
+      (usage & GPUConst.TextureUsage.STORAGE_BINDING) === 0 ||
+      isTextureFormatUsableAsStorageFormat(format, t.isCompatibility);
+
     const success =
-      sampleCount === 1 ||
-      (sampleCount === 4 &&
-        (dimension === '2d' || dimension === undefined) &&
-        kTextureFormatInfo[format].multisample &&
-        mipLevelCount === 1 &&
-        arrayLayerCount === 1 &&
-        (usage & GPUConst.TextureUsage.RENDER_ATTACHMENT) !== 0 &&
-        (usage & GPUConst.TextureUsage.STORAGE_BINDING) === 0);
+      usableWithStorageUsage &&
+      (sampleCount === 1 ||
+        (sampleCount === 4 &&
+          (dimension === '2d' || dimension === undefined) &&
+          kTextureFormatInfo[format].multisample &&
+          mipLevelCount === 1 &&
+          arrayLayerCount === 1 &&
+          (usage & GPUConst.TextureUsage.RENDER_ATTACHMENT) !== 0 &&
+          (usage & GPUConst.TextureUsage.STORAGE_BINDING) === 0));
 
     t.expectValidationError(() => {
       t.device.createTexture(descriptor);
@@ -1058,7 +1064,11 @@ g.test('texture_usage')
     // Note that we unconditionally test copy usages for all formats. We don't check copySrc/copyDst in kTextureFormatInfo in capability_info.js
     // if (!info.copySrc && (usage & GPUTextureUsage.COPY_SRC) !== 0) success = false;
     // if (!info.copyDst && (usage & GPUTextureUsage.COPY_DST) !== 0) success = false;
-    if (!info.color?.storage && (usage & GPUTextureUsage.STORAGE_BINDING) !== 0) success = false;
+    if (
+      (usage & GPUTextureUsage.STORAGE_BINDING) !== 0 &&
+      !isTextureFormatUsableAsStorageFormat(format, t.isCompatibility)
+    )
+      success = false;
     if (
       (!info.renderable || (appliedDimension !== '2d' && appliedDimension !== '3d')) &&
       (usage & GPUTextureUsage.RENDER_ATTACHMENT) !== 0

--- a/src/webgpu/format_info.ts
+++ b/src/webgpu/format_info.ts
@@ -1931,6 +1931,21 @@ export function isCompressedTextureFormat(format: GPUTextureFormat) {
   return format in kCompressedTextureFormatInfo;
 }
 
+export function isTextureFormatUsableAsStorageFormat(
+  format: GPUTextureFormat,
+  isCompatibilityMode: boolean
+) {
+  if (isCompatibilityMode) {
+    switch (format) {
+      case 'rg32float':
+      case 'rg32sint':
+      case 'rg32uint':
+        return false;
+    }
+  }
+  return kTextureFormatInfo[format].color?.storage;
+}
+
 export function isEncodableTextureformat(format: GPUTextureFormat) {
   return format in kEncodableTextureFormatInfo;
 }

--- a/src/webgpu/format_info.ts
+++ b/src/webgpu/format_info.ts
@@ -1943,7 +1943,7 @@ export function isTextureFormatUsableAsStorageFormat(
         return false;
     }
   }
-  return kTextureFormatInfo[format].color?.storage;
+  return !!kTextureFormatInfo[format].color?.storage;
 }
 
 export function isEncodableTextureformat(format: GPUTextureFormat) {

--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -35,6 +35,7 @@ import {
   EncodableTextureFormat,
   isCompressedTextureFormat,
   ColorTextureFormat,
+  isTextureFormatUsableAsStorageFormat,
 } from './format_info.js';
 import { makeBufferWithContents } from './util/buffer.js';
 import { checkElementsEqual, checkElementsBetween } from './util/check_contents.js';
@@ -248,6 +249,14 @@ export class GPUTestSubcaseBatchState extends SubcaseBatchState {
         if (dimension === 'cube-array') {
           this.skip(`texture view dimension '${dimension}' is not supported`);
         }
+      }
+    }
+  }
+
+  skipIfTextureFormatNotUsableAsStorageTexture(...formats: (GPUTextureFormat | undefined)[]) {
+    for (const format of formats) {
+      if (format && !isTextureFormatUsableAsStorageFormat(format, this.isCompatibility)) {
+        this.skip(`Texture with ${format} is not usable as a storage texture`);
       }
     }
   }


### PR DESCRIPTION
rg32float, rg32sint, rg32uint texture formats don't support storage texture usage in compat mode.

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
