### PR TITLE
Fix maxBindGroupsPlusVertexBuffers test

### DIFF
--- a/src/webgpu/api/validation/capability_checks/limits/maxBindGroupsPlusVertexBuffers.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxBindGroupsPlusVertexBuffers.spec.ts
@@ -93,6 +93,10 @@ function getPipelineDescriptor(
       ${attribUsage}
       return vec4f(0);
     }
+
+    @fragment fn fs() -> @location(0) vec4f {
+      return vec4f(0);
+    }
   `;
 
   const module = device.createShaderModule({ code });
@@ -146,8 +150,13 @@ g.test('createRenderPipeline,at_over')
         const maxUsableBindGroupsPlusVertexBuffers =
           device.limits.maxBindGroups + device.limits.maxVertexBuffers;
         t.skipIf(
-          actualLimit > maxUsableBindGroupsPlusVertexBuffers,
+          maxUsableBindGroupsPlusVertexBuffers < actualLimit,
           `can not test because the max usable bindGroups + vertexBuffers (${maxUsableBindGroupsPlusVertexBuffers}) is < maxBindGroupsAndVertexBuffers (${actualLimit})`
+        );
+        t.skipIf(
+          maxUsableBindGroupsPlusVertexBuffers === actualLimit && testValue > actualLimit,
+          `can not test because the max usable bindGroups + vertexBuffers (${maxUsableBindGroupsPlusVertexBuffers}) === maxBindGroupsAndVertexBuffers (${actualLimit})
+           but the testValue (${testValue}) > maxBindGroupsAndVertexBuffers (${actualLimit})`
         );
 
         const { code, descriptor } = getPipelineDescriptor(
@@ -190,8 +199,13 @@ g.test('draw,at_over')
         const maxUsableBindGroupsPlusVertexBuffers =
           device.limits.maxBindGroups + maxUsableVertexBuffers;
         t.skipIf(
-          actualLimit > maxUsableBindGroupsPlusVertexBuffers,
-          `can not test because the max usable bindGroups + vertexBuffers (${maxUsableBindGroupsPlusVertexBuffers}) is < the maxBindGroupsAndVertexBuffers (${actualLimit})`
+          maxUsableBindGroupsPlusVertexBuffers < actualLimit,
+          `can not test because the max usable bindGroups + vertexBuffers (${maxUsableBindGroupsPlusVertexBuffers}) is < maxBindGroupsAndVertexBuffers (${actualLimit})`
+        );
+        t.skipIf(
+          maxUsableBindGroupsPlusVertexBuffers === actualLimit && testValue > actualLimit,
+          `can not test because the max usable bindGroups + vertexBuffers (${maxUsableBindGroupsPlusVertexBuffers}) === maxBindGroupsAndVertexBuffers (${actualLimit})
+           but the testValue (${testValue}) > maxBindGroupsAndVertexBuffers (${actualLimit})`
         );
 
         // Get the numVertexBuffers and numBindGroups we could use given testValue as a total.
@@ -204,14 +218,18 @@ g.test('draw,at_over')
 
         const module = device.createShaderModule({
           code: `
-        @vertex fn vs() -> @builtin(position) vec4f {
-          return vec4f(0);
-        }
-        `,
+            @vertex fn vs() -> @builtin(position) vec4f {
+              return vec4f(0);
+            }
+            @fragment fn fs() -> @location(0) vec4f {
+              return vec4f(0);
+            }
+            `,
         });
         const pipeline = device.createRenderPipeline({
           layout: 'auto',
           vertex: { module },
+          fragment: { module, targets: [{ format: 'rgba8unorm' }] },
         });
 
         const vertexBuffer = device.createBuffer({
@@ -244,7 +262,7 @@ g.test('draw,at_over')
             passEncoder.setPipeline(pipeline);
 
             const indirectBuffer = device.createBuffer({
-              size: 4,
+              size: 20,
               usage: GPUBufferUsage.INDIRECT,
             });
             t.trackForCleanup(indirectBuffer);


### PR DESCRIPTION
I think this works now. I tested by hacking up the CTS to force a lower limit that Chrome could test

see: https://gist.github.com/greggman/c3c56b8d53174453df166a5a2383b1c3#maxbindgroupsplusvertexbuffers

I also changed it so it can test at limit tests (vs over limit tests). This should mean some tests run on browsers where maxBindGroups + maxVertexBuffers === maxBindGroupsPlusVertexBuffers.


Hopefully it's correct now.


Issue: #3376

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
