### PR TITLE
Relax the fragment builtin tests

### DIFF
--- a/src/webgpu/shader/execution/shader_io/fragment_builtins.spec.ts
+++ b/src/webgpu/shader/execution/shader_io/fragment_builtins.spec.ts
@@ -794,7 +794,7 @@ g.test('inputs,position')
         sampleCount,
         actual,
         expected,
-        maxDiffULPsForFloatFormat: 2,
+        maxDiffULPsForFloatFormat: 4,
       })
     );
   });
@@ -873,7 +873,7 @@ g.test('inputs,interStage')
         sampleCount,
         actual,
         expected,
-        maxDiffULPsForFloatFormat: 3,
+        maxDiffULPsForFloatFormat: 4,
       })
     );
   });


### PR DESCRIPTION
Checking runs on various GPUs this should hopefully pass more and be ok.

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
