### PR TITLE
Switch memory model tests to use PRNG

### DIFF
--- a/src/webgpu/shader/execution/memory_model/memory_model_setup.ts
+++ b/src/webgpu/shader/execution/memory_model/memory_model_setup.ts
@@ -522,12 +522,12 @@ export class MemoryModelTester {
     );
   }
 
-  /** Returns a random integer between 0 and the max. */
+  /** Returns a random integer in the range [0, max). */
   protected getRandomInt(max: number): number {
     return this.prng.randomU32() % max;
   }
 
-  /** Returns a random number in between the min and max values. */
+  /** Returns a random number in the range [min, max). */
   protected getRandomInRange(min: number, max: number): number {
     if (min === max) {
       return min;

--- a/src/webgpu/shader/execution/memory_model/memory_model_setup.ts
+++ b/src/webgpu/shader/execution/memory_model/memory_model_setup.ts
@@ -1,6 +1,7 @@
 import { GPUTest } from '../../../gpu_test.js';
 import { checkElementsPassPredicate } from '../../../util/check_contents.js';
 import { align } from '../../../util/math.js';
+import { PRNG } from '../../../util/prng.js';
 
 /* All buffer sizes are counted in units of 4-byte words. */
 
@@ -191,6 +192,7 @@ export class MemoryModelTester {
   protected testBindGroup: GPUBindGroup;
   protected resultPipeline: GPUComputePipeline;
   protected resultBindGroup: GPUBindGroup;
+  protected prng: PRNG;
 
   /** Sets up a memory model test by initializing buffers and pipeline layouts. */
   constructor(
@@ -200,6 +202,7 @@ export class MemoryModelTester {
     resultShader: string,
     accessValueType: AccessValueType = 'u32'
   ) {
+    this.prng = new PRNG(1);
     this.test = t;
     this.params = params;
 
@@ -521,7 +524,7 @@ export class MemoryModelTester {
 
   /** Returns a random integer between 0 and the max. */
   protected getRandomInt(max: number): number {
-    return Math.floor(Math.random() * max);
+    return this.prng.randomU32() % max;
   }
 
   /** Returns a random number in between the min and max values. */


### PR DESCRIPTION
* Switch to PRNG from Math.random




Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [ ] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [ ] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
