### PR TITLE
Slightly expand more copyWidth params for image_copy tests to add compat coverage

### DIFF
--- a/src/webgpu/api/operation/command_buffer/image_copy.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/image_copy.spec.ts
@@ -1522,8 +1522,9 @@ works for every format with 2d and 2d-array textures.
 
   Covers spceial cases for OpenGL Compat:
     offset % 4 > 0 while:
-      - padding bytes at end of each row: bytesPerRow % 256 > 0
+      - padding bytes at end of each row / layer: bytesPerRow % 256 > 0 || rowsPerImage > copyDepth
       - rows/layers are compact: bytesPerRow % 256 == 0 && rowsPerImage == copyDepth
+      - padding bytes at front and end of the same 4-byte word: format == 'r8snorm' && copyWidth <= 2
 
   TODO: Cover the special code paths for 3D textures in D3D12.
   TODO: Make a variant for depth-stencil formats.
@@ -1539,7 +1540,7 @@ works for every format with 2d and 2d-array textures.
       .beginSubcases()
       .combineWithParams(kOffsetsAndSizesParams.offsetsAndPaddings)
       .combine('copyDepth', kOffsetsAndSizesParams.copyDepth) // 2d and 2d-array textures
-      .combine('copyWidth', [3, 128, 256] as const)
+      .combine('copyWidth', [1, 2, 3, 127, 128, 255, 256] as const)
       .combine('rowsPerImageEqualsCopyHeight', [true, false] as const)
       .unless(p => p.dimension === '1d' && p.copyDepth !== 1)
   )

--- a/src/webgpu/api/operation/command_buffer/image_copy.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/image_copy.spec.ts
@@ -1522,7 +1522,7 @@ works for every format with 2d and 2d-array textures.
 
   Covers spceial cases for OpenGL Compat:
     offset % 4 > 0 while:
-      - padding bytes at end of each row / layer: bytesPerRow % 256 > 0 || rowsPerImage > copyDepth
+      - padding bytes at end of each row/layer: bytesPerRow % 256 > 0 || rowsPerImage > copyDepth
       - rows/layers are compact: bytesPerRow % 256 == 0 && rowsPerImage == copyDepth
       - padding bytes at front and end of the same 4-byte word: format == 'r8snorm' && copyWidth <= 2
 


### PR DESCRIPTION
Issue: [dawn/2314](https://bugs.chromium.org/p/dawn/issues/detail?id=2314)

Add some more copyWidth.

Tests passed verified on Chrome linux vulkan.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
