### PR TITLE
Add compat mode testing to the PR checklist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,6 +10,7 @@ Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->
 - [ ] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
 - [ ] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
 - [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
+- [ ] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)
 
 **Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**
 


### PR DESCRIPTION
I'm not sure it's valid to put this here as for example, Safari will not have compat mode. But, at least at the moment, we have the issue that new tests can fail in compat and should either be refactored if they can be or else skipped.

It's also possible to enforce compat validation via an extension so I could go write one for Safari if the need is there. 

Most just hoping that adding this will remind me and others to test compat if possible.