### PR TITLE
Clean up deprecated .sampleType/.copySrc from kTextureFormatInfo

### DIFF
--- a/src/unittests/texture_ok.spec.ts
+++ b/src/unittests/texture_ok.spec.ts
@@ -4,7 +4,6 @@ Test for texture_ok utils.
 
 import { makeTestGroup } from '../common/framework/test_group.js';
 import { typedArrayFromParam, typedArrayParam } from '../common/util/util.js';
-import { RegularTextureFormat } from '../webgpu/format_info.js';
 import { TexelView } from '../webgpu/util/texture/texel_view.js';
 import { findFailedPixels } from '../webgpu/util/texture/texture_ok.js';
 
@@ -30,103 +29,103 @@ g.test('findFailedPixels')
     u.combineWithParams([
       // Sanity Check
       {
-        format: 'rgba8unorm' as RegularTextureFormat,
+        format: 'rgba8unorm',
         actual: typedArrayParam('Uint8Array', [0x00, 0x40, 0x80, 0xff]),
         expected: typedArrayParam('Uint8Array', [0x00, 0x40, 0x80, 0xff]),
         isSame: true,
       },
       // Slightly different values
       {
-        format: 'rgba8unorm' as RegularTextureFormat,
+        format: 'rgba8unorm',
         actual: typedArrayParam('Uint8Array', [0x00, 0x40, 0x80, 0xff]),
         expected: typedArrayParam('Uint8Array', [0x00, 0x40, 0x81, 0xff]),
         isSame: false,
       },
       // Different representations of the same value
       {
-        format: 'rgb9e5ufloat' as RegularTextureFormat,
+        format: 'rgb9e5ufloat',
         actual: typedArrayParam('Uint8Array', [0x78, 0x56, 0x34, 0x12]),
         expected: typedArrayParam('Uint8Array', [0xf0, 0xac, 0x68, 0x0c]),
         isSame: true,
       },
       // Slightly different values
       {
-        format: 'rgb9e5ufloat' as RegularTextureFormat,
+        format: 'rgb9e5ufloat',
         actual: typedArrayParam('Uint8Array', [0x78, 0x56, 0x34, 0x12]),
         expected: typedArrayParam('Uint8Array', [0xf1, 0xac, 0x68, 0x0c]),
         isSame: false,
       },
       // Test NaN === NaN
       {
-        format: 'r32float' as RegularTextureFormat,
+        format: 'r32float',
         actual: typedArrayParam('Float32Array', [parseFloat('abc')]),
         expected: typedArrayParam('Float32Array', [parseFloat('def')]),
         isSame: true,
       },
       // Sanity Check
       {
-        format: 'r32float' as RegularTextureFormat,
+        format: 'r32float',
         actual: typedArrayParam('Float32Array', [1.23]),
         expected: typedArrayParam('Float32Array', [1.23]),
         isSame: true,
       },
       // Slightly different values.
       {
-        format: 'r32float' as RegularTextureFormat,
+        format: 'r32float',
         actual: typedArrayParam('Uint32Array', [0x3f9d70a4]),
         expected: typedArrayParam('Uint32Array', [0x3f9d70a5]),
         isSame: false,
       },
       // Slightly different
       {
-        format: 'rg11b10ufloat' as RegularTextureFormat,
+        format: 'rg11b10ufloat',
         actual: typedArrayParam('Uint32Array', [0x3ce]),
         expected: typedArrayParam('Uint32Array', [0x3cf]),
         isSame: false,
       },
       // Positive.Infinity === Positive.Infinity (red)
       {
-        format: 'rg11b10ufloat' as RegularTextureFormat,
+        format: 'rg11b10ufloat',
         actual: typedArrayParam('Uint32Array', [0b11111000000]),
         expected: typedArrayParam('Uint32Array', [0b11111000000]),
         isSame: true,
       },
       // Positive.Infinity === Positive.Infinity (green)
       {
-        format: 'rg11b10ufloat' as RegularTextureFormat,
+        format: 'rg11b10ufloat',
         actual: typedArrayParam('Uint32Array', [0b11111000000_00000000000]),
         expected: typedArrayParam('Uint32Array', [0b11111000000_00000000000]),
         isSame: true,
       },
       // Positive.Infinity === Positive.Infinity (blue)
       {
-        format: 'rg11b10ufloat' as RegularTextureFormat,
+        format: 'rg11b10ufloat',
         actual: typedArrayParam('Uint32Array', [0b1111100000_00000000000_00000000000]),
         expected: typedArrayParam('Uint32Array', [0b1111100000_00000000000_00000000000]),
         isSame: true,
       },
       // NaN === NaN (red)
       {
-        format: 'rg11b10ufloat' as RegularTextureFormat,
+        format: 'rg11b10ufloat',
         actual: typedArrayParam('Uint32Array', [0b11111000001]),
         expected: typedArrayParam('Uint32Array', [0b11111000010]),
         isSame: true,
       },
       // NaN === NaN (green)
       {
-        format: 'rg11b10ufloat' as RegularTextureFormat,
+        format: 'rg11b10ufloat',
         actual: typedArrayParam('Uint32Array', [0b11111000100_00000000000]),
         expected: typedArrayParam('Uint32Array', [0b11111001000_00000000000]),
         isSame: true,
       },
       // NaN === NaN (blue)
       {
-        format: 'rg11b10ufloat' as RegularTextureFormat,
+        format: 'rg11b10ufloat',
         actual: typedArrayParam('Uint32Array', [0b1111110000_00000000000_00000000000]),
         expected: typedArrayParam('Uint32Array', [0b1111101000_00000000000_00000000000]),
         isSame: true,
       },
-    ])
+    ] as const)
   )
   .fn(t => {
     const { format, actual, expected, isSame } = t.params;

--- a/src/webgpu/api/operation/command_buffer/copyTextureToTexture.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/copyTextureToTexture.spec.ts
@@ -17,9 +17,9 @@ import {
   DepthStencilFormat,
   ColorTextureFormat,
   isCompressedTextureFormat,
-  isEncodableTextureformat,
   viewCompatible,
-  EncodableTextureFormat,
+  RegularTextureFormat,
+  isRegularTextureFormat,
 } from '../../../format_info.js';
 import { GPUTest, TextureTestMixin } from '../../../gpu_test.js';
 import { makeBufferWithContents } from '../../../util/buffer.js';
@@ -346,21 +346,21 @@ class F extends TextureTestMixin(GPUTest) {
       return;
     }
 
-    assert(isEncodableTextureformat(dstFormat));
-    const encodableDstFormat = dstFormat as EncodableTextureFormat;
+    assert(isRegularTextureFormat(dstFormat));
+    const regularDstFormat = dstFormat as RegularTextureFormat;
 
     // Verify the content of the whole subresource of dstTexture at dstCopyLevel (in dstBuffer) is expected.
     const checkByTextureFormat = (actual: Uint8Array) => {
       const zero = { x: 0, y: 0, z: 0 };
 
-      const actTexelView = TexelView.fromTextureDataByReference(encodableDstFormat, actual, {
+      const actTexelView = TexelView.fromTextureDataByReference(regularDstFormat, actual, {
         bytesPerRow: bytesInRow,
         rowsPerImage: dstBlockRowsPerImage,
         subrectOrigin: zero,
         subrectSize: dstTextureSizeAtLevel,
       });
       const expTexelView = TexelView.fromTextureDataByReference(
-        encodableDstFormat,
+        regularDstFormat,
         expectedUint8DataWithPadding,
         {
           bytesPerRow: bytesInRow,
@@ -371,7 +371,7 @@ class F extends TextureTestMixin(GPUTest) {
       );
 
       const failedPixelsMessage = findFailedPixels(
-        encodableDstFormat,
+        regularDstFormat,
         zero,
         dstTextureSizeAtLevel,
         { actTexelView, expTexelView },

--- a/src/webgpu/api/operation/rendering/color_target_state.spec.ts
+++ b/src/webgpu/api/operation/rendering/color_target_state.spec.ts
@@ -11,7 +11,7 @@ import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { assert, TypedArrayBufferView, unreachable } from '../../../../common/util/util.js';
 import { kBlendFactors, kBlendOperations } from '../../../capability_info.js';
 import { GPUConst } from '../../../constants.js';
-import { kEncodableTextureFormats, kTextureFormatInfo } from '../../../format_info.js';
+import { kRegularTextureFormats, kTextureFormatInfo } from '../../../format_info.js';
 import { GPUTest, TextureTestMixin } from '../../../gpu_test.js';
 import { clamp } from '../../../util/math.js';
 import { TexelView } from '../../../util/texture/texel_view.js';
@@ -318,9 +318,9 @@ struct Uniform {
     );
   });
 
-const kBlendableFormats = kEncodableTextureFormats.filter(f => {
+const kBlendableFormats = kRegularTextureFormats.filter(f => {
   const info = kTextureFormatInfo[f];
-  return info.renderable && info.sampleType === 'float';
+  return info.colorRender && info.color.type === 'float';
 });
 
 g.test('blending,formats')

--- a/src/webgpu/api/validation/image_copy/image_copy.ts
+++ b/src/webgpu/api/validation/image_copy/image_copy.ts
@@ -255,9 +255,9 @@ export function formatCopyableWithMethod({ format, method }: WithFormatAndMethod
     return supportedAspects.length > 0;
   }
   if (method === 'CopyT2B') {
-    return info.copySrc;
+    return info.color.copySrc;
   } else {
-    return info.copyDst;
+    return info.color.copyDst;
   }
 }
 

--- a/src/webgpu/api/validation/render_pipeline/common.ts
+++ b/src/webgpu/api/validation/render_pipeline/common.ts
@@ -1,4 +1,4 @@
-import { kTextureFormatInfo } from '../../../format_info.js';
+import { ColorTextureFormat, kTextureFormatInfo } from '../../../format_info.js';
 import {
   getFragmentShaderCodeWithOutput,
   getPlainTypeInfo,
@@ -6,12 +6,14 @@ import {
 } from '../../../util/shader.js';
 import { ValidationTest } from '../validation_test.js';
 
+type ColorTargetState = GPUColorTargetState & { format: ColorTextureFormat };
+
 const values = [0, 1, 0, 1];
 export class CreateRenderPipelineValidationTest extends ValidationTest {
   getDescriptor(
     options: {
       primitive?: GPUPrimitiveState;
-      targets?: GPUColorTargetState[];
+      targets?: ColorTargetState[];
       multisample?: GPUMultisampleState;
       depthStencil?: GPUDepthStencilState;
       fragmentShaderCode?: string;
@@ -19,17 +21,16 @@ export class CreateRenderPipelineValidationTest extends ValidationTest {
       fragmentConstants?: Record<string, GPUPipelineConstantValue>;
     } = {}
   ): GPURenderPipelineDescriptor {
-    const defaultTargets: GPUColorTargetState[] = [{ format: 'rgba8unorm' }];
     const {
       primitive = {},
-      targets = defaultTargets,
+      targets = [{ format: 'rgba8unorm' }] as const,
       multisample = {},
       depthStencil,
       fragmentShaderCode = getFragmentShaderCodeWithOutput([
         {
           values,
           plainType: getPlainTypeInfo(
-            kTextureFormatInfo[targets[0] ? targets[0].format : 'rgba8unorm'].sampleType
+            kTextureFormatInfo[targets[0] ? targets[0].format : 'rgba8unorm'].color.type
           ),
           componentCount: 4,
         },

--- a/src/webgpu/api/validation/render_pipeline/fragment_state.spec.ts
+++ b/src/webgpu/api/validation/render_pipeline/fragment_state.spec.ts
@@ -211,24 +211,12 @@ g.test('limits,maxColorAttachmentBytesPerSample,unaligned')
         // become 4 and 4+4+8+16+1 > 32. Re-ordering this so the R8Unorm's are at the end, however
         // is allowed: 4+8+16+1+1 < 32.
         {
-          formats: [
-            'r8unorm',
-            'r32float',
-            'rgba8unorm',
-            'rgba32float',
-            'r8unorm',
-          ] as GPUTextureFormat[],
+          formats: ['r8unorm', 'r32float', 'rgba8unorm', 'rgba32float', 'r8unorm'],
         },
         {
-          formats: [
-            'r32float',
-            'rgba8unorm',
-            'rgba32float',
-            'r8unorm',
-            'r8unorm',
-          ] as GPUTextureFormat[],
+          formats: ['r32float', 'rgba8unorm', 'rgba32float', 'r8unorm', 'r8unorm'],
         },
-      ])
+      ] as const)
       .beginSubcases()
       .combine('isAsync', [false, true])
   )

--- a/src/webgpu/format_info.ts
+++ b/src/webgpu/format_info.ts
@@ -32,8 +32,6 @@ const kFormatUniversalDefaults = {
   baseFormat: undefined,
 
   /** @deprecated */
-  copySrc: undefined,
-  /** @deprecated */
   copyDst: undefined,
   /** @deprecated Use `.color.bytes`, `.depth.bytes`, or `.stencil.bytes`. */
   bytesPerBlock: undefined,
@@ -78,7 +76,7 @@ function formatTableWithDefaults<Defaults extends {}, Table extends { readonly [
 
 /** "plain color formats", plus rgb9e5ufloat. */
 const kRegularTextureFormatInfo = formatTableWithDefaults({
-  defaults: { blockWidth: 1, blockHeight: 1, copySrc: true, copyDst: true },
+  defaults: { blockWidth: 1, blockHeight: 1, copyDst: true },
   table: {
     // plain, 8 bits per component
 
@@ -685,7 +683,7 @@ const kRegularTextureFormatInfo = formatTableWithDefaults({
 // because one aspect can be sized and one can be unsized. This should be cleaned up, but is kept
 // this way during a migration phase.
 const kSizedDepthStencilFormatInfo = formatTableWithDefaults({
-  defaults: { blockWidth: 1, blockHeight: 1, multisample: true, copySrc: true, renderable: true },
+  defaults: { blockWidth: 1, blockHeight: 1, multisample: true, renderable: true },
   table: {
     stencil8: {
       stencil: {
@@ -737,7 +735,6 @@ const kUnsizedDepthStencilFormatInfo = formatTableWithDefaults({
         readWriteStorage: false,
         bytes: undefined,
       },
-      copySrc: false,
       copyDst: false,
       renderable: true,
     },
@@ -758,7 +755,6 @@ const kUnsizedDepthStencilFormatInfo = formatTableWithDefaults({
         readWriteStorage: false,
         bytes: 1,
       },
-      copySrc: false,
       copyDst: false,
       renderable: true,
     },
@@ -780,7 +776,6 @@ const kUnsizedDepthStencilFormatInfo = formatTableWithDefaults({
         bytes: 1,
       },
       feature: 'depth32float-stencil8',
-      copySrc: false,
       copyDst: false,
       renderable: true,
     },
@@ -793,7 +788,6 @@ const kBCTextureFormatInfo = formatTableWithDefaults({
     blockHeight: 4,
     multisample: false,
     feature: 'texture-compression-bc',
-    copySrc: true,
     copyDst: true,
   },
   table: {
@@ -974,7 +968,6 @@ const kETC2TextureFormatInfo = formatTableWithDefaults({
     blockHeight: 4,
     multisample: false,
     feature: 'texture-compression-etc2',
-    copySrc: true,
     copyDst: true,
   },
   table: {
@@ -1105,7 +1098,6 @@ const kASTCTextureFormatInfo = formatTableWithDefaults({
   defaults: {
     multisample: false,
     feature: 'texture-compression-astc',
-    copySrc: true,
     copyDst: true,
   },
   table: {
@@ -1616,7 +1608,6 @@ type TextureFormatInfo_TypeCheck = {
   baseFormat: GPUTextureFormat | undefined;
   feature: GPUFeatureName | undefined;
 
-  copySrc: boolean;
   copyDst: boolean;
   bytesPerBlock: number | undefined;
   renderable: boolean;

--- a/src/webgpu/format_info.ts
+++ b/src/webgpu/format_info.ts
@@ -1949,8 +1949,8 @@ export function isTextureFormatUsableAsStorageFormat(
   return !!kTextureFormatInfo[format].color?.storage;
 }
 
-export function isEncodableTextureformat(format: GPUTextureFormat) {
-  return format in kEncodableTextureFormatInfo;
+export function isRegularTextureFormat(format: GPUTextureFormat) {
+  return format in kRegularTextureFormatInfo;
 }
 
 export const kFeaturesForFormats = getFeaturesForFormats(kAllTextureFormats);

--- a/src/webgpu/format_info.ts
+++ b/src/webgpu/format_info.ts
@@ -32,8 +32,6 @@ const kFormatUniversalDefaults = {
   baseFormat: undefined,
 
   /** @deprecated */
-  sampleType: undefined,
-  /** @deprecated */
   copySrc: undefined,
   /** @deprecated */
   copyDst: undefined,
@@ -98,7 +96,6 @@ const kRegularTextureFormatInfo = formatTableWithDefaults({
       /*prettier-ignore*/ get renderTargetComponentAlignment() { return this.colorRender.alignment; },
       /*prettier-ignore*/ get renderTargetPixelByteCost() { return this.colorRender.byteCost; },
       multisample: true,
-      /*prettier-ignore*/ get sampleType() { return this.color.type; },
       /*prettier-ignore*/ get bytesPerBlock() { return this.color.bytes; },
     },
     r8snorm: {
@@ -111,7 +108,6 @@ const kRegularTextureFormatInfo = formatTableWithDefaults({
         bytes: 1,
       },
       multisample: false,
-      /*prettier-ignore*/ get sampleType() { return this.color.type; },
       /*prettier-ignore*/ get bytesPerBlock() { return this.color.bytes; },
     },
     r8uint: {
@@ -128,7 +124,6 @@ const kRegularTextureFormatInfo = formatTableWithDefaults({
       /*prettier-ignore*/ get renderTargetComponentAlignment() { return this.colorRender.alignment; },
       /*prettier-ignore*/ get renderTargetPixelByteCost() { return this.colorRender.byteCost; },
       multisample: true,
-      /*prettier-ignore*/ get sampleType() { return this.color.type; },
       /*prettier-ignore*/ get bytesPerBlock() { return this.color.bytes; },
     },
     r8sint: {
@@ -145,7 +140,6 @@ const kRegularTextureFormatInfo = formatTableWithDefaults({
       /*prettier-ignore*/ get renderTargetComponentAlignment() { return this.colorRender.alignment; },
       /*prettier-ignore*/ get renderTargetPixelByteCost() { return this.colorRender.byteCost; },
       multisample: true,
-      /*prettier-ignore*/ get sampleType() { return this.color.type; },
       /*prettier-ignore*/ get bytesPerBlock() { return this.color.bytes; },
     },
 
@@ -163,7 +157,6 @@ const kRegularTextureFormatInfo = formatTableWithDefaults({
       /*prettier-ignore*/ get renderTargetComponentAlignment() { return this.colorRender.alignment; },
       /*prettier-ignore*/ get renderTargetPixelByteCost() { return this.colorRender.byteCost; },
       multisample: true,
-      /*prettier-ignore*/ get sampleType() { return this.color.type; },
       /*prettier-ignore*/ get bytesPerBlock() { return this.color.bytes; },
     },
     rg8snorm: {
@@ -176,7 +169,6 @@ const kRegularTextureFormatInfo = formatTableWithDefaults({
         bytes: 2,
       },
       multisample: false,
-      /*prettier-ignore*/ get sampleType() { return this.color.type; },
       /*prettier-ignore*/ get bytesPerBlock() { return this.color.bytes; },
     },
     rg8uint: {
@@ -193,7 +185,6 @@ const kRegularTextureFormatInfo = formatTableWithDefaults({
       /*prettier-ignore*/ get renderTargetComponentAlignment() { return this.colorRender.alignment; },
       /*prettier-ignore*/ get renderTargetPixelByteCost() { return this.colorRender.byteCost; },
       multisample: true,
-      /*prettier-ignore*/ get sampleType() { return this.color.type; },
       /*prettier-ignore*/ get bytesPerBlock() { return this.color.bytes; },
     },
     rg8sint: {
@@ -210,7 +201,6 @@ const kRegularTextureFormatInfo = formatTableWithDefaults({
       /*prettier-ignore*/ get renderTargetComponentAlignment() { return this.colorRender.alignment; },
       /*prettier-ignore*/ get renderTargetPixelByteCost() { return this.colorRender.byteCost; },
       multisample: true,
-      /*prettier-ignore*/ get sampleType() { return this.color.type; },
       /*prettier-ignore*/ get bytesPerBlock() { return this.color.bytes; },
     },
 
@@ -229,7 +219,6 @@ const kRegularTextureFormatInfo = formatTableWithDefaults({
       /*prettier-ignore*/ get renderTargetPixelByteCost() { return this.colorRender.byteCost; },
       multisample: true,
       baseFormat: 'rgba8unorm',
-      /*prettier-ignore*/ get sampleType() { return this.color.type; },
       /*prettier-ignore*/ get bytesPerBlock() { return this.color.bytes; },
     },
     'rgba8unorm-srgb': {
@@ -247,7 +236,6 @@ const kRegularTextureFormatInfo = formatTableWithDefaults({
       /*prettier-ignore*/ get renderTargetPixelByteCost() { return this.colorRender.byteCost; },
       multisample: true,
       baseFormat: 'rgba8unorm',
-      /*prettier-ignore*/ get sampleType() { return this.color.type; },
       /*prettier-ignore*/ get bytesPerBlock() { return this.color.bytes; },
     },
     rgba8snorm: {
@@ -260,7 +248,6 @@ const kRegularTextureFormatInfo = formatTableWithDefaults({
         bytes: 4,
       },
       multisample: false,
-      /*prettier-ignore*/ get sampleType() { return this.color.type; },
       /*prettier-ignore*/ get bytesPerBlock() { return this.color.bytes; },
     },
     rgba8uint: {
@@ -277,7 +264,6 @@ const kRegularTextureFormatInfo = formatTableWithDefaults({
       /*prettier-ignore*/ get renderTargetComponentAlignment() { return this.colorRender.alignment; },
       /*prettier-ignore*/ get renderTargetPixelByteCost() { return this.colorRender.byteCost; },
       multisample: true,
-      /*prettier-ignore*/ get sampleType() { return this.color.type; },
       /*prettier-ignore*/ get bytesPerBlock() { return this.color.bytes; },
     },
     rgba8sint: {
@@ -294,7 +280,6 @@ const kRegularTextureFormatInfo = formatTableWithDefaults({
       /*prettier-ignore*/ get renderTargetComponentAlignment() { return this.colorRender.alignment; },
       /*prettier-ignore*/ get renderTargetPixelByteCost() { return this.colorRender.byteCost; },
       multisample: true,
-      /*prettier-ignore*/ get sampleType() { return this.color.type; },
       /*prettier-ignore*/ get bytesPerBlock() { return this.color.bytes; },
     },
     bgra8unorm: {
@@ -312,7 +297,6 @@ const kRegularTextureFormatInfo = formatTableWithDefaults({
       /*prettier-ignore*/ get renderTargetPixelByteCost() { return this.colorRender.byteCost; },
       multisample: true,
       baseFormat: 'bgra8unorm',
-      /*prettier-ignore*/ get sampleType() { return this.color.type; },
       /*prettier-ignore*/ get bytesPerBlock() { return this.color.bytes; },
     },
     'bgra8unorm-srgb': {
@@ -330,7 +314,6 @@ const kRegularTextureFormatInfo = formatTableWithDefaults({
       /*prettier-ignore*/ get renderTargetPixelByteCost() { return this.colorRender.byteCost; },
       multisample: true,
       baseFormat: 'bgra8unorm',
-      /*prettier-ignore*/ get sampleType() { return this.color.type; },
       /*prettier-ignore*/ get bytesPerBlock() { return this.color.bytes; },
     },
 
@@ -350,7 +333,6 @@ const kRegularTextureFormatInfo = formatTableWithDefaults({
       /*prettier-ignore*/ get renderTargetComponentAlignment() { return this.colorRender.alignment; },
       /*prettier-ignore*/ get renderTargetPixelByteCost() { return this.colorRender.byteCost; },
       multisample: true,
-      /*prettier-ignore*/ get sampleType() { return this.color.type; },
       /*prettier-ignore*/ get bytesPerBlock() { return this.color.bytes; },
     },
     r16sint: {
@@ -367,7 +349,6 @@ const kRegularTextureFormatInfo = formatTableWithDefaults({
       /*prettier-ignore*/ get renderTargetComponentAlignment() { return this.colorRender.alignment; },
       /*prettier-ignore*/ get renderTargetPixelByteCost() { return this.colorRender.byteCost; },
       multisample: true,
-      /*prettier-ignore*/ get sampleType() { return this.color.type; },
       /*prettier-ignore*/ get bytesPerBlock() { return this.color.bytes; },
     },
     r16float: {
@@ -384,7 +365,6 @@ const kRegularTextureFormatInfo = formatTableWithDefaults({
       /*prettier-ignore*/ get renderTargetComponentAlignment() { return this.colorRender.alignment; },
       /*prettier-ignore*/ get renderTargetPixelByteCost() { return this.colorRender.byteCost; },
       multisample: true,
-      /*prettier-ignore*/ get sampleType() { return this.color.type; },
       /*prettier-ignore*/ get bytesPerBlock() { return this.color.bytes; },
     },
 
@@ -402,7 +382,6 @@ const kRegularTextureFormatInfo = formatTableWithDefaults({
       /*prettier-ignore*/ get renderTargetComponentAlignment() { return this.colorRender.alignment; },
       /*prettier-ignore*/ get renderTargetPixelByteCost() { return this.colorRender.byteCost; },
       multisample: true,
-      /*prettier-ignore*/ get sampleType() { return this.color.type; },
       /*prettier-ignore*/ get bytesPerBlock() { return this.color.bytes; },
     },
     rg16sint: {
@@ -419,7 +398,6 @@ const kRegularTextureFormatInfo = formatTableWithDefaults({
       /*prettier-ignore*/ get renderTargetComponentAlignment() { return this.colorRender.alignment; },
       /*prettier-ignore*/ get renderTargetPixelByteCost() { return this.colorRender.byteCost; },
       multisample: true,
-      /*prettier-ignore*/ get sampleType() { return this.color.type; },
       /*prettier-ignore*/ get bytesPerBlock() { return this.color.bytes; },
     },
     rg16float: {
@@ -436,7 +414,6 @@ const kRegularTextureFormatInfo = formatTableWithDefaults({
       /*prettier-ignore*/ get renderTargetComponentAlignment() { return this.colorRender.alignment; },
       /*prettier-ignore*/ get renderTargetPixelByteCost() { return this.colorRender.byteCost; },
       multisample: true,
-      /*prettier-ignore*/ get sampleType() { return this.color.type; },
       /*prettier-ignore*/ get bytesPerBlock() { return this.color.bytes; },
     },
 
@@ -454,7 +431,6 @@ const kRegularTextureFormatInfo = formatTableWithDefaults({
       /*prettier-ignore*/ get renderTargetComponentAlignment() { return this.colorRender.alignment; },
       /*prettier-ignore*/ get renderTargetPixelByteCost() { return this.colorRender.byteCost; },
       multisample: true,
-      /*prettier-ignore*/ get sampleType() { return this.color.type; },
       /*prettier-ignore*/ get bytesPerBlock() { return this.color.bytes; },
     },
     rgba16sint: {
@@ -471,7 +447,6 @@ const kRegularTextureFormatInfo = formatTableWithDefaults({
       /*prettier-ignore*/ get renderTargetComponentAlignment() { return this.colorRender.alignment; },
       /*prettier-ignore*/ get renderTargetPixelByteCost() { return this.colorRender.byteCost; },
       multisample: true,
-      /*prettier-ignore*/ get sampleType() { return this.color.type; },
       /*prettier-ignore*/ get bytesPerBlock() { return this.color.bytes; },
     },
     rgba16float: {
@@ -488,7 +463,6 @@ const kRegularTextureFormatInfo = formatTableWithDefaults({
       /*prettier-ignore*/ get renderTargetComponentAlignment() { return this.colorRender.alignment; },
       /*prettier-ignore*/ get renderTargetPixelByteCost() { return this.colorRender.byteCost; },
       multisample: true,
-      /*prettier-ignore*/ get sampleType() { return this.color.type; },
       /*prettier-ignore*/ get bytesPerBlock() { return this.color.bytes; },
     },
 
@@ -508,7 +482,6 @@ const kRegularTextureFormatInfo = formatTableWithDefaults({
       /*prettier-ignore*/ get renderTargetComponentAlignment() { return this.colorRender.alignment; },
       /*prettier-ignore*/ get renderTargetPixelByteCost() { return this.colorRender.byteCost; },
       multisample: false,
-      /*prettier-ignore*/ get sampleType() { return this.color.type; },
       /*prettier-ignore*/ get bytesPerBlock() { return this.color.bytes; },
     },
     r32sint: {
@@ -525,7 +498,6 @@ const kRegularTextureFormatInfo = formatTableWithDefaults({
       /*prettier-ignore*/ get renderTargetComponentAlignment() { return this.colorRender.alignment; },
       /*prettier-ignore*/ get renderTargetPixelByteCost() { return this.colorRender.byteCost; },
       multisample: false,
-      /*prettier-ignore*/ get sampleType() { return this.color.type; },
       /*prettier-ignore*/ get bytesPerBlock() { return this.color.bytes; },
     },
     r32float: {
@@ -542,7 +514,6 @@ const kRegularTextureFormatInfo = formatTableWithDefaults({
       /*prettier-ignore*/ get renderTargetComponentAlignment() { return this.colorRender.alignment; },
       /*prettier-ignore*/ get renderTargetPixelByteCost() { return this.colorRender.byteCost; },
       multisample: true,
-      /*prettier-ignore*/ get sampleType() { return this.color.type; },
       /*prettier-ignore*/ get bytesPerBlock() { return this.color.bytes; },
     },
 
@@ -560,7 +531,6 @@ const kRegularTextureFormatInfo = formatTableWithDefaults({
       /*prettier-ignore*/ get renderTargetComponentAlignment() { return this.colorRender.alignment; },
       /*prettier-ignore*/ get renderTargetPixelByteCost() { return this.colorRender.byteCost; },
       multisample: false,
-      /*prettier-ignore*/ get sampleType() { return this.color.type; },
       /*prettier-ignore*/ get bytesPerBlock() { return this.color.bytes; },
     },
     rg32sint: {
@@ -577,7 +547,6 @@ const kRegularTextureFormatInfo = formatTableWithDefaults({
       /*prettier-ignore*/ get renderTargetComponentAlignment() { return this.colorRender.alignment; },
       /*prettier-ignore*/ get renderTargetPixelByteCost() { return this.colorRender.byteCost; },
       multisample: false,
-      /*prettier-ignore*/ get sampleType() { return this.color.type; },
       /*prettier-ignore*/ get bytesPerBlock() { return this.color.bytes; },
     },
     rg32float: {
@@ -594,7 +563,6 @@ const kRegularTextureFormatInfo = formatTableWithDefaults({
       /*prettier-ignore*/ get renderTargetComponentAlignment() { return this.colorRender.alignment; },
       /*prettier-ignore*/ get renderTargetPixelByteCost() { return this.colorRender.byteCost; },
       multisample: false,
-      /*prettier-ignore*/ get sampleType() { return this.color.type; },
       /*prettier-ignore*/ get bytesPerBlock() { return this.color.bytes; },
     },
 
@@ -612,7 +580,6 @@ const kRegularTextureFormatInfo = formatTableWithDefaults({
       /*prettier-ignore*/ get renderTargetComponentAlignment() { return this.colorRender.alignment; },
       /*prettier-ignore*/ get renderTargetPixelByteCost() { return this.colorRender.byteCost; },
       multisample: false,
-      /*prettier-ignore*/ get sampleType() { return this.color.type; },
       /*prettier-ignore*/ get bytesPerBlock() { return this.color.bytes; },
     },
     rgba32sint: {
@@ -629,7 +596,6 @@ const kRegularTextureFormatInfo = formatTableWithDefaults({
       /*prettier-ignore*/ get renderTargetComponentAlignment() { return this.colorRender.alignment; },
       /*prettier-ignore*/ get renderTargetPixelByteCost() { return this.colorRender.byteCost; },
       multisample: false,
-      /*prettier-ignore*/ get sampleType() { return this.color.type; },
       /*prettier-ignore*/ get bytesPerBlock() { return this.color.bytes; },
     },
     rgba32float: {
@@ -646,7 +612,6 @@ const kRegularTextureFormatInfo = formatTableWithDefaults({
       /*prettier-ignore*/ get renderTargetComponentAlignment() { return this.colorRender.alignment; },
       /*prettier-ignore*/ get renderTargetPixelByteCost() { return this.colorRender.byteCost; },
       multisample: false,
-      /*prettier-ignore*/ get sampleType() { return this.color.type; },
       /*prettier-ignore*/ get bytesPerBlock() { return this.color.bytes; },
     },
 
@@ -666,7 +631,6 @@ const kRegularTextureFormatInfo = formatTableWithDefaults({
       /*prettier-ignore*/ get renderTargetComponentAlignment() { return this.colorRender.alignment; },
       /*prettier-ignore*/ get renderTargetPixelByteCost() { return this.colorRender.byteCost; },
       multisample: true,
-      /*prettier-ignore*/ get sampleType() { return this.color.type; },
       /*prettier-ignore*/ get bytesPerBlock() { return this.color.bytes; },
     },
     rgb10a2unorm: {
@@ -683,7 +647,6 @@ const kRegularTextureFormatInfo = formatTableWithDefaults({
       /*prettier-ignore*/ get renderTargetComponentAlignment() { return this.colorRender.alignment; },
       /*prettier-ignore*/ get renderTargetPixelByteCost() { return this.colorRender.byteCost; },
       multisample: true,
-      /*prettier-ignore*/ get sampleType() { return this.color.type; },
       /*prettier-ignore*/ get bytesPerBlock() { return this.color.bytes; },
     },
     rg11b10ufloat: {
@@ -696,7 +659,6 @@ const kRegularTextureFormatInfo = formatTableWithDefaults({
         bytes: 4,
       },
       multisample: false,
-      /*prettier-ignore*/ get sampleType() { return this.color.type; },
       /*prettier-ignore*/ get bytesPerBlock() { return this.color.bytes; },
       renderTargetPixelByteCost: 8,
       renderTargetComponentAlignment: 4,
@@ -714,7 +676,6 @@ const kRegularTextureFormatInfo = formatTableWithDefaults({
         bytes: 4,
       },
       multisample: false,
-      /*prettier-ignore*/ get sampleType() { return this.color.type; },
       /*prettier-ignore*/ get bytesPerBlock() { return this.color.bytes; },
     },
   },
@@ -735,7 +696,6 @@ const kSizedDepthStencilFormatInfo = formatTableWithDefaults({
         readWriteStorage: false,
         bytes: 1,
       },
-      sampleType: 'uint',
       copyDst: true,
       bytesPerBlock: 1,
     },
@@ -748,7 +708,6 @@ const kSizedDepthStencilFormatInfo = formatTableWithDefaults({
         readWriteStorage: false,
         bytes: 2,
       },
-      sampleType: 'depth',
       copyDst: true,
       bytesPerBlock: 2,
     },
@@ -761,7 +720,6 @@ const kSizedDepthStencilFormatInfo = formatTableWithDefaults({
         readWriteStorage: false,
         bytes: 4,
       },
-      sampleType: 'depth',
       copyDst: false,
       bytesPerBlock: 4,
     },
@@ -781,7 +739,6 @@ const kUnsizedDepthStencilFormatInfo = formatTableWithDefaults({
       },
       copySrc: false,
       copyDst: false,
-      sampleType: 'depth',
       renderable: true,
     },
     'depth24plus-stencil8': {
@@ -803,7 +760,6 @@ const kUnsizedDepthStencilFormatInfo = formatTableWithDefaults({
       },
       copySrc: false,
       copyDst: false,
-      sampleType: 'depth',
       renderable: true,
     },
     'depth32float-stencil8': {
@@ -826,7 +782,6 @@ const kUnsizedDepthStencilFormatInfo = formatTableWithDefaults({
       feature: 'depth32float-stencil8',
       copySrc: false,
       copyDst: false,
-      sampleType: 'depth',
       renderable: true,
     },
   },
@@ -838,7 +793,6 @@ const kBCTextureFormatInfo = formatTableWithDefaults({
     blockHeight: 4,
     multisample: false,
     feature: 'texture-compression-bc',
-    sampleType: 'float',
     copySrc: true,
     copyDst: true,
   },
@@ -1020,7 +974,6 @@ const kETC2TextureFormatInfo = formatTableWithDefaults({
     blockHeight: 4,
     multisample: false,
     feature: 'texture-compression-etc2',
-    sampleType: 'float',
     copySrc: true,
     copyDst: true,
   },
@@ -1152,7 +1105,6 @@ const kASTCTextureFormatInfo = formatTableWithDefaults({
   defaults: {
     multisample: false,
     feature: 'texture-compression-astc',
-    sampleType: 'float',
     copySrc: true,
     copyDst: true,
   },
@@ -1664,7 +1616,6 @@ type TextureFormatInfo_TypeCheck = {
   baseFormat: GPUTextureFormat | undefined;
   feature: GPUFeatureName | undefined;
 
-  sampleType: GPUTextureSampleType;
   copySrc: boolean;
   copyDst: boolean;
   bytesPerBlock: number | undefined;

--- a/src/webgpu/shader/execution/expression/call/builtin/textureDimensions.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureDimensions.spec.ts
@@ -12,6 +12,7 @@ import {
   kAllTextureFormats,
   kColorTextureFormats,
   kTextureFormatInfo,
+  sampleTypeForFormatAndAspect,
   textureDimensionAndFormatCompatible,
 } from '../../../../../format_info.js';
 import { GPUTest } from '../../../../../gpu_test.js';
@@ -309,7 +310,7 @@ Parameters:
   .params(u =>
     u
       .combine('format', kAllTextureFormats)
-      .unless(u => kTextureFormatInfo[u.format].sampleType === 'unfilterable-float')
+      .unless(p => kTextureFormatInfo[p.format].color?.type === 'unfilterable-float')
       .expand('aspect', u => aspectsForFormat(u.format))
       .expand('samples', u => samplesForFormat(u.format))
       .beginSubcases()
@@ -345,11 +346,8 @@ Parameters:
     function wgslSampledTextureType(): string {
       const base = t.params.samples !== 1 ? 'texture_multisampled' : 'texture';
       const dimensions = t.params.dimensions.replace('-', '_');
-      if (t.params.aspect === 'stencil-only') {
-        return `${base}_${dimensions}<u32>`;
-      }
-      const formatInfo = kTextureFormatInfo[t.params.format];
-      switch (formatInfo.sampleType) {
+      const sampleType = sampleTypeForFormatAndAspect(t.params.format, t.params.aspect);
+      switch (sampleType) {
         case 'depth':
         case 'float':
           return `${base}_${dimensions}<f32>`;
@@ -389,7 +387,7 @@ Parameters:
   .params(u =>
     u
       .combine('format', kAllTextureFormats)
-      .filter(u => kTextureFormatInfo[u.format].sampleType === 'depth')
+      .filter(p => !!kTextureFormatInfo[p.format].depth)
       .expand('aspect', u => aspectsForFormat(u.format))
       .unless(u => u.aspect === 'stencil-only')
       .expand('samples', u => samplesForFormat(u.format))

--- a/src/webgpu/util/texture/texel_view.ts
+++ b/src/webgpu/util/texture/texel_view.ts
@@ -166,9 +166,13 @@ export class TexelView {
     const info = kTextureFormatInfo[this.format];
     const repr = kTexelRepresentationInfo[this.format];
 
-    const numericToString = numericToStringBuilder(
-      info.sampleType === 'uint' || info.sampleType === 'sint'
-    );
+    // MAINTENANCE_TODO: Print depth-stencil formats as float+int instead of float+float.
+    const printAsInteger = info.color
+      ? // For color, pick the type based on the format type
+        ['uint', 'sint'].includes(info.color.type)
+      : // Print depth as "float", depth-stencil as "float,float", stencil as "int".
+        !info.depth;
+    const numericToString = numericToStringBuilder(printAsInteger);
 
     const componentOrderStr = repr.componentOrder.join(',') + ':';
     const subrectCoords = [...fullSubrectCoordinates(subrectOrigin, subrectSize)];

--- a/src/webgpu/util/texture/texture_ok.ts
+++ b/src/webgpu/util/texture/texture_ok.ts
@@ -223,9 +223,13 @@ export function findFailedPixels(
 
   const info = kTextureFormatInfo[format];
   const repr = kTexelRepresentationInfo[format];
-  const numericToString = numericToStringBuilder(
-    info.sampleType === 'uint' || info.sampleType === 'sint'
-  );
+  // MAINTENANCE_TODO: Print depth-stencil formats as float+int instead of float+float.
+  const printAsInteger = info.color
+    ? // For color, pick the type based on the format type
+      ['uint', 'sint'].includes(info.color.type)
+    : // Print depth as "float", depth-stencil as "float,float", stencil as "int".
+      !info.depth;
+  const numericToString = numericToStringBuilder(printAsInteger);
 
   const componentOrderStr = repr.componentOrder.join(',') + ':';
 


### PR DESCRIPTION
Verified:

- `webgpu:api,operation,command_buffer,copyTextureToTexture:*` passing
- `webgpu:shader,execution,expression,call,builtin,textureDimensions:*` passing (fully, after rebase over #3413)

All the other changes should be trivial enough that there isn't danger of breaking anything. Hopefully.

Part 5 of Issue: #2495

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
