### PR TITLE
Compat: Fix depth bias test

### DIFF
--- a/src/webgpu/compat/api/validation/render_pipeline/depth_stencil_state.spec.ts
+++ b/src/webgpu/compat/api/validation/render_pipeline/depth_stencil_state.spec.ts
@@ -42,6 +42,8 @@ g.test('depthBiasClamp')
       },
       depthStencil: {
         format: 'depth24plus',
+        depthWriteEnabled: true,
+        depthCompare: 'always',
         ...(depthBiasClamp !== undefined && { depthBiasClamp }),
       },
     };


### PR DESCRIPTION
Using a depthStencilAttachment requires depthWriteEnabled and depthCompare set

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
