### PR TITLE
Slightly expand image_copy tests to cover more snorm cases for compat

### DIFF
--- a/src/webgpu/api/operation/command_buffer/image_copy.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/image_copy.spec.ts
@@ -1576,7 +1576,8 @@ works for every format with 2d and 2d-array textures.
       textureHeight = info.blockHeight;
       rowsPerImage = 1;
     }
-    const textureSize = [copyWidth * info.blockWidth, textureHeight, copyDepth] as const;
+    // Add textureWidth by 1 to make sure we are doing a partial copy.
+    const textureSize = [(copyWidth + 1) * info.blockWidth, textureHeight, copyDepth] as const;
 
     const minDataSize = dataBytesForCopyOrFail({
       layout: { offset, bytesPerRow, rowsPerImage },
@@ -1586,7 +1587,7 @@ works for every format with 2d and 2d-array textures.
     });
     const dataSize = minDataSize + dataPaddingInBytes;
 
-    // We're copying a (copyWidth x 3 x copyDepth) (in texel blocks) part of a (align(copyDepth, 4) x 4 x copyDepth)
+    // We're copying a (copyWidth x 3 x copyDepth) (in texel blocks) part of a copyWidth x 4 x copyDepth)
     // (in texel blocks) texture with no origin.
     t.uploadTextureAndVerifyCopy({
       textureDataLayout: { offset, bytesPerRow, rowsPerImage },

--- a/src/webgpu/api/operation/command_buffer/image_copy.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/image_copy.spec.ts
@@ -1576,7 +1576,7 @@ works for every format with 2d and 2d-array textures.
       textureHeight = info.blockHeight;
       rowsPerImage = 1;
     }
-    const textureSize = [align(copyWidth, 4) * info.blockWidth, textureHeight, copyDepth] as const;
+    const textureSize = [copyWidth * info.blockWidth, textureHeight, copyDepth] as const;
 
     const minDataSize = dataBytesForCopyOrFail({
       layout: { offset, bytesPerRow, rowsPerImage },
@@ -1586,7 +1586,7 @@ works for every format with 2d and 2d-array textures.
     });
     const dataSize = minDataSize + dataPaddingInBytes;
 
-    // We're copying a (copyDepth x 3 x copyDepth) (in texel blocks) part of a (align(copyDepth, 4) x 4 x copyDepth)
+    // We're copying a (copyWidth x 3 x copyDepth) (in texel blocks) part of a (align(copyDepth, 4) x 4 x copyDepth)
     // (in texel blocks) texture with no origin.
     t.uploadTextureAndVerifyCopy({
       textureDataLayout: { offset, bytesPerRow, rowsPerImage },

--- a/src/webgpu/api/operation/command_buffer/image_copy.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/image_copy.spec.ts
@@ -1540,6 +1540,7 @@ works for every format with 2d and 2d-array textures.
       .combineWithParams(kOffsetsAndSizesParams.offsetsAndPaddings)
       .combine('copyDepth', kOffsetsAndSizesParams.copyDepth) // 2d and 2d-array textures
       .combine('copyWidth', [3, 128, 256] as const)
+      .combine('rowsPerImageEqualsCopyHeight', [true, false] as const)
       .unless(p => p.dimension === '1d' && p.copyDepth !== 1)
   )
   .beforeAllSubcases(t => {
@@ -1557,6 +1558,7 @@ works for every format with 2d and 2d-array textures.
       initMethod,
       checkMethod,
       copyWidth,
+      rowsPerImageEqualsCopyHeight,
     } = t.params;
     const info = kTextureFormatInfo[format];
 
@@ -1568,7 +1570,7 @@ works for every format with 2d and 2d-array textures.
       depthOrArrayLayers: copyDepth,
     };
     let textureHeight = 4 * info.blockHeight;
-    let rowsPerImage = copyHeight;
+    let rowsPerImage = rowsPerImageEqualsCopyHeight ? copyHeight : copyHeight + 1;
     const bytesPerRow = Math.max(256, align(copyWidth * info.bytesPerBlock, 256));
 
     if (dimension === '1d') {


### PR DESCRIPTION

Issue: [dawn/2314](https://bugs.chromium.org/p/dawn/issues/detail?id=2314)

Add some more cases to cover compat copy path for r8snorm, rg8snorm format.

Tests passed verified on Chrome linux vulkan.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
