### PR TITLE
op: bgra8unorm as read-only storage texture format

### DIFF
--- a/src/webgpu/api/operation/storage_texture/read_only.spec.ts
+++ b/src/webgpu/api/operation/storage_texture/read_only.spec.ts
@@ -71,11 +71,12 @@ class F extends GPUTest {
       texelValue: number,
       outputValue: number,
       texelDataIndex: number,
-      component: number
+      component: number,
+      outputComponent: number = component
     ) => {
       const texelComponentIndex = texelDataIndex * componentCount + component;
       texelTypedDataView[texelComponentIndex] = texelValue;
-      const outputTexelComponentIndex = texelDataIndex * 4 + component;
+      const outputTexelComponentIndex = texelDataIndex * 4 + outputComponent;
       outputBufferTypedData[outputTexelComponentIndex] = outputValue;
     };
     for (let z = 0; z < depthOrArrayLayers; ++z) {
@@ -109,25 +110,11 @@ class F extends GPUTest {
               }
               case 'bgra8unorm': {
                 const texelValue = (4 * texelDataIndex + component + 1) % 256;
-                const texelComponentIndex = texelDataIndex * componentCount + component;
-                texelTypedDataView[texelComponentIndex] = texelValue;
-
                 const outputValue = texelValue / 255.0;
-                let outputComponent = 0;
-                switch (component) {
-                  case 0:
-                    outputComponent = 2;
-                    break;
-                  case 2:
-                    outputComponent = 0;
-                    break;
-                  case 1:
-                  case 3:
-                    outputComponent = component;
-                    break;
-                }
-                const outputTexelComponentIndex = texelDataIndex * 4 + outputComponent;
-                outputBufferTypedData[outputTexelComponentIndex] = outputValue;
+                // BGRA -> RGBA
+                assert(component < 4);
+                const outputComponent = [2, 1, 0, 3][component];
+                SetData(texelValue, outputValue, texelDataIndex, component, outputComponent);
                 break;
               }
               case 'r32sint':


### PR DESCRIPTION
This patch adds the operation tests on the use of `bgra8unorm` as the format of read-only storage textures when the WebGPU extension `bgra8unorm-storage` is enabled.




Issue: #3078

<hr>

**Requirements for PR author:**

- [*] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [*] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [*] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
