### PR TITLE
Test maxBindGroupsPlusVertexBuffers limits

### DIFF
--- a/src/webgpu/api/validation/capability_checks/limits/limit_utils.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/limit_utils.ts
@@ -1006,6 +1006,29 @@ export class LimitTestsImpl extends GPUTestBase {
   }
 
   /**
+   * Test a method on GPURenderCommandsMixin or GPUBindingCommandsMixin
+   * The function will be called with the mixin.
+   */
+  async testGPURenderAndBindingCommandsMixin(
+    encoderType: RenderEncoderType,
+    fn: ({
+      mixin,
+      bindGroup,
+    }: {
+      mixin: GPURenderCommandsMixin & GPUBindingCommandsMixin;
+      bindGroup: GPUBindGroup;
+    }) => void,
+    shouldError: boolean,
+    msg = ''
+  ) {
+    const { mixin, prep, test, bindGroup } = this._getGPURenderCommandsMixin(encoderType);
+    fn({ mixin, bindGroup });
+    prep();
+
+    await this.expectValidationError(test, shouldError, msg);
+  }
+
+  /**
    * Creates GPUBindingCommandsMixin setup with some initial state.
    */
   _getGPUBindingCommandsMixin(encoderType: EncoderType) {

--- a/src/webgpu/api/validation/capability_checks/limits/limit_utils.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/limit_utils.ts
@@ -879,7 +879,7 @@ export class LimitTestsImpl extends GPUTestBase {
   /**
    * Creates an GPURenderCommandsMixin setup with some initial state.
    */
-  _getGPURenderCommandsMixin(encoderType: RenderEncoderType) {
+  #getGPURenderCommandsMixin(encoderType: RenderEncoderType) {
     const { device } = this;
 
     switch (encoderType) {
@@ -920,7 +920,7 @@ export class LimitTestsImpl extends GPUTestBase {
         });
 
         const encoder = device.createCommandEncoder();
-        const mixin = encoder.beginRenderPass({
+        const passEncoder = encoder.beginRenderPass({
           colorAttachments: [
             {
               view: texture.createView(),
@@ -931,10 +931,10 @@ export class LimitTestsImpl extends GPUTestBase {
         });
 
         return {
-          mixin,
+          passEncoder,
           bindGroup,
           prep() {
-            mixin.end();
+            passEncoder.end();
           },
           test() {
             encoder.finish();
@@ -971,16 +971,16 @@ export class LimitTestsImpl extends GPUTestBase {
           ],
         });
 
-        const mixin = device.createRenderBundleEncoder({
+        const passEncoder = device.createRenderBundleEncoder({
           colorFormats: ['rgba8unorm'],
         });
 
         return {
-          mixin,
+          passEncoder,
           bindGroup,
           prep() {},
           test() {
-            mixin.finish();
+            passEncoder.finish();
           },
         };
         break;
@@ -989,40 +989,23 @@ export class LimitTestsImpl extends GPUTestBase {
   }
 
   /**
-   * Tests a method on GPURenderCommandsMixin
-   * The function will be called with the mixin.
-   */
-  async testGPURenderCommandsMixin(
-    encoderType: RenderEncoderType,
-    fn: ({ mixin }: { mixin: GPURenderCommandsMixin }) => void,
-    shouldError: boolean,
-    msg = ''
-  ) {
-    const { mixin, prep, test } = this._getGPURenderCommandsMixin(encoderType);
-    fn({ mixin });
-    prep();
-
-    await this.expectValidationError(test, shouldError, msg);
-  }
-
-  /**
    * Test a method on GPURenderCommandsMixin or GPUBindingCommandsMixin
-   * The function will be called with the mixin.
+   * The function will be called with the passEncoder.
    */
   async testGPURenderAndBindingCommandsMixin(
     encoderType: RenderEncoderType,
     fn: ({
-      mixin,
+      passEncoder,
       bindGroup,
     }: {
-      mixin: GPURenderCommandsMixin & GPUBindingCommandsMixin;
+      passEncoder: GPURenderCommandsMixin & GPUBindingCommandsMixin;
       bindGroup: GPUBindGroup;
     }) => void,
     shouldError: boolean,
     msg = ''
   ) {
-    const { mixin, prep, test, bindGroup } = this._getGPURenderCommandsMixin(encoderType);
-    fn({ mixin, bindGroup });
+    const { passEncoder, prep, test, bindGroup } = this.#getGPURenderCommandsMixin(encoderType);
+    fn({ passEncoder, bindGroup });
     prep();
 
     await this.expectValidationError(test, shouldError, msg);
@@ -1031,7 +1014,7 @@ export class LimitTestsImpl extends GPUTestBase {
   /**
    * Creates GPUBindingCommandsMixin setup with some initial state.
    */
-  _getGPUBindingCommandsMixin(encoderType: EncoderType) {
+  #getGPUBindingCommandsMixin(encoderType: EncoderType) {
     const { device } = this;
 
     switch (encoderType) {
@@ -1064,12 +1047,12 @@ export class LimitTestsImpl extends GPUTestBase {
         });
 
         const encoder = device.createCommandEncoder();
-        const mixin = encoder.beginComputePass();
+        const passEncoder = encoder.beginComputePass();
         return {
-          mixin,
+          passEncoder,
           bindGroup,
           prep() {
-            mixin.end();
+            passEncoder.end();
           },
           test() {
             encoder.finish();
@@ -1078,24 +1061,24 @@ export class LimitTestsImpl extends GPUTestBase {
         break;
       }
       case 'render':
-        return this._getGPURenderCommandsMixin('render');
+        return this.#getGPURenderCommandsMixin('render');
       case 'renderBundle':
-        return this._getGPURenderCommandsMixin('renderBundle');
+        return this.#getGPURenderCommandsMixin('renderBundle');
     }
   }
 
   /**
    * Tests a method on GPUBindingCommandsMixin
-   * The function pass will be called with the mixin and a bindGroup
+   * The function pass will be called with the passEncoder and a bindGroup
    */
   async testGPUBindingCommandsMixin(
     encoderType: EncoderType,
-    fn: ({ bindGroup }: { mixin: GPUBindingCommandsMixin; bindGroup: GPUBindGroup }) => void,
+    fn: ({ bindGroup }: { passEncoder: GPUBindingCommandsMixin; bindGroup: GPUBindGroup }) => void,
     shouldError: boolean,
     msg = ''
   ) {
-    const { mixin, bindGroup, prep, test } = this._getGPUBindingCommandsMixin(encoderType);
-    fn({ mixin, bindGroup });
+    const { passEncoder, bindGroup, prep, test } = this.#getGPUBindingCommandsMixin(encoderType);
+    fn({ passEncoder, bindGroup });
     prep();
 
     await this.expectValidationError(test, shouldError, msg);

--- a/src/webgpu/api/validation/capability_checks/limits/maxBindGroups.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxBindGroups.spec.ts
@@ -198,8 +198,8 @@ g.test('setBindGroup,at_over')
         const lastIndex = testValue - 1;
         await t.testGPUBindingCommandsMixin(
           encoderType,
-          ({ mixin, bindGroup }) => {
-            mixin.setBindGroup(lastIndex, bindGroup);
+          ({ passEncoder, bindGroup }) => {
+            passEncoder.setBindGroup(lastIndex, bindGroup);
           },
           shouldError,
           `shouldError: ${shouldError}, actualLimit: ${actualLimit}, testValue: ${lastIndex}`

--- a/src/webgpu/api/validation/capability_checks/limits/maxBindGroupsPlusVertexBuffers.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxBindGroupsPlusVertexBuffers.spec.ts
@@ -182,7 +182,7 @@ g.test('draw,at_over')
           device.limits.maxBindGroups + maxUsableVertexBuffers;
         t.skipIf(
           actualLimit > maxUsableBindGroupsPlusVertexBuffers,
-          `can not test because the max usable bindGroups + vertexBuffers (${maxUsableBindGroupsPlusVertexBuffers}) is < the maxBindGroupsAndVertexBuffers(${actualLimit})`
+          `can not test because the max usable bindGroups + vertexBuffers (${maxUsableBindGroupsPlusVertexBuffers}) is < the maxBindGroupsAndVertexBuffers (${actualLimit})`
         );
 
         // Get the numVertexBuffers and numBindGroups we could use given testValue as a total.

--- a/src/webgpu/api/validation/capability_checks/limits/maxBindGroupsPlusVertexBuffers.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxBindGroupsPlusVertexBuffers.spec.ts
@@ -112,7 +112,7 @@ function getPipelineDescriptor(device: GPUDevice, preference: VertexBufferBindGr
         module,
         targets: [{ format: 'rgba8unorm' }],
       },
-    } as GPURenderPipelineDescriptor,
+    } as const,
   };
 }
 

--- a/src/webgpu/api/validation/capability_checks/limits/maxBindGroupsPlusVertexBuffers.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxBindGroupsPlusVertexBuffers.spec.ts
@@ -143,7 +143,7 @@ g.test('createRenderPipeline,at_over')
           device.limits.maxBindGroups + device.limits.maxVertexBuffers;
         t.skipIf(
           actualLimit > maxUsableBindGroupsPlusVertexBuffers,
-          `can not test because the max usable bindGroups + vertexBuffers (${maxUsableBindGroupsPlusVertexBuffers}) is < maxBindGroupsAndVertexBuffers(${actualLimit})`
+          `can not test because the max usable bindGroups + vertexBuffers (${maxUsableBindGroupsPlusVertexBuffers}) is < maxBindGroupsAndVertexBuffers (${actualLimit})`
         );
 
         const { code, descriptor } = getPipelineDescriptor(device, preference, testValue, layoutType);

--- a/src/webgpu/api/validation/capability_checks/limits/maxBindGroupsPlusVertexBuffers.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxBindGroupsPlusVertexBuffers.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable prettier/prettier */
 import {
   kRenderEncoderTypes,
   kMaximumLimitBaseParams,
@@ -10,7 +9,7 @@ const kVertexBufferBindGroupPreferences = ['vertexBuffers', 'bindGroups'] as con
 type VertexBufferBindGroupPreference = (typeof kVertexBufferBindGroupPreferences)[number];
 
 const kLayoutTypes = ['auto', 'explicit'] as const;
-type LayoutType = typeof kLayoutTypes[number];
+type LayoutType = (typeof kLayoutTypes)[number];
 
 /**
  * Given testValue, choose more vertex buffers or more bind groups based on preference
@@ -48,11 +47,11 @@ function createLayout(device: GPUDevice, layoutType: LayoutType, numBindGroups: 
               binding: 0,
               visibility: GPUShaderStage.VERTEX,
               buffer: {},
-            }
+            },
           ],
         });
       }
-      return device.createPipelineLayout({ bindGroupLayouts })
+      return device.createPipelineLayout({ bindGroupLayouts });
     }
   }
 }
@@ -60,7 +59,12 @@ function createLayout(device: GPUDevice, layoutType: LayoutType, numBindGroups: 
 /**
  * Generate a render pipeline that can be used to test maxBindGroupsPlusVertexBuffers
  */
-function getPipelineDescriptor(device: GPUDevice, preference: VertexBufferBindGroupPreference, testValue: number, layoutType: LayoutType) {
+function getPipelineDescriptor(
+  device: GPUDevice,
+  preference: VertexBufferBindGroupPreference,
+  testValue: number,
+  layoutType: LayoutType
+) {
   // Get the numVertexBuffers and numBindGroups we could use given testValue as a total.
   // We will only use 1 of each but we'll use the last index.
   const { numVertexBuffers, numBindGroups } = getNumBindGroupsAndNumVertexBuffers(
@@ -146,7 +150,12 @@ g.test('createRenderPipeline,at_over')
           `can not test because the max usable bindGroups + vertexBuffers (${maxUsableBindGroupsPlusVertexBuffers}) is < maxBindGroupsAndVertexBuffers (${actualLimit})`
         );
 
-        const { code, descriptor } = getPipelineDescriptor(device, preference, testValue, layoutType);
+        const { code, descriptor } = getPipelineDescriptor(
+          device,
+          preference,
+          testValue,
+          layoutType
+        );
 
         await t.testCreateRenderPipeline(
           descriptor,
@@ -213,26 +222,26 @@ g.test('draw,at_over')
 
         await t.testGPURenderAndBindingCommandsMixin(
           encoderType,
-          ({ bindGroup, mixin }) => {
+          ({ bindGroup, passEncoder }) => {
             // Set the last vertex buffer and clear it. This should have no effect
             // unless there is a bug in bookkeeping in the implementation.
-            mixin.setVertexBuffer(device.limits.maxVertexBuffers - 1, vertexBuffer);
-            mixin.setVertexBuffer(device.limits.maxVertexBuffers - 1, null);
+            passEncoder.setVertexBuffer(device.limits.maxVertexBuffers - 1, vertexBuffer);
+            passEncoder.setVertexBuffer(device.limits.maxVertexBuffers - 1, null);
 
             // Set the last bindGroup and clear it. This should have no effect
             // unless there is a bug in bookkeeping in the implementation.
-            mixin.setBindGroup(device.limits.maxBindGroups - 1, bindGroup);
-            mixin.setBindGroup(device.limits.maxBindGroups - 1, null);
+            passEncoder.setBindGroup(device.limits.maxBindGroups - 1, bindGroup);
+            passEncoder.setBindGroup(device.limits.maxBindGroups - 1, null);
 
             if (numVertexBuffers) {
-              mixin.setVertexBuffer(numVertexBuffers - 1, vertexBuffer);
+              passEncoder.setVertexBuffer(numVertexBuffers - 1, vertexBuffer);
             }
 
             if (numBindGroups) {
-              mixin.setBindGroup(numBindGroups - 1, bindGroup);
+              passEncoder.setBindGroup(numBindGroups - 1, bindGroup);
             }
 
-            mixin.setPipeline(pipeline);
+            passEncoder.setPipeline(pipeline);
 
             const indirectBuffer = device.createBuffer({
               size: 4,
@@ -248,18 +257,18 @@ g.test('draw,at_over')
 
             switch (drawType) {
               case 'draw':
-                mixin.draw(0);
+                passEncoder.draw(0);
                 break;
               case 'drawIndexed':
-                mixin.setIndexBuffer(indexBuffer, 'uint16');
-                mixin.drawIndexed(0);
+                passEncoder.setIndexBuffer(indexBuffer, 'uint16');
+                passEncoder.drawIndexed(0);
                 break;
               case 'drawIndirect':
-                mixin.drawIndirect(indirectBuffer, 0);
+                passEncoder.drawIndirect(indirectBuffer, 0);
                 break;
               case 'drawIndexedIndirect':
-                mixin.setIndexBuffer(indexBuffer, 'uint16');
-                mixin.drawIndexedIndirect(indirectBuffer, 0);
+                passEncoder.setIndexBuffer(indexBuffer, 'uint16');
+                passEncoder.drawIndexedIndirect(indirectBuffer, 0);
                 break;
             }
           },

--- a/src/webgpu/api/validation/capability_checks/limits/maxBindGroupsPlusVertexBuffers.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxBindGroupsPlusVertexBuffers.spec.ts
@@ -92,7 +92,7 @@ function getPipelineDescriptor(device: GPUDevice, preference: VertexBufferBindGr
   `;
 
   const module = device.createShaderModule({ code });
-  const buffers = new Array(numVertexBuffers);
+  const buffers = new Array<GPUVertexBufferLayout | null>(numVertexBuffers);
   if (numVertexBuffers > 0) {
     buffers[numVertexBuffers - 1] = {
       arrayStride: 16,

--- a/src/webgpu/api/validation/capability_checks/limits/maxBindGroupsPlusVertexBuffers.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxBindGroupsPlusVertexBuffers.spec.ts
@@ -1,0 +1,274 @@
+/* eslint-disable prettier/prettier */
+import {
+  kRenderEncoderTypes,
+  kMaximumLimitBaseParams,
+  makeLimitTestGroup,
+  LimitsRequest,
+} from './limit_utils.js';
+
+const kVertexBufferBindGroupPreferences = ['vertexBuffers', 'bindGroups'] as const;
+type VertexBufferBindGroupPreference = (typeof kVertexBufferBindGroupPreferences)[number];
+
+const kLayoutTypes = ['auto', 'explicit'] as const;
+type LayoutType = typeof kLayoutTypes[number];
+
+/**
+ * Given testValue, choose more vertex buffers or more bind groups based on preference
+ */
+function getNumBindGroupsAndNumVertexBuffers(
+  device: GPUDevice,
+  preference: VertexBufferBindGroupPreference,
+  testValue: number
+) {
+  switch (preference) {
+    case 'bindGroups': {
+      const numBindGroups = Math.min(testValue, device.limits.maxBindGroups);
+      const numVertexBuffers = Math.max(0, testValue - numBindGroups);
+      return { numVertexBuffers, numBindGroups };
+    }
+    case 'vertexBuffers': {
+      const numVertexBuffers = Math.min(testValue, device.limits.maxVertexBuffers);
+      const numBindGroups = Math.max(0, testValue - numVertexBuffers);
+      return { numVertexBuffers, numBindGroups };
+    }
+  }
+}
+
+function createLayout(device: GPUDevice, layoutType: LayoutType, numBindGroups: number) {
+  switch (layoutType) {
+    case 'auto':
+      return 'auto';
+    case 'explicit': {
+      const bindGroupLayouts = new Array(numBindGroups);
+      if (numBindGroups > 0) {
+        bindGroupLayouts.fill(device.createBindGroupLayout({ entries: [] }));
+        bindGroupLayouts[numBindGroups - 1] = device.createBindGroupLayout({
+          entries: [
+            {
+              binding: 0,
+              visibility: GPUShaderStage.VERTEX,
+              buffer: {},
+            }
+          ],
+        });
+      }
+      return device.createPipelineLayout({ bindGroupLayouts })
+    }
+  }
+}
+
+/**
+ * Generate a render pipeline that can be used to test maxBindGroupsPlusVertexBuffers
+ */
+function getPipelineDescriptor(device: GPUDevice, preference: VertexBufferBindGroupPreference, testValue: number, layoutType: LayoutType) {
+  // Get the numVertexBuffers and numBindGroups we could use given testValue as a total.
+  // We will only use 1 of each but we'll use the last index.
+  const { numVertexBuffers, numBindGroups } = getNumBindGroupsAndNumVertexBuffers(
+    device,
+    preference,
+    testValue
+  );
+
+  const layout = createLayout(device, layoutType, numBindGroups);
+
+  const [bindGroupDecl, bindGroupUsage] =
+    numBindGroups === 0
+      ? ['', '']
+      : [`@group(${numBindGroups - 1}) @binding(0) var<uniform> u: f32;`, `_ = u;`];
+
+  const [attribDecl, attribUsage] =
+    numVertexBuffers === 0
+      ? ['', '']
+      : ['@location(0) v: vec4f', `_ = v; // will use vertex buffer ${numVertexBuffers - 1}`];
+
+  const code = `
+    ${bindGroupDecl}
+
+    @vertex fn vs(${attribDecl}) -> @builtin(position) vec4f {
+      ${bindGroupUsage}
+      ${attribUsage}
+      return vec4f(0);
+    }
+  `;
+
+  const module = device.createShaderModule({ code });
+  const buffers = new Array(numVertexBuffers);
+  if (numVertexBuffers > 0) {
+    buffers[numVertexBuffers - 1] = {
+      arrayStride: 16,
+      attributes: [{ shaderLocation: 0, offset: 0, format: 'float32' }],
+    };
+  }
+
+  return {
+    code,
+    descriptor: {
+      layout,
+      vertex: {
+        module,
+        buffers,
+      },
+      fragment: {
+        module,
+        targets: [{ format: 'rgba8unorm' }],
+      },
+    } as GPURenderPipelineDescriptor,
+  };
+}
+
+const kExtraLimits: LimitsRequest = {
+  maxBindGroups: 'adapterLimit',
+  maxVertexBuffers: 'adapterLimit',
+};
+
+const limit = 'maxBindGroupsPlusVertexBuffers';
+export const { g, description } = makeLimitTestGroup(limit);
+
+g.test('createRenderPipeline,at_over')
+  .desc(`Test using at and over ${limit} limit in createRenderPipeline(Async).`)
+  .params(
+    kMaximumLimitBaseParams
+      .combine('async', [false, true])
+      .beginSubcases()
+      .combine('preference', kVertexBufferBindGroupPreferences)
+      .combine('layoutType', kLayoutTypes)
+  )
+  .fn(async t => {
+    const { limitTest, testValueName, async, preference, layoutType } = t.params;
+    await t.testDeviceWithRequestedMaximumLimits(
+      limitTest,
+      testValueName,
+      async ({ device, testValue, shouldError, actualLimit }) => {
+        const maxUsableBindGroupsPlusVertexBuffers =
+          device.limits.maxBindGroups + device.limits.maxVertexBuffers;
+        t.skipIf(
+          actualLimit > maxUsableBindGroupsPlusVertexBuffers,
+          `can not test because the max usable bindGroups + vertexBuffers (${maxUsableBindGroupsPlusVertexBuffers}) is < maxBindGroupsAndVertexBuffers(${actualLimit})`
+        );
+
+        const { code, descriptor } = getPipelineDescriptor(device, preference, testValue, layoutType);
+
+        await t.testCreateRenderPipeline(
+          descriptor,
+          async,
+          shouldError,
+          `testValue: ${testValue}, actualLimit: ${actualLimit}, shouldError: ${shouldError}\n${code}`
+        );
+      },
+      kExtraLimits
+    );
+  });
+
+g.test('draw,at_over')
+  .desc(`Test using at and over ${limit} limit draw/drawIndexed/drawIndirect/drawIndexedIndirect`)
+  .params(
+    kMaximumLimitBaseParams
+      .combine('encoderType', kRenderEncoderTypes)
+      .beginSubcases()
+      .combine('preference', kVertexBufferBindGroupPreferences)
+      .combine('drawType', ['draw', 'drawIndexed', 'drawIndirect', 'drawIndexedIndirect'] as const)
+  )
+  .fn(async t => {
+    const { limitTest, testValueName, encoderType, drawType, preference } = t.params;
+    await t.testDeviceWithRequestedMaximumLimits(
+      limitTest,
+      testValueName,
+      async ({ device, testValue, shouldError, actualLimit }) => {
+        const maxUsableVertexBuffers = Math.min(
+          device.limits.maxVertexBuffers,
+          device.limits.maxVertexAttributes
+        );
+        const maxUsableBindGroupsPlusVertexBuffers =
+          device.limits.maxBindGroups + maxUsableVertexBuffers;
+        t.skipIf(
+          actualLimit > maxUsableBindGroupsPlusVertexBuffers,
+          `can not test because the max usable bindGroups + vertexBuffers (${maxUsableBindGroupsPlusVertexBuffers}) is < the maxBindGroupsAndVertexBuffers(${actualLimit})`
+        );
+
+        // Get the numVertexBuffers and numBindGroups we could use given testValue as a total.
+        // We will only use 1 of each but we'll use the last index.
+        const { numVertexBuffers, numBindGroups } = getNumBindGroupsAndNumVertexBuffers(
+          device,
+          preference,
+          testValue
+        );
+
+        const module = device.createShaderModule({
+          code: `
+        @vertex fn vs() -> @builtin(position) vec4f {
+          return vec4f(0);
+        }
+        `,
+        });
+        const pipeline = device.createRenderPipeline({
+          layout: 'auto',
+          vertex: { module },
+        });
+
+        const vertexBuffer = device.createBuffer({
+          size: 16,
+          usage: GPUBufferUsage.VERTEX,
+        });
+        t.trackForCleanup(vertexBuffer);
+
+        await t.testGPURenderAndBindingCommandsMixin(
+          encoderType,
+          ({ bindGroup, mixin }) => {
+            // Set the last vertex buffer and clear it. This should have no effect
+            // unless there is a bug in bookkeeping in the implementation.
+            mixin.setVertexBuffer(device.limits.maxVertexBuffers - 1, vertexBuffer);
+            mixin.setVertexBuffer(device.limits.maxVertexBuffers - 1, null);
+
+            // Set the last bindGroup and clear it. This should have no effect
+            // unless there is a bug in bookkeeping in the implementation.
+            mixin.setBindGroup(device.limits.maxBindGroups - 1, bindGroup);
+            mixin.setBindGroup(device.limits.maxBindGroups - 1, null);
+
+            if (numVertexBuffers) {
+              mixin.setVertexBuffer(numVertexBuffers - 1, vertexBuffer);
+            }
+
+            if (numBindGroups) {
+              mixin.setBindGroup(numBindGroups - 1, bindGroup);
+            }
+
+            mixin.setPipeline(pipeline);
+
+            const indirectBuffer = device.createBuffer({
+              size: 4,
+              usage: GPUBufferUsage.INDIRECT,
+            });
+            t.trackForCleanup(indirectBuffer);
+
+            const indexBuffer = device.createBuffer({
+              size: 4,
+              usage: GPUBufferUsage.INDEX,
+            });
+            t.trackForCleanup(indexBuffer);
+
+            switch (drawType) {
+              case 'draw':
+                mixin.draw(0);
+                break;
+              case 'drawIndexed':
+                mixin.setIndexBuffer(indexBuffer, 'uint16');
+                mixin.drawIndexed(0);
+                break;
+              case 'drawIndirect':
+                mixin.drawIndirect(indirectBuffer, 0);
+                break;
+              case 'drawIndexedIndirect':
+                mixin.setIndexBuffer(indexBuffer, 'uint16');
+                mixin.drawIndexedIndirect(indirectBuffer, 0);
+                break;
+            }
+          },
+          shouldError,
+          `testValue: ${testValue}, actualLimit: ${actualLimit}, shouldError: ${shouldError}`
+        );
+
+        vertexBuffer.destroy();
+      },
+      kExtraLimits
+    );
+  });

--- a/src/webgpu/api/validation/capability_checks/limits/maxVertexBuffers.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxVertexBuffers.spec.ts
@@ -63,10 +63,10 @@ g.test('setVertexBuffer,at_over')
           usage: GPUBufferUsage.VERTEX,
         });
 
-        await t.testGPURenderCommandsMixin(
+        await t.testGPURenderAndBindingCommandsMixin(
           encoderType,
-          ({ mixin }) => {
-            mixin.setVertexBuffer(lastIndex, buffer);
+          ({ passEncoder }) => {
+            passEncoder.setVertexBuffer(lastIndex, buffer);
           },
           shouldError,
           `lastIndex: ${lastIndex}, actualLimit: ${actualLimit}, shouldError: ${shouldError}`

--- a/src/webgpu/listing_meta.json
+++ b/src/webgpu/listing_meta.json
@@ -283,6 +283,8 @@
   "webgpu:api,validation,capability_checks,limits,maxBindGroups:createPipelineLayout,at_over:*": { "subcaseMS": 9.310 },
   "webgpu:api,validation,capability_checks,limits,maxBindGroups:setBindGroup,at_over:*": { "subcaseMS": 9.984 },
   "webgpu:api,validation,capability_checks,limits,maxBindGroups:validate,maxBindGroupsPlusVertexBuffers:*": { "subcaseMS": 11.200 },
+  "webgpu:api,validation,capability_checks,limits,maxBindGroupsPlusVertexBuffers:createRenderPipeline,at_over:*": { "subcaseMS": 11.200 },
+  "webgpu:api,validation,capability_checks,limits,maxBindGroupsPlusVertexBuffers:draw,at_over:*": { "subcaseMS": 11.200 },
   "webgpu:api,validation,capability_checks,limits,maxBindingsPerBindGroup:createBindGroupLayout,at_over:*": { "subcaseMS": 12.441 },
   "webgpu:api,validation,capability_checks,limits,maxBindingsPerBindGroup:createPipeline,at_over:*": { "subcaseMS": 11.179 },
   "webgpu:api,validation,capability_checks,limits,maxBindingsPerBindGroup:validate:*": { "subcaseMS": 12.401 },


### PR DESCRIPTION
Here's an updated test for `maxBindGroupPlusVertexBuffers`. I can't easily test with explicit pipeline layouts because it's currently impossible to create sparse explicit pipeline layouts but the code is there for when it becomes possible which seems like a future plan.

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
