### PR TITLE
wgsl: Add `dot4I8Packed` and `dot4U8Packed` execution tests

### DIFF
--- a/src/webgpu/listing_meta.json
+++ b/src/webgpu/listing_meta.json
@@ -1226,6 +1226,8 @@
   "webgpu:shader,execution,expression,call,builtin,dot:f32_vec4:*": { "subcaseMS": 11.876 },
   "webgpu:shader,execution,expression,call,builtin,dot:i32:*": { "subcaseMS": 3.103 },
   "webgpu:shader,execution,expression,call,builtin,dot:u32:*": { "subcaseMS": 3.101 },
+  "webgpu:shader,execution,expression,call,builtin,dot4I8Packed:basic:*": { "subcaseMS": 1.000 },
+  "webgpu:shader,execution,expression,call,builtin,dot4U8Packed:basic:*": { "subcaseMS": 1.000 },
   "webgpu:shader,execution,expression,call,builtin,dpdx:f32:*": { "subcaseMS": 22.804 },
   "webgpu:shader,execution,expression,call,builtin,dpdxCoarse:f32:*": { "subcaseMS": 22.404 },
   "webgpu:shader,execution,expression,call,builtin,dpdxFine:f32:*": { "subcaseMS": 17.708 },

--- a/src/webgpu/shader/execution/expression/call/builtin/dot4I8Packed.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/dot4I8Packed.spec.ts
@@ -1,0 +1,47 @@
+export const description = `
+Execution tests for the 'dot4I8Packed' builtin function
+
+@const fn dot4I8Packed(e1: u32 ,e2: u32) -> i32
+e1 and e2 are interpreted as vectors with four 8-bit signed integer components. Return the signed
+integer dot product of these two vectors. Each component is sign-extended to i32 before performing
+the multiply, and then the add operations are done in WGSL i32 with wrapping behaviour.
+`;
+
+import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
+import { GPUTest } from '../../../../../gpu_test.js';
+import { TypeI32, TypeU32, i32, u32 } from '../../../../../util/conversion.js';
+import { allInputSources, Config, run } from '../../expression.js';
+
+import { builtin } from './builtin.js';
+
+export const g = makeTestGroup(GPUTest);
+
+g.test('basic')
+  .specURL('https://www.w3.org/TR/WGSL/#dot4I8Packed-builtin')
+  .desc(
+    `
+@const fn dot4I8Packed(e1: u32, e2: u32) -> i32
+  `
+  )
+  .params(u => u.combine('inputSource', allInputSources))
+  .fn(async t => {
+    const cfg: Config = t.params;
+    await run(t, builtin('dot4I8Packed'), [TypeU32, TypeU32], TypeI32, cfg, [
+      // dot({0, 0, 0, 0}, {0, 0, 0, 0})
+      { input: [u32(0), u32(0)], expected: i32(0) },
+      // dot({127, 127, 127, 127}, {127, 127, 127, 127})
+      { input: [u32(0x7f7f7f7f), u32(0x7f7f7f7f)], expected: i32(64516) },
+      // dot({-128, -128, -128, -128}, {-128, -128, -128, -128})
+      { input: [u32(0x80808080), u32(0x80808080)], expected: i32(65536) },
+      // dot({127, 127, 127, 127}, {-128, -128, -128, -128})
+      { input: [u32(0x7f7f7f7f), u32(0x80808080)], expected: i32(-65024) },
+      // dot({1, 2, 3, 4}, {5, 6, 7, 8})
+      { input: [u32(0x01020304), u32(0x05060708)], expected: i32(70) },
+      // dot({1, 2, 3, 4}, {-1, -2, -3, -4})
+      { input: [u32(0x01020304), u32(0xfffefdfc)], expected: i32(-30) },
+      // dot({-5, -6, -7, -8}, {5, 6, 7, 8})
+      { input: [u32(0xfbfaf9f8), u32(0x05060708)], expected: i32(-174) },
+      // dot({-9, -10, -11, -12}, {-13, -14, -15, -16})
+      { input: [u32(0xf7f6f5f4), u32(0xf3f2f1f0)], expected: i32(614) },
+    ]);
+  });

--- a/src/webgpu/shader/execution/expression/call/builtin/dot4I8Packed.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/dot4I8Packed.spec.ts
@@ -10,6 +10,7 @@ the multiply, and then the add operations are done in WGSL i32 with wrapping beh
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
 import { TypeI32, TypeU32, i32, u32 } from '../../../../../util/conversion.js';
+import { Case } from '../../case.js';
 import { allInputSources, Config, run } from '../../expression.js';
 
 import { builtin } from './builtin.js';
@@ -26,22 +27,48 @@ g.test('basic')
   .params(u => u.combine('inputSource', allInputSources))
   .fn(async t => {
     const cfg: Config = t.params;
-    await run(t, builtin('dot4I8Packed'), [TypeU32, TypeU32], TypeI32, cfg, [
+
+    const dot4I8Packed = (e1: number, e2: number) => {
+      let result = 0;
+      for (let i = 0; i < 4; ++i) {
+        let e1_i = (e1 >> (i * 8)) & 0xff;
+        if (e1_i >= 128) {
+          e1_i -= 256;
+        }
+        let e2_i = (e2 >> (i * 8)) & 0xff;
+        if (e2_i >= 128) {
+          e2_i -= 256;
+        }
+        result += e1_i * e2_i;
+      }
+      return result;
+    };
+
+    const testInputs = [
       // dot({0, 0, 0, 0}, {0, 0, 0, 0})
-      { input: [u32(0), u32(0)], expected: i32(0) },
+      [0, 0],
       // dot({127, 127, 127, 127}, {127, 127, 127, 127})
-      { input: [u32(0x7f7f7f7f), u32(0x7f7f7f7f)], expected: i32(64516) },
+      [0x7f7f7f7f, 0x7f7f7f7f],
       // dot({-128, -128, -128, -128}, {-128, -128, -128, -128})
-      { input: [u32(0x80808080), u32(0x80808080)], expected: i32(65536) },
+      [0x80808080, 0x80808080],
       // dot({127, 127, 127, 127}, {-128, -128, -128, -128})
-      { input: [u32(0x7f7f7f7f), u32(0x80808080)], expected: i32(-65024) },
+      [0x7f7f7f7f, 0x80808080],
       // dot({1, 2, 3, 4}, {5, 6, 7, 8})
-      { input: [u32(0x01020304), u32(0x05060708)], expected: i32(70) },
+      [0x01020304, 0x05060708],
       // dot({1, 2, 3, 4}, {-1, -2, -3, -4})
-      { input: [u32(0x01020304), u32(0xfffefdfc)], expected: i32(-30) },
+      [0x01020304, 0xfffefdfc],
       // dot({-5, -6, -7, -8}, {5, 6, 7, 8})
-      { input: [u32(0xfbfaf9f8), u32(0x05060708)], expected: i32(-174) },
+      [0xfbfaf9f8, 0x05060708],
       // dot({-9, -10, -11, -12}, {-13, -14, -15, -16})
-      { input: [u32(0xf7f6f5f4), u32(0xf3f2f1f0)], expected: i32(614) },
-    ]);
+      [0xf7f6f5f4, 0xf3f2f1f0],
+    ] as const;
+
+    const makeCase = (x: number, y: number): Case => {
+      return { input: [u32(x), u32(y)], expected: i32(dot4I8Packed(x, y)) };
+    };
+    const cases: Array<Case> = testInputs.flatMap(v => {
+      return [makeCase(...(v as [number, number]))];
+    });
+
+    await run(t, builtin('dot4I8Packed'), [TypeU32, TypeU32], TypeI32, cfg, cases);
   });

--- a/src/webgpu/shader/execution/expression/call/builtin/dot4U8Packed.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/dot4U8Packed.spec.ts
@@ -1,0 +1,38 @@
+export const description = `
+Execution tests for the 'dot4U8Packed' builtin function
+
+@const fn dot4U8Packed(e1: u32 ,e2: u32) -> u32
+e1 and e2 are interpreted as vectors with four 8-bit unsigned integer components. Return the
+unsigned integer dot product of these two vectors.
+`;
+
+import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
+import { GPUTest } from '../../../../../gpu_test.js';
+import { TypeU32, u32 } from '../../../../../util/conversion.js';
+import { allInputSources, Config, run } from '../../expression.js';
+
+import { builtin } from './builtin.js';
+
+export const g = makeTestGroup(GPUTest);
+
+g.test('basic')
+  .specURL('https://www.w3.org/TR/WGSL/#dot4U8Packed-builtin')
+  .desc(
+    `
+@const fn dot4U8Packed(e1: u32, e2: u32) -> u32
+  `
+  )
+  .params(u => u.combine('inputSource', allInputSources))
+  .fn(async t => {
+    const cfg: Config = t.params;
+    await run(t, builtin('dot4U8Packed'), [TypeU32, TypeU32], TypeU32, cfg, [
+      // dot({0u, 0u, 0u, 0u}, {0u, 0u, 0u, 0u})
+      { input: [u32(0), u32(0)], expected: u32(0) },
+      // dot({255u, 255u, 255u, 255u}, {255u, 255u, 255u, 255u})
+      { input: [u32(0xffffffff), u32(0xffffffff)], expected: u32(260100) },
+      // dot({1u, 2u, 3u, 4u}, {5u, 6u, 7u, 8u})
+      { input: [u32(0x01020304), u32(0x05060708)], expected: u32(70) },
+      // dot({120u, 90u, 60u, 30u}, {50u, 100u, 150u, 200u})
+      { input: [u32(0x785a3c1e), u32(0x326496c8)], expected: u32(30000) },
+    ]);
+  });


### PR DESCRIPTION


Issue:  #3180 #3247 #3248

<hr>

**Requirements for PR author:**

- [*] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [*] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [*] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
