### PR TITLE
Fix scaling issue in canvas image rendering test

### DIFF
--- a/src/webgpu/web_platform/reftests/canvas_image_rendering.https.html
+++ b/src/webgpu/web_platform/reftests/canvas_image_rendering.https.html
@@ -5,11 +5,11 @@
   <link rel="help" href="https://gpuweb.github.io/gpuweb/" />
   <meta name="assert" content="WebGPU canvas with image-rendering set should be rendered correctly" />
   <link rel="match" href="./ref/canvas_image_rendering-ref.html" />
-  <canvas id="elem1" width="64" height="64" style="width: 99px; height: 99px;"></canvas>
-  <canvas id="elem2" width="64" height="64" style="width: 99px; height: 99px; image-rendering: pixelated;"></canvas>
-  <canvas id="elem3" width="64" height="64" style="width: 99px; height: 99px; image-rendering: crisp-edges"></canvas>
-  <canvas id="elem4" width="64" height="64" style="width: 99px; height: 99px;"></canvas>
-  <canvas id="elem5" width="64" height="64" style="width: 99px; height: 99px; image-rendering: pixelated;"></canvas>
-  <canvas id="elem6" width="64" height="64" style="width: 99px; height: 99px; image-rendering: crisp-edges"></canvas>
+  <canvas id="elem1" width="64" height="64" style="width: 128px; height: 128px;"></canvas>
+  <canvas id="elem2" width="64" height="64" style="width: 128px; height: 128px; image-rendering: pixelated;"></canvas>
+  <canvas id="elem3" width="64" height="64" style="width: 128px; height: 128px; image-rendering: crisp-edges"></canvas>
+  <canvas id="elem4" width="64" height="64" style="width: 128px; height: 128px;"></canvas>
+  <canvas id="elem5" width="64" height="64" style="width: 128px; height: 128px; image-rendering: pixelated;"></canvas>
+  <canvas id="elem6" width="64" height="64" style="width: 128px; height: 128px; image-rendering: crisp-edges"></canvas>
   <script type="module" src="canvas_image_rendering.html.js"></script>
 </html>

--- a/src/webgpu/web_platform/reftests/ref/canvas_image_rendering-ref.html
+++ b/src/webgpu/web_platform/reftests/ref/canvas_image_rendering-ref.html
@@ -3,12 +3,12 @@
   <title>WebGPU canvas_image_rendering (ref)</title>
   <meta charset="utf-8" />
   <link rel="help" href="https://gpuweb.github.io/gpuweb/" />
-  <img id="elem1" width="64" height="64" style="width: 99px; height: 99px;">
-  <img id="elem2" width="64" height="64" style="width: 99px; height: 99px; image-rendering: pixelated;">
-  <img id="elem3" width="64" height="64" style="width: 99px; height: 99px; image-rendering: crisp-edges">
-  <img id="elem4" width="64" height="64" style="width: 99px; height: 99px;">
-  <img id="elem5" width="64" height="64" style="width: 99px; height: 99px; image-rendering: pixelated;">
-  <img id="elem6" width="64" height="64" style="width: 99px; height: 99px; image-rendering: crisp-edges">
+  <img id="elem1" width="64" height="64" style="width: 128px; height: 128px;">
+  <img id="elem2" width="64" height="64" style="width: 128px; height: 128px; image-rendering: pixelated;">
+  <img id="elem3" width="64" height="64" style="width: 128px; height: 128px; image-rendering: crisp-edges">
+  <img id="elem4" width="64" height="64" style="width: 128px; height: 128px;">
+  <img id="elem5" width="64" height="64" style="width: 128px; height: 128px; image-rendering: pixelated;">
+  <img id="elem6" width="64" height="64" style="width: 128px; height: 128px; image-rendering: crisp-edges">
   <script type="module">
     import { takeScreenshotDelayed } from '../../../../common/util/wpt_reftest_wait.js';
 


### PR DESCRIPTION
IIUC the issue is scaling can happen edge cases, especially given some APIs render with flipped Y so in the pixelated/crisp-edges case they might choose a different edge than the canvas API.

Making the display size exactly double the rendered size seems like it might solve this issue. The test would still show a difference between image-rendering: initial and image-rendeirng: pixelated / crisp-edges but should probably not show any difference otherwise


<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
