### PR TITLE
reftests: Allow large totalPixels for fuzzy matching

### DIFF
--- a/src/webgpu/web_platform/reftests/canvas_colorspace_bgra8unorm.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_colorspace_bgra8unorm.https.html
@@ -14,6 +14,7 @@
   <link rel="help" href="https://gpuweb.github.io/gpuweb/" />
   <meta name="assert" content="WebGPU bgra8norm canvas with colorSpace set should be rendered correctly" />
   <link rel="match" href="./ref/canvas_colorspace-ref.html" />
+  <meta name=fuzzy content="maxDifference=0-2;totalPixels=0-99999">
   <script type="module">
     import { runColorSpaceTest } from './canvas_colorspace.html.js';
     runColorSpaceTest('bgra8unorm');

--- a/src/webgpu/web_platform/reftests/canvas_colorspace_bgra8unorm.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_colorspace_bgra8unorm.https.html
@@ -14,7 +14,7 @@
   <link rel="help" href="https://gpuweb.github.io/gpuweb/" />
   <meta name="assert" content="WebGPU bgra8norm canvas with colorSpace set should be rendered correctly" />
   <link rel="match" href="./ref/canvas_colorspace-ref.html" />
-  <meta name=fuzzy content="maxDifference=0-2;totalPixels=0-99999">
+  <meta name=fuzzy content="maxDifference=0-2;totalPixels=0-9999999">
   <script type="module">
     import { runColorSpaceTest } from './canvas_colorspace.html.js';
     runColorSpaceTest('bgra8unorm');

--- a/src/webgpu/web_platform/reftests/canvas_colorspace_rgba16float.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_colorspace_rgba16float.https.html
@@ -14,7 +14,7 @@
   <link rel="help" href="https://gpuweb.github.io/gpuweb/" />
   <meta name="assert" content="WebGPU rgba16float canvas with colorSpace set should be rendered correctly" />
   <link rel="match" href="./ref/canvas_colorspace-ref.html" />
-  <meta name=fuzzy content="maxDifference=1;totalPixels=8192">
+  <meta name=fuzzy content="maxDifference=0-2;totalPixels=0-99999">
   <script type="module">
     import { runColorSpaceTest } from './canvas_colorspace.html.js';
     runColorSpaceTest('rgba16float');

--- a/src/webgpu/web_platform/reftests/canvas_colorspace_rgba16float.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_colorspace_rgba16float.https.html
@@ -14,7 +14,7 @@
   <link rel="help" href="https://gpuweb.github.io/gpuweb/" />
   <meta name="assert" content="WebGPU rgba16float canvas with colorSpace set should be rendered correctly" />
   <link rel="match" href="./ref/canvas_colorspace-ref.html" />
-  <meta name=fuzzy content="maxDifference=0-2;totalPixels=0-99999">
+  <meta name=fuzzy content="maxDifference=0-2;totalPixels=0-9999999">
   <script type="module">
     import { runColorSpaceTest } from './canvas_colorspace.html.js';
     runColorSpaceTest('rgba16float');

--- a/src/webgpu/web_platform/reftests/canvas_colorspace_rgba8unorm.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_colorspace_rgba8unorm.https.html
@@ -14,7 +14,7 @@
   <link rel="help" href="https://gpuweb.github.io/gpuweb/" />
   <meta name="assert" content="WebGPU rgba8unorm canvas with colorSpace set should be rendered correctly" />
   <link rel="match" href="./ref/canvas_colorspace-ref.html" />
-  <meta name=fuzzy content="maxDifference=0-2;totalPixels=0-99999">
+  <meta name=fuzzy content="maxDifference=0-2;totalPixels=0-9999999">
   <script type="module">
     import { runColorSpaceTest } from './canvas_colorspace.html.js';
     runColorSpaceTest('rgba8unorm');

--- a/src/webgpu/web_platform/reftests/canvas_colorspace_rgba8unorm.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_colorspace_rgba8unorm.https.html
@@ -14,6 +14,7 @@
   <link rel="help" href="https://gpuweb.github.io/gpuweb/" />
   <meta name="assert" content="WebGPU rgba8unorm canvas with colorSpace set should be rendered correctly" />
   <link rel="match" href="./ref/canvas_colorspace-ref.html" />
+  <meta name=fuzzy content="maxDifference=0-2;totalPixels=0-99999">
   <script type="module">
     import { runColorSpaceTest } from './canvas_colorspace.html.js';
     runColorSpaceTest('rgba8unorm');

--- a/src/webgpu/web_platform/reftests/canvas_composite_alpha_bgra8unorm_premultiplied_copy.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_composite_alpha_bgra8unorm_premultiplied_copy.https.html
@@ -8,7 +8,7 @@
     content="WebGPU canvas should have correct orientation, components, scaling, filtering, color space"
   />
   <link rel="match" href="./ref/canvas_composite_alpha_premultiplied-ref.html" />
-  <meta name=fuzzy content="maxDifference=0-2;totalPixels=0-99999">
+  <meta name=fuzzy content="maxDifference=0-2;totalPixels=0-9999999">
   <style>
     body { background-color: #F0E68C; }
     #c-canvas { background-color: #8CF0E6; }

--- a/src/webgpu/web_platform/reftests/canvas_composite_alpha_bgra8unorm_premultiplied_copy.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_composite_alpha_bgra8unorm_premultiplied_copy.https.html
@@ -8,7 +8,7 @@
     content="WebGPU canvas should have correct orientation, components, scaling, filtering, color space"
   />
   <link rel="match" href="./ref/canvas_composite_alpha_premultiplied-ref.html" />
-  <meta name=fuzzy content="maxDifference=0-2;totalPixels=0-400">
+  <meta name=fuzzy content="maxDifference=0-2;totalPixels=0-99999">
   <style>
     body { background-color: #F0E68C; }
     #c-canvas { background-color: #8CF0E6; }

--- a/src/webgpu/web_platform/reftests/canvas_composite_alpha_bgra8unorm_premultiplied_draw.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_composite_alpha_bgra8unorm_premultiplied_draw.https.html
@@ -8,7 +8,7 @@
     content="WebGPU canvas should have correct orientation, components, scaling, filtering, color space"
   />
   <link rel="match" href="./ref/canvas_composite_alpha_premultiplied-ref.html" />
-  <meta name=fuzzy content="maxDifference=0-2;totalPixels=0-99999">
+  <meta name=fuzzy content="maxDifference=0-2;totalPixels=0-9999999">
   <style>
     body { background-color: #F0E68C; }
     #c-canvas { background-color: #8CF0E6; }

--- a/src/webgpu/web_platform/reftests/canvas_composite_alpha_bgra8unorm_premultiplied_draw.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_composite_alpha_bgra8unorm_premultiplied_draw.https.html
@@ -8,7 +8,7 @@
     content="WebGPU canvas should have correct orientation, components, scaling, filtering, color space"
   />
   <link rel="match" href="./ref/canvas_composite_alpha_premultiplied-ref.html" />
-  <meta name=fuzzy content="maxDifference=0-2;totalPixels=0-400">
+  <meta name=fuzzy content="maxDifference=0-2;totalPixels=0-99999">
   <style>
     body { background-color: #F0E68C; }
     #c-canvas { background-color: #8CF0E6; }

--- a/src/webgpu/web_platform/reftests/canvas_composite_alpha_rgba16float_premultiplied_copy.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_composite_alpha_rgba16float_premultiplied_copy.https.html
@@ -8,7 +8,7 @@
     content="WebGPU canvas should have correct orientation, components, scaling, filtering, color space"
   />
   <link rel="match" href="./ref/canvas_composite_alpha_premultiplied-ref.html" />
-  <meta name=fuzzy content="maxDifference=0-2;totalPixels=0-99999">
+  <meta name=fuzzy content="maxDifference=0-2;totalPixels=0-9999999">
   <style>
     body { background-color: #F0E68C; }
     #c-canvas { background-color: #8CF0E6; }

--- a/src/webgpu/web_platform/reftests/canvas_composite_alpha_rgba16float_premultiplied_copy.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_composite_alpha_rgba16float_premultiplied_copy.https.html
@@ -8,7 +8,7 @@
     content="WebGPU canvas should have correct orientation, components, scaling, filtering, color space"
   />
   <link rel="match" href="./ref/canvas_composite_alpha_premultiplied-ref.html" />
-  <meta name=fuzzy content="maxDifference=0-2;totalPixels=0-400">
+  <meta name=fuzzy content="maxDifference=0-2;totalPixels=0-99999">
   <style>
     body { background-color: #F0E68C; }
     #c-canvas { background-color: #8CF0E6; }

--- a/src/webgpu/web_platform/reftests/canvas_composite_alpha_rgba16float_premultiplied_draw.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_composite_alpha_rgba16float_premultiplied_draw.https.html
@@ -8,7 +8,7 @@
     content="WebGPU canvas should have correct orientation, components, scaling, filtering, color space"
   />
   <link rel="match" href="./ref/canvas_composite_alpha_premultiplied-ref.html" />
-  <meta name=fuzzy content="maxDifference=0-2;totalPixels=0-99999">
+  <meta name=fuzzy content="maxDifference=0-2;totalPixels=0-9999999">
   <style>
     body { background-color: #F0E68C; }
     #c-canvas { background-color: #8CF0E6; }

--- a/src/webgpu/web_platform/reftests/canvas_composite_alpha_rgba16float_premultiplied_draw.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_composite_alpha_rgba16float_premultiplied_draw.https.html
@@ -8,7 +8,7 @@
     content="WebGPU canvas should have correct orientation, components, scaling, filtering, color space"
   />
   <link rel="match" href="./ref/canvas_composite_alpha_premultiplied-ref.html" />
-  <meta name=fuzzy content="maxDifference=0-2;totalPixels=0-400">
+  <meta name=fuzzy content="maxDifference=0-2;totalPixels=0-99999">
   <style>
     body { background-color: #F0E68C; }
     #c-canvas { background-color: #8CF0E6; }

--- a/src/webgpu/web_platform/reftests/canvas_composite_alpha_rgba8unorm_premultiplied_copy.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_composite_alpha_rgba8unorm_premultiplied_copy.https.html
@@ -8,7 +8,7 @@
     content="WebGPU canvas should have correct orientation, components, scaling, filtering, color space"
   />
   <link rel="match" href="./ref/canvas_composite_alpha_premultiplied-ref.html" />
-  <meta name=fuzzy content="maxDifference=0-2;totalPixels=0-99999">
+  <meta name=fuzzy content="maxDifference=0-2;totalPixels=0-9999999">
   <style>
     body { background-color: #F0E68C; }
     #c-canvas { background-color: #8CF0E6; }

--- a/src/webgpu/web_platform/reftests/canvas_composite_alpha_rgba8unorm_premultiplied_copy.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_composite_alpha_rgba8unorm_premultiplied_copy.https.html
@@ -8,7 +8,7 @@
     content="WebGPU canvas should have correct orientation, components, scaling, filtering, color space"
   />
   <link rel="match" href="./ref/canvas_composite_alpha_premultiplied-ref.html" />
-  <meta name=fuzzy content="maxDifference=0-2;totalPixels=0-400">
+  <meta name=fuzzy content="maxDifference=0-2;totalPixels=0-99999">
   <style>
     body { background-color: #F0E68C; }
     #c-canvas { background-color: #8CF0E6; }

--- a/src/webgpu/web_platform/reftests/canvas_composite_alpha_rgba8unorm_premultiplied_draw.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_composite_alpha_rgba8unorm_premultiplied_draw.https.html
@@ -8,7 +8,7 @@
     content="WebGPU canvas should have correct orientation, components, scaling, filtering, color space"
   />
   <link rel="match" href="./ref/canvas_composite_alpha_premultiplied-ref.html" />
-  <meta name=fuzzy content="maxDifference=0-2;totalPixels=0-99999">
+  <meta name=fuzzy content="maxDifference=0-2;totalPixels=0-9999999">
   <style>
     body { background-color: #F0E68C; }
     #c-canvas { background-color: #8CF0E6; }

--- a/src/webgpu/web_platform/reftests/canvas_composite_alpha_rgba8unorm_premultiplied_draw.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_composite_alpha_rgba8unorm_premultiplied_draw.https.html
@@ -8,7 +8,7 @@
     content="WebGPU canvas should have correct orientation, components, scaling, filtering, color space"
   />
   <link rel="match" href="./ref/canvas_composite_alpha_premultiplied-ref.html" />
-  <meta name=fuzzy content="maxDifference=0-2;totalPixels=0-400">
+  <meta name=fuzzy content="maxDifference=0-2;totalPixels=0-99999">
   <style>
     body { background-color: #F0E68C; }
     #c-canvas { background-color: #8CF0E6; }


### PR DESCRIPTION
For these tests the fuzzy matching is only to allow for slight differences like rounding errors. We don't care about how many pixels are different.
https://web-platform-tests.org/writing-tests/reftests.html#fuzzy-matching

Also adds fuzzy matching to two more canvas_colorspace tests because it's not important to have extremely precise results for any test that does color conversions or blending (at least right now).

I haven't tested this exact change but in the linked Chromium CL below we saw the following:
```
01:01:43.047 7604 Found pixels_different: 500, max_channel_diff: 1
Allowed pixels_different; 0-400, max_channel_diff: 0-2
```
```
01:01:44.062 7604 Found pixels_different: 700, max_channel_diff: 2
Allowed pixels_different; 0-400, max_channel_diff: 0-2
```
So this should definitely work.

Some other tests that we're not currently passing for other reasons render quite large areas, so we set totalPixels very large. For example the canvas_colorspace tests render twelve `(128 * devicePixelRatio)`-squared canvases.

Issue: #1045, https://chromium-review.googlesource.com/c/chromium/src/+/5134470

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
