### PR TITLE
Add timing information to server CTS runner

### DIFF
--- a/src/common/runtime/server.ts
+++ b/src/common/runtime/server.ts
@@ -48,6 +48,8 @@ interface RunResult {
   status: Status;
   // Any additional messages printed
   message: string;
+  // The time it took to execute the test
+  durationMS: number;
   // Code coverage data, if the server was started with `--coverage`
   // This data is opaque (implementation defined).
   coverageData?: string;
@@ -202,14 +204,16 @@ if (verbose) {
             if (codeCoverage !== undefined) {
               codeCoverage.begin();
             }
+            const start = performance.now();
             const result = await runTestcase(testcase);
+            const durationMS = performance.now() - start;
             const coverageData = codeCoverage !== undefined ? codeCoverage.end() : undefined;
             let message = '';
             if (result.logs !== undefined) {
               message = result.logs.map(log => prettyPrintLog(log)).join('\n');
             }
             const status = result.status;
-            const res: RunResult = { status, message, coverageData };
+            const res: RunResult = { status, message, durationMS, coverageData };
             response.statusCode = 200;
             response.end(JSON.stringify(res));
           } else {


### PR DESCRIPTION
<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
