### PR TITLE
add f16 to webgpu/shader/types.ts utilities

### DIFF
--- a/src/webgpu/shader/execution/robust_access.spec.ts
+++ b/src/webgpu/shader/execution/robust_access.spec.ts
@@ -126,6 +126,7 @@ g.test('linear_memory')
     TODO: Test types like vec2<atomic<i32>>, if that's allowed.
     TODO: Test exprIndexAddon as constexpr.
     TODO: Test exprIndexAddon as pipeline-overridable constant expression.
+    TODO: Adjust test logic to support array of f16 in the uniform address space
   `
   )
   .params(u =>
@@ -202,7 +203,7 @@ g.test('linear_memory')
       // Array elements must be aligned to 16 bytes, but the logic in generateTypes
       // creates an array of vec4 of the baseType. But for f16 that's only 8 bytes.
       // We would need to write more complex logic for that.
-      t.skip('TODO: Test logic does not handle array of f16 in the uniform address space');
+      t.skip('Test logic does not handle array of f16 in the uniform address space');
     }
 
     let usesCanary = false;

--- a/src/webgpu/shader/execution/robust_access.spec.ts
+++ b/src/webgpu/shader/execution/robust_access.spec.ts
@@ -7,6 +7,7 @@ TODO: add tests to check that textureLoad operations stay in-bounds.
 
 import { makeTestGroup } from '../../../common/framework/test_group.js';
 import { assert } from '../../../common/util/util.js';
+import { Float16Array } from '../../../external/petamoriken/float16/float16.js';
 import { GPUTest } from '../../gpu_test.js';
 import { align } from '../../util/math.js';
 import { generateTypes, supportedScalarTypes, supportsAtomics } from '../types.js';
@@ -25,6 +26,7 @@ const kMinI32 = -0x8000_0000;
  */
 async function runShaderTest(
   t: GPUTest,
+  enables: string,
   stage: GPUShaderStageFlags,
   testSource: string,
   layout: GPUPipelineLayout,
@@ -41,7 +43,7 @@ async function runShaderTest(
     usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE,
   });
 
-  const source = `
+  const source = `${enables}
 struct Constants {
   zero: u32
 };
@@ -96,10 +98,12 @@ fn main() {
 /** Fill an ArrayBuffer with sentinel values, except clear a region to zero. */
 function testFillArrayBuffer(
   array: ArrayBuffer,
-  type: 'u32' | 'i32' | 'f32',
+  type: 'u32' | 'i32' | 'f16' | 'f32',
   { zeroByteStart, zeroByteCount }: { zeroByteStart: number; zeroByteCount: number }
 ) {
-  const constructor = { u32: Uint32Array, i32: Int32Array, f32: Float32Array }[type];
+  const constructor = { u32: Uint32Array, i32: Int32Array, f16: Float16Array, f32: Float32Array }[
+    type
+  ];
   assert(zeroByteCount % constructor.BYTES_PER_ELEMENT === 0);
   new constructor(array).fill(42);
   new constructor(array, zeroByteStart, zeroByteCount / constructor.BYTES_PER_ELEMENT).fill(0);
@@ -168,10 +172,15 @@ g.test('linear_memory')
         { shadowingMode: 'function-scope' },
       ])
       .expand('isAtomic', p => (supportsAtomics(p) ? [false, true] : [false]))
-      .beginSubcases()
       .expand('baseType', supportedScalarTypes)
+      .beginSubcases()
       .expandWithParams(generateTypes)
   )
+  .beforeAllSubcases(t => {
+    if (t.params.baseType === 'f16') {
+      t.selectDeviceOrSkipTestCase('shader-f16');
+    }
+  })
   .fn(async t => {
     const {
       addressSpace,
@@ -188,6 +197,13 @@ g.test('linear_memory')
 
     assert(_kTypeInfo !== undefined, 'not an indexable type');
     assert('arrayLength' in _kTypeInfo);
+
+    if (baseType === 'f16' && addressSpace === 'uniform' && containerType === 'array') {
+      // Array elements must be aligned to 16 bytes, but the logic in generateTypes
+      // creates an array of vec4 of the baseType. But for f16 that's only 8 bytes.
+      // We would need to write more complex logic for that.
+      t.skip('TODO: Test logic does not handle array of f16 in the uniform address space');
+    }
 
     let usesCanary = false;
     let globalSource = '';
@@ -429,6 +445,8 @@ fn runTest() -> u32 {
       ],
     });
 
+    const enables = t.params.baseType === 'f16' ? 'enable f16;' : '';
+
     // Run it.
     if (bufferBindingSize !== undefined && baseType !== 'bool') {
       const expectedData = new ArrayBuffer(testBufferSize);
@@ -450,6 +468,7 @@ fn runTest() -> u32 {
       // Run the shader, accessing the buffer.
       await runShaderTest(
         t,
+        enables,
         GPUShaderStage.COMPUTE,
         testSource,
         layout,
@@ -475,6 +494,6 @@ fn runTest() -> u32 {
         bufferBindingEnd
       );
     } else {
-      await runShaderTest(t, GPUShaderStage.COMPUTE, testSource, layout, []);
+      await runShaderTest(t, enables, GPUShaderStage.COMPUTE, testSource, layout, []);
     }
   });

--- a/src/webgpu/shader/execution/zero_init.spec.ts
+++ b/src/webgpu/shader/execution/zero_init.spec.ts
@@ -107,6 +107,10 @@ g.test('compute,zero_init')
               ? [true, false]
               : [false]) {
               for (const scalarType of supportedScalarTypes({ isAtomic, ...p })) {
+                // Fewer subcases: supportedScalarTypes was expanded to include f16
+                // but that may take too much time. It would require more complex code.
+                if (scalarType === 'f16') continue;
+
                 // Fewer subcases: For nested types, skip atomic u32 and non-atomic i32.
                 if (p._containerDepth > 0) {
                   if (scalarType === 'u32' && isAtomic) continue;

--- a/src/webgpu/shader/types.ts
+++ b/src/webgpu/shader/types.ts
@@ -247,7 +247,7 @@ export function* generateTypes({
     assert(scalarInfo.supportsAtomics, 'type does not support atomics');
     assert(
       containerType === 'scalar' || containerType === 'array',
-      'atomics are only supported for scalars and arrays'
+      "can only generate atomic inner types with containerType 'scalar' or 'array'"
     );
   }
   const scalarType = isAtomic ? `atomic<${baseType}>` : baseType;

--- a/src/webgpu/shader/types.ts
+++ b/src/webgpu/shader/types.ts
@@ -342,7 +342,7 @@ export function* generateTypes({
     const arrayTypeInfo = {
       elementBaseType: `${baseType}`,
       arrayLength: arrayElementCount,
-      layout: scalarInfo.layout ? layout : undefined,
+      layout,
       supportsAtomics,
     };
 

--- a/src/webgpu/shader/types.ts
+++ b/src/webgpu/shader/types.ts
@@ -218,20 +218,25 @@ export function* generateTypes({
   isAtomic?: boolean;
 }): Generator<
   {
-    type: string; // WGSL name for the generated type
+    /** WGSL name for the generated type */
+    type: string;
     _kTypeInfo: {
-      // WGSL name for:
-      // - the generated type if it is scalar or atomic
-      // - the column vector type if the generated type is a matrix
-      // - the base type if the generated type is an array
+      /**
+       * WGSL name for:
+       * - the generated type if it is scalar or atomic
+       * - the column vector type if the generated type is a matrix
+       * - the base type if the generated type is an array
+       */
       elementBaseType: string;
-      // Layout details if host-shareable, and undefined otherwise.
+      /** Layout details if host-shareable, and undefined otherwise. */
       layout: undefined | AlignmentAndSize;
       supportsAtomics: boolean;
-      // The number of elementBaseType items in the container.
+      /** The number of elementBaseType items in the container. */
       arrayLength: number;
-      // 0 for scalar and vector.
-      // For a matrix type, this is the number of rows in the matrix.
+      /**
+       * 0 for scalar and vector.
+       * For a matrix type, this is the number of rows in the matrix.
+       */
       innerLength?: number;
     };
   },

--- a/src/webgpu/shader/types.ts
+++ b/src/webgpu/shader/types.ts
@@ -347,14 +347,7 @@ export function* generateTypes({
     };
 
     // Sized
-    if (addressSpace === 'uniform') {
-      yield {
-        type: `array<${arrayElemType},${arrayElementCount}>`,
-        _kTypeInfo: arrayTypeInfo,
-      };
-    } else {
-      yield { type: `array<${arrayElemType},${arrayElementCount}>`, _kTypeInfo: arrayTypeInfo };
-    }
+    yield { type: `array<${arrayElemType},${arrayElementCount}>`, _kTypeInfo: arrayTypeInfo };
     // Unsized
     if (addressSpace === 'storage') {
       yield { type: `array<${arrayElemType}>`, _kTypeInfo: arrayTypeInfo };

--- a/src/webgpu/util/check_contents.ts
+++ b/src/webgpu/util/check_contents.ts
@@ -43,7 +43,10 @@ export function checkElementsEqual(
   expected: TypedArrayBufferView
 ): ErrorWithExtra | undefined {
   assert(actual.constructor === expected.constructor, 'TypedArray type mismatch');
-  assert(actual.length === expected.length, 'size mismatch');
+  assert(
+    actual.length === expected.length,
+    `length mismatch: expected ${expected.length} got ${actual.length}`
+  );
 
   let failedElementsFirstMaybe: number | undefined = undefined;
   /** Sparse array with `true` for elements that failed. */


### PR DESCRIPTION
Udpate affected tests;
- webgpu:shader,execution,zero_init: skip f16 cases
- webgpu:shader,execution,robust_access: generalize to cover most f16 cases

Bug: #3405




Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [ ] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
