### PR TITLE
Fix maxVertexBuffers test

### DIFF
--- a/src/webgpu/api/validation/capability_checks/limits/maxVertexBuffers.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxVertexBuffers.spec.ts
@@ -1,41 +1,23 @@
-import { range } from '../../../../../common/util/util.js';
-
 import { kRenderEncoderTypes, kMaximumLimitBaseParams, makeLimitTestGroup } from './limit_utils.js';
 
-const kPipelineTypes = ['withoutLocations', 'withLocations'] as const;
-type PipelineType = (typeof kPipelineTypes)[number];
+function getPipelineDescriptor(device: GPUDevice, testValue: number): GPURenderPipelineDescriptor {
+  const module = device.createShaderModule({
+    code: `
+      @vertex fn vs(@location(0) p: vec4f) -> @builtin(position) vec4f {
+        return p;
+      }`,
+  });
+  const buffers = new Array<GPUVertexBufferLayout>(testValue);
+  buffers[testValue - 1] = {
+    arrayStride: 16,
+    attributes: [{ shaderLocation: 0, offset: 0, format: 'float32' }],
+  };
 
-function getPipelineDescriptor(
-  device: GPUDevice,
-  pipelineType: PipelineType,
-  testValue: number
-): GPURenderPipelineDescriptor {
-  const code =
-    pipelineType === 'withLocations'
-      ? `
-        struct VSInput {
-          ${range(testValue, i => `@location(${i}) p${i}: f32,`).join('\n')}
-        }
-        @vertex fn vs(v: VSInput) -> @builtin(position) vec4f {
-          let x = ${range(testValue, i => `v.p${i}`).join(' + ')};
-          return vec4f(x, 0, 0, 1);
-        }
-        `
-      : `
-        @vertex fn vs() -> @builtin(position) vec4f {
-          return vec4f(0);
-        }
-        `;
-  const module = device.createShaderModule({ code });
   return {
     layout: 'auto',
     vertex: {
       module,
-      entryPoint: 'vs',
-      buffers: range(testValue, i => ({
-        arrayStride: 32,
-        attributes: [{ shaderLocation: i, offset: 0, format: 'float32' }],
-      })),
+      buffers,
     },
   };
 }
@@ -45,18 +27,22 @@ export const { g, description } = makeLimitTestGroup(limit);
 
 g.test('createRenderPipeline,at_over')
   .desc(`Test using at and over ${limit} limit in createRenderPipeline(Async)`)
-  .params(
-    kMaximumLimitBaseParams.combine('async', [false, true]).combine('pipelineType', kPipelineTypes)
-  )
+  .params(kMaximumLimitBaseParams.combine('async', [false, true]))
   .fn(async t => {
-    const { limitTest, testValueName, async, pipelineType } = t.params;
+    const { limitTest, testValueName, async } = t.params;
     await t.testDeviceWithRequestedMaximumLimits(
       limitTest,
       testValueName,
-      async ({ device, testValue, shouldError }) => {
-        const pipelineDescriptor = getPipelineDescriptor(device, pipelineType, testValue);
+      async ({ device, testValue, shouldError, actualLimit }) => {
+        const pipelineDescriptor = getPipelineDescriptor(device, testValue);
+        const lastIndex = testValue - 1;
 
-        await t.testCreateRenderPipeline(pipelineDescriptor, async, shouldError);
+        await t.testCreateRenderPipeline(
+          pipelineDescriptor,
+          async,
+          shouldError,
+          `lastIndex: ${lastIndex}, actualLimit: ${actualLimit}, shouldError: ${shouldError}`
+        );
       }
     );
   });


### PR DESCRIPTION
The first test was completely invalid 😱. Now it should be correct.




Issue: #3346

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
