### PR TITLE
Fix resize test for offscreen canvas

### DIFF
--- a/src/webgpu/web_platform/canvas/getCurrentTexture.spec.ts
+++ b/src/webgpu/web_platform/canvas/getCurrentTexture.spec.ts
@@ -293,28 +293,31 @@ g.test('resize')
       exp: { R: 0, G: 0, B: 0, A: 0 },
     });
 
-    // Ensure canvas goes back to defaults when set to negative numbers.
-    ctx.canvas.width = -1;
-    currentTexture = ctx.getCurrentTexture();
-    t.expect(currentTexture.width === 300);
-    t.expect(currentTexture.height === 4);
+    // HTMLCanvasElement behaves differently than OffscreenCanvas
+    if (t.params.canvasType === 'onscreen') {
+      // Ensure canvas goes back to defaults when set to negative numbers.
+      ctx.canvas.width = -1;
+      currentTexture = ctx.getCurrentTexture();
+      t.expect(currentTexture.width === 300);
+      t.expect(currentTexture.height === 4);
 
-    ctx.canvas.height = -1;
-    currentTexture = ctx.getCurrentTexture();
-    t.expect(currentTexture.width === 300);
-    t.expect(currentTexture.height === 150);
-    prevTexture = currentTexture;
+      ctx.canvas.height = -1;
+      currentTexture = ctx.getCurrentTexture();
+      t.expect(currentTexture.width === 300);
+      t.expect(currentTexture.height === 150);
 
-    // Setting the canvas width and height values to their current values should
-    // still trigger a change in the texture.
-    const { width, height } = ctx.canvas;
-    ctx.canvas.width = width;
-    ctx.canvas.height = height;
+      // Setting the canvas width and height values to their current values should
+      // still trigger a change in the texture.
+      prevTexture = ctx.getCurrentTexture();
+      const { width, height } = ctx.canvas;
+      ctx.canvas.width = width;
+      ctx.canvas.height = height;
 
-    t.expectTextureDestroyed(prevTexture);
+      t.expectTextureDestroyed(prevTexture);
 
-    currentTexture = ctx.getCurrentTexture();
-    t.expect(prevTexture !== currentTexture);
+      currentTexture = ctx.getCurrentTexture();
+      t.expect(prevTexture !== currentTexture);
+    }
   });
 
 g.test('expiry')


### PR DESCRIPTION
OffscreenCanvas has different rules than HTMLCanvasElement

HTMLCanvasElement can have width or height set to negative numbers and will then set the canvas width or height to its default, 300 for width, 150 for height

OffscreenCanvas will throw an error with a negative width or height.

For OffscreenCanvas, all 3 major browsers do not reset the canvas if width or height are set to the same value they already are

For HTMLCanvasElement, Beacuse there are issues with requestAnimationFrame, ResizeObserver, and compositing the page, it seems like, at least for HTMLCanvasElement, all 3 APIs should behave the same.


<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
