### PR TITLE
op: read-only storage textures in fragment shader

### DIFF
--- a/src/webgpu/api/operation/storage_texture/read_only.spec.ts
+++ b/src/webgpu/api/operation/storage_texture/read_only.spec.ts
@@ -12,13 +12,13 @@ TODO:
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { unreachable, assert } from '../../../../common/util/util.js';
 import { Float16Array } from '../../../../external/petamoriken/float16/float16.js';
-import { GPUConst } from '../../../constants.js';
 import {
   ColorTextureFormat,
   kColorTextureFormats,
   kTextureFormatInfo,
 } from '../../../format_info.js';
 import { GPUTest } from '../../../gpu_test.js';
+import { ShaderStage } from '../../../shader/validation/decl/util.js';
 
 function ComponentCount(format: ColorTextureFormat): number {
   switch (format) {
@@ -226,7 +226,7 @@ class F extends GPUTest {
 
   DoTransform(
     storageTexture: GPUTexture,
-    shaderStage: GPUShaderStageFlags,
+    shaderStage: ShaderStage,
     format: ColorTextureFormat,
     outputBuffer: GPUBuffer
   ) {
@@ -257,7 +257,7 @@ class F extends GPUTest {
     const commandEncoder = this.device.createCommandEncoder();
 
     switch (shaderStage) {
-      case GPUConst.ShaderStage.COMPUTE: {
+      case 'compute': {
         const textureLoadCoord =
           storageTexture.depthOrArrayLayers > 1
             ? `vec2u(invocationID.x, invocationID.y), invocationID.z`
@@ -293,7 +293,7 @@ class F extends GPUTest {
         computePassEncoder.end();
         break;
       }
-      case GPUConst.ShaderStage.FRAGMENT: {
+      case 'fragment': {
         const textureLoadCoord =
           storageTexture.depthOrArrayLayers > 1 ? 'textureCoord, z' : 'textureCoord';
 
@@ -375,7 +375,7 @@ class F extends GPUTest {
         renderPassEncoder.end();
         break;
       }
-      case GPUConst.ShaderStage.VERTEX: {
+      case 'vertex': {
         unreachable();
         break;
       }
@@ -397,10 +397,7 @@ g.test('basic')
     u
       .combine('format', kColorTextureFormats)
       .filter(p => kTextureFormatInfo[p.format].color?.storage === true)
-      .combine('shaderStage', [
-        GPUConst.ShaderStage.COMPUTE,
-        GPUConst.ShaderStage.FRAGMENT,
-      ] as const)
+      .combine('shaderStage', ['fragment', 'compute'] as const)
       .combine('depthOrArrayLayers', [1, 2] as const)
   )
   .fn(t => {

--- a/src/webgpu/api/operation/storage_texture/read_only.spec.ts
+++ b/src/webgpu/api/operation/storage_texture/read_only.spec.ts
@@ -2,7 +2,7 @@ export const description = `
 Tests for the behavior of read-only storage textures.
 
 TODO:
-- Test the use of read-only storage textures in vertex and fragment shaders
+- Test the use of read-only storage textures in vertex shader
 - Test 1D and 3D textures
 - Test mipmap level > 0
 - Test bgra8unorm with 'bgra8unorm-storage'
@@ -12,6 +12,7 @@ TODO:
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { unreachable, assert } from '../../../../common/util/util.js';
 import { Float16Array } from '../../../../external/petamoriken/float16/float16.js';
+import { GPUConst } from '../../../constants.js';
 import {
   ColorTextureFormat,
   kColorTextureFormats,
@@ -223,61 +224,163 @@ class F extends GPUTest {
     }
   }
 
-  DoTransform(storageTexture: GPUTexture, format: ColorTextureFormat, outputBuffer: GPUBuffer) {
+  DoTransform(
+    storageTexture: GPUTexture,
+    shaderStage: GPUShaderStageFlags,
+    format: ColorTextureFormat,
+    outputBuffer: GPUBuffer
+  ) {
     const declaration =
       storageTexture.depthOrArrayLayers > 1 ? 'texture_storage_2d_array' : 'texture_storage_2d';
     const textureDeclaration = `
     @group(0) @binding(0) var readOnlyTexture: ${declaration}<${format}, read>;
     `;
-
-    const textureLoadCoord =
-      storageTexture.depthOrArrayLayers > 1
-        ? `vec2u(invocationID.x, invocationID.y), invocationID.z`
-        : `vec2u(invocationID.x, invocationID.y)`;
-    const computeShader = `
+    const bindingResourceDeclaration = `
     ${textureDeclaration}
     @group(0) @binding(1)
     var<storage,read_write> outputBuffer : array<${this.GetOutputBufferWGSLType(format)}>;
-    @compute
-    @workgroup_size(${storageTexture.width}, ${storageTexture.height}, ${
-      storageTexture.depthOrArrayLayers
-    })
-    fn main(
-      @builtin(local_invocation_id) invocationID: vec3u,
-      @builtin(local_invocation_index) invocationIndex: u32) {
-      let initialValue = textureLoad(readOnlyTexture, ${textureLoadCoord});
-      outputBuffer[invocationIndex] = initialValue;
-    }`;
-    const computePipeline = this.device.createComputePipeline({
-      compute: {
-        module: this.device.createShaderModule({
-          code: computeShader,
-        }),
+    `;
+
+    const bindGroupEntries = [
+      {
+        binding: 0,
+        resource: storageTexture.createView(),
       },
-      layout: 'auto',
-    });
-    const bindGroup = this.device.createBindGroup({
-      layout: computePipeline.getBindGroupLayout(0),
-      entries: [
-        {
-          binding: 0,
-          resource: storageTexture.createView(),
+      {
+        binding: 1,
+        resource: {
+          buffer: outputBuffer,
         },
-        {
-          binding: 1,
-          resource: {
-            buffer: outputBuffer,
-          },
-        },
-      ],
-    });
+      },
+    ];
 
     const commandEncoder = this.device.createCommandEncoder();
-    const computePassEncoder = commandEncoder.beginComputePass();
-    computePassEncoder.setPipeline(computePipeline);
-    computePassEncoder.setBindGroup(0, bindGroup);
-    computePassEncoder.dispatchWorkgroups(1);
-    computePassEncoder.end();
+
+    switch (shaderStage) {
+      case GPUConst.ShaderStage.COMPUTE: {
+        const textureLoadCoord =
+          storageTexture.depthOrArrayLayers > 1
+            ? `vec2u(invocationID.x, invocationID.y), invocationID.z`
+            : `vec2u(invocationID.x, invocationID.y)`;
+
+        const computeShader = `
+      ${bindingResourceDeclaration}
+      @compute
+      @workgroup_size(${storageTexture.width}, ${storageTexture.height}, ${storageTexture.depthOrArrayLayers})
+      fn main(
+        @builtin(local_invocation_id) invocationID: vec3u,
+        @builtin(local_invocation_index) invocationIndex: u32) {
+        let initialValue = textureLoad(readOnlyTexture, ${textureLoadCoord});
+        outputBuffer[invocationIndex] = initialValue;
+      }`;
+        const computePipeline = this.device.createComputePipeline({
+          compute: {
+            module: this.device.createShaderModule({
+              code: computeShader,
+            }),
+          },
+          layout: 'auto',
+        });
+        const bindGroup = this.device.createBindGroup({
+          layout: computePipeline.getBindGroupLayout(0),
+          entries: bindGroupEntries,
+        });
+
+        const computePassEncoder = commandEncoder.beginComputePass();
+        computePassEncoder.setPipeline(computePipeline);
+        computePassEncoder.setBindGroup(0, bindGroup);
+        computePassEncoder.dispatchWorkgroups(1);
+        computePassEncoder.end();
+        break;
+      }
+      case GPUConst.ShaderStage.FRAGMENT: {
+        const textureLoadCoord =
+          storageTexture.depthOrArrayLayers > 1 ? 'textureCoord, z' : 'textureCoord';
+
+        const fragmentShader = `
+        ${bindingResourceDeclaration}
+        @fragment
+        fn main(@builtin(position) fragCoord: vec4f) -> @location(0) vec4f {
+          let textureCoord = vec2u(fragCoord.xy);
+          let storageTextureTexelCountPerImage = ${storageTexture.width * storageTexture.height}u;
+          for (var z = 0u; z < ${storageTexture.depthOrArrayLayers}; z++) {
+            let initialValue = textureLoad(readOnlyTexture, ${textureLoadCoord});
+            let outputIndex =
+              storageTextureTexelCountPerImage * z + textureCoord.y * ${storageTexture.height} +
+              textureCoord.x;
+            outputBuffer[outputIndex] = initialValue;
+          }
+          return vec4f(0.0, 1.0, 0.0, 1.0);
+        }`;
+        const vertexShader = `
+            @vertex
+            fn main(@builtin(vertex_index) VertexIndex : u32) -> @builtin(position) vec4f {
+                var pos = array(
+                  vec2f(-1.0, -1.0),
+                  vec2f(-1.0,  1.0),
+                  vec2f( 1.0, -1.0),
+                  vec2f(-1.0,  1.0),
+                  vec2f( 1.0, -1.0),
+                  vec2f( 1.0,  1.0));
+                return vec4f(pos[VertexIndex], 0.0, 1.0);
+            }
+          `;
+        const renderPipeline = this.device.createRenderPipeline({
+          layout: 'auto',
+          vertex: {
+            module: this.device.createShaderModule({
+              code: vertexShader,
+            }),
+          },
+          fragment: {
+            module: this.device.createShaderModule({
+              code: fragmentShader,
+            }),
+            targets: [
+              {
+                format: 'rgba8unorm',
+              },
+            ],
+          },
+          primitive: {
+            topology: 'triangle-list',
+          },
+        });
+
+        const bindGroup = this.device.createBindGroup({
+          layout: renderPipeline.getBindGroupLayout(0),
+          entries: bindGroupEntries,
+        });
+
+        const placeholderColorTexture = this.device.createTexture({
+          size: [storageTexture.width, storageTexture.height, 1],
+          usage: GPUTextureUsage.RENDER_ATTACHMENT,
+          format: 'rgba8unorm',
+        });
+        this.trackForCleanup(placeholderColorTexture);
+
+        const renderPassEncoder = commandEncoder.beginRenderPass({
+          colorAttachments: [
+            {
+              view: placeholderColorTexture.createView(),
+              loadOp: 'clear',
+              clearValue: { r: 0, g: 0, b: 0, a: 0 },
+              storeOp: 'store',
+            },
+          ],
+        });
+        renderPassEncoder.setPipeline(renderPipeline);
+        renderPassEncoder.setBindGroup(0, bindGroup);
+        renderPassEncoder.draw(6);
+        renderPassEncoder.end();
+        break;
+      }
+      case GPUConst.ShaderStage.VERTEX: {
+        unreachable();
+        break;
+      }
+    }
+
     this.queue.submit([commandEncoder.finish()]);
   }
 }
@@ -294,10 +397,14 @@ g.test('basic')
     u
       .combine('format', kColorTextureFormats)
       .filter(p => kTextureFormatInfo[p.format].color?.storage === true)
+      .combine('shaderStage', [
+        GPUConst.ShaderStage.COMPUTE,
+        GPUConst.ShaderStage.FRAGMENT,
+      ] as const)
       .combine('depthOrArrayLayers', [1, 2] as const)
   )
   .fn(t => {
-    const { format, depthOrArrayLayers } = t.params;
+    const { format, shaderStage, depthOrArrayLayers } = t.params;
 
     const kWidth = 8;
     const height = 8;
@@ -317,7 +424,7 @@ g.test('basic')
     });
     t.trackForCleanup(outputBuffer);
 
-    t.DoTransform(storageTexture, format, outputBuffer);
+    t.DoTransform(storageTexture, shaderStage, format, outputBuffer);
 
     switch (kTextureFormatInfo[format].color.type) {
       case 'uint':

--- a/src/webgpu/api/operation/storage_texture/read_only.spec.ts
+++ b/src/webgpu/api/operation/storage_texture/read_only.spec.ts
@@ -376,6 +376,7 @@ class F extends GPUTest {
         break;
       }
       case 'vertex': {
+        // Not implemented yet.
         unreachable();
         break;
       }

--- a/src/webgpu/api/operation/storage_texture/read_only.spec.ts
+++ b/src/webgpu/api/operation/storage_texture/read_only.spec.ts
@@ -306,7 +306,7 @@ class F extends GPUTest {
           for (var z = 0u; z < ${storageTexture.depthOrArrayLayers}; z++) {
             let initialValue = textureLoad(readOnlyTexture, ${textureLoadCoord});
             let outputIndex =
-              storageTextureTexelCountPerImage * z + textureCoord.y * ${storageTexture.height} +
+              storageTextureTexelCountPerImage * z + textureCoord.y * ${storageTexture.width} +
               textureCoord.x;
             outputBuffer[outputIndex] = initialValue;
           }

--- a/src/webgpu/api/operation/storage_texture/read_only.spec.ts
+++ b/src/webgpu/api/operation/storage_texture/read_only.spec.ts
@@ -314,7 +314,7 @@ class F extends GPUTest {
         }`;
         const vertexShader = `
             @vertex
-            fn main(@builtin(vertex_index) VertexIndex : u32) -> @builtin(position) vec4f {
+            fn main(@builtin(vertex_index) vertexIndex : u32) -> @builtin(position) vec4f {
                 var pos = array(
                   vec2f(-1.0, -1.0),
                   vec2f(-1.0,  1.0),
@@ -322,7 +322,7 @@ class F extends GPUTest {
                   vec2f(-1.0,  1.0),
                   vec2f( 1.0, -1.0),
                   vec2f( 1.0,  1.0));
-                return vec4f(pos[VertexIndex], 0.0, 1.0);
+                return vec4f(pos[vertexIndex], 0.0, 1.0);
             }
           `;
         const renderPipeline = this.device.createRenderPipeline({

--- a/src/webgpu/api/operation/storage_texture/read_only.spec.ts
+++ b/src/webgpu/api/operation/storage_texture/read_only.spec.ts
@@ -17,7 +17,7 @@ import {
   kTextureFormatInfo,
 } from '../../../format_info.js';
 import { GPUTest } from '../../../gpu_test.js';
-import { ShaderStage } from '../../../shader/validation/decl/util.js';
+import { TValidShaderStage } from '../../../util/shader.js';
 
 function ComponentCount(format: ColorTextureFormat): number {
   switch (format) {
@@ -237,7 +237,7 @@ class F extends GPUTest {
 
   DoTransform(
     storageTexture: GPUTexture,
-    shaderStage: ShaderStage,
+    shaderStage: TValidShaderStage,
     format: ColorTextureFormat,
     outputBuffer: GPUBuffer
   ) {
@@ -386,11 +386,10 @@ class F extends GPUTest {
         renderPassEncoder.end();
         break;
       }
-      case 'vertex': {
+      case 'vertex':
         // Not implemented yet.
         unreachable();
         break;
-      }
     }
 
     this.queue.submit([commandEncoder.finish()]);

--- a/src/webgpu/util/shader.ts
+++ b/src/webgpu/util/shader.ts
@@ -178,7 +178,9 @@ export function getFragmentShaderCodeWithOutput(
     }`;
 }
 
-export type TShaderStage = 'compute' | 'vertex' | 'fragment' | 'empty';
+export const kValidShaderStages = ['compute', 'vertex', 'fragment'] as const;
+export type TValidShaderStage = (typeof kValidShaderStages)[number];
+export type TShaderStage = TValidShaderStage | 'empty';
 
 /**
  * Return a foo shader of the given stage with the given entry point


### PR DESCRIPTION


Issue: #3078

<hr>

**Requirements for PR author:**

- [*] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [*] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [*] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
