### PR TITLE
User IO passthrough shader tests

### DIFF
--- a/src/webgpu/listing_meta.json
+++ b/src/webgpu/listing_meta.json
@@ -1743,6 +1743,7 @@
   "webgpu:shader,execution,shader_io,shared_structs:shared_between_stages:*": { "subcaseMS": 9.601 },
   "webgpu:shader,execution,shader_io,shared_structs:shared_with_buffer:*": { "subcaseMS": 20.701 },
   "webgpu:shader,execution,shader_io,shared_structs:shared_with_non_entry_point_function:*": { "subcaseMS": 6.801 },
+  "webgpu:shader,execution,shader_io,user_io:interstage_passthrough:*": { "subcaseMS": 332.670 },
   "webgpu:shader,execution,shader_io,workgroup_size:workgroup_size:*": { "subcaseMS": 0.000 },
   "webgpu:shader,execution,shadow:builtin:*": { "subcaseMS": 4.700 },
   "webgpu:shader,execution,shadow:declaration:*": { "subcaseMS": 9.700 },

--- a/src/webgpu/listing_meta.json
+++ b/src/webgpu/listing_meta.json
@@ -1743,7 +1743,7 @@
   "webgpu:shader,execution,shader_io,shared_structs:shared_between_stages:*": { "subcaseMS": 9.601 },
   "webgpu:shader,execution,shader_io,shared_structs:shared_with_buffer:*": { "subcaseMS": 20.701 },
   "webgpu:shader,execution,shader_io,shared_structs:shared_with_non_entry_point_function:*": { "subcaseMS": 6.801 },
-  "webgpu:shader,execution,shader_io,user_io:interstage_passthrough:*": { "subcaseMS": 332.670 },
+  "webgpu:shader,execution,shader_io,user_io:passthrough:*": { "subcaseMS": 373.385 },
   "webgpu:shader,execution,shader_io,workgroup_size:workgroup_size:*": { "subcaseMS": 0.000 },
   "webgpu:shader,execution,shadow:builtin:*": { "subcaseMS": 4.700 },
   "webgpu:shader,execution,shadow:declaration:*": { "subcaseMS": 9.700 },

--- a/src/webgpu/shader/execution/shader_io/user_io.spec.ts
+++ b/src/webgpu/shader/execution/shader_io/user_io.spec.ts
@@ -1,0 +1,152 @@
+export const description = `
+Test for user-defined shader I/O.
+`;
+
+import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { range } from '../../../../common/util/util.js';
+import { GPUTest } from '../../../gpu_test.js';
+
+export const g = makeTestGroup(GPUTest);
+
+function generateInterstagePassthroughCode(type: string): string {
+  return `
+${type === 'f16' ? 'enable f16;' : ''}
+struct IOData {
+  @builtin(position) pos : vec4f,
+  @location(0) @interpolate(flat) user0 : ${type},
+  @location(1) @interpolate(flat) user1 : vec2<${type}>,
+  @location(2) @interpolate(flat) user2 : vec4<${type}>,
+}
+
+@vertex
+fn vsMain(@builtin(vertex_index) input : u32) -> IOData {
+  const vertices = array(
+    vec4f(-1, -1, 0, 1),
+    vec4f(-1,  1, 0, 1),
+    vec4f( 1, -1, 0, 1),
+  );
+  var data : IOData;
+  data.pos = vertices[input];
+  data.user0 = 1;
+  data.user1 = vec2(2);
+  data.user2 = vec4(3);
+  return data;
+}
+
+struct FragOutput {
+  @location(0) out0 : u32,
+  @location(1) out1 : vec2u,
+  @location(2) out2 : vec4u,
+}
+
+@fragment
+fn fsMain(input : IOData) -> FragOutput {
+  var out : FragOutput;
+  out.out0 = u32(input.user0);
+  out.out1 = vec2u(input.user1);
+  out.out2 = vec4u(input.user2);
+  return out;
+}
+`;
+}
+
+function drawPassthrough(t: GPUTest, code: string) {
+  // Default limit is 32 bytes of color attachments.
+  // These attachments use 28 bytes (which is why vec3 is skipped).
+  const formats: GPUTextureFormat[] = ['r32uint', 'rg32uint', 'rgba32uint'];
+  const components = [1, 2, 4];
+  const pipeline = t.device.createRenderPipeline({
+    layout: 'auto',
+    vertex: {
+      module: t.device.createShaderModule({ code }),
+      entryPoint: 'vsMain',
+    },
+    fragment: {
+      module: t.device.createShaderModule({ code }),
+      entryPoint: 'fsMain',
+      targets: [{ format: formats[0] }, { format: formats[1] }, { format: formats[2] }],
+    },
+    primitive: {
+      topology: 'triangle-list',
+    },
+  });
+
+  const bytesPerComponent = 4;
+  // 256 is the minimum bytes per row for texture to buffer copies.
+  const width = 256 / bytesPerComponent;
+  const height = 2;
+  const copyWidth = 4;
+  const outputTextures = range(3, i => {
+    const texture = t.device.createTexture({
+      size: [width, height],
+      usage:
+        GPUTextureUsage.COPY_SRC |
+        GPUTextureUsage.RENDER_ATTACHMENT |
+        GPUTextureUsage.TEXTURE_BINDING,
+      format: formats[i],
+    });
+    t.trackForCleanup(texture);
+    return texture;
+  });
+
+  let bufferSize = 1;
+  for (const comp of components) {
+    bufferSize *= comp;
+  }
+  bufferSize *= outputTextures.length * bytesPerComponent * copyWidth;
+  const outputBuffer = t.device.createBuffer({
+    size: bufferSize,
+    usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.COPY_DST,
+  });
+  t.trackForCleanup(outputBuffer);
+
+  const encoder = t.device.createCommandEncoder();
+  const pass = encoder.beginRenderPass({
+    colorAttachments: outputTextures.map(t => ({
+      view: t.createView(),
+      loadOp: 'clear',
+      storeOp: 'store',
+    })),
+  });
+  pass.setPipeline(pipeline);
+  pass.draw(3);
+  pass.end();
+
+  // Copy 'copyWidth' samples from each attachment into a buffer to check the results.
+  let offset = 0;
+  let expectArray: number[] = [];
+  for (let i = 0; i < outputTextures.length; i++) {
+    encoder.copyTextureToBuffer(
+      { texture: outputTextures[i] },
+      {
+        buffer: outputBuffer,
+        offset,
+        bytesPerRow: bytesPerComponent * components[i] * width,
+        rowsPerImage: height,
+      },
+      { width: copyWidth, height: 1 }
+    );
+    offset += components[i] * bytesPerComponent * copyWidth;
+    for (let j = 0; j < components[i]; j++) {
+      const value = i + 1;
+      expectArray = expectArray.concat([value, value, value, value]);
+    }
+  }
+  t.queue.submit([encoder.finish()]);
+
+  const expect = new Uint32Array(expectArray);
+  t.expectGPUBufferValuesEqual(outputBuffer, expect);
+}
+
+g.test('interstage_passthrough')
+  .desc('Tests passing user-defined data between vertex and fragment shaders')
+  .params(u => u.combine('type', ['f32', 'f16', 'i32', 'u32'] as const))
+  .beforeAllSubcases(t => {
+    if (t.params.type === 'f16') {
+      t.selectDeviceOrSkipTestCase('shader-f16');
+    }
+  })
+  .fn(t => {
+    const code = generateInterstagePassthroughCode(t.params.type);
+    drawPassthrough(t, code);
+  });


### PR DESCRIPTION
Tests user-defined IO passthrough in shaders.
Vertex buffer -> vertex output -> fragment input -> fragment output

For simplicity, vertex input and fragment output are always converted to uints. Tests scalar and vectors. Internal types cover u32, i32, f32, and f16.

Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
