### PR TITLE
wgsl: Update value creation and type comparisons

### DIFF
--- a/src/webgpu/shader/validation/expression/binary/and_or_xor.spec.ts
+++ b/src/webgpu/shader/validation/expression/binary/and_or_xor.spec.ts
@@ -61,8 +61,8 @@ g.test('scalar_vector')
     const hasF16 = lhsElement === Type.f16 || rhsElement === Type.f16;
     const code = `
 ${hasF16 ? 'enable f16;' : ''}
-const lhs = ${lhs.create(lhsElement.kind === 'abstract-int' ? 0n : 0).wgsl()};
-const rhs = ${rhs.create(rhsElement.kind === 'abstract-int' ? 0n : 0).wgsl()};
+const lhs = ${lhs.create(0).wgsl()};
+const rhs = ${rhs.create(0).wgsl()};
 const foo = lhs ${op.op} rhs;
 `;
 
@@ -92,7 +92,7 @@ const foo = lhs ${op.op} rhs;
       valid = lhs.width === rhs.width && elementIsCompatible;
     }
 
-    if (lhsElement.kind === 'bool') {
+    if (lhsElement === Type.bool) {
       valid &&= op.supportsBool;
     }
 

--- a/src/webgpu/shader/validation/expression/binary/comparison.spec.ts
+++ b/src/webgpu/shader/validation/expression/binary/comparison.spec.ts
@@ -64,8 +64,8 @@ g.test('scalar_vector')
     const hasF16 = lhsElement === Type.f16 || rhsElement === Type.f16;
     const code = `
 ${hasF16 ? 'enable f16;' : ''}
-const lhs = ${lhs.create(lhsElement.kind === 'abstract-int' ? 0n : 0).wgsl()};
-const rhs = ${rhs.create(rhsElement.kind === 'abstract-int' ? 0n : 0).wgsl()};
+const lhs = ${lhs.create(0).wgsl()};
+const rhs = ${rhs.create(0).wgsl()};
 const foo = lhs ${kComparisonOperators[t.params.op].op} rhs;
 `;
 
@@ -73,16 +73,16 @@ const foo = lhs ${kComparisonOperators[t.params.op].op} rhs;
 
     // Determine if the element types are comparable.
     let elementIsCompatible = false;
-    if (lhsElement.kind === 'abstract-int') {
+    if (lhsElement === Type.abstractInt) {
       // Abstract integers are comparable to any other numeric type.
-      elementIsCompatible = rhsElement.kind !== 'bool';
-    } else if (rhsElement.kind === 'abstract-int') {
+      elementIsCompatible = rhsElement !== Type.bool;
+    } else if (rhsElement === Type.abstractInt) {
       // Abstract integers are comparable to any other numeric type.
-      elementIsCompatible = lhsElement.kind !== 'bool';
-    } else if (lhsElement.kind === 'abstract-float') {
+      elementIsCompatible = lhsElement !== Type.bool;
+    } else if (lhsElement === Type.abstractFloat) {
       // Abstract floats are comparable to any other float type.
       elementIsCompatible = isFloatType(rhsElement);
-    } else if (rhsElement.kind === 'abstract-float') {
+    } else if (rhsElement === Type.abstractFloat) {
       // Abstract floats are comparable to any other float type.
       elementIsCompatible = isFloatType(lhsElement);
     } else {
@@ -98,7 +98,7 @@ const foo = lhs ${kComparisonOperators[t.params.op].op} rhs;
       valid = lhs.width === rhs.width && elementIsCompatible;
     }
 
-    if (lhsElement.kind === 'bool') {
+    if (lhsElement === Type.bool) {
       valid &&= kComparisonOperators[t.params.op].supportsBool;
     }
 

--- a/src/webgpu/shader/validation/expression/unary/logical_negation.spec.ts
+++ b/src/webgpu/shader/validation/expression/unary/logical_negation.spec.ts
@@ -30,7 +30,7 @@ g.test('scalar_vector')
     const hasF16 = elementTy === Type.f16;
     const code = `
 ${hasF16 ? 'enable f16;' : ''}
-const rhs = ${type.create(elementTy.kind === 'abstract-int' ? 0n : 0).wgsl()};
+const rhs = ${type.create(0).wgsl()};
 const foo = !rhs;
 `;
 


### PR DESCRIPTION
We can now just pass `0` to type.create() regardless of the type. Type comparisons are also switched from `type.kind === '<typename>'` to `type === Type.<type>`.

