### PR TITLE
[wgsl] Validate continue inside switch control flow.

### DIFF
--- a/src/webgpu/listing_meta.json
+++ b/src/webgpu/listing_meta.json
@@ -1669,7 +1669,7 @@
   "webgpu:shader,execution,flow_control,switch:switch_default_only:*": { "subcaseMS": 12.550 },
   "webgpu:shader,execution,flow_control,switch:switch_multiple_case:*": { "subcaseMS": 5.550 },
   "webgpu:shader,execution,flow_control,switch:switch_multiple_case_default:*": { "subcaseMS": 12.000 },
-  "webgpu:shader,execution,flow_control,switch,switch_inside_loop_with_continue:*": { "subcaseMS": 0 },
+  "webgpu:shader,execution,flow_control,switch:switch_inside_loop_with_continue:*": { "subcaseMS": 0 },
   "webgpu:shader,execution,flow_control,while:while_basic:*": { "subcaseMS": 5.951 },
   "webgpu:shader,execution,flow_control,while:while_break:*": { "subcaseMS": 12.450 },
   "webgpu:shader,execution,flow_control,while:while_continue:*": { "subcaseMS": 5.650 },

--- a/src/webgpu/listing_meta.json
+++ b/src/webgpu/listing_meta.json
@@ -1669,6 +1669,7 @@
   "webgpu:shader,execution,flow_control,switch:switch_default_only:*": { "subcaseMS": 12.550 },
   "webgpu:shader,execution,flow_control,switch:switch_multiple_case:*": { "subcaseMS": 5.550 },
   "webgpu:shader,execution,flow_control,switch:switch_multiple_case_default:*": { "subcaseMS": 12.000 },
+  "webgpu:shader,execution,flow_control,switch,switch_inside_loop_with_continue:*": { "subcaseMS": 0 },
   "webgpu:shader,execution,flow_control,while:while_basic:*": { "subcaseMS": 5.951 },
   "webgpu:shader,execution,flow_control,while:while_break:*": { "subcaseMS": 12.450 },
   "webgpu:shader,execution,flow_control,while:while_continue:*": { "subcaseMS": 5.650 },

--- a/src/webgpu/shader/execution/flow_control/switch.spec.ts
+++ b/src/webgpu/shader/execution/flow_control/switch.spec.ts
@@ -154,3 +154,36 @@ ${f.expect_order(2)}
 `
     );
   });
+
+g.test('switch_inside_loop_with_continue')
+  .desc('Test that flow control executes correct for a switch calling continue inside a loop')
+  .params(u => u.combine('preventValueOptimizations', [true, false]))
+  .fn(t => {
+    runFlowControlTest(
+      t,
+      f => `
+${f.expect_order(0)}
+var i = ${f.value(0)};
+loop {
+  switch (i) {
+    case 1: {
+      ${f.expect_order(4)}
+      continue;
+    }
+    default: {
+      ${f.expect_order(1)}
+      break;
+    }
+  }
+  ${f.expect_order(2)}
+
+  continuing {
+    ${f.expect_order(3, 5)}
+    i++;
+    break if i >= 2;
+  }
+}
+${f.expect_order(6)}
+`
+    );
+  });


### PR DESCRIPTION
This Cl adds a test that the execution of a `continue` instruction inside of a `switch` has the correct control flow.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
