### PR TITLE
Add textureBarrier tests

### DIFF
--- a/src/webgpu/shader/execution/memory_model/barrier.spec.ts
+++ b/src/webgpu/shader/execution/memory_model/barrier.spec.ts
@@ -64,7 +64,7 @@ const storageMemoryBarrierStoreLoadTestCode = `
 `;
 
 const textureMemoryBarrierStoreLoadTestCode = `
-  textureStore(texture_locations, indexToCoord(x_0), vec4u(1,0,0,0));
+  textureStore(texture_locations, indexToCoord(x_0), vec4u(1));
   textureBarrier();
   let r0 = textureLoad(texture_locations, indexToCoord(x_1)).x;
   atomicStore(&results.value[shuffled_workgroup * workgroupXSize + id_1].r0, r0);
@@ -94,7 +94,7 @@ const storageMemoryBarrierLoadStoreTestCode = `
 const textureMemoryBarrierLoadStoreTestCode = `
   let r0 = textureLoad(texture_locations, indexToCoord(x_0)).x;
   textureBarrier();
-  textureStore(texture_locations, indexToCoord(x_1), vec4u(1,0,0,0));
+  textureStore(texture_locations, indexToCoord(x_1), vec4u(1));
   atomicStore(&results.value[shuffled_workgroup * workgroupXSize + id_0].r0, r0);
 `;
 
@@ -119,11 +119,11 @@ const storageMemoryBarrierStoreStoreTestCode = `
 `;
 
 const textureMemoryBarrierStoreStoreTestCode = `
-  textureStore(texture_locations, indexToCoord(x_0), vec4u(1,0,0,0));
+  textureStore(texture_locations, indexToCoord(x_0), vec4u(1));
   textureBarrier();
-  textureStore(texture_locations, indexToCoord(x_1), vec4u(2,0,0,0));
+  textureStore(texture_locations, indexToCoord(x_1), vec4u(2));
   textureBarrier();
-  test_locations.value[shuffled_workgroup * workgroupXSize * stress_params.mem_stride * 2u + x_1] = textureLoad(texture_locations, indexToCoord(x_1)).x;
+  test_locations.value[x_1] = textureLoad(texture_locations, indexToCoord(x_1)).x;
 `;
 
 const workgroupMemoryBarrierStoreStoreTestCode = `

--- a/src/webgpu/shader/execution/memory_model/barrier.spec.ts
+++ b/src/webgpu/shader/execution/memory_model/barrier.spec.ts
@@ -43,19 +43,30 @@ const memoryModelTestParams: MemoryModelTestParams = {
   numBehaviors: 2,
 };
 
-// The two kinds of non-atomic accesses tested.
+// The three kinds of non-atomic accesses tested.
 //  rw: read -> barrier -> write
 //  wr: write -> barrier -> read
 //  ww: write -> barrier -> write
 type AccessPair = 'rw' | 'wr' | 'ww';
 
 // Test the non-atomic memory types.
-const kMemTypes = [MemoryType.NonAtomicStorageClass, MemoryType.NonAtomicWorkgroupClass] as const;
+const kMemTypes = [
+  MemoryType.NonAtomicStorageClass,
+  MemoryType.NonAtomicWorkgroupClass,
+  MemoryType.NonAtomicTextureClass,
+] as const;
 
 const storageMemoryBarrierStoreLoadTestCode = `
   test_locations.value[x_0] = 1;
-  workgroupBarrier();
+  storageBarrier();
   let r0 = u32(test_locations.value[x_1]);
+  atomicStore(&results.value[shuffled_workgroup * workgroupXSize + id_1].r0, r0);
+`;
+
+const textureMemoryBarrierStoreLoadTestCode = `
+  textureStore(texture_locations, indexToCoord(x_0), vec4u(1,0,0,0));
+  textureBarrier();
+  let r0 = textureLoad(texture_locations, indexToCoord(x_1)).x;
   atomicStore(&results.value[shuffled_workgroup * workgroupXSize + id_1].r0, r0);
 `;
 
@@ -75,8 +86,15 @@ const workgroupUniformLoadMemoryBarrierStoreLoadTestCode = `
 
 const storageMemoryBarrierLoadStoreTestCode = `
   let r0 = u32(test_locations.value[x_0]);
-  workgroupBarrier();
+  storageBarrier();
   test_locations.value[x_1] = 1;
+  atomicStore(&results.value[shuffled_workgroup * workgroupXSize + id_0].r0, r0);
+`;
+
+const textureMemoryBarrierLoadStoreTestCode = `
+  let r0 = textureLoad(texture_locations, indexToCoord(x_0)).x;
+  textureBarrier();
+  textureStore(texture_locations, indexToCoord(x_1), vec4u(1,0,0,0));
   atomicStore(&results.value[shuffled_workgroup * workgroupXSize + id_0].r0, r0);
 `;
 
@@ -98,6 +116,14 @@ const storageMemoryBarrierStoreStoreTestCode = `
   test_locations.value[x_0] = 1;
   storageBarrier();
   test_locations.value[x_1] = 2;
+`;
+
+const textureMemoryBarrierStoreStoreTestCode = `
+  textureStore(texture_locations, indexToCoord(x_0), vec4u(1,0,0,0));
+  textureBarrier();
+  textureStore(texture_locations, indexToCoord(x_1), vec4u(2,0,0,0));
+  textureBarrier();
+  test_locations.value[shuffled_workgroup * workgroupXSize * stress_params.mem_stride * 2u + x_1] = textureLoad(texture_locations, indexToCoord(x_1)).x;
 `;
 
 const workgroupMemoryBarrierStoreStoreTestCode = `
@@ -122,24 +148,42 @@ function getTestCode(p: {
   normalBarrier: boolean;
 }): string {
   switch (p.accessPair) {
-    case 'rw':
-      return p.memType === MemoryType.NonAtomicStorageClass
-        ? storageMemoryBarrierLoadStoreTestCode
-        : p.normalBarrier
-        ? workgroupMemoryBarrierLoadStoreTestCode
-        : workgroupUniformLoadMemoryBarrierLoadStoreTestCode;
-    case 'wr':
-      return p.memType === MemoryType.NonAtomicStorageClass
-        ? storageMemoryBarrierStoreLoadTestCode
-        : p.normalBarrier
-        ? workgroupMemoryBarrierStoreLoadTestCode
-        : workgroupUniformLoadMemoryBarrierStoreLoadTestCode;
-    case 'ww':
-      return p.memType === MemoryType.NonAtomicStorageClass
-        ? storageMemoryBarrierStoreStoreTestCode
-        : p.normalBarrier
-        ? workgroupMemoryBarrierStoreStoreTestCode
-        : workgroupUniformLoadMemoryBarrierStoreStoreTestCode;
+    case 'rw': {
+      switch (p.memType) {
+        case MemoryType.NonAtomicStorageClass:
+          return storageMemoryBarrierLoadStoreTestCode;
+        case MemoryType.NonAtomicTextureClass:
+          return textureMemoryBarrierLoadStoreTestCode;
+        default:
+          return p.normalBarrier
+            ? workgroupMemoryBarrierLoadStoreTestCode
+            : workgroupUniformLoadMemoryBarrierLoadStoreTestCode;
+      }
+    }
+    case 'wr': {
+      switch (p.memType) {
+        case MemoryType.NonAtomicStorageClass:
+          return storageMemoryBarrierStoreLoadTestCode;
+        case MemoryType.NonAtomicTextureClass:
+          return textureMemoryBarrierStoreLoadTestCode;
+        default:
+          return p.normalBarrier
+            ? workgroupMemoryBarrierStoreLoadTestCode
+            : workgroupUniformLoadMemoryBarrierStoreLoadTestCode;
+      }
+    }
+    case 'ww': {
+      switch (p.memType) {
+        case MemoryType.NonAtomicStorageClass:
+          return storageMemoryBarrierStoreStoreTestCode;
+        case MemoryType.NonAtomicTextureClass:
+          return textureMemoryBarrierStoreStoreTestCode;
+        default:
+          return p.normalBarrier
+            ? workgroupMemoryBarrierStoreStoreTestCode
+            : workgroupUniformLoadMemoryBarrierStoreStoreTestCode;
+      }
+    }
   }
 }
 
@@ -162,11 +206,21 @@ g.test('workgroup_barrier_store_load')
       t.selectDeviceOrSkipTestCase('shader-f16');
     }
     t.skipIf(
-      !t.params.normalBarrier && t.params.memType === MemoryType.NonAtomicStorageClass,
+      !t.params.normalBarrier && t.params.memType !== MemoryType.NonAtomicWorkgroupClass,
       'workgroupUniformLoad does not have storage memory semantics'
+    );
+    t.skipIf(
+      t.params.memType === MemoryType.NonAtomicTextureClass && t.params.accessValueType !== 'u32',
+      'textures do not support f16 access'
     );
   })
   .fn(async t => {
+    t.skipIf(
+      t.params.memType === MemoryType.NonAtomicTextureClass &&
+        !t.hasLanguageFeature('readonly_and_readwrite_storage_textures'),
+      'requires RW storage textures feature'
+    );
+
     const resultCode = `
       if (r0 == 1u) {
         atomicAdd(&test_results.seq, 1u);
@@ -192,7 +246,8 @@ g.test('workgroup_barrier_store_load')
       memoryModelTestParams,
       testShader,
       resultShader,
-      t.params.accessValueType
+      t.params.accessValueType,
+      t.params.memType === MemoryType.NonAtomicTextureClass
     );
     await memModelTester.run(15, 1);
   });
@@ -216,11 +271,21 @@ g.test('workgroup_barrier_load_store')
       t.selectDeviceOrSkipTestCase('shader-f16');
     }
     t.skipIf(
-      !t.params.normalBarrier && t.params.memType === MemoryType.NonAtomicStorageClass,
+      !t.params.normalBarrier && t.params.memType !== MemoryType.NonAtomicWorkgroupClass,
       'workgroupUniformLoad does not have storage memory semantics'
+    );
+    t.skipIf(
+      t.params.memType === MemoryType.NonAtomicTextureClass && t.params.accessValueType !== 'u32',
+      'textures do not support f16 access'
     );
   })
   .fn(async t => {
+    t.skipIf(
+      t.params.memType === MemoryType.NonAtomicTextureClass &&
+        !t.hasLanguageFeature('readonly_and_readwrite_storage_textures'),
+      'requires RW storage textures feature'
+    );
+
     const resultCode = `
       if (r0 == 0u) {
         atomicAdd(&test_results.seq, 1u);
@@ -246,7 +311,8 @@ g.test('workgroup_barrier_load_store')
       memoryModelTestParams,
       testShader,
       resultShader,
-      t.params.accessValueType
+      t.params.accessValueType,
+      t.params.memType === MemoryType.NonAtomicTextureClass
     );
     await memModelTester.run(12, 1);
   });
@@ -270,11 +336,21 @@ g.test('workgroup_barrier_store_store')
       t.selectDeviceOrSkipTestCase('shader-f16');
     }
     t.skipIf(
-      !t.params.normalBarrier && t.params.memType === MemoryType.NonAtomicStorageClass,
+      !t.params.normalBarrier && t.params.memType !== MemoryType.NonAtomicWorkgroupClass,
       'workgroupUniformLoad does not have storage memory semantics'
+    );
+    t.skipIf(
+      t.params.memType === MemoryType.NonAtomicTextureClass && t.params.accessValueType !== 'u32',
+      'textures do not support f16 access'
     );
   })
   .fn(async t => {
+    t.skipIf(
+      t.params.memType === MemoryType.NonAtomicTextureClass &&
+        !t.hasLanguageFeature('readonly_and_readwrite_storage_textures'),
+      'requires RW storage textures feature'
+    );
+
     const resultCode = `
       if (mem_x_0 == 2u) {
         atomicAdd(&test_results.seq, 1u);
@@ -300,7 +376,8 @@ g.test('workgroup_barrier_store_store')
       memoryModelTestParams,
       testShader,
       resultShader,
-      t.params.accessValueType
+      t.params.accessValueType,
+      t.params.memType === MemoryType.NonAtomicTextureClass
     );
     await memModelTester.run(10, 1);
   });

--- a/src/webgpu/shader/execution/memory_model/barrier.spec.ts
+++ b/src/webgpu/shader/execution/memory_model/barrier.spec.ts
@@ -210,7 +210,7 @@ g.test('workgroup_barrier_store_load')
       'workgroupUniformLoad does not have storage memory semantics'
     );
     t.skipIf(
-      t.params.memType === MemoryType.NonAtomicTextureClass && t.params.accessValueType !== 'u32',
+      t.params.memType === MemoryType.NonAtomicTextureClass && t.params.accessValueType === 'f16',
       'textures do not support f16 access'
     );
   })
@@ -275,7 +275,7 @@ g.test('workgroup_barrier_load_store')
       'workgroupUniformLoad does not have storage memory semantics'
     );
     t.skipIf(
-      t.params.memType === MemoryType.NonAtomicTextureClass && t.params.accessValueType !== 'u32',
+      t.params.memType === MemoryType.NonAtomicTextureClass && t.params.accessValueType === 'f16',
       'textures do not support f16 access'
     );
   })
@@ -340,7 +340,7 @@ g.test('workgroup_barrier_store_store')
       'workgroupUniformLoad does not have storage memory semantics'
     );
     t.skipIf(
-      t.params.memType === MemoryType.NonAtomicTextureClass && t.params.accessValueType !== 'u32',
+      t.params.memType === MemoryType.NonAtomicTextureClass && t.params.accessValueType === 'f16',
       'textures do not support f16 access'
     );
   })

--- a/src/webgpu/shader/execution/memory_model/memory_model_setup.ts
+++ b/src/webgpu/shader/execution/memory_model/memory_model_setup.ts
@@ -17,8 +17,8 @@ import { PRNG } from '../../../util/prng.js';
 export type AccessValueType = 'f16' | 'u32';
 export const kAccessValueTypes = ['f16', 'u32'] as const;
 
-/** The width used for textures (default limit in WebGPU). */
-const kWidth = 8192;
+/** The width used for textures (default compat limit in WebGPU). */
+const kWidth = 4096;
 
 /* Parameter values are set heuristically, typically by a time-intensive search. */
 export type MemoryModelTestParams = {
@@ -877,11 +877,9 @@ const nonAtomicTestShaderBindings = [
 ].join('\n');
 
 /** The extra binding for texture non-atomic texture tests. */
-const textureBindings = [
-  `
-  @group(1) @binding(0) var texture_locations : texture_storage_2d<r32uint, read_write>;
-`,
-].join('\n');
+const textureBindings = `
+@group(1) @binding(0) var texture_locations : texture_storage_2d<r32uint, read_write>;
+`;
 
 /** Bindings used in the result aggregation phase of the test. */
 const resultShaderBindings = `

--- a/src/webgpu/shader/execution/memory_model/memory_model_setup.ts
+++ b/src/webgpu/shader/execution/memory_model/memory_model_setup.ts
@@ -427,12 +427,13 @@ export class MemoryModelTester {
       });
       layouts = [testLayout, textureLayout];
 
+      const texLocations = (this.textures as MemoryModelTextures).testLocations.deviceTex;
       this.textureBindGroup = this.test.device.createBindGroup({
         label: 'textureBindGroup',
         entries: [
           {
             binding: 0,
-            resource: (this.textures as MemoryModelTextures).testLocations.deviceTex.createView(),
+            resource: texLocations.createView(),
           },
         ],
         layout: textureLayout,
@@ -1249,15 +1250,15 @@ export function buildTestShader(
   testType: TestType
 ): string {
   let memoryTypeCode;
-  let isStorageAS = false;
+  let isGlobalSpace = false;
   switch (memoryType) {
     case MemoryType.AtomicStorageClass:
       memoryTypeCode = storageMemoryAtomicTestShaderCode;
-      isStorageAS = true;
+      isGlobalSpace = true;
       break;
     case MemoryType.NonAtomicStorageClass:
       memoryTypeCode = storageMemoryNonAtomicTestShaderCode;
-      isStorageAS = true;
+      isGlobalSpace = true;
       break;
     case MemoryType.AtomicWorkgroupClass:
       memoryTypeCode = workgroupMemoryAtomicTestShaderCode;
@@ -1267,6 +1268,7 @@ export function buildTestShader(
       break;
     case MemoryType.NonAtomicTextureClass:
       memoryTypeCode = textureMemoryNonAtomicTestShaderCode;
+      isGlobalSpace = true;
       break;
   }
   let testTypeCode;
@@ -1275,7 +1277,7 @@ export function buildTestShader(
       testTypeCode = interWorkgroupTestShaderCode;
       break;
     case TestType.IntraWorkgroup:
-      if (isStorageAS) {
+      if (isGlobalSpace) {
         testTypeCode = storageIntraWorkgroupTestShaderCode;
       } else {
         testTypeCode = intraWorkgroupTestShaderCode;

--- a/src/webgpu/shader/execution/memory_model/memory_model_setup.ts
+++ b/src/webgpu/shader/execution/memory_model/memory_model_setup.ts
@@ -17,6 +17,9 @@ import { PRNG } from '../../../util/prng.js';
 export type AccessValueType = 'f16' | 'u32';
 export const kAccessValueTypes = ['f16', 'u32'] as const;
 
+/** The width used for textures (default limit in WebGPU). */
+const kWidth = 8192;
+
 /* Parameter values are set heuristically, typically by a time-intensive search. */
 export type MemoryModelTestParams = {
   /* Number of invocations per workgroup. The workgroups are 1-dimensional. */
@@ -84,6 +87,16 @@ type BufferWithSource = {
   size: number;
 };
 
+/** Represents a device texture and a utility buffer for resetting memory and copying parameters. */
+type TextureWithSource = {
+  /** Texture used by shader code. */
+  deviceTex: GPUTexture;
+  /** Buffer populated from the host side, data is copied to device buffer for use by shader. */
+  srcBuf: GPUBuffer;
+  /** Size in bytes of the buffer. */
+  size: number;
+};
+
 type SubBufferWithSource = {
   /** Buffer used by shader code. This buffer is shared for multiple used */
   deviceBuf: GPUBuffer;
@@ -113,6 +126,10 @@ type MemoryModelBuffers = {
   scratchMemoryLocations: BufferWithSource;
   /** Parameters that are used by the shader to calculate memory locations and perform stress. */
   stressParams: BufferWithSource;
+};
+
+type MemoryModelTextures = {
+  testLocations: TextureWithSource;
 };
 
 /** The number of stress params to add to the stress params buffer. */
@@ -188,11 +205,14 @@ export class MemoryModelTester {
   protected test: GPUTest;
   protected params: MemoryModelTestParams;
   protected buffers: MemoryModelBuffers;
+  protected textures: MemoryModelTextures | undefined;
   protected testPipeline: GPUComputePipeline;
   protected testBindGroup: GPUBindGroup;
+  protected textureBindGroup: GPUBindGroup | undefined;
   protected resultPipeline: GPUComputePipeline;
   protected resultBindGroup: GPUBindGroup;
   protected prng: PRNG;
+  protected useTexture: boolean;
 
   /** Sets up a memory model test by initializing buffers and pipeline layouts. */
   constructor(
@@ -200,11 +220,13 @@ export class MemoryModelTester {
     params: MemoryModelTestParams,
     testShader: string,
     resultShader: string,
-    accessValueType: AccessValueType = 'u32'
+    accessValueType: AccessValueType = 'u32',
+    useTexture: boolean = false
   ) {
     this.prng = new PRNG(1);
     this.test = t;
     this.params = params;
+    this.useTexture = useTexture;
 
     const workgroupXSize = Math.min(params.workgroupSize, t.device.limits.maxComputeWorkgroupSizeX);
     const constants = `
@@ -276,6 +298,26 @@ export class MemoryModelTester {
       }),
       size: shuffledWorkgroupsSize,
     };
+
+    if (this.useTexture) {
+      const numTexels = testLocationsSize / bytesPerWord;
+      const width = kWidth;
+      const height = numTexels / width;
+      const textureSize: GPUExtent3D = { width, height };
+      const textureLocations: TextureWithSource = {
+        deviceTex: this.test.device.createTexture({
+          format: 'r32uint',
+          dimension: '2d',
+          size: textureSize,
+          usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+        }),
+        srcBuf: testLocationsBuffer.srcBuf,
+        size: testLocationsSize,
+      };
+      this.textures = {
+        testLocations: textureLocations,
+      };
+    }
 
     // Combine 3 arrays into 1 buffer as we need to keep the number of storage buffers to 4 for compat.
     const falseSharingAvoidanceQuantum = 4096;
@@ -366,10 +408,40 @@ export class MemoryModelTester {
         { binding: 4, visibility: GPUShaderStage.COMPUTE, buffer: { type: 'uniform' } },
       ],
     });
+
+    let layouts: GPUBindGroupLayout[] = [testLayout];
+    if (this.useTexture) {
+      const textureLayout = this.test.device.createBindGroupLayout({
+        label: 'textureLayout',
+        entries: [
+          {
+            binding: 0,
+            visibility: GPUShaderStage.COMPUTE,
+            storageTexture: {
+              access: 'read-write',
+              format: 'r32uint',
+              viewDimension: '2d',
+            },
+          },
+        ],
+      });
+      layouts = [testLayout, textureLayout];
+
+      this.textureBindGroup = this.test.device.createBindGroup({
+        label: 'textureBindGroup',
+        entries: [
+          {
+            binding: 0,
+            resource: (this.textures as MemoryModelTextures).testLocations.deviceTex.createView(),
+          },
+        ],
+        layout: textureLayout,
+      });
+    }
     this.testPipeline = this.test.device.createComputePipeline({
       label: 'testPipeline',
       layout: this.test.device.createPipelineLayout({
-        bindGroupLayouts: [testLayout],
+        bindGroupLayouts: layouts,
       }),
       compute: {
         module: this.test.device.createShaderModule({
@@ -447,10 +519,16 @@ export class MemoryModelTester {
       this.copyBufferToBuffer(encoder, this.buffers.scratchpad);
       this.copyBufferToBuffer(encoder, this.buffers.scratchMemoryLocations);
       this.copyBufferToBuffer(encoder, this.buffers.stressParams);
+      if (this.useTexture) {
+        this.copyBufferToTexture(encoder, (this.textures as MemoryModelTextures).testLocations);
+      }
 
       const testPass = encoder.beginComputePass();
       testPass.setPipeline(this.testPipeline);
       testPass.setBindGroup(0, this.testBindGroup);
+      if (this.useTexture) {
+        testPass.setBindGroup(1, this.textureBindGroup as GPUBindGroup);
+      }
       testPass.dispatchWorkgroups(numWorkgroups);
       testPass.end();
 
@@ -519,6 +597,23 @@ export class MemoryModelTester {
       buffer.deviceBuf,
       (buffer as SubBufferWithSource).offset || 0,
       buffer.size
+    );
+  }
+
+  /** Utility method that simplifies copying source buffers to device textures. */
+  protected copyBufferToTexture(encoder: GPUCommandEncoder, texture: TextureWithSource): void {
+    const bytesPerWord = 4; // always uses r32uint format.
+    const numTexels = texture.size / bytesPerWord;
+    const size: GPUExtent3D = { width: kWidth, height: numTexels / kWidth };
+    encoder.copyBufferToTexture(
+      {
+        buffer: texture.srcBuf,
+        offset: 0,
+        bytesPerRow: kWidth * bytesPerWord,
+        rowsPerImage: size.height,
+      },
+      { texture: texture.deviceTex },
+      size
     );
   }
 
@@ -780,6 +875,13 @@ const nonAtomicTestShaderBindings = [
   commonTestShaderBindings,
 ].join('\n');
 
+/** The extra binding for texture non-atomic texture tests. */
+const textureBindings = [
+  `
+  @group(1) @binding(0) var texture_locations : texture_storage_2d<r32uint, read_write>;
+`,
+].join('\n');
+
 /** Bindings used in the result aggregation phase of the test. */
 const resultShaderBindings = `
   @group(0) @binding(0) var<storage, read_write> test_locations : Memory;
@@ -818,6 +920,16 @@ const memoryLocationFunctions = `
 
   fn stripe_workgroup(workgroup_id: u32, local_id: u32) -> u32 {
     return (workgroup_id + 1u + local_id % (stress_params.testing_workgroups - 1u)) % stress_params.testing_workgroups;
+  }
+`;
+
+/**
+ * Function to convert an index into an equivalent 2D coordinate for the texture.
+ */
+const textureFunctions = `
+  const kWidth = ${kWidth};
+  fn indexToCoord(idx : u32) -> vec2u {
+    return vec2u(idx % kWidth, idx / kWidth);
   }
 `;
 
@@ -1051,6 +1163,18 @@ const storageMemoryNonAtomicTestShaderCode = [
   testShaderCommonHeader,
 ].join('\n');
 
+/** The common shader code for the test shaders that perform non-atomic texture memory litmus tests. */
+const textureMemoryNonAtomicTestShaderCode = [
+  shaderMemStructures,
+  nonAtomicTestShaderBindings,
+  textureBindings,
+  memoryLocationFunctions,
+  textureFunctions,
+  testShaderFunctions,
+  shaderEntryPoint,
+  testShaderCommonHeader,
+].join('\n');
+
 /** The common shader code for test shaders that perform atomic workgroup class memory litmus tests. */
 const workgroupMemoryAtomicTestShaderCode = [
   shaderMemStructures,
@@ -1094,6 +1218,8 @@ export enum MemoryType {
   AtomicWorkgroupClass = 'atomic_workgroup',
   /** Non-atomic memory in the workgroup address space. */
   NonAtomicWorkgroupClass = 'non_atomic_workgroup',
+  /** Non-atomic memory in a texture. */
+  NonAtomicTextureClass = 'non_atomic_texture',
 }
 
 /**
@@ -1138,6 +1264,10 @@ export function buildTestShader(
       break;
     case MemoryType.NonAtomicWorkgroupClass:
       memoryTypeCode = workgroupMemoryNonAtomicTestShaderCode;
+      break;
+    case MemoryType.NonAtomicTextureClass:
+      memoryTypeCode = textureMemoryNonAtomicTestShaderCode;
+      break;
   }
   let testTypeCode;
   switch (testType) {


### PR DESCRIPTION
* Extend the current non-atomic barrier tests to cover RW storage textures and textureBarrier
* Fix barrier used in some storage memory tests
* Setup code creates an extra texture (in a separate bind group) for texture based tests
  * source data (zeroes) is the same as the test data for the buffer tests




Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [ ] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [ ] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
