### PR TITLE
fullyExpandSubtrees & ability to disable no long path assert

### DIFF
--- a/src/common/internal/file_loader.ts
+++ b/src/common/internal/file_loader.ts
@@ -73,9 +73,9 @@ export abstract class TestFileLoader extends EventTarget {
     query: TestQuery,
     {
       subqueriesToExpand = [],
-      expandAll = false,
+      fullyExpandSubtrees = [],
       maxChunkTime = Infinity,
-    }: { subqueriesToExpand?: string[]; expandAll?: boolean; maxChunkTime?: number } = {}
+    }: { subqueriesToExpand?: string[]; fullyExpandSubtrees?: string[]; maxChunkTime?: number } = {}
   ): Promise<TestTree> {
     const tree = await loadTreeForQuery(this, query, {
       subqueriesToExpand: subqueriesToExpand.map(s => {
@@ -83,7 +83,7 @@ export abstract class TestFileLoader extends EventTarget {
         assert(q.level >= 2, () => `subqueriesToExpand entries should not be multi-file:\n  ${q}`);
         return q;
       }),
-      expandAll,
+      fullyExpandSubtrees: fullyExpandSubtrees.map(s => parseQuery(s)),
       maxChunkTime,
     });
     this.dispatchEvent(new MessageEvent<void>('finish'));

--- a/src/common/internal/file_loader.ts
+++ b/src/common/internal/file_loader.ts
@@ -73,8 +73,9 @@ export abstract class TestFileLoader extends EventTarget {
     query: TestQuery,
     {
       subqueriesToExpand = [],
+      expandAll = false,
       maxChunkTime = Infinity,
-    }: { subqueriesToExpand?: string[]; maxChunkTime?: number } = {}
+    }: { subqueriesToExpand?: string[]; expandAll?: boolean; maxChunkTime?: number } = {}
   ): Promise<TestTree> {
     const tree = await loadTreeForQuery(this, query, {
       subqueriesToExpand: subqueriesToExpand.map(s => {
@@ -82,6 +83,7 @@ export abstract class TestFileLoader extends EventTarget {
         assert(q.level >= 2, () => `subqueriesToExpand entries should not be multi-file:\n  ${q}`);
         return q;
       }),
+      expandAll,
       maxChunkTime,
     });
     this.dispatchEvent(new MessageEvent<void>('finish'));

--- a/src/common/internal/tree.ts
+++ b/src/common/internal/tree.ts
@@ -286,8 +286,9 @@ export async function loadTreeForQuery(
   queryToLoad: TestQuery,
   {
     subqueriesToExpand,
+    expandAll = false,
     maxChunkTime = Infinity,
-  }: { subqueriesToExpand: TestQuery[]; maxChunkTime?: number }
+  }: { subqueriesToExpand: TestQuery[]; expandAll?: boolean; maxChunkTime?: number }
 ): Promise<TestTree> {
   const suite = queryToLoad.suite;
   const specs = await loader.listing(suite);
@@ -302,6 +303,7 @@ export async function loadTreeForQuery(
 
       // If toExpand == subquery, no expansion is needed (but it's still "seen").
       if (ordering === Ordering.Equal) seenSubqueriesToExpand[i] = true;
+      if (expandAll) return ordering === Ordering.Unordered;
       return ordering !== Ordering.StrictSubset;
     });
 

--- a/src/common/internal/tree.ts
+++ b/src/common/internal/tree.ts
@@ -286,9 +286,9 @@ export async function loadTreeForQuery(
   queryToLoad: TestQuery,
   {
     subqueriesToExpand,
-    expandAll = false,
+    fullyExpandSubtrees = [],
     maxChunkTime = Infinity,
-  }: { subqueriesToExpand: TestQuery[]; expandAll?: boolean; maxChunkTime?: number }
+  }: { subqueriesToExpand: TestQuery[]; fullyExpandSubtrees?: TestQuery[]; maxChunkTime?: number }
 ): Promise<TestTree> {
   const suite = queryToLoad.suite;
   const specs = await loader.listing(suite);
@@ -303,8 +303,11 @@ export async function loadTreeForQuery(
 
       // If toExpand == subquery, no expansion is needed (but it's still "seen").
       if (ordering === Ordering.Equal) seenSubqueriesToExpand[i] = true;
-      if (expandAll) return ordering === Ordering.Unordered;
       return ordering !== Ordering.StrictSubset;
+    }) &&
+    fullyExpandSubtrees.every(toExpand => {
+      const ordering = compareQueries(toExpand, subquery);
+      return ordering === Ordering.Unordered;
     });
 
   // L0 = suite-level, e.g. suite:*

--- a/src/common/tools/gen_wpt_cts_html.ts
+++ b/src/common/tools/gen_wpt_cts_html.ts
@@ -178,7 +178,7 @@ let config: Config;
     config.expectations
   );
 
-  // Load expectations (if any)
+  // Load fullyExpandSubtrees queries (if any)
   const fullyExpand: Map<string, string[]> = await loadQueryFile(
     config.argumentsPrefixes,
     config.fullyExpandSubtrees

--- a/src/common/tools/gen_wpt_cts_html.ts
+++ b/src/common/tools/gen_wpt_cts_html.ts
@@ -70,6 +70,8 @@ interface ConfigJSON {
     file: string;
     /** The prefix to trim from every line of the expectations_file. */
     prefix: string;
+    /** Expend all subtrees for provided expectations */
+    expandAll?: boolean;
   };
   /*No long path assert */
   noLongPathAssert?: boolean;
@@ -85,6 +87,7 @@ interface Config {
   expectations?: {
     file: string;
     prefix: string;
+    expandAll: boolean;
   };
 }
 
@@ -110,6 +113,7 @@ let config: Config;
         config.expectations = {
           file: path.resolve(jsonFileDir, configJSON.expectations.file),
           prefix: configJSON.expectations.prefix,
+          expandAll: configJSON.expectations.expandAll ?? false,
         };
       }
       break;
@@ -143,6 +147,7 @@ let config: Config;
         config.expectations = {
           file: expectationsFile,
           prefix: expectationsPrefix,
+          expandAll: false,
         };
       }
       break;
@@ -188,6 +193,7 @@ let config: Config;
     const rootQuery = new TestQueryMultiFile(config.suite, []);
     const tree = await loader.loadTree(rootQuery, {
       subqueriesToExpand: expectations.get(prefix),
+      expandAll: config.expectations?.expandAll,
       maxChunkTime: config.maxChunkTimeMS,
     });
 


### PR DESCRIPTION
Assert is not valid (at least in servo's case) as only one expectation file is used for all variants. Another option would be to reduce assert to warning (depending on how much it is needed elsewhere).

fullyExpandSubtrees expends all subs recursively that are part of provided query.

Issue: #3233 

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
