### PR TITLE
Fix maxXXXPerShaderStage tests

### DIFF
--- a/src/webgpu/api/validation/capability_checks/limits/limit_utils.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/limit_utils.ts
@@ -45,32 +45,47 @@ export function getPipelineTypeForBindingCombination(bindingCombination: Binding
   }
 }
 
-function getBindGroupIndex(bindGroupTest: BindGroupTest, i: number) {
+function getBindGroupIndex(bindGroupTest: BindGroupTest, numBindGroups: number, i: number) {
   switch (bindGroupTest) {
     case 'sameGroup':
       return 0;
     case 'differentGroups':
-      return i % 3;
+      return i % numBindGroups;
+  }
+}
+
+function getBindingIndex(bindGroupTest: BindGroupTest, numBindGroups: number, i: number) {
+  switch (bindGroupTest) {
+    case 'sameGroup':
+      return i;
+    case 'differentGroups':
+      return (i / numBindGroups) | 0;
   }
 }
 
 function getWGSLBindings(
-  order: ReorderOrder,
-  bindGroupTest: BindGroupTest,
-  storageDefinitionWGSLSnippetFn: (i: number, j: number) => string,
+  {
+    order,
+    bindGroupTest,
+    storageDefinitionWGSLSnippetFn,
+    numBindGroups,
+  }: {
+    order: ReorderOrder;
+    bindGroupTest: BindGroupTest;
+    storageDefinitionWGSLSnippetFn: (i: number, j: number) => string;
+    numBindGroups: number;
+  },
   numBindings: number,
   id: number
 ) {
   return reorder(
     order,
-    range(
-      numBindings,
-      i =>
-        `@group(${getBindGroupIndex(
-          bindGroupTest,
-          i
-        )}) @binding(${i}) ${storageDefinitionWGSLSnippetFn(i, id)};`
-    )
+    range(numBindings, i => {
+      const groupNdx = getBindGroupIndex(bindGroupTest, numBindGroups, i);
+      const bindingNdx = getBindingIndex(bindGroupTest, numBindGroups, i);
+      const storageWGSL = storageDefinitionWGSLSnippetFn(i, id);
+      return `@group(${groupNdx}) @binding(${bindingNdx}) ${storageWGSL};`;
+    })
   ).join('\n        ');
 }
 
@@ -80,15 +95,22 @@ export function getPerStageWGSLForBindingCombinationImpl(
   bindGroupTest: BindGroupTest,
   storageDefinitionWGSLSnippetFn: (i: number, j: number) => string,
   bodyFn: (numBindings: number, set: number) => string,
+  numBindGroups: number,
   numBindings: number,
   extraWGSL = ''
 ) {
+  const bindingParams = {
+    order,
+    bindGroupTest,
+    storageDefinitionWGSLSnippetFn,
+    numBindGroups,
+  };
   switch (bindingCombination) {
     case 'vertex':
       return `
         ${extraWGSL}
 
-        ${getWGSLBindings(order, bindGroupTest, storageDefinitionWGSLSnippetFn, numBindings, 0)}
+        ${getWGSLBindings(bindingParams, numBindings, 0)}
 
         @vertex fn mainVS() -> @builtin(position) vec4f {
           ${bodyFn(numBindings, 0)}
@@ -99,7 +121,7 @@ export function getPerStageWGSLForBindingCombinationImpl(
       return `
         ${extraWGSL}
 
-        ${getWGSLBindings(order, bindGroupTest, storageDefinitionWGSLSnippetFn, numBindings, 0)}
+        ${getWGSLBindings(bindingParams, numBindings, 0)}
 
         @vertex fn mainVS() -> @builtin(position) vec4f {
           return vec4f(0);
@@ -113,9 +135,9 @@ export function getPerStageWGSLForBindingCombinationImpl(
       return `
         ${extraWGSL}
 
-        ${getWGSLBindings(order, bindGroupTest, storageDefinitionWGSLSnippetFn, numBindings, 0)}
+        ${getWGSLBindings(bindingParams, numBindings, 0)}
 
-        ${getWGSLBindings(order, bindGroupTest, storageDefinitionWGSLSnippetFn, numBindings - 1, 1)}
+        ${getWGSLBindings(bindingParams, numBindings - 1, 1)}
 
         @vertex fn mainVS() -> @builtin(position) vec4f {
           ${bodyFn(numBindings, 0)}
@@ -131,9 +153,9 @@ export function getPerStageWGSLForBindingCombinationImpl(
       return `
         ${extraWGSL}
 
-        ${getWGSLBindings(order, bindGroupTest, storageDefinitionWGSLSnippetFn, numBindings - 1, 0)}
+        ${getWGSLBindings(bindingParams, numBindings - 1, 0)}
 
-        ${getWGSLBindings(order, bindGroupTest, storageDefinitionWGSLSnippetFn, numBindings, 1)}
+        ${getWGSLBindings(bindingParams, numBindings, 1)}
 
         @vertex fn mainVS() -> @builtin(position) vec4f {
           ${bodyFn(numBindings - 1, 0)}
@@ -148,8 +170,7 @@ export function getPerStageWGSLForBindingCombinationImpl(
     case 'compute':
       return `
         ${extraWGSL}
-        ${getWGSLBindings(order, bindGroupTest, storageDefinitionWGSLSnippetFn, numBindings, 0)}
-        @group(3) @binding(0) var<storage, read_write> d: f32;
+        ${getWGSLBindings(bindingParams, numBindings, 0)}
         @compute @workgroup_size(1) fn main() {
           ${bodyFn(numBindings, 0)}
         }
@@ -164,6 +185,7 @@ export function getPerStageWGSLForBindingCombination(
   bindGroupTest: BindGroupTest,
   storageDefinitionWGSLSnippetFn: (i: number, j: number) => string,
   usageWGSLSnippetFn: (i: number, j: number) => string,
+  maxBindGroups: number,
   numBindings: number,
   extraWGSL = ''
 ) {
@@ -174,6 +196,7 @@ export function getPerStageWGSLForBindingCombination(
     storageDefinitionWGSLSnippetFn,
     (numBindings: number, set: number) =>
       `${range(numBindings, i => usageWGSLSnippetFn(i, set)).join('\n          ')}`,
+    maxBindGroups,
     numBindings,
     extraWGSL
   );
@@ -185,6 +208,7 @@ export function getPerStageWGSLForBindingCombinationStorageTextures(
   bindGroupTest: BindGroupTest,
   storageDefinitionWGSLSnippetFn: (i: number, j: number) => string,
   usageWGSLSnippetFn: (i: number, j: number) => string,
+  numBindGroups: number,
   numBindings: number,
   extraWGSL = ''
 ) {
@@ -195,6 +219,7 @@ export function getPerStageWGSLForBindingCombinationStorageTextures(
     storageDefinitionWGSLSnippetFn,
     (numBindings: number, set: number) =>
       `${range(numBindings, i => usageWGSLSnippetFn(i, set)).join('\n          ')}`,
+    numBindGroups,
     numBindings,
     extraWGSL
   );

--- a/src/webgpu/api/validation/capability_checks/limits/maxSampledTexturesPerShaderStage.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxSampledTexturesPerShaderStage.spec.ts
@@ -107,7 +107,7 @@ g.test('createPipelineLayout,at_over')
         const kNumGroups = Math.ceil(testValue / maxBindingsPerBindGroup);
 
         // Not sure what to do in this case but best we get notified if it happens.
-        assert(kNumGroups < t.device.limits.maxBindGroups);
+        assert(kNumGroups <= t.device.limits.maxBindGroups);
 
         const bindGroupLayouts = range(kNumGroups, i => {
           const numInGroup = Math.min(

--- a/src/webgpu/api/validation/capability_checks/limits/maxSampledTexturesPerShaderStage.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxSampledTexturesPerShaderStage.spec.ts
@@ -3,6 +3,7 @@ import {
   reorder,
   kReorderOrderKeys,
   ReorderOrder,
+  assert,
 } from '../../../../../common/util/util.js';
 import { kShaderStageCombinationsWithStage } from '../../../../capability_info.js';
 
@@ -13,7 +14,13 @@ import {
   kBindingCombinations,
   getPipelineTypeForBindingCombination,
   getPerStageWGSLForBindingCombination,
+  LimitsRequest,
 } from './limit_utils.js';
+
+const kExtraLimits: LimitsRequest = {
+  maxBindingsPerBindGroup: 'adapterLimit',
+  maxBindGroups: 'adapterLimit',
+};
 
 const limit = 'maxSampledTexturesPerShaderStage';
 export const { g, description } = makeLimitTestGroup(limit);
@@ -43,6 +50,9 @@ g.test('createBindGroupLayout,at_over')
 
   Note: We also test order to make sure the implementation isn't just looking
   at just the last entry.
+
+  Note: It's also possible the maxBindingsPerBindGroup is lower than
+  ${limit} in which case skip the test since we can not hit the limit.
   `
   )
   .params(
@@ -56,11 +66,17 @@ g.test('createBindGroupLayout,at_over')
       limitTest,
       testValueName,
       async ({ device, testValue, shouldError }) => {
+        t.skipIf(
+          t.adapter.limits.maxBindingsPerBindGroup < testValue,
+          `maxBindingsPerBindGroup = ${t.adapter.limits.maxBindingsPerBindGroup} which is less than ${testValue}`
+        );
+
         await t.expectValidationError(
           () => createBindGroupLayout(device, visibility, order, testValue),
           shouldError
         );
-      }
+      },
+      kExtraLimits
     );
   });
 
@@ -83,18 +99,30 @@ g.test('createPipelineLayout,at_over')
     await t.testDeviceWithRequestedMaximumLimits(
       limitTest,
       testValueName,
-      async ({ device, testValue, shouldError }) => {
-        const kNumGroups = 3;
+      async ({ device, testValue, shouldError, actualLimit }) => {
+        const maxBindingsPerBindGroup = Math.min(
+          t.device.limits.maxBindingsPerBindGroup,
+          actualLimit
+        );
+        const kNumGroups = Math.ceil(testValue / maxBindingsPerBindGroup);
+
+        // Not sure what to do in this case but best we get notified if it happens.
+        assert(kNumGroups < t.device.limits.maxBindGroups);
+
         const bindGroupLayouts = range(kNumGroups, i => {
-          const minInGroup = Math.floor(testValue / kNumGroups);
-          const numInGroup = i ? minInGroup : testValue - minInGroup * (kNumGroups - 1);
+          const numInGroup = Math.min(
+            testValue - i * maxBindingsPerBindGroup,
+            maxBindingsPerBindGroup
+          );
           return createBindGroupLayout(device, visibility, order, numInGroup);
         });
+
         await t.expectValidationError(
           () => device.createPipelineLayout({ bindGroupLayouts }),
           shouldError
         );
-      }
+      },
+      kExtraLimits
     );
   });
 
@@ -122,16 +150,21 @@ g.test('createPipeline,at_over')
       limitTest,
       testValueName,
       async ({ device, testValue, actualLimit, shouldError }) => {
+        t.skipIf(
+          bindGroupTest === 'sameGroup' && testValue > device.limits.maxBindingsPerBindGroup,
+          `can not test ${testValue} bindings in same group because maxBindingsPerBindGroup = ${device.limits.maxBindingsPerBindGroup}`
+        );
+
         const code = getPerStageWGSLForBindingCombination(
           bindingCombination,
           order,
           bindGroupTest,
           (i, j) => `var u${j}_${i}: texture_2d<f32>`,
           (i, j) => `_ = textureLoad(u${j}_${i}, vec2u(0), 0);`,
+          device.limits.maxBindGroups,
           testValue
         );
         const module = device.createShaderModule({ code });
-
         await t.testCreatePipeline(
           pipelineType,
           async,
@@ -139,6 +172,7 @@ g.test('createPipeline,at_over')
           shouldError,
           `actualLimit: ${actualLimit}, testValue: ${testValue}\n:${code}`
         );
-      }
+      },
+      kExtraLimits
     );
   });

--- a/src/webgpu/api/validation/capability_checks/limits/maxSamplersPerShaderStage.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxSamplersPerShaderStage.spec.ts
@@ -3,6 +3,7 @@ import {
   reorder,
   kReorderOrderKeys,
   ReorderOrder,
+  assert,
 } from '../../../../../common/util/util.js';
 import { kShaderStageCombinationsWithStage } from '../../../../capability_info.js';
 
@@ -13,7 +14,13 @@ import {
   kBindingCombinations,
   getPipelineTypeForBindingCombination,
   getPerStageWGSLForBindingCombination,
+  LimitsRequest,
 } from './limit_utils.js';
+
+const kExtraLimits: LimitsRequest = {
+  maxBindingsPerBindGroup: 'adapterLimit',
+  maxBindGroups: 'adapterLimit',
+};
 
 const limit = 'maxSamplersPerShaderStage';
 export const { g, description } = makeLimitTestGroup(limit);
@@ -56,11 +63,17 @@ g.test('createBindGroupLayout,at_over')
       limitTest,
       testValueName,
       async ({ device, testValue, shouldError }) => {
+        t.skipIf(
+          t.adapter.limits.maxBindingsPerBindGroup < testValue,
+          `maxBindingsPerBindGroup = ${t.adapter.limits.maxBindingsPerBindGroup} which is less than ${testValue}`
+        );
+
         await t.expectValidationError(
           () => createBindGroupLayout(device, visibility, order, testValue),
           shouldError
         );
-      }
+      },
+      kExtraLimits
     );
   });
 
@@ -83,18 +96,29 @@ g.test('createPipelineLayout,at_over')
     await t.testDeviceWithRequestedMaximumLimits(
       limitTest,
       testValueName,
-      async ({ device, testValue, shouldError }) => {
-        const kNumGroups = 3;
+      async ({ device, testValue, shouldError, actualLimit }) => {
+        const maxBindingsPerBindGroup = Math.min(
+          t.device.limits.maxBindingsPerBindGroup,
+          actualLimit
+        );
+        const kNumGroups = Math.ceil(testValue / maxBindingsPerBindGroup);
+
+        // Not sure what to do in this case but best we get notified if it happens.
+        assert(kNumGroups < t.device.limits.maxBindGroups);
+
         const bindGroupLayouts = range(kNumGroups, i => {
-          const minInGroup = Math.floor(testValue / kNumGroups);
-          const numInGroup = i ? minInGroup : testValue - minInGroup * (kNumGroups - 1);
+          const numInGroup = Math.min(
+            testValue - i * maxBindingsPerBindGroup,
+            maxBindingsPerBindGroup
+          );
           return createBindGroupLayout(device, visibility, order, numInGroup);
         });
         await t.expectValidationError(
           () => device.createPipelineLayout({ bindGroupLayouts }),
           shouldError
         );
-      }
+      },
+      kExtraLimits
     );
   });
 
@@ -122,14 +146,27 @@ g.test('createPipeline,at_over')
       limitTest,
       testValueName,
       async ({ device, testValue, actualLimit, shouldError }) => {
+        t.skipIf(
+          bindGroupTest === 'sameGroup' && testValue > device.limits.maxBindingsPerBindGroup,
+          `can not test ${testValue} bindings in same group because maxBindingsPerBindGroup = ${device.limits.maxBindingsPerBindGroup}`
+        );
+
+        // If this was false the texture binding would overlap the sampler bindings.
+        assert(testValue < device.limits.maxBindGroups * device.limits.maxBindingsPerBindGroup);
+
+        // Put the texture on the last possible binding.
+        const groupNdx = device.limits.maxBindGroups - 1;
+        const bindingNdx = device.limits.maxBindingsPerBindGroup - 1;
+
         const code = getPerStageWGSLForBindingCombination(
           bindingCombination,
           order,
           bindGroupTest,
           (i, j) => `var u${j}_${i}: sampler`,
           (i, j) => `_ = textureGather(0, tex, u${j}_${i}, vec2f(0));`,
+          device.limits.maxBindGroups,
           testValue,
-          '@group(3) @binding(1) var tex: texture_2d<f32>;'
+          `@group(${groupNdx}) @binding(${bindingNdx}) var tex: texture_2d<f32>;`
         );
         const module = device.createShaderModule({ code });
 
@@ -140,6 +177,7 @@ g.test('createPipeline,at_over')
           shouldError,
           `actualLimit: ${actualLimit}, testValue: ${testValue}\n:${code}`
         );
-      }
+      },
+      kExtraLimits
     );
   });

--- a/src/webgpu/api/validation/capability_checks/limits/maxSamplersPerShaderStage.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxSamplersPerShaderStage.spec.ts
@@ -104,7 +104,7 @@ g.test('createPipelineLayout,at_over')
         const kNumGroups = Math.ceil(testValue / maxBindingsPerBindGroup);
 
         // Not sure what to do in this case but best we get notified if it happens.
-        assert(kNumGroups < t.device.limits.maxBindGroups);
+        assert(kNumGroups <= t.device.limits.maxBindGroups);
 
         const bindGroupLayouts = range(kNumGroups, i => {
           const numInGroup = Math.min(

--- a/src/webgpu/api/validation/capability_checks/limits/maxStorageBuffersPerShaderStage.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxStorageBuffersPerShaderStage.spec.ts
@@ -3,7 +3,9 @@ import {
   reorder,
   kReorderOrderKeys,
   ReorderOrder,
+  assert,
 } from '../../../../../common/util/util.js';
+import { kShaderStageCombinationsWithStage } from '../../../../capability_info.js';
 import { GPUConst } from '../../../../constants.js';
 
 import {
@@ -13,7 +15,13 @@ import {
   kBindingCombinations,
   getPipelineTypeForBindingCombination,
   getPerStageWGSLForBindingCombination,
+  LimitsRequest,
 } from './limit_utils.js';
+
+const kExtraLimits: LimitsRequest = {
+  maxBindingsPerBindGroup: 'adapterLimit',
+  maxBindGroups: 'adapterLimit',
+};
 
 const limit = 'maxStorageBuffersPerShaderStage';
 export const { g, description } = makeLimitTestGroup(limit);
@@ -48,34 +56,31 @@ g.test('createBindGroupLayout,at_over')
   )
   .params(
     kMaximumLimitBaseParams
-      .combine('visibility', [
-        GPUConst.ShaderStage.VERTEX,
-        GPUConst.ShaderStage.FRAGMENT,
-        GPUConst.ShaderStage.VERTEX | GPUConst.ShaderStage.FRAGMENT,
-        GPUConst.ShaderStage.COMPUTE,
-        GPUConst.ShaderStage.VERTEX | GPUConst.ShaderStage.COMPUTE,
-        GPUConst.ShaderStage.FRAGMENT | GPUConst.ShaderStage.COMPUTE,
-        GPUConst.ShaderStage.VERTEX | GPUConst.ShaderStage.FRAGMENT | GPUConst.ShaderStage.COMPUTE,
-      ])
+      .combine('visibility', kShaderStageCombinationsWithStage)
       .combine('type', ['storage', 'read-only-storage'] as GPUBufferBindingType[])
       .combine('order', kReorderOrderKeys)
+      .filter(
+        ({ visibility, type }) =>
+          (visibility & GPUConst.ShaderStage.VERTEX) === 0 || type !== 'storage'
+      )
   )
   .fn(async t => {
     const { limitTest, testValueName, visibility, order, type } = t.params;
-
-    if (visibility & GPUConst.ShaderStage.VERTEX && type === 'storage') {
-      // vertex stage does not support storage buffers
-      return;
-    }
 
     await t.testDeviceWithRequestedMaximumLimits(
       limitTest,
       testValueName,
       async ({ device, testValue, shouldError }) => {
+        t.skipIf(
+          t.adapter.limits.maxBindingsPerBindGroup < testValue,
+          `maxBindingsPerBindGroup = ${t.adapter.limits.maxBindingsPerBindGroup} which is less than ${testValue}`
+        );
+
         await t.expectValidationError(() => {
           createBindGroupLayout(device, visibility, type, order, testValue);
         }, shouldError);
-      }
+      },
+      kExtraLimits
     );
   });
 
@@ -90,41 +95,44 @@ g.test('createPipelineLayout,at_over')
   )
   .params(
     kMaximumLimitBaseParams
-      .combine('visibility', [
-        GPUConst.ShaderStage.VERTEX,
-        GPUConst.ShaderStage.FRAGMENT,
-        GPUConst.ShaderStage.VERTEX | GPUConst.ShaderStage.FRAGMENT,
-        GPUConst.ShaderStage.COMPUTE,
-        GPUConst.ShaderStage.VERTEX | GPUConst.ShaderStage.COMPUTE,
-        GPUConst.ShaderStage.FRAGMENT | GPUConst.ShaderStage.COMPUTE,
-        GPUConst.ShaderStage.VERTEX | GPUConst.ShaderStage.FRAGMENT | GPUConst.ShaderStage.COMPUTE,
-      ])
+      .combine('visibility', kShaderStageCombinationsWithStage)
       .combine('type', ['storage', 'read-only-storage'] as GPUBufferBindingType[])
       .combine('order', kReorderOrderKeys)
+      .filter(
+        ({ visibility, type }) =>
+          (visibility & GPUConst.ShaderStage.VERTEX) === 0 || type !== 'storage'
+      )
   )
   .fn(async t => {
     const { limitTest, testValueName, visibility, order, type } = t.params;
 
-    if (visibility & GPUConst.ShaderStage.VERTEX && type === 'storage') {
-      // vertex stage does not support storage buffers
-      return;
-    }
-
     await t.testDeviceWithRequestedMaximumLimits(
       limitTest,
       testValueName,
-      async ({ device, testValue, shouldError }) => {
-        const kNumGroups = 3;
+      async ({ device, testValue, shouldError, actualLimit }) => {
+        const maxBindingsPerBindGroup = Math.min(
+          t.device.limits.maxBindingsPerBindGroup,
+          actualLimit
+        );
+        const kNumGroups = Math.ceil(testValue / maxBindingsPerBindGroup);
+
+        // Not sure what to do in this case but best we get notified if it happens.
+        assert(kNumGroups < t.device.limits.maxBindGroups);
+
         const bindGroupLayouts = range(kNumGroups, i => {
-          const minInGroup = Math.floor(testValue / kNumGroups);
-          const numInGroup = i ? minInGroup : testValue - minInGroup * (kNumGroups - 1);
+          const numInGroup = Math.min(
+            testValue - i * maxBindingsPerBindGroup,
+            maxBindingsPerBindGroup
+          );
           return createBindGroupLayout(device, visibility, type, order, numInGroup);
         });
+
         await t.expectValidationError(
           () => device.createPipelineLayout({ bindGroupLayouts }),
           shouldError
         );
-      }
+      },
+      kExtraLimits
     );
   });
 
@@ -152,12 +160,18 @@ g.test('createPipeline,at_over')
       limitTest,
       testValueName,
       async ({ device, testValue, actualLimit, shouldError }) => {
+        t.skipIf(
+          bindGroupTest === 'sameGroup' && testValue > device.limits.maxBindingsPerBindGroup,
+          `can not test ${testValue} bindings in same group because maxBindingsPerBindGroup = ${device.limits.maxBindingsPerBindGroup}`
+        );
+
         const code = getPerStageWGSLForBindingCombination(
           bindingCombination,
           order,
           bindGroupTest,
           (i, j) => `var<storage> u${j}_${i}: f32`,
           (i, j) => `_ = u${j}_${i};`,
+          device.limits.maxBindGroups,
           testValue
         );
         const module = device.createShaderModule({ code });
@@ -169,6 +183,7 @@ g.test('createPipeline,at_over')
           shouldError,
           `actualLimit: ${actualLimit}, testValue: ${testValue}\n:${code}`
         );
-      }
+      },
+      kExtraLimits
     );
   });

--- a/src/webgpu/api/validation/capability_checks/limits/maxStorageBuffersPerShaderStage.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxStorageBuffersPerShaderStage.spec.ts
@@ -117,7 +117,7 @@ g.test('createPipelineLayout,at_over')
         const kNumGroups = Math.ceil(testValue / maxBindingsPerBindGroup);
 
         // Not sure what to do in this case but best we get notified if it happens.
-        assert(kNumGroups < t.device.limits.maxBindGroups);
+        assert(kNumGroups <= t.device.limits.maxBindGroups);
 
         const bindGroupLayouts = range(kNumGroups, i => {
           const numInGroup = Math.min(

--- a/src/webgpu/api/validation/capability_checks/limits/maxStorageTexturesPerShaderStage.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxStorageTexturesPerShaderStage.spec.ts
@@ -3,6 +3,7 @@ import {
   reorder,
   ReorderOrder,
   kReorderOrderKeys,
+  assert,
 } from '../../../../../common/util/util.js';
 import { GPUConst } from '../../../../constants.js';
 
@@ -13,7 +14,13 @@ import {
   getPerStageWGSLForBindingCombinationStorageTextures,
   getPipelineTypeForBindingCombination,
   BindingCombination,
+  LimitsRequest,
 } from './limit_utils.js';
+
+const kExtraLimits: LimitsRequest = {
+  maxBindingsPerBindGroup: 'adapterLimit',
+  maxBindGroups: 'adapterLimit',
+};
 
 const limit = 'maxStorageTexturesPerShaderStage';
 export const { g, description } = makeLimitTestGroup(limit);
@@ -60,11 +67,17 @@ g.test('createBindGroupLayout,at_over')
       limitTest,
       testValueName,
       async ({ device, testValue, shouldError }) => {
+        t.skipIf(
+          t.adapter.limits.maxBindingsPerBindGroup < testValue,
+          `maxBindingsPerBindGroup = ${t.adapter.limits.maxBindingsPerBindGroup} which is less than ${testValue}`
+        );
+
         await t.expectValidationError(
           () => createBindGroupLayout(device, visibility, order, testValue),
           shouldError
         );
-      }
+      },
+      kExtraLimits
     );
   });
 
@@ -91,18 +104,30 @@ g.test('createPipelineLayout,at_over')
     await t.testDeviceWithRequestedMaximumLimits(
       limitTest,
       testValueName,
-      async ({ device, testValue, shouldError }) => {
-        const kNumGroups = 3;
+      async ({ device, testValue, shouldError, actualLimit }) => {
+        const maxBindingsPerBindGroup = Math.min(
+          t.device.limits.maxBindingsPerBindGroup,
+          actualLimit
+        );
+        const kNumGroups = Math.ceil(testValue / maxBindingsPerBindGroup);
+
+        // Not sure what to do in this case but best we get notified if it happens.
+        assert(kNumGroups < t.device.limits.maxBindGroups);
+
         const bindGroupLayouts = range(kNumGroups, i => {
-          const minInGroup = Math.floor(testValue / kNumGroups);
-          const numInGroup = i ? minInGroup : testValue - minInGroup * (kNumGroups - 1);
+          const numInGroup = Math.min(
+            testValue - i * maxBindingsPerBindGroup,
+            maxBindingsPerBindGroup
+          );
           return createBindGroupLayout(device, visibility, order, numInGroup);
         });
+
         await t.expectValidationError(
           () => device.createPipelineLayout({ bindGroupLayouts }),
           shouldError
         );
-      }
+      },
+      kExtraLimits
     );
   });
 
@@ -130,6 +155,11 @@ g.test('createPipeline,at_over')
       limitTest,
       testValueName,
       async ({ device, testValue, actualLimit, shouldError }) => {
+        t.skipIf(
+          bindGroupTest === 'sameGroup' && testValue > device.limits.maxBindingsPerBindGroup,
+          `can not test ${testValue} bindings in same group because maxBindingsPerBindGroup = ${device.limits.maxBindingsPerBindGroup}`
+        );
+
         if (bindingCombination === 'fragment') {
           return;
         }
@@ -140,6 +170,7 @@ g.test('createPipeline,at_over')
           bindGroupTest,
           (i, j) => `var u${j}_${i}: texture_storage_2d<rgba8unorm, write>`,
           (i, j) => `textureStore(u${j}_${i}, vec2u(0), vec4f(1));`,
+          device.limits.maxBindGroups,
           testValue
         );
         const module = device.createShaderModule({ code });
@@ -151,6 +182,7 @@ g.test('createPipeline,at_over')
           shouldError,
           `actualLimit: ${actualLimit}, testValue: ${testValue}\n:${code}`
         );
-      }
+      },
+      kExtraLimits
     );
   });

--- a/src/webgpu/api/validation/capability_checks/limits/maxStorageTexturesPerShaderStage.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxStorageTexturesPerShaderStage.spec.ts
@@ -112,7 +112,7 @@ g.test('createPipelineLayout,at_over')
         const kNumGroups = Math.ceil(testValue / maxBindingsPerBindGroup);
 
         // Not sure what to do in this case but best we get notified if it happens.
-        assert(kNumGroups < t.device.limits.maxBindGroups);
+        assert(kNumGroups <= t.device.limits.maxBindGroups);
 
         const bindGroupLayouts = range(kNumGroups, i => {
           const numInGroup = Math.min(

--- a/src/webgpu/api/validation/capability_checks/limits/maxUniformBuffersPerShaderStage.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxUniformBuffersPerShaderStage.spec.ts
@@ -3,6 +3,7 @@ import {
   reorder,
   kReorderOrderKeys,
   ReorderOrder,
+  assert,
 } from '../../../../../common/util/util.js';
 import { kShaderStageCombinationsWithStage } from '../../../../capability_info.js';
 
@@ -13,7 +14,13 @@ import {
   kBindingCombinations,
   getPipelineTypeForBindingCombination,
   getPerStageWGSLForBindingCombination,
+  LimitsRequest,
 } from './limit_utils.js';
+
+const kExtraLimits: LimitsRequest = {
+  maxBindingsPerBindGroup: 'adapterLimit',
+  maxBindGroups: 'adapterLimit',
+};
 
 const limit = 'maxUniformBuffersPerShaderStage';
 export const { g, description } = makeLimitTestGroup(limit);
@@ -56,11 +63,17 @@ g.test('createBindGroupLayout,at_over')
       limitTest,
       testValueName,
       async ({ device, testValue, shouldError }) => {
+        t.skipIf(
+          t.adapter.limits.maxBindingsPerBindGroup < testValue,
+          `maxBindingsPerBindGroup = ${t.adapter.limits.maxBindingsPerBindGroup} which is less than ${testValue}`
+        );
+
         await t.expectValidationError(
           () => createBindGroupLayout(device, visibility, order, testValue),
           shouldError
         );
-      }
+      },
+      kExtraLimits
     );
   });
 
@@ -83,18 +96,30 @@ g.test('createPipelineLayout,at_over')
     await t.testDeviceWithRequestedMaximumLimits(
       limitTest,
       testValueName,
-      async ({ device, testValue, shouldError }) => {
-        const kNumGroups = 3;
+      async ({ device, testValue, shouldError, actualLimit }) => {
+        const maxBindingsPerBindGroup = Math.min(
+          t.device.limits.maxBindingsPerBindGroup,
+          actualLimit
+        );
+        const kNumGroups = Math.ceil(testValue / maxBindingsPerBindGroup);
+
+        // Not sure what to do in this case but best we get notified if it happens.
+        assert(kNumGroups < t.device.limits.maxBindGroups);
+
         const bindGroupLayouts = range(kNumGroups, i => {
-          const minInGroup = Math.floor(testValue / kNumGroups);
-          const numInGroup = i ? minInGroup : testValue - minInGroup * (kNumGroups - 1);
+          const numInGroup = Math.min(
+            testValue - i * maxBindingsPerBindGroup,
+            maxBindingsPerBindGroup
+          );
           return createBindGroupLayout(device, visibility, order, numInGroup);
         });
+
         await t.expectValidationError(
           () => device.createPipelineLayout({ bindGroupLayouts }),
           shouldError
         );
-      }
+      },
+      kExtraLimits
     );
   });
 
@@ -122,12 +147,18 @@ g.test('createPipeline,at_over')
       limitTest,
       testValueName,
       async ({ device, testValue, actualLimit, shouldError }) => {
+        t.skipIf(
+          bindGroupTest === 'sameGroup' && testValue > device.limits.maxBindingsPerBindGroup,
+          `can not test ${testValue} bindings in same group because maxBindingsPerBindGroup = ${device.limits.maxBindingsPerBindGroup}`
+        );
+
         const code = getPerStageWGSLForBindingCombination(
           bindingCombination,
           order,
           bindGroupTest,
           (i, j) => `var<uniform> u${j}_${i}: f32`,
           (i, j) => `_ = u${j}_${i};`,
+          device.limits.maxBindGroups,
           testValue
         );
         const module = device.createShaderModule({ code });
@@ -139,6 +170,7 @@ g.test('createPipeline,at_over')
           shouldError,
           `actualLimit: ${actualLimit}, testValue: ${testValue}\n:${code}`
         );
-      }
+      },
+      kExtraLimits
     );
   });

--- a/src/webgpu/api/validation/capability_checks/limits/maxUniformBuffersPerShaderStage.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxUniformBuffersPerShaderStage.spec.ts
@@ -104,7 +104,7 @@ g.test('createPipelineLayout,at_over')
         const kNumGroups = Math.ceil(testValue / maxBindingsPerBindGroup);
 
         // Not sure what to do in this case but best we get notified if it happens.
-        assert(kNumGroups < t.device.limits.maxBindGroups);
+        assert(kNumGroups <= t.device.limits.maxBindGroups);
 
         const bindGroupLayouts = range(kNumGroups, i => {
           const numInGroup = Math.min(


### PR DESCRIPTION
There's no requirement that maxXXXPerShaderStage is less than maxBindingsPerBindGroup and further, it's possible that given a low maxBindingsPerBindGroup we'd need to use multiple bind groups to bind enough XXX to test the maxXXXPerShaderStage limit. So we ask for maxBindingPerBindGroup and maxBindGroups and confirm we can actually test the limit.




Issue: #3346 

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
