### PR TITLE
Add textureBarrier() to uniformity tests

### DIFF
--- a/src/webgpu/shader/validation/uniformity/uniformity.spec.ts
+++ b/src/webgpu/shader/validation/uniformity/uniformity.spec.ts
@@ -21,6 +21,7 @@ const kCollectiveOps = [
   { op: 'fwidthCoarse', stage: 'fragment' },
   { op: 'fwidthFine', stage: 'fragment' },
   { op: 'storageBarrier', stage: 'compute' },
+  { op: 'textureBarrier', stage: 'compute' },
   { op: 'workgroupBarrier', stage: 'compute' },
   { op: 'workgroupUniformLoad', stage: 'compute' },
 ];
@@ -116,6 +117,7 @@ function generateOp(op: string): string {
       return `let x = ${op}(tex_depth, s_comp, vec2(0,0), 0);\n`;
     }
     case 'storageBarrier':
+    case 'textureBarrier':
     case 'workgroupBarrier': {
       return `${op}();\n`;
     }
@@ -187,6 +189,10 @@ g.test('basics')
       .beginSubcases()
   )
   .fn(t => {
+    if (t.params.op === 'textureBarrier') {
+      t.skipIfLanguageFeatureNotSupported('readonly_and_readwrite_storage_textures');
+    }
+
     let code = `
  @group(0) @binding(0) var s : sampler;
  @group(0) @binding(1) var s_comp : sampler_comparison;


### PR DESCRIPTION
Only if the language feature is supported.

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
