### PR TITLE
Fix bitcast of AFloat to F32 tests to allow FTZ

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/bitcast.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/bitcast.spec.ts
@@ -496,7 +496,7 @@ g.test('af_to_f32')
   )
   .fn(async t => {
     const cases = scalarF32Range().map(u => {
-      const res = FP['f32'].correctlyRounded(u).map(f => {
+      const res = FP['f32'].addFlushedIfNeeded([u]).map(f => {
         return f32(f);
       });
       return {


### PR DESCRIPTION
These tests were failing CTS on Windows when using FXC, which converts subnormal literals to 0.

Issue: #3325

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
