### PR TITLE
Compat: Skip workgroupUniformLoad tests > max invocations

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/workgroupUniformLoad.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/workgroupUniformLoad.spec.ts
@@ -99,6 +99,7 @@ g.test('types')
     u.combine('type', keysOf(kTypes)).combine('wgsize', [
       [1, 1],
       [3, 7],
+      [1, 128],
       [16, 16],
     ])
   )
@@ -109,6 +110,11 @@ g.test('types')
     const num_invocations = wgsize_x * wgsize_y;
     const num_words_per_invocation = type.expected.length;
     const total_host_words = num_invocations * num_words_per_invocation;
+
+    t.skipIf(
+      num_invocations > t.device.limits.maxComputeInvocationsPerWorkgroup,
+      `num_invocations (${num_invocations}) > maxComputeInvocationsPerWorkgroup (${t.device.limits.maxComputeInvocationsPerWorkgroup})`
+    );
 
     let load = `workgroupUniformLoad(&wgvar)`;
     if (type.to_host) {


### PR DESCRIPTION
I'm not sure if you want me to add a [8, 16] or [16, 8] subcase for compat's 128 limit

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [X] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
