### PR TITLE
Fix device_pool refactor

### DIFF
--- a/src/webgpu/util/device_pool.ts
+++ b/src/webgpu/util/device_pool.ts
@@ -22,7 +22,7 @@ class FeaturesNotSupported extends Error {}
 export class TestOOMedShouldAttemptGC extends Error {}
 
 export class DevicePool {
-  private holders: 'uninitialized' | 'failed' | DescriptorToHolderMap = 'uninitialized';
+  private holders = new DescriptorToHolderMap();
 
   async requestAdapter(recorder: TestCaseRecorder) {
     const gpu = getGPU(recorder);
@@ -36,28 +36,7 @@ export class DevicePool {
     adapter: GPUAdapter,
     descriptor?: UncanonicalizedDeviceDescriptor
   ): Promise<DeviceProvider> {
-    let holder;
-    if (this.holders === 'uninitialized') {
-      this.holders = new DescriptorToHolderMap();
-    }
-
-    let errorMessage = '';
-    if (this.holders !== 'failed') {
-      try {
-        holder = await this.holders.getOrCreate(adapter, descriptor);
-      } catch (ex) {
-        this.holders = 'failed';
-        if (ex instanceof Error) {
-          errorMessage = ` with ${ex.name} "${ex.message}"`;
-        }
-      }
-    }
-
-    assert(
-      this.holders !== 'failed',
-      `WebGPU device failed to initialize${errorMessage}; not retrying`
-    );
-    assert(!!holder);
+    const holder = await this.holders.getOrCreate(adapter, descriptor);
     assert(holder.state === 'free', 'Device was in use on DevicePool.acquire');
     holder.state = 'acquired';
     holder.beginTestScope();


### PR DESCRIPTION
The old version made one device with no descriptor. If that fail then it stopped creating any devices period.

The previous refactor was bad in that if the any device failed it would just stop making devices.

This one is simplified. It just used the pool as a pool. There is no special handling for failed devices.


Note: I could check if no description is passed in and it fails then assume all other requests will fail. Should I add that in or leave it as is?

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [X] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
