### PR TITLE
Add storage texture loads to uniformity tests

### DIFF
--- a/src/webgpu/shader/validation/uniformity/uniformity.spec.ts
+++ b/src/webgpu/shader/validation/uniformity/uniformity.spec.ts
@@ -44,6 +44,8 @@ const kConditions = [
   { cond: 'nonuniform_and2', expectation: false },
   { cond: 'uniform_func_var', expectation: true },
   { cond: 'nonuniform_func_var', expectation: false },
+  { cond: 'storage_texture_ro', expectation: true },
+  { cond: 'storage_texture_rw', expectation: false },
 ];
 
 function generateCondition(condition: string): string {
@@ -98,6 +100,12 @@ function generateCondition(condition: string): string {
     }
     case 'nonuniform_func_var': {
       return `n_f == 0`;
+    }
+    case 'storage_texture_ro': {
+      return `textureLoad(ro_storage_texture, vec2()).x == 0`;
+    }
+    case 'storage_texture_rw': {
+      return `textureLoad(rw_storage_texture, vec2()).x == 0`;
     }
     default: {
       unreachable(`Unhandled condition`);
@@ -189,7 +197,7 @@ g.test('basics')
       .beginSubcases()
   )
   .fn(t => {
-    if (t.params.op === 'textureBarrier') {
+    if (t.params.op === 'textureBarrier' || t.params.cond.startsWith('storage_texture')) {
       t.skipIfLanguageFeatureNotSupported('readonly_and_readwrite_storage_textures');
     }
 
@@ -202,6 +210,9 @@ g.test('basics')
  @group(1) @binding(0) var<storage, read> ro_buffer : array<f32, 4>;
  @group(1) @binding(1) var<storage, read_write> rw_buffer : array<f32, 4>;
  @group(1) @binding(2) var<uniform> uniform_buffer : vec4<f32>;
+
+ @group(2) @binding(0) var ro_storage_texture : texture_storage_2d<rgba8unorm, read>;
+ @group(2) @binding(1) var rw_storage_texture : texture_storage_2d<rgba8unorm, read_write>;
 
  var<private> priv_var : array<f32, 4> = array(0,0,0,0);
 


### PR DESCRIPTION
Loads from a read-write storage texture are considered non-uniform, whereas loads from a read-only storage texture are uniform.

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
