### PR TITLE
Add recommended extensions to code-workspace

### DIFF
--- a/cts.code-workspace
+++ b/cts.code-workspace
@@ -10,6 +10,11 @@
       "path": "src/webgpu"
     }
   ],
+  "extensions": {
+    "recommendations": [
+      "esbenp.prettier-vscode"
+    ]
+  },
   "settings": {
     "editor.defaultFormatter": "esbenp.prettier-vscode",
     "editor.detectIndentation": false,


### PR DESCRIPTION
Recommended extensions are useful, as Code will ask the user if they wish to install the recommended extensions when opening the workspace. They also appear in the Extensions panel under "Workspace Recommendations".

Currently only contains "esbenp.prettier-vscode".

