### PR TITLE
shader/execution: Fix struct padding for `f16`s

### DIFF
--- a/src/webgpu/shader/execution/expression/expression.ts
+++ b/src/webgpu/shader/execution/expression/expression.ts
@@ -158,7 +158,10 @@ function wgslMembers(members: Type[], source: InputSource, memberName: (i: numbe
   });
   const padding = layout.stride - layout.size;
   if (padding > 0) {
-    lines.push(`  @size(${padding}) padding : i32,`);
+    // Pad with a 'f16' if the padding requires an odd multiple of 2 bytes.
+    // This is required as 'i32' has an alignment and size of 4 bytes.
+    const ty = (padding & 2) !== 0 ? 'f16' : 'i32';
+    lines.push(`  @size(${padding}) padding : ${ty},`);
   }
   return lines.join('\n');
 }


### PR DESCRIPTION
`wgslMembers()` was using an `i32` to pad the structure to its alignment, however `i32` has an alignment and size of 4 bytes. If the structure holds an odd number of `f16` scalars, then `i32` cannot be used for this padding due to the 4-byte size and alignment. Pad with `f16` if the padding is an odd multiple of 2 bytes.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
