### PR TITLE
Compat: Skip tests with depth_bias clamp != 0

### DIFF
--- a/src/webgpu/api/operation/rendering/depth_bias.spec.ts
+++ b/src/webgpu/api/operation/rendering/depth_bias.spec.ts
@@ -304,6 +304,12 @@ g.test('depth_bias')
         },
       ] as const)
   )
+  .beforeAllSubcases(t => {
+    t.skipIf(
+      t.isCompatibility && t.params.biasClamp !== 0,
+      'non zero depthBiasClamp is not supported in compatibility mode'
+    );
+  })
   .fn(t => {
     t.runDepthBiasTest('depth32float', t.params);
   });
@@ -346,6 +352,12 @@ g.test('depth_bias_24bit_format')
         },
       ] as const)
   )
+  .beforeAllSubcases(t => {
+    t.skipIf(
+      t.isCompatibility && t.params.biasClamp !== 0,
+      'non zero depthBiasClamp is not supported in compatibility mode'
+    );
+  })
   .fn(t => {
     const { format } = t.params;
     t.runDepthBiasTestFor24BitFormat(format, t.params);


### PR DESCRIPTION



<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
