### PR TITLE
Compat: Fix tests that use @interpole(linear/sample)

### DIFF
--- a/src/webgpu/api/validation/render_pipeline/inter_stage.spec.ts
+++ b/src/webgpu/api/validation/render_pipeline/inter_stage.spec.ts
@@ -159,20 +159,27 @@ g.test('interpolation_type')
       { output: '@interpolate(linear)', input: '@interpolate(perspective)' },
       { output: '@interpolate(flat)', input: '@interpolate(perspective)' },
       { output: '@interpolate(linear)', input: '@interpolate(flat)' },
-      { output: '@interpolate(linear, center)', input: '@interpolate(linear, center)' },
+      {
+        output: '@interpolate(linear, center)',
+        input: '@interpolate(linear, center)',
+        _compat_success: false,
+      },
     ])
   )
   .fn(t => {
-    const { isAsync, output, input, _success } = t.params;
+    const { isAsync, output, input, _success, _compat_success } = t.params;
 
     const descriptor = t.getDescriptorWithStates(
       t.getVertexStateWithOutputs([`@location(0) ${output} vout0: f32`]),
       t.getFragmentStateWithInputs([`@location(0) ${input} fin0: f32`])
     );
 
-    t.doCreateRenderPipelineTest(isAsync, _success ?? output === input, descriptor);
-  });
+    const shouldSucceed =
+      (_success ?? output === input) && (!t.isCompatibility || _compat_success !== false);
 
+    t.doCreateRenderPipelineTest(isAsync, shouldSucceed, descriptor);
+  });
+1;
 g.test('interpolation_sampling')
   .desc(
     `Tests that validation should fail when interpolation sampling of vertex output and fragment input at the same location doesn't match.`
@@ -186,7 +193,12 @@ g.test('interpolation_sampling')
         input: '@interpolate(perspective, center)',
         _success: true,
       },
-      { output: '@interpolate(linear, center)', input: '@interpolate(linear)', _success: true },
+      {
+        output: '@interpolate(linear, center)',
+        input: '@interpolate(linear)',
+        _success: true,
+        _compat_success: false,
+      },
       { output: '@interpolate(flat)', input: '@interpolate(flat)' },
       { output: '@interpolate(perspective)', input: '@interpolate(perspective, sample)' },
       { output: '@interpolate(perspective, center)', input: '@interpolate(perspective, sample)' },
@@ -198,14 +210,17 @@ g.test('interpolation_sampling')
     ])
   )
   .fn(t => {
-    const { isAsync, output, input, _success } = t.params;
+    const { isAsync, output, input, _success, _compat_success } = t.params;
 
     const descriptor = t.getDescriptorWithStates(
       t.getVertexStateWithOutputs([`@location(0) ${output} vout0: f32`]),
       t.getFragmentStateWithInputs([`@location(0) ${input} fin0: f32`])
     );
 
-    t.doCreateRenderPipelineTest(isAsync, _success ?? output === input, descriptor);
+    const shouldSucceed =
+      (_success ?? output === input) && (!t.isCompatibility || _compat_success !== false);
+
+    t.doCreateRenderPipelineTest(isAsync, shouldSucceed, descriptor);
   });
 
 g.test('max_shader_variable_location')


### PR DESCRIPTION
Update tests so the expect to fail when `@interpolate(linear/sample)` is used.

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
