### PR TITLE
wgsl: Add bitwise complement validation tests

### DIFF
--- a/src/webgpu/listing_meta.json
+++ b/src/webgpu/listing_meta.json
@@ -1941,6 +1941,8 @@
   "webgpu:shader,validation,expression,unary,address_of_and_indirection:basic:*": { "subcaseMS": 0.000 },
   "webgpu:shader,validation,expression,unary,address_of_and_indirection:composite:*": { "subcaseMS": 0.000 },
   "webgpu:shader,validation,expression,unary,address_of_and_indirection:invalid:*": { "subcaseMS": 0.000 },
+  "webgpu:shader,validation,expression,unary,bitwise_complement:invalid_types:*": { "subcaseMS": 7.564 },
+  "webgpu:shader,validation,expression,unary,bitwise_complement:scalar_vector:*": { "subcaseMS": 73.852 },
   "webgpu:shader,validation,expression,unary,logical_negation:invalid_types:*": { "subcaseMS": 7.100 },
   "webgpu:shader,validation,expression,unary,logical_negation:scalar_vector:*": { "subcaseMS": 84.680 },
   "webgpu:shader,validation,extension,pointer_composite_access:deref:*": { "subcaseMS": 0.000 },

--- a/src/webgpu/shader/validation/expression/unary/bitwise_complement.spec.ts
+++ b/src/webgpu/shader/validation/expression/unary/bitwise_complement.spec.ts
@@ -1,0 +1,114 @@
+export const description = `
+Validation tests for bitwise complement expressions.
+`;
+
+import { makeTestGroup } from '../../../../../common/framework/test_group.js';
+import { keysOf, objectsToRecord } from '../../../../../common/util/data_tables.js';
+import { kAllScalarsAndVectors, scalarTypeOf, Type } from '../../../../util/conversion.js';
+import { ShaderValidationTest } from '../../shader_validation_test.js';
+
+export const g = makeTestGroup(ShaderValidationTest);
+
+// A list of scalar and vector types.
+const kScalarAndVectorTypes = objectsToRecord(kAllScalarsAndVectors);
+
+g.test('scalar_vector')
+  .desc(
+    `
+  Validates that scalar and vector bitwise complement expressions are only accepted for integers.
+  `
+  )
+  .params(u => u.combine('type', keysOf(kScalarAndVectorTypes)).beginSubcases())
+  .beforeAllSubcases(t => {
+    if (scalarTypeOf(kScalarAndVectorTypes[t.params.type]) === Type.f16) {
+      t.selectDeviceOrSkipTestCase('shader-f16');
+    }
+  })
+  .fn(t => {
+    const type = kScalarAndVectorTypes[t.params.type];
+    const elementTy = scalarTypeOf(type);
+    const hasF16 = elementTy === Type.f16;
+    const code = `
+${hasF16 ? 'enable f16;' : ''}
+const rhs = ${type.create(0).wgsl()};
+const foo = ~rhs;
+`;
+
+    t.expectCompileResult([Type.abstractInt, Type.i32, Type.u32].includes(elementTy), code);
+  });
+
+interface InvalidTypeConfig {
+  // An expression that produces a value of the target type.
+  expr: string;
+  // A function that converts an expression of the target type into a valid complement operand.
+  control: (x: string) => string;
+}
+const kInvalidTypes: Record<string, InvalidTypeConfig> = {
+  mat2x2f: {
+    expr: 'm',
+    control: e => `i32(${e}[0][0])`,
+  },
+
+  array: {
+    expr: 'arr',
+    control: e => `${e}[0]`,
+  },
+
+  ptr: {
+    expr: '(&u)',
+    control: e => `*${e}`,
+  },
+
+  atomic: {
+    expr: 'a',
+    control: e => `atomicLoad(&${e})`,
+  },
+
+  texture: {
+    expr: 't',
+    control: e => `i32(textureLoad(${e}, vec2(), 0).x)`,
+  },
+
+  sampler: {
+    expr: 's',
+    control: e => `i32(textureSampleLevel(t, ${e}, vec2(), 0).x)`,
+  },
+
+  struct: {
+    expr: 'str',
+    control: e => `${e}.u`,
+  },
+};
+
+g.test('invalid_types')
+  .desc(
+    `
+  Validates that bitwise complement expressions are never accepted for non-scalar and non-vector types.
+  `
+  )
+  .params(u =>
+    u.combine('type', keysOf(kInvalidTypes)).combine('control', [true, false]).beginSubcases()
+  )
+  .fn(t => {
+    const type = kInvalidTypes[t.params.type];
+    const expr = t.params.control ? type.control(type.expr) : type.expr;
+    const code = `
+@group(0) @binding(0) var t : texture_2d<f32>;
+@group(0) @binding(1) var s : sampler;
+@group(0) @binding(2) var<storage, read_write> a : atomic<i32>;
+
+struct S { u : u32 }
+
+var<private> u : u32;
+var<private> m : mat2x2f;
+var<private> arr : array<u32, 4>;
+var<private> str : S;
+
+@compute @workgroup_size(1)
+fn main() {
+  let foo = ~${expr};
+}
+`;
+
+    t.expectCompileResult(t.params.control, code);
+  });


### PR DESCRIPTION
Test that the bitwise complement operator is only accepted for integer scalar and vector types.

Issue: #1631 

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [X] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
