### PR TITLE
Test default layout bindgroups

### DIFF
--- a/src/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.ts
+++ b/src/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.ts
@@ -358,9 +358,9 @@ class F extends ValidationTest {
         const nonEmptyBindGroupLayout = pipeline.getBindGroupLayout(kNonEmptyBindGroupNdx);
         return { emptyBindGroupLayout, nonEmptyBindGroupLayout, pipeline };
       } else {
-        // Testing non-empty
-        //   emptyBindGroupLayout comes from the pipeline we'll render/compute with
-        //   nonEmptyBindGroupLayout comes from a possibly incompatible place.
+        // Testing non-empty:
+        // - emptyBindGroupLayout comes from the pipeline we'll render/compute with.
+        // - nonEmptyBindGroupLayout comes from a possibly incompatible place.
         const pipeline = pipelineType === 'auto0' ? pipelineAuto0 : pipelineExplicit;
         const nonEmptyBindGroupLayout =
           bindingType === 'explicit'

--- a/src/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.ts
+++ b/src/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.ts
@@ -37,6 +37,9 @@ type PipelineType = (typeof kPipelineTypes)[number];
 const kBindingTypes = ['auto0', 'auto1', 'explicit'] as const;
 type BindingType = (typeof kBindingTypes)[number];
 
+const kEmptyBindGroupNdx = 0;
+const kNonEmptyBindGroupNdx = 1;
+
 // Test resource type compatibility in pipeline and bind group
 // [1]: Need to add externalTexture
 const kResourceTypes: ValidBindableResource[] = [
@@ -281,6 +284,117 @@ class F extends ValidationTest {
     }
 
     validateFinish(success);
+  }
+
+  runDefaultLayoutBindingTest<T extends GPURenderPipeline | GPUComputePipeline>({
+    visibility,
+    empty,
+    pipelineType,
+    bindingType,
+    makePipelinesFn,
+    doCommandFn,
+  }: {
+    visibility: number;
+    empty: boolean;
+    pipelineType: PipelineType;
+    bindingType: BindingType;
+    makePipelinesFn: (t: F, explicitPipelineLayout: GPUPipelineLayout) => T[];
+    doCommandFn: (params: {
+      t: F;
+      encoder: GPUCommandEncoder;
+      pipeline: T;
+      emptyBindGroup: GPUBindGroup;
+      nonEmptyBindGroup: GPUBindGroup;
+    }) => void;
+  }) {
+    const { device } = this;
+    const explicitEmptyBindGroupLayout = device.createBindGroupLayout({
+      entries: [],
+    });
+    const explicitBindGroupLayout = device.createBindGroupLayout({
+      entries: [
+        {
+          binding: 0,
+          visibility,
+          buffer: {},
+        },
+      ],
+    });
+    const explicitPipelineLayout = device.createPipelineLayout({
+      bindGroupLayouts: [explicitEmptyBindGroupLayout, explicitBindGroupLayout],
+    });
+
+    const [pipelineAuto0, pipelineAuto1, pipelineExplicit] = makePipelinesFn(
+      this,
+      explicitPipelineLayout
+    );
+
+    const buffer = device.createBuffer({
+      size: 16,
+      usage: GPUBufferUsage.UNIFORM,
+    });
+    this.trackForCleanup(buffer);
+
+    const kEmptyBindGroupNdx = 0;
+    const kNonEmptyBindGroupNdx = 1;
+
+    const {
+      emptyBindGroupLayout,
+      nonEmptyBindGroupLayout,
+      pipeline,
+    }: {
+      emptyBindGroupLayout: GPUBindGroupLayout;
+      nonEmptyBindGroupLayout: GPUBindGroupLayout;
+      pipeline: T;
+    } = (() => {
+      if (empty) {
+        // Testing empty so
+        //   nonEmptyBindGroupLayout comes from the pipeline we'll render/compute with
+        //   emptyBindGroupLayout comes from a possibly incompatible place.
+        const pipeline = pipelineType === 'auto0' ? pipelineAuto0 : pipelineExplicit;
+        const emptyBindGroupLayout =
+          bindingType === 'explicit'
+            ? explicitEmptyBindGroupLayout
+            : bindingType === 'auto0'
+            ? pipelineAuto0.getBindGroupLayout(kEmptyBindGroupNdx)
+            : pipelineAuto1.getBindGroupLayout(kEmptyBindGroupNdx);
+        const nonEmptyBindGroupLayout = pipeline.getBindGroupLayout(kNonEmptyBindGroupNdx);
+        return { emptyBindGroupLayout, nonEmptyBindGroupLayout, pipeline };
+      } else {
+        // Testing non-empty
+        //   emptyBindGroupLayout comes from the pipeline we'll render/compute with
+        //   nonEmptyBindGroupLayout comes from a possibly incompatible place.
+        const pipeline = pipelineType === 'auto0' ? pipelineAuto0 : pipelineExplicit;
+        const nonEmptyBindGroupLayout =
+          bindingType === 'explicit'
+            ? explicitBindGroupLayout
+            : bindingType === 'auto0'
+            ? pipelineAuto0.getBindGroupLayout(kNonEmptyBindGroupNdx)
+            : pipelineAuto1.getBindGroupLayout(kNonEmptyBindGroupNdx);
+        const emptyBindGroupLayout = pipeline.getBindGroupLayout(kEmptyBindGroupNdx);
+        return { emptyBindGroupLayout, nonEmptyBindGroupLayout, pipeline };
+      }
+    })();
+
+    const emptyBindGroup = device.createBindGroup({
+      layout: emptyBindGroupLayout,
+      entries: [],
+    });
+
+    const nonEmptyBindGroup = device.createBindGroup({
+      layout: nonEmptyBindGroupLayout,
+      entries: [{ binding: 0, resource: { buffer } }],
+    });
+
+    const encoder = device.createCommandEncoder();
+
+    doCommandFn({ t: this, encoder, pipeline, emptyBindGroup, nonEmptyBindGroup });
+
+    const success = bindingType === pipelineType;
+
+    this.expectValidationError(() => {
+      encoder.finish();
+    }, !success);
   }
 }
 
@@ -807,12 +921,17 @@ g.test('default_bind_group_layouts_never_match,compute_pass')
   * Test that a pipeline with an explicit layout can not be used with a bindGroup from an auto layout
   * Test that a pipeline with an auto layout can not be used with a bindGroup from an explicit layout
   * Test that an auto layout from one pipeline can not be used with an auto layout from a different pipeline.
+
+  TODO:
+  * Test empty bindgroup layouts on the same default layout pipeline are not compatible. In other words if
+    you only define group(2) then group(0)'s empty layout and group(1)'s empty layout should be incompatible.
   `
   )
   .params(u =>
     u
       .combine('pipelineAndBinding', [
-        { pipelineType: 'auto0', bindingType: 'auto0' }, // successful
+        { pipelineType: 'auto0', bindingType: 'auto0' }, // successful case
+        { pipelineType: 'explicit', bindingType: 'explicit' }, // successful case
         { pipelineType: 'explicit', bindingType: 'auto0' },
         { pipelineType: 'auto0', bindingType: 'explicit' },
         { pipelineType: 'auto0', bindingType: 'auto1' },
@@ -827,102 +946,36 @@ g.test('default_bind_group_layouts_never_match,compute_pass')
       empty,
     } = t.params;
 
-    const explicitEmptyBindGroupLayout = t.device.createBindGroupLayout({
-      entries: [],
+    t.runDefaultLayoutBindingTest<GPUComputePipeline>({
+      visibility: GPUShaderStage.COMPUTE,
+      empty,
+      pipelineType,
+      bindingType,
+      makePipelinesFn: (t, explicitPipelineLayout) => {
+        return (['auto', 'auto', explicitPipelineLayout] as const).map<GPUComputePipeline>(layout =>
+          t.device.createComputePipeline({
+            layout,
+            compute: {
+              module: t.device.createShaderModule({
+                code: `
+                @group(1) @binding(0) var<uniform> u: vec4f;
+                @compute @workgroup_size(1) fn main() { _ = u; }
+              `,
+              }),
+              entryPoint: 'main',
+            },
+          })
+        );
+      },
+      doCommandFn: ({ t, encoder, pipeline, emptyBindGroup, nonEmptyBindGroup }) => {
+        const pass = encoder.beginComputePass();
+        pass.setPipeline(pipeline);
+        pass.setBindGroup(kEmptyBindGroupNdx, emptyBindGroup);
+        pass.setBindGroup(kNonEmptyBindGroupNdx, nonEmptyBindGroup);
+        t.doCompute(pass, computeCommand, true);
+        pass.end();
+      },
     });
-    const explicitBindGroupLayout = t.device.createBindGroupLayout({
-      entries: [
-        {
-          binding: 0,
-          visibility: GPUShaderStage.COMPUTE,
-          buffer: {},
-        },
-      ],
-    });
-    const explicitPipelineLayout = t.device.createPipelineLayout({
-      bindGroupLayouts: [explicitEmptyBindGroupLayout, explicitBindGroupLayout],
-    });
-
-    const [pipelineAuto0, pipelineAuto1, pipelineExplicit] = (
-      ['auto', 'auto', explicitPipelineLayout] as const
-    ).map(layout =>
-      t.device.createComputePipeline({
-        layout,
-        compute: {
-          module: t.device.createShaderModule({
-            code: `
-            @group(1) @binding(0) var<uniform> u: vec4f;
-            @compute @workgroup_size(1) fn main() { _ = u; }
-          `,
-          }),
-          entryPoint: 'main',
-        },
-      })
-    );
-
-    const encoder = t.device.createCommandEncoder();
-
-    const buffer = t.device.createBuffer({
-      size: 16,
-      usage: GPUBufferUsage.UNIFORM,
-    });
-    t.trackForCleanup(buffer);
-
-    const kEmptyBindGroupNdx = 0;
-    const kNonEmptyBindGroupNdx = 1;
-
-    const { emptyBindGroupLayout, nonEmptyBindGroupLayout, pipeline } = (() => {
-      if (empty) {
-        // Testing empty so
-        //   nonEmptyBindGroupLayout comes from the pipeline we'll render with
-        //   emptyBindGroupLayout comes from an incompatible place.
-        const pipeline = pipelineType === 'auto0' ? pipelineAuto0 : pipelineExplicit;
-        const emptyBindGroupLayout =
-          bindingType === 'explicit'
-            ? explicitEmptyBindGroupLayout
-            : bindingType === 'auto0'
-            ? pipelineAuto0.getBindGroupLayout(kEmptyBindGroupNdx)
-            : pipelineAuto1.getBindGroupLayout(kEmptyBindGroupNdx);
-        const nonEmptyBindGroupLayout = pipeline.getBindGroupLayout(kNonEmptyBindGroupNdx);
-        return { emptyBindGroupLayout, nonEmptyBindGroupLayout, pipeline };
-      } else {
-        // Testing non-empty
-        //   emptyBindGroupLayout comes from the pipeline we'll render with
-        //   nonEmptyBindGroupLayout comes from an incompatible place.
-        const pipeline = pipelineType === 'auto0' ? pipelineAuto0 : pipelineExplicit;
-        const nonEmptyBindGroupLayout =
-          bindingType === 'explicit'
-            ? explicitBindGroupLayout
-            : bindingType === 'auto0'
-            ? pipelineAuto0.getBindGroupLayout(kNonEmptyBindGroupNdx)
-            : pipelineAuto1.getBindGroupLayout(kNonEmptyBindGroupNdx);
-        const emptyBindGroupLayout = pipeline.getBindGroupLayout(kEmptyBindGroupNdx);
-        return { emptyBindGroupLayout, nonEmptyBindGroupLayout, pipeline };
-      }
-    })();
-
-    const emptyBindGroup = t.device.createBindGroup({
-      layout: emptyBindGroupLayout,
-      entries: [],
-    });
-
-    const nonEmptyBindGroup = t.device.createBindGroup({
-      layout: nonEmptyBindGroupLayout,
-      entries: [{ binding: 0, resource: { buffer } }],
-    });
-
-    const pass = encoder.beginComputePass();
-    pass.setPipeline(pipeline);
-    pass.setBindGroup(kEmptyBindGroupNdx, emptyBindGroup);
-    pass.setBindGroup(kNonEmptyBindGroupNdx, nonEmptyBindGroup);
-    t.doCompute(pass, computeCommand, true);
-    pass.end();
-
-    const success = bindingType === pipelineType;
-
-    t.expectValidationError(() => {
-      encoder.finish();
-    }, !success);
   });
 
 g.test('default_bind_group_layouts_never_match,render_pass')
@@ -933,12 +986,17 @@ g.test('default_bind_group_layouts_never_match,render_pass')
   * Test that a pipeline with an explicit layout can not be used with a bindGroup from an auto layout
   * Test that a pipeline with an auto layout can not be used with a bindGroup from an explicit layout
   * Test that an auto layout from one pipeline can not be used with an auto layout from a different pipeline.
+
+  TODO:
+  * Test empty bindgroup layouts on the same default layout pipeline are not compatible. In other words if
+    you only define group(2) then group(0)'s empty layout and group(1)'s empty layout should be incompatible.
   `
   )
   .params(u =>
     u
       .combine('pipelineAndBinding', [
-        { pipelineType: 'auto0', bindingType: 'auto0' }, // successful
+        { pipelineType: 'auto0', bindingType: 'auto0' }, // successful case
+        { pipelineType: 'explicit', bindingType: 'explicit' }, // successful case
         { pipelineType: 'explicit', bindingType: 'auto0' },
         { pipelineType: 'auto0', bindingType: 'explicit' },
         { pipelineType: 'auto0', bindingType: 'auto1' },
@@ -958,125 +1016,61 @@ g.test('default_bind_group_layouts_never_match,render_pass')
       empty,
     } = t.params;
 
-    const explicitEmptyBindGroupLayout = t.device.createBindGroupLayout({
-      entries: [],
+    t.runDefaultLayoutBindingTest<GPURenderPipeline>({
+      visibility: GPUShaderStage.VERTEX,
+      empty,
+      pipelineType,
+      bindingType,
+      makePipelinesFn: (t, explicitPipelineLayout) => {
+        return (['auto', 'auto', explicitPipelineLayout] as const).map<GPURenderPipeline>(
+          layout => {
+            const colorFormat = 'rgba8unorm';
+            return t.device.createRenderPipeline({
+              layout,
+              vertex: {
+                module: t.device.createShaderModule({
+                  code: `
+                @group(1) @binding(0) var<uniform> u: vec4f;
+                @vertex fn main() -> @builtin(position) vec4f { return u; }
+              `,
+                }),
+                entryPoint: 'main',
+              },
+              fragment: {
+                module: t.device.createShaderModule({
+                  code: `@fragment fn main() {}`,
+                }),
+                entryPoint: 'main',
+                targets: [{ format: colorFormat, writeMask: 0 }],
+              },
+            });
+          }
+        );
+      },
+      doCommandFn: ({ t, encoder, pipeline, emptyBindGroup, nonEmptyBindGroup }) => {
+        const attachmentTexture = t.device.createTexture({
+          format: 'rgba8unorm',
+          size: { width: 16, height: 16, depthOrArrayLayers: 1 },
+          usage: GPUTextureUsage.RENDER_ATTACHMENT,
+        });
+        t.trackForCleanup(attachmentTexture);
+
+        const renderPass = encoder.beginRenderPass({
+          colorAttachments: [
+            {
+              view: attachmentTexture.createView(),
+              clearValue: [0, 0, 0, 0],
+              loadOp: 'clear',
+              storeOp: 'store',
+            },
+          ],
+        });
+
+        renderPass.setPipeline(pipeline);
+        renderPass.setBindGroup(kEmptyBindGroupNdx, emptyBindGroup);
+        renderPass.setBindGroup(kNonEmptyBindGroupNdx, nonEmptyBindGroup);
+        t.doRender(renderPass, renderCommand, true);
+        renderPass.end();
+      },
     });
-    const explicitBindGroupLayout = t.device.createBindGroupLayout({
-      entries: [
-        {
-          binding: 0,
-          visibility: GPUShaderStage.VERTEX,
-          buffer: {},
-        },
-      ],
-    });
-    const explicitPipelineLayout = t.device.createPipelineLayout({
-      bindGroupLayouts: [explicitEmptyBindGroupLayout, explicitBindGroupLayout],
-    });
-
-    const colorFormat = 'rgba8unorm';
-    const [pipelineAuto0, pipelineAuto1, pipelineExplicit] = (
-      ['auto', 'auto', explicitPipelineLayout] as const
-    ).map(layout =>
-      t.device.createRenderPipeline({
-        layout,
-        vertex: {
-          module: t.device.createShaderModule({
-            code: `
-            @group(1) @binding(0) var<uniform> u: vec4f;
-            @vertex fn main() -> @builtin(position) vec4f { return u; }
-          `,
-          }),
-          entryPoint: 'main',
-        },
-        fragment: {
-          module: t.device.createShaderModule({
-            code: `@fragment fn main() {}`,
-          }),
-          entryPoint: 'main',
-          targets: [{ format: colorFormat, writeMask: 0 }],
-        },
-      })
-    );
-
-    const encoder = t.device.createCommandEncoder();
-
-    const attachmentTexture = t.device.createTexture({
-      format: 'rgba8unorm',
-      size: { width: 16, height: 16, depthOrArrayLayers: 1 },
-      usage: GPUTextureUsage.RENDER_ATTACHMENT,
-    });
-    t.trackForCleanup(attachmentTexture);
-
-    const buffer = t.device.createBuffer({
-      size: 16,
-      usage: GPUBufferUsage.UNIFORM,
-    });
-    t.trackForCleanup(buffer);
-
-    const kEmptyBindGroupNdx = 0;
-    const kNonEmptyBindGroupNdx = 1;
-
-    const { emptyBindGroupLayout, nonEmptyBindGroupLayout, pipeline } = (() => {
-      if (empty) {
-        // Testing empty so
-        //   nonEmptyBindGroupLayout comes from the pipeline we'll render with
-        //   emptyBindGroupLayout comes from an incompatible place.
-        const pipeline = pipelineType === 'auto0' ? pipelineAuto0 : pipelineExplicit;
-        const emptyBindGroupLayout =
-          bindingType === 'explicit'
-            ? explicitEmptyBindGroupLayout
-            : bindingType === 'auto0'
-            ? pipelineAuto0.getBindGroupLayout(kEmptyBindGroupNdx)
-            : pipelineAuto1.getBindGroupLayout(kEmptyBindGroupNdx);
-        const nonEmptyBindGroupLayout = pipeline.getBindGroupLayout(kNonEmptyBindGroupNdx);
-        return { emptyBindGroupLayout, nonEmptyBindGroupLayout, pipeline };
-      } else {
-        // Testing non-empty
-        //   emptyBindGroupLayout comes from the pipeline we'll render with
-        //   nonEmptyBindGroupLayout comes from an incompatible place.
-        const pipeline = pipelineType === 'auto0' ? pipelineAuto0 : pipelineExplicit;
-        const nonEmptyBindGroupLayout =
-          bindingType === 'explicit'
-            ? explicitBindGroupLayout
-            : bindingType === 'auto0'
-            ? pipelineAuto0.getBindGroupLayout(kNonEmptyBindGroupNdx)
-            : pipelineAuto1.getBindGroupLayout(kNonEmptyBindGroupNdx);
-        const emptyBindGroupLayout = pipeline.getBindGroupLayout(kEmptyBindGroupNdx);
-        return { emptyBindGroupLayout, nonEmptyBindGroupLayout, pipeline };
-      }
-    })();
-
-    const emptyBindGroup = t.device.createBindGroup({
-      layout: emptyBindGroupLayout,
-      entries: [],
-    });
-
-    const nonEmptyBindGroup = t.device.createBindGroup({
-      layout: nonEmptyBindGroupLayout,
-      entries: [{ binding: 0, resource: { buffer } }],
-    });
-
-    const renderPass = encoder.beginRenderPass({
-      colorAttachments: [
-        {
-          view: attachmentTexture.createView(),
-          clearValue: [0, 0, 0, 0],
-          loadOp: 'clear',
-          storeOp: 'store',
-        },
-      ],
-    });
-
-    renderPass.setPipeline(pipeline);
-    renderPass.setBindGroup(kEmptyBindGroupNdx, emptyBindGroup);
-    renderPass.setBindGroup(kNonEmptyBindGroupNdx, nonEmptyBindGroup);
-    t.doRender(renderPass, renderCommand, true);
-    renderPass.end();
-
-    const success = bindingType === pipelineType;
-
-    t.expectValidationError(() => {
-      encoder.finish();
-    }, !success);
   });

--- a/src/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.ts
+++ b/src/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.ts
@@ -345,9 +345,9 @@ class F extends ValidationTest {
       pipeline: T;
     } = (() => {
       if (empty) {
-        // Testing empty so
-        //   nonEmptyBindGroupLayout comes from the pipeline we'll render/compute with
-        //   emptyBindGroupLayout comes from a possibly incompatible place.
+        // Testing empty:
+        // - nonEmptyBindGroupLayout comes from the pipeline we'll render/compute with.
+        // - emptyBindGroupLayout comes from a possibly incompatible place.
         const pipeline = pipelineType === 'auto0' ? pipelineAuto0 : pipelineExplicit;
         const emptyBindGroupLayout =
           bindingType === 'explicit'

--- a/src/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.ts
+++ b/src/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.ts
@@ -335,9 +335,6 @@ class F extends ValidationTest {
     });
     this.trackForCleanup(buffer);
 
-    const kEmptyBindGroupNdx = 0;
-    const kNonEmptyBindGroupNdx = 1;
-
     const {
       emptyBindGroupLayout,
       nonEmptyBindGroupLayout,

--- a/src/webgpu/listing_meta.json
+++ b/src/webgpu/listing_meta.json
@@ -539,6 +539,8 @@
   "webgpu:api,validation,encoding,programmable,pipeline_bind_group_compat:bgl_visibility_mismatch:*": { "subcaseMS": 0.608 },
   "webgpu:api,validation,encoding,programmable,pipeline_bind_group_compat:bind_groups_and_pipeline_layout_mismatch:*": { "subcaseMS": 1.535 },
   "webgpu:api,validation,encoding,programmable,pipeline_bind_group_compat:buffer_binding,render_pipeline:*": { "subcaseMS": 1.734 },
+  "webgpu:api,validation,encoding,programmable,pipeline_bind_group_compat:default_bind_group_layouts_never_match,compute_pass:*": { "subcaseMS": 1.734 },
+  "webgpu:api,validation,encoding,programmable,pipeline_bind_group_compat:default_bind_group_layouts_never_match,render_pass:*": { "subcaseMS": 1.734 },
   "webgpu:api,validation,encoding,programmable,pipeline_bind_group_compat:empty_bind_group_layouts_requires_empty_bind_groups,compute_pass:*": { "subcaseMS": 2.325 },
   "webgpu:api,validation,encoding,programmable,pipeline_bind_group_compat:empty_bind_group_layouts_requires_empty_bind_groups,render_pass:*": { "subcaseMS": 10.838 },
   "webgpu:api,validation,encoding,programmable,pipeline_bind_group_compat:sampler_binding,render_pipeline:*": { "subcaseMS": 10.523 },


### PR DESCRIPTION
It's probably a good idea to decide what we want to happen here and fix it ASAP because as it is, Chrome will allow bind groups made with different `layout: 'auto'` pipelines to work with each other but the spec seems to say that's disallowed. It's easy to imagine lots of WebGPU pages are already breaking this rule.

I also suspect the spec would like to say that all empty bind group layouts are compatible but I don't see that in the spec currently so it's tested that they are not compatible in this PR.

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
