### PR TITLE
Resource compatibility validation

### DIFF
--- a/src/webgpu/api/validation/compute_pipeline.spec.ts
+++ b/src/webgpu/api/validation/compute_pipeline.spec.ts
@@ -703,15 +703,21 @@ g.test('resource_compatibility')
   )
   .params(u =>
     u //
-      .combine('api_resource', kAPIResources)
+      .combine('apiResource', kAPIResources)
       .beginSubcases()
       .combine('isAsync', [true, false] as const)
-      .combine('wgsl_resource', kAPIResources)
+      .combine('wgslResource', kAPIResources)
   )
   .fn(t => {
+    t.skipIf(
+      t.params.wgslResource.storageTexture !== undefined &&
+        !t.hasLanguageFeature('readonly_and_readwrite_storage_textures'),
+      'Storage textures require language feature'
+    );
+
     const layout = t.device.createPipelineLayout({
       bindGroupLayouts: [
-        getAPIBindGroupLayoutForResource(t.device, GPUShaderStage.COMPUTE, t.params.api_resource),
+        getAPIBindGroupLayoutForResource(t.device, GPUShaderStage.COMPUTE, t.params.apiResource),
       ],
     });
 
@@ -719,14 +725,14 @@ g.test('resource_compatibility')
       layout,
       compute: {
         module: t.device.createShaderModule({
-          code: getWGSLShaderForResource('compute', t.params.wgsl_resource),
+          code: getWGSLShaderForResource('compute', t.params.wgslResource),
         }),
         entryPoint: 'main',
       },
     };
     t.doCreateComputePipelineTest(
       t.params.isAsync,
-      doResourcesMatch(t.params.api_resource, t.params.wgsl_resource),
+      doResourcesMatch(t.params.apiResource, t.params.wgslResource),
       descriptor
     );
   });

--- a/src/webgpu/api/validation/utils.ts
+++ b/src/webgpu/api/validation/utils.ts
@@ -1,0 +1,244 @@
+interface Resource {
+  buffer?: GPUBufferBindingLayout;
+  sampler?: GPUSamplerBindingLayout;
+  texture?: GPUTextureBindingLayout;
+  code: string;
+  staticUse?: string;
+}
+
+export const kAPIResources: Resource[] = [
+  // Buffers
+  {
+    buffer: { type: 'uniform' },
+    code: `var<uniform> res : array<vec4u, 16>`,
+    staticUse: `res[0]`,
+  },
+  {
+    buffer: { type: 'storage' },
+    code: `var<storage, read_write> res : array<vec4u>`,
+    staticUse: `res[0]`,
+  },
+  {
+    buffer: { type: 'read-only-storage' },
+    code: `var<storage> res : array<vec4u>`,
+    staticUse: `res[0]`,
+  },
+
+  // Samplers
+  {
+    sampler: { type: 'filtering' },
+    code: `var res : sampler`,
+  },
+  {
+    sampler: { type: 'non-filtering' },
+    code: `var res : sampler`,
+  },
+  {
+    sampler: { type: 'comparison' },
+    code: `var res : sampler_comparison`,
+  },
+
+  // Sampled textures
+  {
+    texture: { sampleType: 'float', viewDimension: '1d', multisampled: false },
+    code: `var res : texture_1d<f32>`,
+  },
+  {
+    texture: { sampleType: 'float', viewDimension: '2d', multisampled: false },
+    code: `var res : texture_2d<f32>`,
+  },
+  {
+    texture: { sampleType: 'float', viewDimension: '2d-array', multisampled: false },
+    code: `var res : texture_2d_array<f32>`,
+  },
+  {
+    texture: { sampleType: 'float', viewDimension: '3d', multisampled: false },
+    code: `var res : texture_3d<f32>`,
+  },
+  {
+    texture: { sampleType: 'float', viewDimension: 'cube', multisampled: false },
+    code: `var res : texture_cube<f32>`,
+  },
+  {
+    texture: { sampleType: 'float', viewDimension: 'cube-array', multisampled: false },
+    code: `var res : texture_cube_array<f32>`,
+  },
+  {
+    texture: { sampleType: 'unfilterable-float', viewDimension: '1d', multisampled: false },
+    code: `var res : texture_1d<f32>`,
+  },
+  {
+    texture: { sampleType: 'unfilterable-float', viewDimension: '2d', multisampled: false },
+    code: `var res : texture_2d<f32>`,
+  },
+  {
+    texture: { sampleType: 'unfilterable-float', viewDimension: '2d-array', multisampled: false },
+    code: `var res : texture_2d_array<f32>`,
+  },
+  {
+    texture: { sampleType: 'unfilterable-float', viewDimension: '3d', multisampled: false },
+    code: `var res : texture_3d<f32>`,
+  },
+  {
+    texture: { sampleType: 'unfilterable-float', viewDimension: 'cube', multisampled: false },
+    code: `var res : texture_cube<f32>`,
+  },
+  {
+    texture: { sampleType: 'unfilterable-float', viewDimension: 'cube-array', multisampled: false },
+    code: `var res : texture_cube_array<f32>`,
+  },
+  {
+    texture: { sampleType: 'depth', viewDimension: '2d', multisampled: false },
+    code: `var res : texture_depth_2d`,
+  },
+  {
+    texture: { sampleType: 'depth', viewDimension: '2d', multisampled: true },
+    code: `var res : texture_depth_multisampled_2d`,
+  },
+  {
+    texture: { sampleType: 'depth', viewDimension: '2d-array', multisampled: false },
+    code: `var res : texture_depth_2d_array`,
+  },
+  {
+    texture: { sampleType: 'depth', viewDimension: 'cube', multisampled: false },
+    code: `var res : texture_depth_cube`,
+  },
+  {
+    texture: { sampleType: 'depth', viewDimension: 'cube-array', multisampled: false },
+    code: `var res : texture_depth_cube_array`,
+  },
+  {
+    texture: { sampleType: 'sint', viewDimension: '1d', multisampled: false },
+    code: `var res : texture_1d<i32>`,
+  },
+  {
+    texture: { sampleType: 'sint', viewDimension: '2d', multisampled: false },
+    code: `var res : texture_2d<i32>`,
+  },
+  {
+    texture: { sampleType: 'sint', viewDimension: '2d', multisampled: true },
+    code: `var res : texture_multisampled_2d<i32>`,
+  },
+  {
+    texture: { sampleType: 'sint', viewDimension: '2d-array', multisampled: false },
+    code: `var res : texture_2d_array<i32>`,
+  },
+  {
+    texture: { sampleType: 'sint', viewDimension: '3d', multisampled: false },
+    code: `var res : texture_3d<i32>`,
+  },
+  {
+    texture: { sampleType: 'sint', viewDimension: 'cube', multisampled: false },
+    code: `var res : texture_cube<i32>`,
+  },
+  {
+    texture: { sampleType: 'sint', viewDimension: 'cube-array', multisampled: false },
+    code: `var res : texture_cube_array<i32>`,
+  },
+  {
+    texture: { sampleType: 'uint', viewDimension: '1d', multisampled: false },
+    code: `var res : texture_1d<u32>`,
+  },
+  {
+    texture: { sampleType: 'uint', viewDimension: '2d', multisampled: false },
+    code: `var res : texture_2d<u32>`,
+  },
+  {
+    texture: { sampleType: 'uint', viewDimension: '2d', multisampled: true },
+    code: `var res : texture_multisampled_2d<u32>`,
+  },
+  {
+    texture: { sampleType: 'uint', viewDimension: '2d-array', multisampled: false },
+    code: `var res : texture_2d_array<u32>`,
+  },
+  {
+    texture: { sampleType: 'uint', viewDimension: '3d', multisampled: false },
+    code: `var res : texture_3d<u32>`,
+  },
+  {
+    texture: { sampleType: 'uint', viewDimension: 'cube', multisampled: false },
+    code: `var res : texture_cube<u32>`,
+  },
+  {
+    texture: { sampleType: 'uint', viewDimension: 'cube-array', multisampled: false },
+    code: `var res : texture_cube_array<u32>`,
+  },
+];
+
+export function getWGSLShaderForResource(stage: string, resource: Resource): string {
+  let code = `@group(0) @binding(0) ${resource.code};\n`;
+
+  code += `@${stage}`;
+  if (stage === 'compute') {
+    code += `@workgroup_size(1)`;
+  }
+
+  code += `
+fn main() {
+  _ = ${resource.staticUse ? resource.staticUse : 'res'};
+}
+`;
+
+  return code;
+}
+
+export function getAPIBindGroupLayoutForResource(
+  device: GPUDevice,
+  stage: GPUShaderStageFlags,
+  resource: Resource
+): GPUBindGroupLayout {
+  const entry: GPUBindGroupLayoutEntry = {
+    binding: 0,
+    visibility: stage,
+  };
+  if (resource.buffer) {
+    entry.buffer = resource.buffer;
+  }
+  if (resource.sampler) {
+    entry.sampler = resource.sampler;
+  }
+  if (resource.texture) {
+    entry.texture = resource.texture;
+  }
+
+  return device.createBindGroupLayout({ entries: [entry] });
+}
+
+function doSampleTypesMatch(api: GPUTextureSampleType, wgsl: GPUTextureSampleType): boolean {
+  if (api === 'float' || api === 'unfilterable-float') {
+    return wgsl === 'float' || wgsl === 'unfilterable-float';
+  }
+  return api === wgsl;
+}
+
+export function doResourcesMatch(api: Resource, wgsl: Resource): boolean {
+  if (api.buffer) {
+    if (!wgsl.buffer) {
+      return false;
+    }
+    return api.buffer.type === wgsl.buffer.type;
+  }
+  if (api.sampler) {
+    if (!wgsl.sampler) {
+      return false;
+    }
+    return (
+      api.sampler.type === wgsl.sampler.type ||
+      (api.sampler.type !== 'comparison' && wgsl.sampler.type !== 'comparison')
+    );
+  }
+  if (api.texture) {
+    if (!wgsl.texture) {
+      return false;
+    }
+    const aType = api.texture.sampleType as GPUTextureSampleType;
+    const wType = wgsl.texture.sampleType as GPUTextureSampleType;
+    return (
+      doSampleTypesMatch(aType, wType) &&
+      api.texture.viewDimension === wgsl.texture.viewDimension &&
+      api.texture.multisampled === wgsl.texture.multisampled
+    );
+  }
+
+  return false;
+}

--- a/src/webgpu/api/validation/utils.ts
+++ b/src/webgpu/api/validation/utils.ts
@@ -1,14 +1,14 @@
 interface Resource {
-  buffer?: GPUBufferBindingLayout;
-  sampler?: GPUSamplerBindingLayout;
-  texture?: GPUTextureBindingLayout;
-  storageTexture?: GPUStorageTextureBindingLayout;
-  externalTexture?: GPUExternalTextureBindingLayout;
-  code: string;
-  staticUse?: string;
+  readonly buffer?: GPUBufferBindingLayout;
+  readonly sampler?: GPUSamplerBindingLayout;
+  readonly texture?: GPUTextureBindingLayout;
+  readonly storageTexture?: GPUStorageTextureBindingLayout;
+  readonly externalTexture?: GPUExternalTextureBindingLayout;
+  readonly code: string;
+  readonly staticUse?: string;
 }
 
-export const kAPIResources: Resource[] = [
+export const kAPIResources: readonly Resource[] = [
   // Buffers
   {
     buffer: { type: 'uniform' },
@@ -326,7 +326,7 @@ export function getWGSLShaderForResource(stage: string, resource: Resource): str
   const retVal = stage === 'vertex' ? 'return vecf();' : '';
   code += `
 fn main() ${retTy} {
-  _ = ${resource.staticUse ? resource.staticUse : 'res'};
+  _ = ${resource.staticUse ?? 'res'};
   ${retVal}
 }
 `;

--- a/src/webgpu/api/validation/utils.ts
+++ b/src/webgpu/api/validation/utils.ts
@@ -2,6 +2,8 @@ interface Resource {
   buffer?: GPUBufferBindingLayout;
   sampler?: GPUSamplerBindingLayout;
   texture?: GPUTextureBindingLayout;
+  storageTexture?: GPUStorageTextureBindingLayout;
+  externalTexture?: GPUExternalTextureBindingLayout;
   code: string;
   staticUse?: string;
 }
@@ -163,6 +165,153 @@ export const kAPIResources: Resource[] = [
     texture: { sampleType: 'uint', viewDimension: 'cube-array', multisampled: false },
     code: `var res : texture_cube_array<u32>`,
   },
+
+  // Storage textures
+  // Only cover r32uint, r32sint, and r32float here for ease of testing.
+  {
+    storageTexture: { access: 'write-only', format: 'r32uint', viewDimension: '1d' },
+    code: `var res : texture_storage_1d<r32uint, write>`,
+  },
+  {
+    storageTexture: { access: 'write-only', format: 'r32sint', viewDimension: '1d' },
+    code: `var res : texture_storage_1d<r32sint, write>`,
+  },
+  {
+    storageTexture: { access: 'write-only', format: 'r32float', viewDimension: '1d' },
+    code: `var res : texture_storage_1d<r32float, write>`,
+  },
+  {
+    storageTexture: { access: 'write-only', format: 'r32uint', viewDimension: '2d' },
+    code: `var res : texture_storage_2d<r32uint, write>`,
+  },
+  {
+    storageTexture: { access: 'write-only', format: 'r32sint', viewDimension: '2d' },
+    code: `var res : texture_storage_2d<r32sint, write>`,
+  },
+  {
+    storageTexture: { access: 'write-only', format: 'r32float', viewDimension: '2d' },
+    code: `var res : texture_storage_2d<r32float, write>`,
+  },
+  {
+    storageTexture: { access: 'write-only', format: 'r32uint', viewDimension: '2d-array' },
+    code: `var res : texture_storage_2d_array<r32uint, write>`,
+  },
+  {
+    storageTexture: { access: 'write-only', format: 'r32sint', viewDimension: '2d-array' },
+    code: `var res : texture_storage_2d_array<r32sint, write>`,
+  },
+  {
+    storageTexture: { access: 'write-only', format: 'r32float', viewDimension: '2d-array' },
+    code: `var res : texture_storage_2d_array<r32float, write>`,
+  },
+  {
+    storageTexture: { access: 'write-only', format: 'r32uint', viewDimension: '3d' },
+    code: `var res : texture_storage_3d<r32uint, write>`,
+  },
+  {
+    storageTexture: { access: 'write-only', format: 'r32sint', viewDimension: '3d' },
+    code: `var res : texture_storage_3d<r32sint, write>`,
+  },
+  {
+    storageTexture: { access: 'write-only', format: 'r32float', viewDimension: '3d' },
+    code: `var res : texture_storage_3d<r32float, write>`,
+  },
+  {
+    storageTexture: { access: 'read-only', format: 'r32uint', viewDimension: '1d' },
+    code: `var res : texture_storage_1d<r32uint, read>`,
+  },
+  {
+    storageTexture: { access: 'read-only', format: 'r32sint', viewDimension: '1d' },
+    code: `var res : texture_storage_1d<r32sint, read>`,
+  },
+  {
+    storageTexture: { access: 'read-only', format: 'r32float', viewDimension: '1d' },
+    code: `var res : texture_storage_1d<r32float, read>`,
+  },
+  {
+    storageTexture: { access: 'read-only', format: 'r32uint', viewDimension: '2d' },
+    code: `var res : texture_storage_2d<r32uint, read>`,
+  },
+  {
+    storageTexture: { access: 'read-only', format: 'r32sint', viewDimension: '2d' },
+    code: `var res : texture_storage_2d<r32sint, read>`,
+  },
+  {
+    storageTexture: { access: 'read-only', format: 'r32float', viewDimension: '2d' },
+    code: `var res : texture_storage_2d<r32float, read>`,
+  },
+  {
+    storageTexture: { access: 'read-only', format: 'r32uint', viewDimension: '2d-array' },
+    code: `var res : texture_storage_2d_array<r32uint, read>`,
+  },
+  {
+    storageTexture: { access: 'read-only', format: 'r32sint', viewDimension: '2d-array' },
+    code: `var res : texture_storage_2d_array<r32sint, read>`,
+  },
+  {
+    storageTexture: { access: 'read-only', format: 'r32float', viewDimension: '2d-array' },
+    code: `var res : texture_storage_2d_array<r32float, read>`,
+  },
+  {
+    storageTexture: { access: 'read-only', format: 'r32uint', viewDimension: '3d' },
+    code: `var res : texture_storage_3d<r32uint, read>`,
+  },
+  {
+    storageTexture: { access: 'read-only', format: 'r32sint', viewDimension: '3d' },
+    code: `var res : texture_storage_3d<r32sint, read>`,
+  },
+  {
+    storageTexture: { access: 'read-only', format: 'r32float', viewDimension: '3d' },
+    code: `var res : texture_storage_3d<r32float, read>`,
+  },
+  {
+    storageTexture: { access: 'read-write', format: 'r32uint', viewDimension: '1d' },
+    code: `var res : texture_storage_1d<r32uint, read_write>`,
+  },
+  {
+    storageTexture: { access: 'read-write', format: 'r32sint', viewDimension: '1d' },
+    code: `var res : texture_storage_1d<r32sint, read_write>`,
+  },
+  {
+    storageTexture: { access: 'read-write', format: 'r32float', viewDimension: '1d' },
+    code: `var res : texture_storage_1d<r32float, read_write>`,
+  },
+  {
+    storageTexture: { access: 'read-write', format: 'r32uint', viewDimension: '2d' },
+    code: `var res : texture_storage_2d<r32uint, read_write>`,
+  },
+  {
+    storageTexture: { access: 'read-write', format: 'r32sint', viewDimension: '2d' },
+    code: `var res : texture_storage_2d<r32sint, read_write>`,
+  },
+  {
+    storageTexture: { access: 'read-write', format: 'r32float', viewDimension: '2d' },
+    code: `var res : texture_storage_2d<r32float, read_write>`,
+  },
+  {
+    storageTexture: { access: 'read-write', format: 'r32uint', viewDimension: '2d-array' },
+    code: `var res : texture_storage_2d_array<r32uint, read_write>`,
+  },
+  {
+    storageTexture: { access: 'read-write', format: 'r32sint', viewDimension: '2d-array' },
+    code: `var res : texture_storage_2d_array<r32sint, read_write>`,
+  },
+  {
+    storageTexture: { access: 'read-write', format: 'r32float', viewDimension: '2d-array' },
+    code: `var res : texture_storage_2d_array<r32float, read_write>`,
+  },
+  {
+    storageTexture: { access: 'read-write', format: 'r32uint', viewDimension: '3d' },
+    code: `var res : texture_storage_3d<r32uint, read_write>`,
+  },
+  {
+    storageTexture: { access: 'read-write', format: 'r32sint', viewDimension: '3d' },
+    code: `var res : texture_storage_3d<r32sint, read_write>`,
+  },
+  {
+    storageTexture: { access: 'read-write', format: 'r32float', viewDimension: '3d' },
+    code: `var res : texture_storage_3d<r32float, read_write>`,
+  },
 ];
 
 export function getWGSLShaderForResource(stage: string, resource: Resource): string {
@@ -173,9 +322,12 @@ export function getWGSLShaderForResource(stage: string, resource: Resource): str
     code += `@workgroup_size(1)`;
   }
 
+  const retTy = stage === 'vertex' ? ' -> @builtin(position) vec4f' : '';
+  const retVal = stage === 'vertex' ? 'return vecf();' : '';
   code += `
-fn main() {
+fn main() ${retTy} {
   _ = ${resource.staticUse ? resource.staticUse : 'res'};
+  ${retVal}
 }
 `;
 
@@ -200,13 +352,27 @@ export function getAPIBindGroupLayoutForResource(
   if (resource.texture) {
     entry.texture = resource.texture;
   }
+  if (resource.storageTexture) {
+    entry.storageTexture = resource.storageTexture;
+  }
+  if (resource.externalTexture) {
+    entry.externalTexture = resource.externalTexture;
+  }
 
-  return device.createBindGroupLayout({ entries: [entry] });
+  const entries: GPUBindGroupLayoutEntry[] = [entry];
+  return device.createBindGroupLayout({ entries });
 }
 
 function doSampleTypesMatch(api: GPUTextureSampleType, wgsl: GPUTextureSampleType): boolean {
   if (api === 'float' || api === 'unfilterable-float') {
     return wgsl === 'float' || wgsl === 'unfilterable-float';
+  }
+  return api === wgsl;
+}
+
+function doAccessesMatch(api: GPUStorageTextureAccess, wgsl: GPUStorageTextureAccess): boolean {
+  if (api === 'read-write') {
+    return wgsl === 'read-write' || wgsl === 'write-only';
   }
   return api === wgsl;
 }
@@ -238,6 +404,21 @@ export function doResourcesMatch(api: Resource, wgsl: Resource): boolean {
       api.texture.viewDimension === wgsl.texture.viewDimension &&
       api.texture.multisampled === wgsl.texture.multisampled
     );
+  }
+  if (api.storageTexture) {
+    if (!wgsl.storageTexture) {
+      return false;
+    }
+    const aAccess = api.storageTexture.access as GPUStorageTextureAccess;
+    const wAccess = wgsl.storageTexture.access as GPUStorageTextureAccess;
+    return (
+      doAccessesMatch(aAccess, wAccess) &&
+      api.storageTexture.format === wgsl.storageTexture.format &&
+      api.storageTexture.viewDimension === wgsl.storageTexture.viewDimension
+    );
+  }
+  if (api.externalTexture) {
+    return wgsl.externalTexture !== undefined;
   }
 
   return false;

--- a/src/webgpu/api/validation/utils.ts
+++ b/src/webgpu/api/validation/utils.ts
@@ -8,312 +8,143 @@ interface Resource {
   readonly staticUse?: string;
 }
 
-export const kAPIResources: readonly Resource[] = [
-  // Buffers
-  {
-    buffer: { type: 'uniform' },
-    code: `var<uniform> res : array<vec4u, 16>`,
-    staticUse: `res[0]`,
-  },
-  {
-    buffer: { type: 'storage' },
-    code: `var<storage, read_write> res : array<vec4u>`,
-    staticUse: `res[0]`,
-  },
-  {
-    buffer: { type: 'read-only-storage' },
-    code: `var<storage> res : array<vec4u>`,
-    staticUse: `res[0]`,
-  },
+/**
+ * Returns an array of possible resources
+ */
+function generateResources(): Resource[] {
+  const resources: Resource[] = [
+    // Buffers
+    {
+      buffer: { type: 'uniform' },
+      code: `var<uniform> res : array<vec4u, 16>`,
+      staticUse: `res[0]`,
+    },
+    {
+      buffer: { type: 'storage' },
+      code: `var<storage, read_write> res : array<vec4u>`,
+      staticUse: `res[0]`,
+    },
+    {
+      buffer: { type: 'read-only-storage' },
+      code: `var<storage> res : array<vec4u>`,
+      staticUse: `res[0]`,
+    },
 
-  // Samplers
-  {
-    sampler: { type: 'filtering' },
-    code: `var res : sampler`,
-  },
-  {
-    sampler: { type: 'non-filtering' },
-    code: `var res : sampler`,
-  },
-  {
-    sampler: { type: 'comparison' },
-    code: `var res : sampler_comparison`,
-  },
+    // Samplers
+    {
+      sampler: { type: 'filtering' },
+      code: `var res : sampler`,
+    },
+    {
+      sampler: { type: 'non-filtering' },
+      code: `var res : sampler`,
+    },
+    {
+      sampler: { type: 'comparison' },
+      code: `var res : sampler_comparison`,
+    },
+    // Multisampled textures
+    {
+      texture: { sampleType: 'depth', viewDimension: '2d', multisampled: true },
+      code: `var res : texture_depth_multisampled_2d`,
+    },
+    {
+      texture: { sampleType: 'unfilterable-float', viewDimension: '2d', multisampled: true },
+      code: `var res : texture_multisampled_2d<f32>`,
+    },
+    {
+      texture: { sampleType: 'sint', viewDimension: '2d', multisampled: true },
+      code: `var res : texture_multisampled_2d<i32>`,
+    },
+    {
+      texture: { sampleType: 'uint', viewDimension: '2d', multisampled: true },
+      code: `var res : texture_multisampled_2d<u32>`,
+    },
+  ];
 
   // Sampled textures
-  {
-    texture: { sampleType: 'float', viewDimension: '1d', multisampled: false },
-    code: `var res : texture_1d<f32>`,
-  },
-  {
-    texture: { sampleType: 'float', viewDimension: '2d', multisampled: false },
-    code: `var res : texture_2d<f32>`,
-  },
-  {
-    texture: { sampleType: 'float', viewDimension: '2d-array', multisampled: false },
-    code: `var res : texture_2d_array<f32>`,
-  },
-  {
-    texture: { sampleType: 'float', viewDimension: '3d', multisampled: false },
-    code: `var res : texture_3d<f32>`,
-  },
-  {
-    texture: { sampleType: 'float', viewDimension: 'cube', multisampled: false },
-    code: `var res : texture_cube<f32>`,
-  },
-  {
-    texture: { sampleType: 'float', viewDimension: 'cube-array', multisampled: false },
-    code: `var res : texture_cube_array<f32>`,
-  },
-  {
-    texture: { sampleType: 'unfilterable-float', viewDimension: '1d', multisampled: false },
-    code: `var res : texture_1d<f32>`,
-  },
-  {
-    texture: { sampleType: 'unfilterable-float', viewDimension: '2d', multisampled: false },
-    code: `var res : texture_2d<f32>`,
-  },
-  {
-    texture: { sampleType: 'unfilterable-float', viewDimension: '2d-array', multisampled: false },
-    code: `var res : texture_2d_array<f32>`,
-  },
-  {
-    texture: { sampleType: 'unfilterable-float', viewDimension: '3d', multisampled: false },
-    code: `var res : texture_3d<f32>`,
-  },
-  {
-    texture: { sampleType: 'unfilterable-float', viewDimension: 'cube', multisampled: false },
-    code: `var res : texture_cube<f32>`,
-  },
-  {
-    texture: { sampleType: 'unfilterable-float', viewDimension: 'cube-array', multisampled: false },
-    code: `var res : texture_cube_array<f32>`,
-  },
-  {
-    texture: { sampleType: 'depth', viewDimension: '2d', multisampled: false },
-    code: `var res : texture_depth_2d`,
-  },
-  {
-    texture: { sampleType: 'depth', viewDimension: '2d', multisampled: true },
-    code: `var res : texture_depth_multisampled_2d`,
-  },
-  {
-    texture: { sampleType: 'depth', viewDimension: '2d-array', multisampled: false },
-    code: `var res : texture_depth_2d_array`,
-  },
-  {
-    texture: { sampleType: 'depth', viewDimension: 'cube', multisampled: false },
-    code: `var res : texture_depth_cube`,
-  },
-  {
-    texture: { sampleType: 'depth', viewDimension: 'cube-array', multisampled: false },
-    code: `var res : texture_depth_cube_array`,
-  },
-  {
-    texture: { sampleType: 'sint', viewDimension: '1d', multisampled: false },
-    code: `var res : texture_1d<i32>`,
-  },
-  {
-    texture: { sampleType: 'sint', viewDimension: '2d', multisampled: false },
-    code: `var res : texture_2d<i32>`,
-  },
-  {
-    texture: { sampleType: 'sint', viewDimension: '2d', multisampled: true },
-    code: `var res : texture_multisampled_2d<i32>`,
-  },
-  {
-    texture: { sampleType: 'sint', viewDimension: '2d-array', multisampled: false },
-    code: `var res : texture_2d_array<i32>`,
-  },
-  {
-    texture: { sampleType: 'sint', viewDimension: '3d', multisampled: false },
-    code: `var res : texture_3d<i32>`,
-  },
-  {
-    texture: { sampleType: 'sint', viewDimension: 'cube', multisampled: false },
-    code: `var res : texture_cube<i32>`,
-  },
-  {
-    texture: { sampleType: 'sint', viewDimension: 'cube-array', multisampled: false },
-    code: `var res : texture_cube_array<i32>`,
-  },
-  {
-    texture: { sampleType: 'uint', viewDimension: '1d', multisampled: false },
-    code: `var res : texture_1d<u32>`,
-  },
-  {
-    texture: { sampleType: 'uint', viewDimension: '2d', multisampled: false },
-    code: `var res : texture_2d<u32>`,
-  },
-  {
-    texture: { sampleType: 'uint', viewDimension: '2d', multisampled: true },
-    code: `var res : texture_multisampled_2d<u32>`,
-  },
-  {
-    texture: { sampleType: 'uint', viewDimension: '2d-array', multisampled: false },
-    code: `var res : texture_2d_array<u32>`,
-  },
-  {
-    texture: { sampleType: 'uint', viewDimension: '3d', multisampled: false },
-    code: `var res : texture_3d<u32>`,
-  },
-  {
-    texture: { sampleType: 'uint', viewDimension: 'cube', multisampled: false },
-    code: `var res : texture_cube<u32>`,
-  },
-  {
-    texture: { sampleType: 'uint', viewDimension: 'cube-array', multisampled: false },
-    code: `var res : texture_cube_array<u32>`,
-  },
+  const sampleDims: GPUTextureViewDimension[] = [
+    '1d',
+    '2d',
+    '2d-array',
+    '3d',
+    'cube',
+    'cube-array',
+  ];
+  const sampleTypes: GPUTextureSampleType[] = ['float', 'unfilterable-float', 'sint', 'uint'];
+  const sampleWGSL = ['f32', 'f32', 'i32', 'u32'];
+  for (const dim of sampleDims) {
+    let i = 0;
+    for (const type of sampleTypes) {
+      resources.push({
+        texture: { sampleType: type, viewDimension: dim, multisampled: false },
+        code: `var res : texture_${dim.replace('-', '_')}<${sampleWGSL[i++]}>`,
+      });
+    }
+  }
+
+  // Depth textures
+  const depthDims: GPUTextureViewDimension[] = ['2d', '2d-array', 'cube', 'cube-array'];
+  for (const dim of depthDims) {
+    resources.push({
+      texture: { sampleType: 'depth', viewDimension: dim, multisampled: false },
+      code: `var res : texture_depth_${dim.replace('-', '_')}`,
+    });
+  }
 
   // Storage textures
   // Only cover r32uint, r32sint, and r32float here for ease of testing.
-  {
-    storageTexture: { access: 'write-only', format: 'r32uint', viewDimension: '1d' },
-    code: `var res : texture_storage_1d<r32uint, write>`,
-  },
-  {
-    storageTexture: { access: 'write-only', format: 'r32sint', viewDimension: '1d' },
-    code: `var res : texture_storage_1d<r32sint, write>`,
-  },
-  {
-    storageTexture: { access: 'write-only', format: 'r32float', viewDimension: '1d' },
-    code: `var res : texture_storage_1d<r32float, write>`,
-  },
-  {
-    storageTexture: { access: 'write-only', format: 'r32uint', viewDimension: '2d' },
-    code: `var res : texture_storage_2d<r32uint, write>`,
-  },
-  {
-    storageTexture: { access: 'write-only', format: 'r32sint', viewDimension: '2d' },
-    code: `var res : texture_storage_2d<r32sint, write>`,
-  },
-  {
-    storageTexture: { access: 'write-only', format: 'r32float', viewDimension: '2d' },
-    code: `var res : texture_storage_2d<r32float, write>`,
-  },
-  {
-    storageTexture: { access: 'write-only', format: 'r32uint', viewDimension: '2d-array' },
-    code: `var res : texture_storage_2d_array<r32uint, write>`,
-  },
-  {
-    storageTexture: { access: 'write-only', format: 'r32sint', viewDimension: '2d-array' },
-    code: `var res : texture_storage_2d_array<r32sint, write>`,
-  },
-  {
-    storageTexture: { access: 'write-only', format: 'r32float', viewDimension: '2d-array' },
-    code: `var res : texture_storage_2d_array<r32float, write>`,
-  },
-  {
-    storageTexture: { access: 'write-only', format: 'r32uint', viewDimension: '3d' },
-    code: `var res : texture_storage_3d<r32uint, write>`,
-  },
-  {
-    storageTexture: { access: 'write-only', format: 'r32sint', viewDimension: '3d' },
-    code: `var res : texture_storage_3d<r32sint, write>`,
-  },
-  {
-    storageTexture: { access: 'write-only', format: 'r32float', viewDimension: '3d' },
-    code: `var res : texture_storage_3d<r32float, write>`,
-  },
-  {
-    storageTexture: { access: 'read-only', format: 'r32uint', viewDimension: '1d' },
-    code: `var res : texture_storage_1d<r32uint, read>`,
-  },
-  {
-    storageTexture: { access: 'read-only', format: 'r32sint', viewDimension: '1d' },
-    code: `var res : texture_storage_1d<r32sint, read>`,
-  },
-  {
-    storageTexture: { access: 'read-only', format: 'r32float', viewDimension: '1d' },
-    code: `var res : texture_storage_1d<r32float, read>`,
-  },
-  {
-    storageTexture: { access: 'read-only', format: 'r32uint', viewDimension: '2d' },
-    code: `var res : texture_storage_2d<r32uint, read>`,
-  },
-  {
-    storageTexture: { access: 'read-only', format: 'r32sint', viewDimension: '2d' },
-    code: `var res : texture_storage_2d<r32sint, read>`,
-  },
-  {
-    storageTexture: { access: 'read-only', format: 'r32float', viewDimension: '2d' },
-    code: `var res : texture_storage_2d<r32float, read>`,
-  },
-  {
-    storageTexture: { access: 'read-only', format: 'r32uint', viewDimension: '2d-array' },
-    code: `var res : texture_storage_2d_array<r32uint, read>`,
-  },
-  {
-    storageTexture: { access: 'read-only', format: 'r32sint', viewDimension: '2d-array' },
-    code: `var res : texture_storage_2d_array<r32sint, read>`,
-  },
-  {
-    storageTexture: { access: 'read-only', format: 'r32float', viewDimension: '2d-array' },
-    code: `var res : texture_storage_2d_array<r32float, read>`,
-  },
-  {
-    storageTexture: { access: 'read-only', format: 'r32uint', viewDimension: '3d' },
-    code: `var res : texture_storage_3d<r32uint, read>`,
-  },
-  {
-    storageTexture: { access: 'read-only', format: 'r32sint', viewDimension: '3d' },
-    code: `var res : texture_storage_3d<r32sint, read>`,
-  },
-  {
-    storageTexture: { access: 'read-only', format: 'r32float', viewDimension: '3d' },
-    code: `var res : texture_storage_3d<r32float, read>`,
-  },
-  {
-    storageTexture: { access: 'read-write', format: 'r32uint', viewDimension: '1d' },
-    code: `var res : texture_storage_1d<r32uint, read_write>`,
-  },
-  {
-    storageTexture: { access: 'read-write', format: 'r32sint', viewDimension: '1d' },
-    code: `var res : texture_storage_1d<r32sint, read_write>`,
-  },
-  {
-    storageTexture: { access: 'read-write', format: 'r32float', viewDimension: '1d' },
-    code: `var res : texture_storage_1d<r32float, read_write>`,
-  },
-  {
-    storageTexture: { access: 'read-write', format: 'r32uint', viewDimension: '2d' },
-    code: `var res : texture_storage_2d<r32uint, read_write>`,
-  },
-  {
-    storageTexture: { access: 'read-write', format: 'r32sint', viewDimension: '2d' },
-    code: `var res : texture_storage_2d<r32sint, read_write>`,
-  },
-  {
-    storageTexture: { access: 'read-write', format: 'r32float', viewDimension: '2d' },
-    code: `var res : texture_storage_2d<r32float, read_write>`,
-  },
-  {
-    storageTexture: { access: 'read-write', format: 'r32uint', viewDimension: '2d-array' },
-    code: `var res : texture_storage_2d_array<r32uint, read_write>`,
-  },
-  {
-    storageTexture: { access: 'read-write', format: 'r32sint', viewDimension: '2d-array' },
-    code: `var res : texture_storage_2d_array<r32sint, read_write>`,
-  },
-  {
-    storageTexture: { access: 'read-write', format: 'r32float', viewDimension: '2d-array' },
-    code: `var res : texture_storage_2d_array<r32float, read_write>`,
-  },
-  {
-    storageTexture: { access: 'read-write', format: 'r32uint', viewDimension: '3d' },
-    code: `var res : texture_storage_3d<r32uint, read_write>`,
-  },
-  {
-    storageTexture: { access: 'read-write', format: 'r32sint', viewDimension: '3d' },
-    code: `var res : texture_storage_3d<r32sint, read_write>`,
-  },
-  {
-    storageTexture: { access: 'read-write', format: 'r32float', viewDimension: '3d' },
-    code: `var res : texture_storage_3d<r32float, read_write>`,
-  },
-];
+  const storageDims: GPUTextureViewDimension[] = ['1d', '2d', '2d-array', '3d'];
+  const formats: GPUTextureFormat[] = ['r32float', 'r32sint', 'r32uint'];
+  const accesses: GPUStorageTextureAccess[] = ['write-only', 'read-only', 'read-write'];
+  for (const dim of storageDims) {
+    for (const format of formats) {
+      for (const access of accesses) {
+        resources.push({
+          storageTexture: { access, format, viewDimension: dim },
+          code: `var res : texture_storage_${dim.replace('-', '_')}<${format},${access
+            .replace('-only', '')
+            .replace('-', '_')}>`,
+        });
+      }
+    }
+  }
 
+  return resources;
+}
+
+/**
+ * Returns a string suitable as a Record key.
+ */
+function resourceKey(res: Resource): string {
+  if (res.buffer) {
+    return `${res.buffer.type}_buffer`;
+  }
+  if (res.sampler) {
+    return `${res.sampler.type}_sampler`;
+  }
+  if (res.texture) {
+    return `texture_${res.texture.sampleType}_${res.texture.viewDimension}_${res.texture.multisampled}`;
+  }
+  if (res.storageTexture) {
+    return `storage_texture_${res.storageTexture.viewDimension}_${res.storageTexture.format}_${res.storageTexture.access}`;
+  }
+  if (res.externalTexture) {
+    return `external_texture`;
+  }
+  return ``;
+}
+
+/**
+ * Resource array converted to a Record for nicer test parameterization names.
+ */
+export const kAPIResources: Record<string, Resource> = Object.fromEntries(
+  generateResources().map(x => [resourceKey(x), x])
+) as Record<string, Resource>;
+
+/**
+ * Generates a shader of the specified stage using the specified resource at binding (0,0).
+ */
 export function getWGSLShaderForResource(stage: string, resource: Resource): string {
   let code = `@group(0) @binding(0) ${resource.code};\n`;
 
@@ -334,6 +165,9 @@ fn main() ${retTy} {
   return code;
 }
 
+/**
+ * Generates a bind group layout for for the given resource at binding 0.
+ */
 export function getAPIBindGroupLayoutForResource(
   device: GPUDevice,
   stage: GPUShaderStageFlags,
@@ -363,6 +197,9 @@ export function getAPIBindGroupLayoutForResource(
   return device.createBindGroupLayout({ entries });
 }
 
+/**
+ * Returns true if the sample types are compatible.
+ */
 function doSampleTypesMatch(api: GPUTextureSampleType, wgsl: GPUTextureSampleType): boolean {
   if (api === 'float' || api === 'unfilterable-float') {
     return wgsl === 'float' || wgsl === 'unfilterable-float';
@@ -370,6 +207,9 @@ function doSampleTypesMatch(api: GPUTextureSampleType, wgsl: GPUTextureSampleTyp
   return api === wgsl;
 }
 
+/**
+ * Returns true if the access modes are compatible.
+ */
 function doAccessesMatch(api: GPUStorageTextureAccess, wgsl: GPUStorageTextureAccess): boolean {
   if (api === 'read-write') {
     return wgsl === 'read-write' || wgsl === 'write-only';
@@ -377,6 +217,9 @@ function doAccessesMatch(api: GPUStorageTextureAccess, wgsl: GPUStorageTextureAc
   return api === wgsl;
 }
 
+/**
+ * Returns true if the resources are compatible.
+ */
 export function doResourcesMatch(api: Resource, wgsl: Resource): boolean {
   if (api.buffer) {
     if (!wgsl.buffer) {

--- a/src/webgpu/listing_meta.json
+++ b/src/webgpu/listing_meta.json
@@ -365,6 +365,7 @@
   "webgpu:api,validation,compute_pipeline:overrides,workgroup_size,limits:*": { "subcaseMS": 14.751 },
   "webgpu:api,validation,compute_pipeline:overrides,workgroup_size:*": { "subcaseMS": 6.376 },
   "webgpu:api,validation,compute_pipeline:pipeline_layout,device_mismatch:*": { "subcaseMS": 1.175 },
+  "webgpu:api,validation,compute_pipeline:resource_compatibility:*": { "subcaseMS": 1.175 },
   "webgpu:api,validation,compute_pipeline:shader_module,compute:*": { "subcaseMS": 6.867 },
   "webgpu:api,validation,compute_pipeline:shader_module,device_mismatch:*": { "subcaseMS": 15.350 },
   "webgpu:api,validation,compute_pipeline:shader_module,invalid:*": { "subcaseMS": 2.500 },


### PR DESCRIPTION
Adds tests for compute shader validation bindings. If this looks good I'll make a follow up PR for fragment and vertex stages.

I couldn't make external textures work. Anytime I tried creating a bind group layout for an external texture, I would get a validation error saying the none of the resource layouts were set.

Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [ ] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [ ] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
