### PR TITLE
Compat: Fix storage texture read_write test

### DIFF
--- a/src/webgpu/api/operation/storage_texture/read_write.spec.ts
+++ b/src/webgpu/api/operation/storage_texture/read_write.spec.ts
@@ -318,7 +318,9 @@ g.test('basic')
   .fn(t => {
     const { format, shaderStage, textureDimension, depthOrArrayLayers } = t.params;
 
-    const kWidth = 16;
+    // In compatibility mode the maximum minimum invocations is 128 vs non-compat which is 256
+    // So in non-compat we get 16 * 8 * 2, vs compat where we get 8 * 8 * 2
+    const kWidth = t.isCompatibility ? 8 : 16;
     const height = textureDimension === '1d' ? 1 : 8;
     const textureSize = [kWidth, height, depthOrArrayLayers] as const;
     const storageTexture = t.device.createTexture({

--- a/src/webgpu/api/operation/storage_texture/read_write.spec.ts
+++ b/src/webgpu/api/operation/storage_texture/read_write.spec.ts
@@ -318,7 +318,7 @@ g.test('basic')
   .fn(t => {
     const { format, shaderStage, textureDimension, depthOrArrayLayers } = t.params;
 
-    // In compatibility mode the maximum minimum invocations is 128 vs non-compat which is 256
+    // In compatibility mode the lowest maxComputeInvocationsPerWorkgroup is 128 vs non-compat which is 256
     // So in non-compat we get 16 * 8 * 2, vs compat where we get 8 * 8 * 2
     const kWidth = t.isCompatibility ? 8 : 16;
     const height = textureDimension === '1d' ? 1 : 8;


### PR DESCRIPTION
The test used 256 invocations but compat only supports 128

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
