### PR TITLE
fragment builtins: document missing test, or other places to find them               

### DIFF
--- a/src/webgpu/api/operation/render_pipeline/sample_mask.spec.ts
+++ b/src/webgpu/api/operation/render_pipeline/sample_mask.spec.ts
@@ -6,6 +6,8 @@ Also tested:
 - The positions of samples in the standard sample patterns.
 - Per-sample interpolation sampling: @interpolate(perspective, sample).
 
+TODO: Test sample_mask as an input.
+
 TODO: add a test without a 0th color attachment (sparse color attachment), with different color attachments and alpha value output.
 The cross-platform behavior is unknown. could be any of:
 - coverage is always 100%

--- a/src/webgpu/listing_meta.json
+++ b/src/webgpu/listing_meta.json
@@ -1704,6 +1704,7 @@
   "webgpu:shader,execution,shader_io,fragment_builtins:inputs,interStage,centroid:*": { "subcaseMS": 1.001 },
   "webgpu:shader,execution,shader_io,fragment_builtins:inputs,position:*": { "subcaseMS": 1.001 },
   "webgpu:shader,execution,shader_io,fragment_builtins:inputs,sample_index:*": { "subcaseMS": 1.001 },
+  "webgpu:shader,execution,shader_io,fragment_builtins:inputs,sample_mask:*": { "subcaseMS": 0.050 },
   "webgpu:shader,execution,shader_io,shared_structs:shared_between_stages:*": { "subcaseMS": 9.601 },
   "webgpu:shader,execution,shader_io,shared_structs:shared_with_buffer:*": { "subcaseMS": 20.701 },
   "webgpu:shader,execution,shader_io,shared_structs:shared_with_non_entry_point_function:*": { "subcaseMS": 6.801 },

--- a/src/webgpu/shader/execution/shader_io/fragment_builtins.spec.ts
+++ b/src/webgpu/shader/execution/shader_io/fragment_builtins.spec.ts
@@ -9,8 +9,15 @@ Note: @interpolate settings and sample_index affect whether or not the fragment 
 is evaluated per-fragment or per-sample. With @interpolate(, sample) or usage of
 @builtin(sample_index) the fragment shader should be executed per-sample.
 
+* sample_mask output is tested in
+  src/webgpu/api/operation/render_pipeline/sample_mask.spec.ts
+
+* frag_depth output is tested in
+  src/webgpu/api/operation/rendering/depth_clip_clamp.spec.ts
+
 TODO:
-* test frag_depth
+* test sample_mask in
+  Consider extending the sample_mask out test.
 `;
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
@@ -1210,3 +1217,8 @@ g.test('inputs,front_facing')
       })
     );
   });
+
+// To test sample_mask as a fragment shader output, consider
+// extending the tests in
+// src/webgpu/api/operation/render_pipeline/sample_mask.spec.ts
+g.test('inputs,sample_mask').unimplemented();


### PR DESCRIPTION


<hr>

**Requirements for PR author:**

- [ ] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [ ] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
