### PR TITLE
Test maxBindGroupsPlusVertexBuffers limits

### DIFF
--- a/src/webgpu/api/validation/capability_checks/limits/maxBindGroupsPlusVertexBuffers.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxBindGroupsPlusVertexBuffers.spec.ts
@@ -1,0 +1,254 @@
+import { assert, range } from '../../../../../common/util/util.js';
+
+import {
+  kRenderEncoderTypes,
+  kMaximumLimitBaseParams,
+  makeLimitTestGroup,
+  LimitsRequest,
+  getWGSLBindingDeclarationEntriesForStage,
+  getTotalPossibleBindingsPerStage,
+} from './limit_utils.js';
+
+const kPriorities = ['vertexBuffers', 'bindGroups'] as const;
+type Priority = (typeof kPriorities)[number];
+
+/**
+ * Given testValue, choose more vertex buffers or more bind groups based on priority
+ */
+function getNumBindGroupsAndNumVertexBuffers(
+  device: GPUDevice,
+  priority: Priority,
+  testValue: number
+) {
+  switch (priority) {
+    case 'bindGroups': {
+      const numBindGroups = Math.min(testValue, device.limits.maxBindGroups);
+      const numVertexBuffers = Math.max(0, testValue - numBindGroups);
+      return { numVertexBuffers, numBindGroups };
+    }
+    case 'vertexBuffers': {
+      const numVertexBuffers = Math.min(testValue, device.limits.maxVertexBuffers);
+      const numBindGroups = Math.max(0, testValue - numVertexBuffers);
+      return { numVertexBuffers, numBindGroups };
+    }
+  }
+}
+
+/**
+ * Generate a render pipeline that uses testValue bindGroups + vertex buffers
+ */
+function getPipelineDescriptor(device: GPUDevice, priority: Priority, testValue: number) {
+  const { numVertexBuffers, numBindGroups } = getNumBindGroupsAndNumVertexBuffers(
+    device,
+    priority,
+    testValue
+  );
+
+  const vertexInput =
+    numVertexBuffers === 0
+      ? ''
+      : `
+    struct VInput {
+${range(numVertexBuffers, i => `      @location(${i}) p${i}: vec4f,`).join('\n')}
+    };
+  `;
+
+  const maxBindingsPerStage = getTotalPossibleBindingsPerStage(device);
+  assert(numBindGroups < maxBindingsPerStage * 2);
+  const numBindingsVertStage = Math.min(maxBindingsPerStage, numBindGroups);
+  const numBindingsFragStage = Math.max(0, numBindGroups - numBindingsVertStage);
+
+  const vsIter = getWGSLBindingDeclarationEntriesForStage(device, 'bgVS');
+  const fsIter = getWGSLBindingDeclarationEntriesForStage(device, 'bgFS');
+  const code = `
+${range(numBindingsVertStage, i => `@group(${i}) @binding(0) ${vsIter.next().value};`).join('\n')}
+${vertexInput}
+    @vertex fn vs(${numVertexBuffers ? 'vin: VInput' : ''}) -> @builtin(position) vec4f {
+${range(numBindingsVertStage, i => `      _ = bgVS${i};`).join('\n')}
+      return vec4f(0)
+${range(numVertexBuffers, i => `     + vin.p${i}`).join('\n')}
+      ;
+    }
+
+${range(numBindingsFragStage, i => `@group(${i}) @binding(0) ${fsIter.next().value};`).join('\n')}
+    @fragment fn fs() -> @location(0) vec4f {
+${range(numBindingsFragStage, i => `      _ = bgFS${i};`).join('\n')}
+      return vec4f(0);
+    }
+    `;
+
+  const module = device.createShaderModule({ code });
+  const buffers = range<GPUVertexBufferLayout>(numVertexBuffers, i => ({
+    arrayStride: 16,
+    attributes: [{ shaderLocation: i, offset: 0, format: 'float32' }],
+  }));
+
+  return {
+    code,
+    descriptor: {
+      layout: 'auto',
+      vertex: {
+        module,
+        buffers,
+      },
+      fragment: {
+        module,
+        targets: [{ format: 'rgba8unorm' }],
+      },
+    } as GPURenderPipelineDescriptor,
+  };
+}
+
+const kExtraLimits: LimitsRequest = {
+  maxBindGroups: 'adapterLimit',
+  maxSampledTexturesPerShaderStage: 'adapterLimit',
+  maxSamplersPerShaderStage: 'adapterLimit',
+  maxStorageBuffersPerShaderStage: 'adapterLimit',
+  maxStorageTexturesPerShaderStage: 'adapterLimit',
+  maxUniformBuffersPerShaderStage: 'adapterLimit',
+  maxVertexAttributes: 'adapterLimit',
+  maxVertexBuffers: 'adapterLimit',
+};
+
+const limit = 'maxBindGroupsPlusVertexBuffers';
+export const { g, description } = makeLimitTestGroup(limit);
+
+g.test('createRenderPipeline,at_over')
+  .desc(`Test using at and over ${limit} limit in createRenderPipeline(Async)`)
+  .params(
+    kMaximumLimitBaseParams
+      .combine('async', [false, true])
+      .beginSubcases()
+      .combine('priority', kPriorities)
+  )
+  .fn(async t => {
+    const { limitTest, testValueName, async, priority } = t.params;
+    await t.testDeviceWithRequestedMaximumLimits(
+      limitTest,
+      testValueName,
+      async ({ device, testValue, shouldError, actualLimit }) => {
+        const maxUsableVertexBuffers = Math.min(
+          device.limits.maxVertexBuffers,
+          device.limits.maxVertexAttributes
+        );
+        const maxUsableBindGroupsPlusVertexBuffers =
+          device.limits.maxBindGroups + maxUsableVertexBuffers;
+        t.skipIf(
+          actualLimit > maxUsableBindGroupsPlusVertexBuffers,
+          `can not test because the max usable bindGroups + vertexBuffers (${maxUsableBindGroupsPlusVertexBuffers}) is < the maxBindGroupsAndVertexBuffers(${actualLimit})`
+        );
+
+        const { code, descriptor } = getPipelineDescriptor(device, priority, testValue);
+
+        await t.testCreateRenderPipeline(
+          descriptor,
+          async,
+          shouldError,
+          `testValue: ${testValue}, actualLimit: ${actualLimit}, shouldError: ${shouldError}\n${code}`
+        );
+      },
+      kExtraLimits
+    );
+  });
+
+g.test('draw,at_over')
+  .desc(`Test using at and over ${limit} limit draw/drawIndexed/drawIndirect/drawIndexedIndirect`)
+  .params(
+    kMaximumLimitBaseParams
+      .combine('encoderType', kRenderEncoderTypes)
+      .beginSubcases()
+      .combine('priority', kPriorities)
+      .combine('drawType', ['draw', 'drawIndexed', 'drawIndirect', 'drawIndexedIndirect'] as const)
+  )
+  .fn(async t => {
+    const { limitTest, testValueName, encoderType, drawType, priority } = t.params;
+    await t.testDeviceWithRequestedMaximumLimits(
+      limitTest,
+      testValueName,
+      async ({ device, testValue, shouldError, actualLimit }) => {
+        const maxUsableVertexBuffers = Math.min(
+          device.limits.maxVertexBuffers,
+          device.limits.maxVertexAttributes
+        );
+        const maxUsableBindGroupsPlusVertexBuffers =
+          device.limits.maxBindGroups + maxUsableVertexBuffers;
+        t.skipIf(
+          actualLimit > maxUsableBindGroupsPlusVertexBuffers,
+          `can not test because the max usable bindGroups + vertexBuffers (${maxUsableBindGroupsPlusVertexBuffers}) is < the maxBindGroupsAndVertexBuffers(${actualLimit})`
+        );
+
+        const { numVertexBuffers, numBindGroups } = getNumBindGroupsAndNumVertexBuffers(
+          device,
+          priority,
+          testValue
+        );
+
+        const module = device.createShaderModule({
+          code: `
+        @vertex fn vs() -> @builtin(position) vec4f {
+          return vec4f(0);
+        }
+        `,
+        });
+        const pipeline = device.createRenderPipeline({
+          layout: 'auto',
+          vertex: { module },
+        });
+
+        const buffer = device.createBuffer({
+          size: 16,
+          usage: GPUBufferUsage.VERTEX,
+        });
+        t.trackForCleanup(buffer);
+
+        await t.testGPURenderCommandsMixin(
+          encoderType,
+          ({ bindGroup, mixin }) => {
+            if (numVertexBuffers) {
+              mixin.setVertexBuffer(numVertexBuffers - 1, buffer);
+            }
+
+            if (numBindGroups) {
+              mixin.setBindGroup(numBindGroups - 1, bindGroup);
+            }
+
+            mixin.setPipeline(pipeline);
+
+            const indirectBuffer = device.createBuffer({
+              size: 4,
+              usage: GPUBufferUsage.INDIRECT,
+            });
+            t.trackForCleanup(indirectBuffer);
+
+            const indexBuffer = device.createBuffer({
+              size: 4,
+              usage: GPUBufferUsage.INDEX,
+            });
+            t.trackForCleanup(indexBuffer);
+
+            switch (drawType) {
+              case 'draw':
+                mixin.draw(0);
+                break;
+              case 'drawIndexed':
+                mixin.setIndexBuffer(indexBuffer, 'uint16');
+                mixin.drawIndexed(0);
+                break;
+              case 'drawIndirect':
+                mixin.drawIndirect(indirectBuffer, 0);
+                break;
+              case 'drawIndexedIndirect':
+                mixin.setIndexBuffer(indexBuffer, 'uint16');
+                mixin.drawIndexedIndirect(indirectBuffer, 0);
+                break;
+            }
+          },
+          shouldError,
+          `testValue: ${testValue}, actualLimit: ${actualLimit}, shouldError: ${shouldError}`
+        );
+
+        buffer.destroy();
+      },
+      kExtraLimits
+    );
+  });

--- a/src/webgpu/listing_meta.json
+++ b/src/webgpu/listing_meta.json
@@ -283,6 +283,8 @@
   "webgpu:api,validation,capability_checks,limits,maxBindGroups:createPipelineLayout,at_over:*": { "subcaseMS": 9.310 },
   "webgpu:api,validation,capability_checks,limits,maxBindGroups:setBindGroup,at_over:*": { "subcaseMS": 9.984 },
   "webgpu:api,validation,capability_checks,limits,maxBindGroups:validate,maxBindGroupsPlusVertexBuffers:*": { "subcaseMS": 11.200 },
+  "webgpu:api,validation,capability_checks,limits,maxBindGroupsPlusVertexBuffers:createRenderPipeline,at_over:*": { "subcaseMS": 11.200 },
+  "webgpu:api,validation,capability_checks,limits,maxBindGroupsPlusVertexBuffers:draw,at_over:*": { "subcaseMS": 11.200 },
   "webgpu:api,validation,capability_checks,limits,maxBindingsPerBindGroup:createBindGroupLayout,at_over:*": { "subcaseMS": 12.441 },
   "webgpu:api,validation,capability_checks,limits,maxBindingsPerBindGroup:createPipeline,at_over:*": { "subcaseMS": 11.179 },
   "webgpu:api,validation,capability_checks,limits,maxBindingsPerBindGroup:validate:*": { "subcaseMS": 12.401 },


### PR DESCRIPTION
Testing this is fairly confusing because there's so many things in play. I'm also not sure related tests don't need revisiting.

Testing `maxBindGroupsPlusVertexBuffers` implies to me, testing `maxBindGroups` and `maxVertexBuffers` at their max values. `maxBindGroups` in turn, implies setting `maxSampledTexturesPerShaderStage`, `maxSamplersPerShaderStage`, `maxStorageBuffersPerShaderStage`, `maxStorageTexturesPerShaderStage`, and `maxUniformBuffersPerShaderStage`. That's because, given the combination of parameters, there's no guarantee you can hit `maxBindGroups` if those don't sum to more than `maxBindGroups`.

And, similarly, testing `maxVertexBuffers` implies testing `maxVertexAttributes`, or so it feels. Like, in order to actually make a pipeline that will use `maxVertexBuffers`, the pipeline needs `maxVertexAttributes >= maxVertexBuffers`. 

Note that this doesn't currently test manually created layouts via `createPipelineLayout` + vertex buffers, it only test (1) `createPipeline` with `layout: 'auto'` and (2) `drawXXX`

I can add that but it would be nice to get some feedback on this first

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
