### PR TITLE
Add `abs` parameter validation.

### DIFF
--- a/src/webgpu/listing_meta.json
+++ b/src/webgpu/listing_meta.json
@@ -1807,6 +1807,7 @@
   "webgpu:shader,validation,expression,binary,bitwise_shift:shift_left_vec_size_mismatch:*": { "subcaseMS": 1.367 },
   "webgpu:shader,validation,expression,binary,bitwise_shift:shift_right_concrete:*": { "subcaseMS": 1.237 },
   "webgpu:shader,validation,expression,binary,bitwise_shift:shift_right_vec_size_mismatch:*": { "subcaseMS": 1.334 },
+  "webgpu:shader,validation,expression,call,builtin,abs:parameters:*": { "subcaseMS": 10.133 },
   "webgpu:shader,validation,expression,call,builtin,abs:values:*": { "subcaseMS": 0.391 },
   "webgpu:shader,validation,expression,call,builtin,acos:integer_argument:*": { "subcaseMS": 1.512 },
   "webgpu:shader,validation,expression,call,builtin,acos:values:*": { "subcaseMS": 0.342 },

--- a/src/webgpu/shader/validation/expression/call/builtin/abs.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/abs.spec.ts
@@ -107,6 +107,12 @@ const kTests = {
           _ = abs(p);`,
     pass: false,
   },
+  ptr_deref: {
+    src: `var<function> a = 1u;
+          let p: ptr<function, u32> = &a;
+          _ = abs(*p);`,
+    pass: true,
+  },
   sampler: {
     src: `_ = abs(s);`,
     pass: false,

--- a/src/webgpu/shader/validation/expression/call/builtin/abs.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/abs.spec.ts
@@ -56,3 +56,101 @@ Validates that constant evaluation and override evaluation of ${builtin}() never
       t.params.stage
     );
   });
+
+const kTests = {
+  valid: {
+    src: `_ = abs(1);`,
+    pass: true,
+  },
+  alias: {
+    src: `_ = abs(i32_alias(1));`,
+    pass: true,
+  },
+
+  bool: {
+    src: `_ = abs(false);`,
+    pass: false,
+  },
+  vec_bool: {
+    src: `_ = abs(vec2<bool>(false, true));`,
+    pass: false,
+  },
+  matrix: {
+    src: `_ = abs(mat2x2(1, 1, 1, 1));`,
+    pass: false,
+  },
+  atomic: {
+    src: ` _ = abs(a);`,
+    pass: false,
+  },
+  array: {
+    src: `var a: array<u32, 5>;
+          _ = abs(a);`,
+    pass: false,
+  },
+  array_runtime: {
+    src: `_ = abs(k.arry);`,
+    pass: false,
+  },
+  struct: {
+    src: `var a: A;
+          _ = abs(a);`,
+    pass: false,
+  },
+  enumerant: {
+    src: `_ = abs(read_write);`,
+    pass: false,
+  },
+  ptr: {
+    src: `var<function> a = 1u;
+          let p: ptr<function, u32> = &a;
+          _ = abs(p);`,
+    pass: false,
+  },
+  sampler: {
+    src: `_ = abs(s);`,
+    pass: false,
+  },
+  texture: {
+    src: `_ = abs(t);`,
+    pass: false,
+  },
+  no_params: {
+    src: `_ = abs();`,
+    pass: false,
+  },
+  too_many_params: {
+    src: `_ = abs(1, 2);`,
+    pass: false,
+  },
+};
+
+g.test('parameters')
+  .desc(`Test that ${builtin} is validated correctly.`)
+  .params(u => u.combine('test', keysOf(kTests)))
+  .fn(t => {
+    const src = kTests[t.params.test].src;
+    const code = `
+alias i32_alias = i32;
+
+@group(0) @binding(0) var s: sampler;
+@group(0) @binding(1) var t: texture_2d<f32>;
+
+var<workgroup> a: atomic<u32>;
+
+struct A {
+  i: u32,
+}
+struct B {
+  arry: array<u32>,
+}
+@group(0) @binding(3) var<storage> k: B;
+
+
+@vertex
+fn main() -> @builtin(position) vec4<f32> {
+  ${src}
+  return vec4<f32>(.4, .2, .3, .1);
+}`;
+    t.expectCompileResult(kTests[t.params.test].pass, code);
+  });


### PR DESCRIPTION
This CL adds validation for invalid `abs` parameters.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
