### PR TITLE
Compat: skip tests use rg32xxx formats with createBindGroupLayout

### DIFF
--- a/src/webgpu/api/validation/createBindGroup.spec.ts
+++ b/src/webgpu/api/validation/createBindGroup.spec.ts
@@ -816,8 +816,8 @@ g.test('storage_texture,format')
       .combine('resourceFormat', kStorageTextureFormats)
   )
   .beforeAllSubcases(t => {
-    const { resourceFormat } = t.params;
-    t.skipIfTextureFormatNotUsableAsStorageTexture(resourceFormat);
+    const { storageTextureFormat, resourceFormat } = t.params;
+    t.skipIfTextureFormatNotUsableAsStorageTexture(storageTextureFormat, resourceFormat);
   })
   .fn(t => {
     const { storageTextureFormat, resourceFormat } = t.params;


### PR DESCRIPTION
rg32xxx are not usable as storage textures in compat


<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
