### PR TITLE
Update getCurrentTexture test to match spec.

### DIFF
--- a/src/webgpu/web_platform/canvas/getCurrentTexture.spec.ts
+++ b/src/webgpu/web_platform/canvas/getCurrentTexture.spec.ts
@@ -40,6 +40,27 @@ class GPUContextTest extends GPUTest {
 
     return ctx;
   }
+
+  expectTextureDestroyed(texture: GPUTexture, expectDestroyed = true) {
+    this.expectValidationError(() => {
+      // Try using the texture in a render pass. Because it's a canvas texture
+      // it should have RENDER_ATTACHMENT usage.
+      assert((texture.usage & GPUTextureUsage.RENDER_ATTACHMENT) !== 0);
+      const encoder = this.device.createCommandEncoder();
+      const pass = encoder.beginRenderPass({
+        colorAttachments: [
+          {
+            view: texture.createView(),
+            loadOp: 'clear',
+            storeOp: 'store',
+          },
+        ],
+      });
+      pass.end();
+      // Submitting should generate a validation error if the texture is destroyed.
+      this.queue.submit([encoder.finish()]);
+    }, expectDestroyed);
+  }
 }
 
 export const g = makeTestGroup(GPUContextTest);
@@ -235,6 +256,8 @@ g.test('resize')
     // Trigger a resize by changing the width.
     ctx.canvas.width = 4;
 
+    t.expectTextureDestroyed(prevTexture);
+
     // When the canvas resizes the texture returned by getCurrentTexture should immediately begin
     // returning a new texture matching the update dimensions.
     let currentTexture = ctx.getCurrentTexture();
@@ -263,7 +286,6 @@ g.test('resize')
     t.expect(currentTexture.height === ctx.canvas.height);
     t.expect(prevTexture.width === 4);
     t.expect(prevTexture.height === 2);
-    prevTexture = currentTexture;
 
     // Ensure that texture contents are transparent black.
     t.expectSingleColor(currentTexture, currentTexture.format, {
@@ -271,13 +293,28 @@ g.test('resize')
       exp: { R: 0, G: 0, B: 0, A: 0 },
     });
 
-    // Simply setting the canvas width and height values to their current values should not trigger
-    // a change in the texture.
-    ctx.canvas.width = 4;
-    ctx.canvas.height = 4;
+    // Ensure canvas goes back to defaults when set to negative numbers.
+    ctx.canvas.width = -1;
+    currentTexture = ctx.getCurrentTexture();
+    t.expect(currentTexture.width === 300);
+    t.expect(currentTexture.height === 4);
+
+    ctx.canvas.height = -1;
+    currentTexture = ctx.getCurrentTexture();
+    t.expect(currentTexture.width === 300);
+    t.expect(currentTexture.height === 150);
+    prevTexture = currentTexture;
+
+    // Setting the canvas width and height values to their current values should
+    // still trigger a change in the texture.
+    const { width, height } = ctx.canvas;
+    ctx.canvas.width = width;
+    ctx.canvas.height = height;
+
+    t.expectTextureDestroyed(prevTexture);
 
     currentTexture = ctx.getCurrentTexture();
-    t.expect(prevTexture === currentTexture);
+    t.expect(prevTexture !== currentTexture);
   });
 
 g.test('expiry')


### PR DESCRIPTION
It's not entirely clear from the current WebGPU spec if "modified" = setting to the same dimensions. It seems like that shouldn't matter and is inconsistent with other canvas contents.

Note: This fails in Chrome

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
