### PR TITLE
Dedup kTextureFormats, fix format table docs

### DIFF
--- a/src/webgpu/api/validation/createTexture.spec.ts
+++ b/src/webgpu/api/validation/createTexture.spec.ts
@@ -6,7 +6,7 @@ import { assert, makeValueTestVariant } from '../../../common/util/util.js';
 import { kTextureDimensions, kTextureUsages } from '../../capability_info.js';
 import { GPUConst } from '../../constants.js';
 import {
-  kTextureFormats,
+  kAllTextureFormats,
   kTextureFormatInfo,
   kCompressedTextureFormats,
   kUncompressedTextureFormats,
@@ -104,7 +104,9 @@ g.test('dimension_type_and_format_compatibility')
     `Test every dimension type on every format. Note that compressed formats and depth/stencil formats are not valid for 1D/3D dimension types.`
   )
   .params(u =>
-    u.combine('dimension', [undefined, ...kTextureDimensions]).combine('format', kTextureFormats)
+    u //
+      .combine('dimension', [undefined, ...kTextureDimensions])
+      .combine('format', kAllTextureFormats)
   )
   .beforeAllSubcases(t => {
     const { format } = t.params;
@@ -136,7 +138,7 @@ g.test('mipLevelCount,format')
   .params(u =>
     u
       .combine('dimension', [undefined, ...kTextureDimensions])
-      .combine('format', kTextureFormats)
+      .combine('format', kAllTextureFormats)
       .beginSubcases()
       .combine('mipLevelCount', [1, 2, 3, 6, 7])
       // Filter out incompatible dimension type and format combinations.
@@ -271,7 +273,7 @@ g.test('sampleCount,various_sampleCount_with_all_formats')
   .params(u =>
     u
       .combine('dimension', [undefined, '2d'] as const)
-      .combine('format', kTextureFormats)
+      .combine('format', kAllTextureFormats)
       .beginSubcases()
       .combine('sampleCount', [0, 1, 2, 4, 8, 16, 32, 256])
   )
@@ -318,7 +320,7 @@ g.test('sampleCount,valid_sampleCount_with_other_parameter_varies')
   .params(u =>
     u
       .combine('dimension', [undefined, ...kTextureDimensions])
-      .combine('format', kTextureFormats)
+      .combine('format', kAllTextureFormats)
       .beginSubcases()
       .combine('sampleCount', [1, 4])
       .combine('arrayLayerCount', [1, 2])
@@ -1032,7 +1034,7 @@ g.test('texture_usage')
   .params(u =>
     u
       .combine('dimension', [undefined, ...kTextureDimensions])
-      .combine('format', kTextureFormats)
+      .combine('format', kAllTextureFormats)
       .beginSubcases()
       // If usage0 and usage1 are the same, then the usage being test is a single usage. Otherwise, it is a combined usage.
       .combine('usage0', kTextureUsages)
@@ -1090,10 +1092,10 @@ g.test('viewFormats')
       .combine('viewFormatFeature', kFeaturesForFormats)
       .beginSubcases()
       .expand('format', ({ formatFeature }) =>
-        filterFormatsByFeature(formatFeature, kTextureFormats)
+        filterFormatsByFeature(formatFeature, kAllTextureFormats)
       )
       .expand('viewFormat', ({ viewFormatFeature }) =>
-        filterFormatsByFeature(viewFormatFeature, kTextureFormats)
+        filterFormatsByFeature(viewFormatFeature, kAllTextureFormats)
       )
   )
   .beforeAllSubcases(t => {

--- a/src/webgpu/api/validation/createView.spec.ts
+++ b/src/webgpu/api/validation/createView.spec.ts
@@ -10,7 +10,7 @@ import {
 } from '../../capability_info.js';
 import {
   kTextureFormatInfo,
-  kTextureFormats,
+  kAllTextureFormats,
   kFeaturesForFormats,
   filterFormatsByFeature,
   viewCompatible,
@@ -39,10 +39,10 @@ g.test('format')
       .combine('viewFormatFeature', kFeaturesForFormats)
       .beginSubcases()
       .expand('textureFormat', ({ textureFormatFeature }) =>
-        filterFormatsByFeature(textureFormatFeature, kTextureFormats)
+        filterFormatsByFeature(textureFormatFeature, kAllTextureFormats)
       )
       .expand('viewFormat', ({ viewFormatFeature }) =>
-        filterFormatsByFeature(viewFormatFeature, [undefined, ...kTextureFormats])
+        filterFormatsByFeature(viewFormatFeature, [undefined, ...kAllTextureFormats])
       )
       .combine('useViewFormatList', [false, true])
   )
@@ -124,7 +124,7 @@ g.test('aspect')
   )
   .params(u =>
     u //
-      .combine('format', kTextureFormats)
+      .combine('format', kAllTextureFormats)
       .combine('aspect', kTextureAspects)
   )
   .beforeAllSubcases(t => {

--- a/src/webgpu/api/validation/encoding/cmds/copyTextureToTexture.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/copyTextureToTexture.spec.ts
@@ -6,7 +6,7 @@ import { makeTestGroup } from '../../../../../common/framework/test_group.js';
 import { kTextureUsages, kTextureDimensions } from '../../../../capability_info.js';
 import {
   kTextureFormatInfo,
-  kTextureFormats,
+  kAllTextureFormats,
   kCompressedTextureFormats,
   kDepthStencilFormats,
   kFeaturesForFormats,
@@ -360,10 +360,10 @@ Test the formats of textures in copyTextureToTexture must be copy-compatible.
       .combine('dstFormatFeature', kFeaturesForFormats)
       .beginSubcases()
       .expand('srcFormat', ({ srcFormatFeature }) =>
-        filterFormatsByFeature(srcFormatFeature, kTextureFormats)
+        filterFormatsByFeature(srcFormatFeature, kAllTextureFormats)
       )
       .expand('dstFormat', ({ dstFormatFeature }) =>
-        filterFormatsByFeature(dstFormatFeature, kTextureFormats)
+        filterFormatsByFeature(dstFormatFeature, kAllTextureFormats)
       )
   )
   .beforeAllSubcases(t => {

--- a/src/webgpu/api/validation/queue/copyToTexture/CopyExternalImageToTexture.spec.ts
+++ b/src/webgpu/api/validation/queue/copyToTexture/CopyExternalImageToTexture.spec.ts
@@ -14,7 +14,7 @@ import { raceWithRejectOnTimeout, unreachable, assert } from '../../../../../com
 import { kTextureUsages } from '../../../../capability_info.js';
 import {
   kTextureFormatInfo,
-  kTextureFormats,
+  kAllTextureFormats,
   kValidTextureFormatsForCopyE2T,
 } from '../../../../format_info.js';
 import { kResourceStates } from '../../../../gpu_test.js';
@@ -669,7 +669,7 @@ g.test('destination_texture,format')
   )
   .params(u =>
     u
-      .combine('format', kTextureFormats)
+      .combine('format', kAllTextureFormats)
       .beginSubcases()
       .combine('copySize', [
         { width: 0, height: 0, depthOrArrayLayers: 0 },

--- a/src/webgpu/api/validation/render_pipeline/depth_stencil_state.spec.ts
+++ b/src/webgpu/api/validation/render_pipeline/depth_stencil_state.spec.ts
@@ -5,7 +5,11 @@ This test dedicatedly tests validation of GPUDepthStencilState of createRenderPi
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { unreachable } from '../../../../common/util/util.js';
 import { kCompareFunctions, kStencilOperations } from '../../../capability_info.js';
-import { kTextureFormats, kTextureFormatInfo, kDepthStencilFormats } from '../../../format_info.js';
+import {
+  kAllTextureFormats,
+  kTextureFormatInfo,
+  kDepthStencilFormats,
+} from '../../../format_info.js';
 import { getFragmentShaderCodeWithOutput } from '../../../util/shader.js';
 
 import { CreateRenderPipelineValidationTest } from './common.js';
@@ -14,7 +18,11 @@ export const g = makeTestGroup(CreateRenderPipelineValidationTest);
 
 g.test('format')
   .desc(`The texture format in depthStencilState must be a depth/stencil format.`)
-  .params(u => u.combine('isAsync', [false, true]).combine('format', kTextureFormats))
+  .params(u =>
+    u //
+      .combine('isAsync', [false, true])
+      .combine('format', kAllTextureFormats)
+  )
   .beforeAllSubcases(t => {
     const { format } = t.params;
     const info = kTextureFormatInfo[format];

--- a/src/webgpu/api/validation/render_pipeline/fragment_state.spec.ts
+++ b/src/webgpu/api/validation/render_pipeline/fragment_state.spec.ts
@@ -10,7 +10,7 @@ import {
   kMaxColorAttachmentsToTest,
 } from '../../../capability_info.js';
 import {
-  kTextureFormats,
+  kAllTextureFormats,
   kRenderableColorTextureFormats,
   kTextureFormatInfo,
   computeBytesPerSampleFromFormats,
@@ -51,7 +51,11 @@ g.test('color_target_exists')
 
 g.test('targets_format_renderable')
   .desc(`Tests that color target state format must have RENDER_ATTACHMENT capability.`)
-  .params(u => u.combine('isAsync', [false, true]).combine('format', kTextureFormats))
+  .params(u =>
+    u //
+      .combine('isAsync', [false, true])
+      .combine('format', kAllTextureFormats)
+  )
   .beforeAllSubcases(t => {
     const { format } = t.params;
     const info = kTextureFormatInfo[format];

--- a/src/webgpu/format_info.ts
+++ b/src/webgpu/format_info.ts
@@ -13,24 +13,37 @@ import { ImageCopyType } from './util/texture/layout.js';
  * `formatTableWithDefaults`. This ensures keys are never missing, always explicitly `undefined`.
  *
  * All top-level keys must be defined here, or they won't be exposed at all.
+ * Documentation is also written here; this makes it propagate through to the end types.
  */
 const kFormatUniversalDefaults = {
+  /** Texel block width. */
   blockWidth: undefined,
+  /** Texel block height. */
   blockHeight: undefined,
   color: undefined,
   depth: undefined,
   stencil: undefined,
   colorRender: undefined,
+  /** Whether the format can be used in a multisample texture. */
   multisample: undefined,
+  /** Optional feature required to use this format, or `undefined` if none. */
   feature: undefined,
+  /** The base format for srgb formats. Specified on both srgb and equivalent non-srgb formats. */
   baseFormat: undefined,
 
+  /** @deprecated */
   sampleType: undefined,
+  /** @deprecated */
   copySrc: undefined,
+  /** @deprecated */
   copyDst: undefined,
+  /** @deprecated Use `.color.bytes`, `.depth.bytes`, or `.stencil.bytes`. */
   bytesPerBlock: undefined,
+  /** @deprecated */
   renderable: false,
+  /** @deprecated */
   renderTargetPixelByteCost: undefined,
+  /** @deprecated */
   renderTargetComponentAlignment: undefined,
 
   // IMPORTANT:
@@ -1643,33 +1656,20 @@ interface TextureFormatStencilAspectInfo extends TextureFormatAspectInfo {
  * This is not actually the type of values in kTextureFormatInfo; that type is fully const
  * so that it can be narrowed very precisely at usage sites by the compiler.
  * This type exists only as a type check on the inferred type of kTextureFormatInfo.
- * Documentation is also written here, but not actually visible to the IDE.
  */
 type TextureFormatInfo_TypeCheck = {
-  /** Texel block width. */
   blockWidth: number;
-  /** Texel block height. */
   blockHeight: number;
-  /** Whether the format can be used in a multisample texture. */
   multisample: boolean;
-  /** The base format for srgb formats. Specified on both srgb and equivalent non-srgb formats. */
   baseFormat: GPUTextureFormat | undefined;
-  /** Optional feature required to use this format, or `undefined` if none. */
   feature: GPUFeatureName | undefined;
 
-  /** @deprecated */
   sampleType: GPUTextureSampleType;
-  /** @deprecated */
   copySrc: boolean;
-  /** @deprecated */
   copyDst: boolean;
-  /** @deprecated */
   bytesPerBlock: number | undefined;
-  /** @deprecated */
   renderable: boolean;
-  /** @deprecated */
   renderTargetPixelByteCost: number | undefined;
-  /** @deprecated */
   renderTargetComponentAlignment: number | undefined;
 
   // IMPORTANT:

--- a/src/webgpu/format_info.ts
+++ b/src/webgpu/format_info.ts
@@ -1724,10 +1724,6 @@ const kTextureFormatInfo_TypeCheck: {
   readonly [F in GPUTextureFormat]: TextureFormatInfo_TypeCheck;
 } = kTextureFormatInfo;
 
-/** List of all GPUTextureFormat values. */
-// MAINTENANCE_TODO: dedup with kAllTextureFormats
-export const kTextureFormats: readonly GPUTextureFormat[] = keysOf(kAllTextureFormatInfo);
-
 /** Valid GPUTextureFormats for `copyExternalImageToTexture`, by spec. */
 export const kValidTextureFormatsForCopyE2T = [
   'r8unorm',
@@ -1957,7 +1953,7 @@ export function isEncodableTextureformat(format: GPUTextureFormat) {
   return format in kEncodableTextureFormatInfo;
 }
 
-export const kFeaturesForFormats = getFeaturesForFormats(kTextureFormats);
+export const kFeaturesForFormats = getFeaturesForFormats(kAllTextureFormats);
 
 /**
  * Given an array of texture formats return the number of bytes per sample.

--- a/src/webgpu/web_platform/canvas/configure.spec.ts
+++ b/src/webgpu/web_platform/canvas/configure.spec.ts
@@ -13,7 +13,6 @@ import { GPUConst } from '../../constants.js';
 import {
   kAllTextureFormats,
   kFeaturesForFormats,
-  kTextureFormats,
   filterFormatsByFeature,
   viewCompatible,
 } from '../../format_info.js';
@@ -387,7 +386,7 @@ g.test('viewFormats')
       .combine('viewFormatFeature', kFeaturesForFormats)
       .beginSubcases()
       .expand('viewFormat', ({ viewFormatFeature }) =>
-        filterFormatsByFeature(viewFormatFeature, kTextureFormats)
+        filterFormatsByFeature(viewFormatFeature, kAllTextureFormats)
       )
   )
   .beforeAllSubcases(t => {


### PR DESCRIPTION
- Deduplicate identical kTextureFormats and kAllTextureFormats
- Move documentation so it is actually inherited

Part 3 of Issue: #2495

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
