### PR TITLE
Validation tests for resource compatibility of render pipelines

### DIFF
--- a/src/webgpu/api/validation/render_pipeline/resource_compatibility.spec.ts
+++ b/src/webgpu/api/validation/render_pipeline/resource_compatibility.spec.ts
@@ -1,0 +1,95 @@
+export const description = `
+Tests for resource compatibilty between pipeline layout and shader modules
+  `;
+
+import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { keysOf } from '../../../../common/util/data_tables.js';
+import {
+  kAPIResources,
+  getWGSLShaderForResource,
+  getAPIBindGroupLayoutForResource,
+  doResourcesMatch,
+} from '../utils.js';
+
+import { CreateRenderPipelineValidationTest } from './common.js';
+
+export const g = makeTestGroup(CreateRenderPipelineValidationTest);
+
+g.test('resource_compatibility')
+  .desc(
+    'Tests validation of resource (bind group) compatibility between pipeline layout and WGSL shader'
+  )
+  .params(u =>
+    u //
+      .combine('stage', ['vertex', 'fragment'] as const)
+      .combine('apiResource', keysOf(kAPIResources))
+      .filter(t => {
+        const res = kAPIResources[t.apiResource];
+        if (t.stage === 'vertex') {
+          if (res.buffer && res.buffer.type === 'storage') {
+            return false;
+          }
+          if (res.storageTexture && res.storageTexture.access !== 'read-only') {
+            return false;
+          }
+        }
+        return true;
+      })
+      .beginSubcases()
+      .combine('isAsync', [true, false] as const)
+      .combine('wgslResource', keysOf(kAPIResources))
+  )
+  .fn(t => {
+    const apiResource = kAPIResources[t.params.apiResource];
+    const wgslResource = kAPIResources[t.params.wgslResource];
+    t.skipIf(
+      wgslResource.storageTexture !== undefined &&
+        wgslResource.storageTexture.access !== 'write-only' &&
+        !t.hasLanguageFeature('readonly_and_readwrite_storage_textures'),
+      'Storage textures require language feature'
+    );
+    const emptyVS = `
+@vertex
+fn main() -> @builtin(position) vec4f {
+  return vec4f();
+}
+`;
+    const emptyFS = `
+@fragment
+fn main() -> @location(0) vec4f {
+  return vec4f();
+}
+`;
+
+    const code = getWGSLShaderForResource(t.params.stage, wgslResource);
+    const vsCode = t.params.stage === 'vertex' ? code : emptyVS;
+    const fsCode = t.params.stage === 'fragment' ? code : emptyFS;
+    const gpuStage: GPUShaderStageFlags =
+      t.params.stage === 'vertex' ? GPUShaderStage.VERTEX : GPUShaderStage.FRAGMENT;
+    const layout = t.device.createPipelineLayout({
+      bindGroupLayouts: [getAPIBindGroupLayoutForResource(t.device, gpuStage, apiResource)],
+    });
+
+    const descriptor = {
+      layout,
+      vertex: {
+        module: t.device.createShaderModule({
+          code: vsCode,
+        }),
+        entryPoint: 'main',
+      },
+      fragment: {
+        module: t.device.createShaderModule({
+          code: fsCode,
+        }),
+        entryPoint: 'main',
+        targets: [{ format: 'rgba8unorm' }] as const,
+      },
+    };
+
+    t.doCreateRenderPipelineTest(
+      t.params.isAsync,
+      doResourcesMatch(apiResource, wgslResource),
+      descriptor
+    );
+  });

--- a/src/webgpu/api/validation/utils.ts
+++ b/src/webgpu/api/validation/utils.ts
@@ -153,8 +153,15 @@ export function getWGSLShaderForResource(stage: string, resource: Resource): str
     code += `@workgroup_size(1)`;
   }
 
-  const retTy = stage === 'vertex' ? ' -> @builtin(position) vec4f' : '';
-  const retVal = stage === 'vertex' ? 'return vecf();' : '';
+  let retTy = '';
+  let retVal = '';
+  if (stage === 'vertex') {
+    retTy = ' -> @builtin(position) vec4f';
+    retVal = 'return vec4f();';
+  } else if (stage === 'fragment') {
+    retTy = ' -> @location(0) vec4f';
+    retVal = 'return vec4f();';
+  }
   code += `
 fn main() ${retTy} {
   _ = ${resource.staticUse ?? 'res'};

--- a/src/webgpu/listing_meta.json
+++ b/src/webgpu/listing_meta.json
@@ -747,6 +747,7 @@
   "webgpu:api,validation,render_pipeline,overrides:value,validation_error,vertex:*": { "subcaseMS": 6.022 },
   "webgpu:api,validation,render_pipeline,primitive_state:strip_index_format:*": { "subcaseMS": 5.267 },
   "webgpu:api,validation,render_pipeline,primitive_state:unclipped_depth:*": { "subcaseMS": 1.025 },
+  "webgpu:api,validation,render_pipeline,resource_compatibility:resource_compatibility:*": { "subcaseMS": 1.025 },
   "webgpu:api,validation,render_pipeline,shader_module:device_mismatch:*": { "subcaseMS": 0.700 },
   "webgpu:api,validation,render_pipeline,shader_module:invalid,fragment:*": { "subcaseMS": 5.800 },
   "webgpu:api,validation,render_pipeline,shader_module:invalid,vertex:*": { "subcaseMS": 15.151 },


### PR DESCRIPTION
* Reuses compute pipeline resource infrastructure
  * small update to generate consistent fragment shader
* Filters out writable storge buffer and storage texture resources from the api side for vertex shaders

Followup to #3431.


Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
