### PR TITLE
Add missing types to indirection expression tests

### DIFF
--- a/src/webgpu/shader/execution/expression/unary/indirection.spec.ts
+++ b/src/webgpu/shader/execution/expression/unary/indirection.spec.ts
@@ -48,10 +48,15 @@ Pointer expression dereference.
     u
       .combine('inputSource', allButConstInputSource)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
-      .combine('scalarType', ['u32', 'i32', 'f32'] as ScalarKind[])
+      .combine('scalarType', ['bool', 'u32', 'i32', 'f32', 'f16'] as ScalarKind[])
       .combine('derefType', keysOf(kDerefCases))
       .filter(p => !kDerefCases[p.derefType].requires_pointer_composite_access)
   )
+  .beforeAllSubcases(t => {
+    if (t.params.scalarType === 'f16') {
+      t.selectDeviceOrSkipTestCase({ requiredFeatures: ['shader-f16'] });
+    }
+  })
   .fn(async t => {
     const ty = scalarType(t.params.scalarType);
     const cases = sparseScalarF32Range().map(e => {
@@ -83,9 +88,14 @@ Pointer expression dereference as lhs of index accessor expression
     u
       .combine('inputSource', allButConstInputSource)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
-      .combine('scalarType', ['i32', 'f32'] as ScalarKind[])
+      .combine('scalarType', ['bool', 'u32', 'i32', 'f32', 'f16'] as ScalarKind[])
       .combine('derefType', keysOf(kDerefCases))
   )
+  .beforeAllSubcases(t => {
+    if (t.params.scalarType === 'f16') {
+      t.selectDeviceOrSkipTestCase({ requiredFeatures: ['shader-f16'] });
+    }
+  })
   .fn(async t => {
     if (
       kDerefCases[t.params.derefType].requires_pointer_composite_access &&
@@ -124,9 +134,14 @@ Pointer expression dereference as lhs of member accessor expression
     u
       .combine('inputSource', allButConstInputSource)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
-      .combine('scalarType', ['i32', 'f32'] as ScalarKind[])
+      .combine('scalarType', ['bool', 'u32', 'i32', 'f32', 'f16'] as ScalarKind[])
       .combine('derefType', keysOf(kDerefCases))
   )
+  .beforeAllSubcases(t => {
+    if (t.params.scalarType === 'f16') {
+      t.selectDeviceOrSkipTestCase({ requiredFeatures: ['shader-f16'] });
+    }
+  })
   .fn(async t => {
     if (
       kDerefCases[t.params.derefType].requires_pointer_composite_access &&


### PR DESCRIPTION
Add bool, u32, and f16 to tests.

Issue: #3225 

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
