### PR TITLE
Separate tests for target format supporting usage and being a color format

### DIFF
--- a/src/webgpu/api/validation/render_pipeline/fragment_state.spec.ts
+++ b/src/webgpu/api/validation/render_pipeline/fragment_state.spec.ts
@@ -15,7 +15,6 @@ import {
   kTextureFormatInfo,
   computeBytesPerSampleFromFormats,
   kColorTextureFormats,
-  kDepthStencilFormats,
 } from '../../../format_info.js';
 import {
   getFragmentShaderCodeWithOutput,
@@ -57,14 +56,17 @@ g.test('targets_format_is_color_format')
     `Tests that color target state format must be a color format, regardless of how the
     fragment shader writes to it.`
   )
-  .params(u => {
-    assert(kColorTextureFormats.length + kDepthStencilFormats.length === kAllTextureFormats.length);
-    return u //
+  .params(u =>
+    u
+      // Test all non-color texture formats, plus 'rgba8unorm' as a control case.
+      .combine('format', kAllTextureFormats)
+      .filter(({ format }) => {
+        return format == 'rgba8unorm' || !kTextureFormatInfo[format].color;
+      })
       .combine('isAsync', [false, true])
-      .combine('format', ['rgba8unorm', ...kDepthStencilFormats] as const)
       .beginSubcases()
-      .combine('fragOutType', ['f32', 'u32', 'i32'] as const);
-  })
+      .combine('fragOutType', ['f32', 'u32', 'i32'] as const)
+  )
   .beforeAllSubcases(t => {
     const { format } = t.params;
     const info = kTextureFormatInfo[format];

--- a/src/webgpu/api/validation/render_pipeline/fragment_state.spec.ts
+++ b/src/webgpu/api/validation/render_pipeline/fragment_state.spec.ts
@@ -3,7 +3,7 @@ This test dedicatedly tests validation of GPUFragmentState of createRenderPipeli
 `;
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
-import { assert, range } from '../../../../common/util/util.js';
+import { range } from '../../../../common/util/util.js';
 import {
   kBlendFactors,
   kBlendOperations,
@@ -61,7 +61,7 @@ g.test('targets_format_is_color_format')
       // Test all non-color texture formats, plus 'rgba8unorm' as a control case.
       .combine('format', kAllTextureFormats)
       .filter(({ format }) => {
-        return format == 'rgba8unorm' || !kTextureFormatInfo[format].color;
+        return format === 'rgba8unorm' || !kTextureFormatInfo[format].color;
       })
       .combine('isAsync', [false, true])
       .beginSubcases()

--- a/src/webgpu/listing_meta.json
+++ b/src/webgpu/listing_meta.json
@@ -716,6 +716,7 @@
   "webgpu:api,validation,render_pipeline,fragment_state:pipeline_output_targets:*": { "subcaseMS": 0.497 },
   "webgpu:api,validation,render_pipeline,fragment_state:targets_blend:*": { "subcaseMS": 1.203 },
   "webgpu:api,validation,render_pipeline,fragment_state:targets_format_filterable:*": { "subcaseMS": 2.143 },
+  "webgpu:api,validation,render_pipeline,fragment_state:targets_format_is_color_format:*": { "subcaseMS": 2.000 },
   "webgpu:api,validation,render_pipeline,fragment_state:targets_format_renderable:*": { "subcaseMS": 3.339 },
   "webgpu:api,validation,render_pipeline,fragment_state:targets_write_mask:*": { "subcaseMS": 12.272 },
   "webgpu:api,validation,render_pipeline,inter_stage:interpolation_sampling:*": { "subcaseMS": 3.126 },


### PR DESCRIPTION
This splits two logically separate tests that were part of the same test before. This will make it easier to fix usage of the texture info table: Previously, it would access certain members of the info table assuming they were color, but would actually get the depth component of depth and depth-stencil formats. This wasn't really a problem because those formats were already expected to fail. But cleaner to instead just scope that test to only color formats.

Part 4 of Issue: #2495

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
