### PR TITLE
wgsl: Add `floor` validation tests

### DIFF
--- a/src/webgpu/listing_meta.json
+++ b/src/webgpu/listing_meta.json
@@ -1768,6 +1768,8 @@
   "webgpu:shader,validation,expression,call,builtin,exp2:values:*": { "subcaseMS": 0.410 },
   "webgpu:shader,validation,expression,call,builtin,exp:integer_argument:*": { "subcaseMS": 1.356 },
   "webgpu:shader,validation,expression,call,builtin,exp:values:*": { "subcaseMS": 0.311 },
+  "webgpu:shader,validation,expression,call,builtin,floor:integer_argument:*": { "subcaseMS": 48.400 },
+  "webgpu:shader,validation,expression,call,builtin,floor:values:*": { "subcaseMS": 29.668 },
   "webgpu:shader,validation,expression,call,builtin,inverseSqrt:integer_argument:*": { "subcaseMS": 1.356 },
   "webgpu:shader,validation,expression,call,builtin,inverseSqrt:values:*": { "subcaseMS": 0.315 },
   "webgpu:shader,validation,expression,call,builtin,length:integer_argument:*": { "subcaseMS": 2.011 },

--- a/src/webgpu/shader/validation/expression/call/builtin/floor.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/floor.spec.ts
@@ -1,0 +1,75 @@
+const builtin = 'floor';
+export const description = `
+Validation tests for the ${builtin}() builtin.
+`;
+
+import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
+import { keysOf, objectsToRecord } from '../../../../../../common/util/data_tables.js';
+import {
+  TypeF16,
+  TypeF32,
+  elementType,
+  kAllFloatScalarsAndVectors,
+  kAllIntegerScalarsAndVectors,
+} from '../../../../../util/conversion.js';
+import { ShaderValidationTest } from '../../../shader_validation_test.js';
+
+import {
+  fullRangeForType,
+  kConstantAndOverrideStages,
+  stageSupportsType,
+  validateConstOrOverrideBuiltinEval,
+} from './const_override_validation.js';
+
+export const g = makeTestGroup(ShaderValidationTest);
+
+const kValuesTypes = objectsToRecord(kAllFloatScalarsAndVectors);
+
+g.test('values')
+  .desc(
+    `
+Validates that constant evaluation and override evaluation of ${builtin}() never errors
+`
+  )
+  .params(u =>
+    u
+      .combine('stage', kConstantAndOverrideStages)
+      .combine('type', keysOf(kValuesTypes))
+      .filter(u => stageSupportsType(u.stage, kValuesTypes[u.type]))
+      .expand('value', u => fullRangeForType(kValuesTypes[u.type]))
+  )
+  .beforeAllSubcases(t => {
+    if (elementType(kValuesTypes[t.params.type]) === TypeF16) {
+      t.selectDeviceOrSkipTestCase('shader-f16');
+    }
+  })
+  .fn(t => {
+    const expectedResult = true; // floor() should never error
+    validateConstOrOverrideBuiltinEval(
+      t,
+      builtin,
+      expectedResult,
+      [kValuesTypes[t.params.type].create(t.params.value)],
+      t.params.stage
+    );
+  });
+
+const kIntegerArgumentTypes = objectsToRecord([TypeF32, ...kAllIntegerScalarsAndVectors]);
+
+g.test('integer_argument')
+  .desc(
+    `
+Validates that scalar and vector integer arguments are rejected by ${builtin}()
+`
+  )
+  .params(u => u.combine('type', keysOf(kIntegerArgumentTypes)))
+  .fn(t => {
+    const type = kIntegerArgumentTypes[t.params.type];
+    validateConstOrOverrideBuiltinEval(
+      t,
+      builtin,
+      /* expectedResult */ type === TypeF32,
+      [type.create(0)],
+      'constant'
+    );
+  });


### PR DESCRIPTION
Fixes #3283

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
