### PR TITLE
Copy reftest html files to out/ for gh-pages

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -167,6 +167,12 @@ module.exports = function (grunt) {
           { expand: true, dest: 'out-wpt/', cwd: 'gen', src: 'webgpu/listing.js' },
         ],
       },
+      'htmlfiles-to-out': {
+        // Must run after run:build-out.
+        files: [
+          { expand: true, dest: 'out/', cwd: 'src', src: 'webgpu/**/*.html' },
+        ],
+      },
       'htmlfiles-to-out-wpt': {
         // Must run after run:build-out-wpt.
         files: [
@@ -241,6 +247,7 @@ module.exports = function (grunt) {
     'run:build-out',
     'run:copy-assets',
     'copy:gen-to-out',
+    'copy:htmlfiles-to-out',
   ]);
   grunt.registerTask('build-wpt', 'Build out-wpt/ (no checks; run after generate-common)', [
     'run:build-out-wpt',


### PR DESCRIPTION
This should make URLs like this work:
https://gpuweb.github.io/cts/out/webgpu/web_platform/reftests/canvas_colorspace_rgba16float.https.html

(Minor build infra thing - landing without review)


Issue: None

<hr>

**Requirements for PR author:**

N/A

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
