### PR TITLE
Add validation tests for @must_use function attribute

### DIFF
--- a/src/webgpu/listing_meta.json
+++ b/src/webgpu/listing_meta.json
@@ -1917,6 +1917,7 @@
   "webgpu:shader,validation,parse,must_use:builtin_no_must_use:*": { "subcaseMS": 1.206 },
   "webgpu:shader,validation,parse,must_use:call:*": { "subcaseMS": 1.275 },
   "webgpu:shader,validation,parse,must_use:declaration:*": { "subcaseMS": 1.523 },
+  "webgpu:shader,validation,parse,must_use:ignore_result_of_non_must_use_that_returns_call_of_must_use:*": { "subcaseMS": 0.0 },
   "webgpu:shader,validation,parse,pipeline_stage:compute_parsing:*": { "subcaseMS": 1.000 },
   "webgpu:shader,validation,parse,pipeline_stage:duplicate_compute_on_function:*": { "subcaseMS": 2.651 },
   "webgpu:shader,validation,parse,pipeline_stage:duplicate_fragment_on_function:*": { "subcaseMS": 1.001 },

--- a/src/webgpu/shader/execution/expression/expression.ts
+++ b/src/webgpu/shader/execution/expression/expression.ts
@@ -32,6 +32,7 @@ export const allInputSources: InputSource[] = ['const', 'uniform', 'storage_r', 
 /** Just constant input source */
 export const onlyConstInputSource: InputSource[] = ['const'];
 
+/** All input sources except const */
 export const allButConstInputSource: InputSource[] = ['uniform', 'storage_r', 'storage_rw'];
 
 /** Configuration for running a expression test */

--- a/src/webgpu/shader/validation/parse/must_use.spec.ts
+++ b/src/webgpu/shader/validation/parse/must_use.spec.ts
@@ -57,27 +57,74 @@ g.test('declaration')
   });
 
 const kMustUseCalls = {
+  no_call: ``, // Never calling a @must_use function should pass
   phony: `_ = bar();`,
   let: `let tmp = bar();`,
-  var: `var tmp = bar();`,
+  local_var: `var tmp = bar();`,
+  private_var: `private_var = bar();`,
+  storage_var: `storage_var = bar();`,
+  pointer: `
+    var a : f32;
+    let p = &a;
+    (*p) = bar();`,
+  vector_elem: `
+    var a : vec3<f32>;
+    a.x = bar();`,
+  matrix_elem: `
+    var a : mat3x2<f32>;
+    a[0][0] = bar();`,
   condition: `if bar() == 0 { }`,
   param: `baz(bar());`,
-  statement: `bar();`,
+  return: `return bar();`,
+  statement: `bar();`, // should fail if bar is @must_use
 };
 
 g.test('call')
   .desc(`Validate that a call to must_use function cannot be the whole function call statement`)
-  .params(u => u.combine('use', ['@must_use', ''] as const).combine('call', keysOf(kMustUseCalls)))
+  .params(u =>
+    u //
+      .combine('use', ['@must_use', ''] as const)
+      .combine('call', keysOf(kMustUseCalls))
+  )
   .fn(t => {
     const test = kMustUseCalls[t.params.call];
     const code = `
-    fn baz(param : u32) { }
-    ${t.params.use} fn bar() -> u32 { return 0; }
-    fn foo() {
+    @group(0) @binding(0) var<storage, read_write> storage_var : f32;
+    var<private> private_var : f32;
+
+    fn baz(param : f32) { }
+
+    ${t.params.use} fn bar() -> f32 { return 0; }
+
+    fn foo() ${t.params.call === 'return' ? '-> f32' : ''} {
       ${test}
     }`;
-    const res = t.params.call !== 'statement' || t.params.use === '';
-    t.expectCompileResult(res, code);
+
+    const should_pass = t.params.call !== 'statement' || t.params.use === '';
+    t.expectCompileResult(should_pass, code);
+  });
+
+g.test('ignore_result_of_non_must_use_that_returns_call_of_must_use')
+  .desc(
+    `Test that ignoring the result of a non-@must_use function that returns the result of a @must_use function succeeds`
+  )
+  .fn(t => {
+    const wgsl = `
+    @must_use
+    fn f() -> f32 {
+      return 0;
+    }
+
+    fn g() -> f32 {
+      return f();
+    }
+
+    fn main() {
+      g(); // Ignore result
+    }
+    `;
+
+    t.expectCompileResult(true, wgsl);
   });
 
 const kMustUseBuiltinCalls = {


### PR DESCRIPTION
Issue: #3334

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
