### PR TITLE
Compat: Fix readonly depth-stencil sampling

### DIFF
--- a/src/webgpu/api/operation/memory_sync/texture/readonly_depth_stencil.spec.ts
+++ b/src/webgpu/api/operation/memory_sync/texture/readonly_depth_stencil.spec.ts
@@ -31,7 +31,16 @@ testing while the other one is used for sampling.
       })
   )
   .beforeAllSubcases(t => {
+    const { format } = t.params;
+    const formatInfo = kTextureFormatInfo[format];
+    const hasDepth = formatInfo.depth !== undefined;
+    const hasStencil = formatInfo.stencil !== undefined;
+
     t.selectDeviceForTextureFormatOrSkipTestCase(t.params.format);
+    t.skipIf(
+      t.isCompatibility && hasDepth && hasStencil,
+      'compatibility mode does not support different TEXTURE_BINDING views of the same texture in a single draw calls'
+    );
   })
   .fn(t => {
     const { format, depthReadOnly, stencilReadOnly } = t.params;


### PR DESCRIPTION
It's not entirely clear to me what we should do here. For now, the failing tests are skipped in compat mode

The current compat spec says you can't have 2 different TEXTURE_BINDING views with different settings for the same texture. So you can't view a depth-stencil texture as both an `aspect: 'stencil-only'` in one view and `aspect: 'depth-only'` in another view in the same draw call. 

You can view them as one or the other in separate draw calls. Should we add a path that uses 2 draw calls? If so, can that be a separate PR?


<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
