### PR TITLE
Re-add `gen_listings.ts`

### DIFF
--- a/src/common/tools/gen_listings.ts
+++ b/src/common/tools/gen_listings.ts
@@ -1,0 +1,56 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as process from 'process';
+
+import { crawl } from './crawl.js';
+
+function usage(rc: number): void {
+  console.error(`Usage: tools/gen_listings [options] [OUT_DIR] [SUITE_DIRS...]
+
+For each suite in SUITE_DIRS, generate listings and write each listing.js
+into OUT_DIR/{suite}/listing.js. Example:
+  tools/gen_listings gen/ src/unittests/ src/webgpu/
+
+Options:
+  --help          Print this message and exit.
+`);
+  process.exit(rc);
+}
+
+const argv = process.argv;
+if (argv.indexOf('--help') !== -1) {
+  usage(0);
+}
+
+{
+  // Ignore old argument that is now the default
+  const i = argv.indexOf('--no-validate');
+  if (i !== -1) {
+    argv.splice(i, 1);
+  }
+}
+
+if (argv.length < 4) {
+  usage(0);
+}
+
+const myself = 'src/common/tools/gen_listings.ts';
+
+const outDir = argv[2];
+
+for (const suiteDir of argv.slice(3)) {
+  // Run concurrently for each suite (might be a tiny bit more efficient)
+  void crawl(suiteDir, false).then(listing => {
+    const suite = path.basename(suiteDir);
+    const outFile = path.normalize(path.join(outDir, `${suite}/listing.js`));
+    fs.mkdirSync(path.join(outDir, suite), { recursive: true });
+    fs.writeFileSync(
+      outFile,
+      `\
+// AUTO-GENERATED - DO NOT EDIT. See ${myself}.
+
+export const listing = ${JSON.stringify(listing, undefined, 2)};
+`
+    );
+  });
+}


### PR DESCRIPTION
Chromium build infrastructure depends on this file. In order to migrate to the new `gen_listings_and_webworkers.ts`, we need to do a N-way patch.

<hr>

**Requirements for PR author:**

- [ ] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [ ] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [ ] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
