### PR TITLE
WGSL: Add validation tests for readonly_and_readwrite_storage_textures.

### DIFF
--- a/src/webgpu/listing_meta.json
+++ b/src/webgpu/listing_meta.json
@@ -1922,6 +1922,8 @@
   "webgpu:shader,validation,expression,unary,address_of_and_indirection:invalid:*": { "subcaseMS": 0.000 },
   "webgpu:shader,validation,extension,pointer_composite_access:deref:*": { "subcaseMS": 0.000 },
   "webgpu:shader,validation,extension,pointer_composite_access:pointer:*": { "subcaseMS": 0.000 },
+  "webgpu:shader,validation,extension,readonly_and_readwrite_storage_textures:textureBarrier:*": { "subcaseMS": 1.141 },
+  "webgpu:shader,validation,extension,readonly_and_readwrite_storage_textures:var_decl:*": { "subcaseMS": 42.299 },
   "webgpu:shader,validation,functions,alias_analysis:aliasing_inside_function:*": { "subcaseMS": 1.200 },
   "webgpu:shader,validation,functions,alias_analysis:member_accessors:*": { "subcaseMS": 1.656 },
   "webgpu:shader,validation,functions,alias_analysis:one_atomic_pointer_one_module_scope:*": { "subcaseMS": 0.000 },
@@ -2194,8 +2196,8 @@
   "webgpu:web_platform,copyToTexture,video:copy_from_video:*": { "subcaseMS": 25.101 },
   "webgpu:web_platform,external_texture,video:importExternalTexture,compute:*": { "subcaseMS": 36.270 },
   "webgpu:web_platform,external_texture,video:importExternalTexture,sample:*": { "subcaseMS": 34.968 },
-  "webgpu:web_platform,external_texture,video:importExternalTexture,sample_non_YUV_video_frame:*": { "subcaseMS": 36.270 },
   "webgpu:web_platform,external_texture,video:importExternalTexture,sampleWithVideoFrameWithVisibleRectParam:*": { "subcaseMS": 29.160 },
+  "webgpu:web_platform,external_texture,video:importExternalTexture,sample_non_YUV_video_frame:*": { "subcaseMS": 36.270 },
   "webgpu:web_platform,worker,worker:dedicated_worker:*": { "subcaseMS": 245.901 },
   "webgpu:web_platform,worker,worker:shared_worker:*": { "subcaseMS": 26.801 },
   "_end": ""

--- a/src/webgpu/shader/validation/extension/readonly_and_readwrite_storage_textures.spec.ts
+++ b/src/webgpu/shader/validation/extension/readonly_and_readwrite_storage_textures.spec.ts
@@ -1,0 +1,48 @@
+export const description = `
+Validation tests for the readonly_and_readwrite_storage_textures language feature
+`;
+
+import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { TexelFormats } from '../../types.js';
+import { ShaderValidationTest } from '../shader_validation_test.js';
+
+export const g = makeTestGroup(ShaderValidationTest);
+
+const kFeatureName = 'readonly_and_readwrite_storage_textures';
+
+g.test('var_decl')
+  .desc(
+    `Checks that the read and read_write access modes are only allowed with the language feature present`
+  )
+  .paramsSubcasesOnly(u =>
+    u
+      .combine('type', [
+        'texture_storage_1d',
+        'texture_storage_2d',
+        'texture_storage_2d_array',
+        'texture_storage_3d',
+      ])
+      .combine('format', TexelFormats)
+      .combine('access', ['read', 'write', 'read_write'])
+  )
+  .fn(t => {
+    const { type, format, access } = t.params;
+    const source = `@group(0) @binding(0) var t : ${type}<${format.format}, ${access}>;`;
+    const requiresFeature = access !== 'write';
+    t.expectCompileResult(t.hasLanguageFeature(kFeatureName) || !requiresFeature, source);
+  });
+
+g.test('textureBarrier')
+  .desc(
+    `Checks that the textureBarrier() builtin is only allowed with the language feature present`
+  )
+  .fn(t => {
+    t.expectCompileResult(
+      t.hasLanguageFeature(kFeatureName),
+      `
+        @workgroup_size(1) @compute fn main() {
+            textureBarrier();
+        }
+    `
+    );
+  });


### PR DESCRIPTION


Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [X] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
