### PR TITLE
Compat:Check interpolate linear/sample validation

### DIFF
--- a/src/webgpu/compat/api/validation/render_pipeline/shader_module.spec.ts
+++ b/src/webgpu/compat/api/validation/render_pipeline/shader_module.spec.ts
@@ -72,3 +72,83 @@ Tests that you can not create a render pipeline with a shader module that uses s
       !isValid
     );
   });
+
+g.test('interpolate')
+  .desc(
+    `
+Tests that you can not create a render pipeline with a shader module that uses interpolate(linear) nor interpolate(...,sample) in compat mode.
+
+- Test that a pipeline with a shader that uses interpolate(linear) or interpolate(sample) fails.
+- Test that a pipeline that references a module that has a shader that uses interpolate(linear/sample)
+  but the pipeline does not reference that shader succeeds.
+    `
+  )
+  .params(u =>
+    u
+      .combine('interpolate', [
+        '',
+        '@interpolate(linear)',
+        '@interpolate(linear, sample)',
+        '@interpolate(perspective, sample)',
+      ] as const)
+      .combine('entryPoint', [
+        'fsWithoutInterpolationUsage',
+        'fsWithInterpolationUsage1',
+        'fsWithInterpolationUsage2',
+        'fsWithInterpolationUsage3',
+      ] as const)
+  )
+  .fn(t => {
+    const { entryPoint, interpolate } = t.params;
+
+    const module = t.device.createShaderModule({
+      code: `
+        struct Vertex {
+            @builtin(position) pos: vec4f,
+            @location(0) ${interpolate} color : vec4f,
+        };
+        @vertex fn vs() -> Vertex {
+            var v: Vertex;
+            v.pos = vec4f(1);
+            v.color = vec4f(1);
+            return v;
+        }
+        @fragment fn fsWithoutInterpolationUsage() -> @location(0) vec4f {
+            return vec4f(1);
+        }
+        @fragment fn fsWithInterpolationUsage1(v: Vertex) -> @location(0) vec4f {
+            return vec4f(1);
+        }
+        @fragment fn fsWithInterpolationUsage2(v: Vertex) -> @location(0) vec4f {
+            return v.pos;
+        }
+        @fragment fn fsWithInterpolationUsage3(v: Vertex) -> @location(0) vec4f {
+            return v.color;
+        }
+      `,
+    });
+
+    const pipelineDescriptor: GPURenderPipelineDescriptor = {
+      layout: 'auto',
+      vertex: {
+        module,
+        entryPoint: 'vs',
+      },
+      fragment: {
+        module,
+        entryPoint,
+        targets: [
+          {
+            format: 'rgba8unorm',
+          },
+        ],
+      },
+    };
+
+    const isValid = entryPoint === 'fsWithoutInterpolationUsage' || interpolate === '';
+    t.expectGPUError(
+      'validation',
+      () => t.device.createRenderPipeline(pipelineDescriptor),
+      !isValid
+    );
+  });

--- a/src/webgpu/listing_meta.json
+++ b/src/webgpu/listing_meta.json
@@ -842,6 +842,7 @@
   "webgpu:compat,api,validation,encoding,programmable,pipeline_bind_group_compat:twoDifferentTextureViews,render_pass,unused:*": { "subcaseMS": 16.002 },
   "webgpu:compat,api,validation,encoding,programmable,pipeline_bind_group_compat:twoDifferentTextureViews,render_pass,used:*": { "subcaseMS": 0.000 },
   "webgpu:compat,api,validation,render_pipeline,fragment_state:colorState:*": { "subcaseMS": 32.604 },
+  "webgpu:compat,api,validation,render_pipeline,shader_module:interpolate:*": { "subcaseMS": 1.502 },
   "webgpu:compat,api,validation,render_pipeline,shader_module:sample_mask:*": { "subcaseMS": 14.801 },
   "webgpu:compat,api,validation,render_pipeline,vertex_state:maxVertexAttributesVertexIndexInstanceIndex:*": { "subcaseMS": 3.700 },
   "webgpu:compat,api,validation,texture,createTexture:depthOrArrayLayers_incompatible_with_textureBindingViewDimension:*": { "subcaseMS": 12.712 },


### PR DESCRIPTION
Both don't exist in GLES 3.1

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
