### PR TITLE
Compat: Texture Intra Invocation Coherence

### DIFF
--- a/src/webgpu/shader/execution/memory_model/texture_intra_invocation_coherence.spec.ts
+++ b/src/webgpu/shader/execution/memory_model/texture_intra_invocation_coherence.spec.ts
@@ -147,7 +147,7 @@ g.test('texture_intra_invocation_coherence')
     t.skipIfLanguageFeatureNotSupported('readonly_and_readwrite_storage_textures');
 
     const wgx = 16;
-    const wgy = 16;
+    const wgy = t.device.limits.maxComputeInvocationsPerWorkgroup / wgx;
     const num_wgs_x = 2;
     const num_wgs_y = 2;
     const invocations = wgx * wgy * num_wgs_x * num_wgs_y;


### PR DESCRIPTION
Handle maxComputeInvocationsPerWorkgroup being lower in compat.

fyi: you can add `compatibility=1` in the browser or `--compat` in various command line tools (like dawn.node) to turn on compatibility validation

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [X] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
