### PR TITLE
Test destroyed state of storage textures in bind groups

### DIFF
--- a/src/webgpu/api/validation/queue/destroyed/texture.spec.ts
+++ b/src/webgpu/api/validation/queue/destroyed/texture.spec.ts
@@ -165,15 +165,16 @@ Tests that using a destroyed texture referenced by a bindGroup set with setBindG
     u
       .combine('destroyed', [false, true] as const)
       .combine('encoderType', ['compute pass', 'render pass', 'render bundle'] as const)
+      .combine('bindingType', ['texture', 'storageTexture'] as const)
   )
   .fn(t => {
-    const { destroyed, encoderType } = t.params;
+    const { destroyed, encoderType, bindingType } = t.params;
     const { device } = t;
     const texture = t.trackForCleanup(
       t.device.createTexture({
         size: [1, 1, 1],
         format: 'rgba8unorm',
-        usage: GPUTextureUsage.TEXTURE_BINDING,
+        usage: GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.STORAGE_BINDING,
       })
     );
 
@@ -182,7 +183,9 @@ Tests that using a destroyed texture referenced by a bindGroup set with setBindG
         {
           binding: 0,
           visibility: GPUShaderStage.COMPUTE,
-          texture: {},
+          [bindingType]: {
+            format: texture.format,
+          },
         },
       ],
     });


### PR DESCRIPTION


Issue: crbug.com/1516756

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
