### PR TITLE
Compat: Skip new storage texture rg32 tests

### DIFF
--- a/src/webgpu/api/operation/storage_texture/read_only.spec.ts
+++ b/src/webgpu/api/operation/storage_texture/read_only.spec.ts
@@ -529,9 +529,8 @@ g.test('basic')
       .combine('depthOrArrayLayers', [1, 2] as const)
   )
   .beforeAllSubcases(t => {
-    if (t.params.format === 'bgra8unorm') {
-      t.selectDeviceOrSkipTestCase('bgra8unorm-storage');
-    }
+    t.skipIfTextureFormatNotUsableAsStorageTexture(t.params.format);
+    t.selectDeviceForTextureFormatOrSkipTestCase(t.params.format);
   })
   .fn(t => {
     const { format, shaderStage, depthOrArrayLayers } = t.params;

--- a/src/webgpu/api/operation/storage_texture/read_only.spec.ts
+++ b/src/webgpu/api/operation/storage_texture/read_only.spec.ts
@@ -529,8 +529,12 @@ g.test('basic')
       .combine('depthOrArrayLayers', [1, 2] as const)
   )
   .beforeAllSubcases(t => {
-    t.skipIfTextureFormatNotUsableAsStorageTexture(t.params.format);
-    t.selectDeviceForTextureFormatOrSkipTestCase(t.params.format);
+    if (t.params.format === 'bgra8unorm') {
+      t.selectDeviceOrSkipTestCase('bgra8unorm-storage');
+    }
+    if (t.isCompatibility) {
+      t.skipIfTextureFormatNotUsableAsStorageTexture(t.params.format);
+    }
   })
   .fn(t => {
     const { format, shaderStage, depthOrArrayLayers } = t.params;

--- a/src/webgpu/api/operation/storage_texture/read_write.spec.ts
+++ b/src/webgpu/api/operation/storage_texture/read_write.spec.ts
@@ -316,6 +316,9 @@ g.test('basic')
       .combine('depthOrArrayLayers', [1, 2] as const)
       .unless(p => p.textureDimension === '1d' && p.depthOrArrayLayers > 1)
   )
+  .beforeAllSubcases(t => {
+    t.skipIfTextureFormatNotUsableAsStorageTexture(t.params.format);
+  })
   .fn(t => {
     const { format, shaderStage, textureDimension, depthOrArrayLayers } = t.params;
 


### PR DESCRIPTION
Compat doesn't support rg32xxx textures


<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
