### PR TITLE
bytesPerBlock refactors; generalize validation,image_copy,buffer_related over aspects

### DIFF
--- a/src/webgpu/api/validation/image_copy/image_copy.ts
+++ b/src/webgpu/api/validation/image_copy/image_copy.ts
@@ -4,10 +4,28 @@ import {
   SizedTextureFormat,
   kTextureFormatInfo,
   isCompressedTextureFormat,
+  resolvePerAspectFormat,
+  kCompressedTextureFormats,
+  kDepthStencilFormats,
 } from '../../../format_info.js';
 import { align } from '../../../util/math.js';
 import { ImageCopyType } from '../../../util/texture/layout.js';
 import { ValidationTest } from '../validation_test.js';
+
+export const kReducedFormatsList = [
+  'r8unorm',
+  'rg8uint',
+  'rgba8snorm',
+  'r16sint',
+  'rg16float',
+  'rgba16float',
+  'r32float',
+  'rg32float',
+  'rgba32float',
+  'rgb9e5ufloat',
+  ...kCompressedTextureFormats,
+  ...kDepthStencilFormats,
+] as const;
 
 export class ImageCopyTest extends ValidationTest {
   testRun(
@@ -123,7 +141,7 @@ export class ImageCopyTest extends ValidationTest {
 
   testBuffer(
     buffer: GPUBuffer,
-    texture: GPUTexture,
+    texture: GPUImageCopyTexture,
     textureDataLayout: GPUImageDataLayout,
     size: GPUExtent3D,
     {
@@ -145,14 +163,14 @@ export class ImageCopyTest extends ValidationTest {
         const data = new Uint8Array(dataSize);
 
         this.expectValidationError(() => {
-          this.device.queue.writeTexture({ texture }, data, textureDataLayout, size);
+          this.device.queue.writeTexture(texture, data, textureDataLayout, size);
         }, !success);
 
         break;
       }
       case 'CopyB2T': {
         const { encoder, validateFinish, validateFinishAndSubmit } = this.createEncoder('non-pass');
-        encoder.copyBufferToTexture({ buffer, ...textureDataLayout }, { texture }, size);
+        encoder.copyBufferToTexture({ buffer, ...textureDataLayout }, texture, size);
 
         if (submit) {
           // validation error is expected to come from the submit and encoding should succeed
@@ -165,13 +183,13 @@ export class ImageCopyTest extends ValidationTest {
         break;
       }
       case 'CopyT2B': {
-        if (this.isCompatibility && isCompressedTextureFormat(texture.format)) {
+        if (this.isCompatibility && isCompressedTextureFormat(texture.texture.format)) {
           this.skip(
             'copyTextureToBuffer is not supported for compressed texture formats in compatibility mode.'
           );
         }
         const { encoder, validateFinish, validateFinishAndSubmit } = this.createEncoder('non-pass');
-        encoder.copyTextureToBuffer({ texture }, { buffer, ...textureDataLayout }, size);
+        encoder.copyTextureToBuffer(texture, { buffer, ...textureDataLayout }, size);
 
         if (submit) {
           // validation error is expected to come from the submit and encoding should succeed
@@ -244,7 +262,11 @@ export function texelBlockAlignmentTestExpanderForValueToCoordinate({
   }
 }
 
-// This is a helper function used for filtering test parameters
+/**
+ * This is a helper function used for filtering test parameters.
+ *
+ * @deprecated Prefer `aspectCopyableWithMethod` if possible.
+ */
 export function formatCopyableWithMethod({ format, method }: WithFormatAndMethod): boolean {
   const info = kTextureFormatInfo[format];
   if (info.depth || info.stencil) {
@@ -258,6 +280,20 @@ export function formatCopyableWithMethod({ format, method }: WithFormatAndMethod
     return info.color.copySrc;
   } else {
     return info.color.copyDst;
+  }
+}
+
+/** True iff the (format,aspect) pair can be copied with this method. */
+export function aspectCopyableWithMethod(
+  format: GPUTextureFormat,
+  aspect: 'color' | 'depth' | 'stencil',
+  method: ImageCopyType
+) {
+  const info = kTextureFormatInfo[format][aspect]!;
+  if (method === 'CopyT2B') {
+    return info.copySrc;
+  } else {
+    return info.copyDst;
   }
 }
 

--- a/src/webgpu/api/validation/image_copy/image_copy.ts
+++ b/src/webgpu/api/validation/image_copy/image_copy.ts
@@ -4,7 +4,6 @@ import {
   SizedTextureFormat,
   kTextureFormatInfo,
   isCompressedTextureFormat,
-  resolvePerAspectFormat,
   kCompressedTextureFormats,
   kDepthStencilFormats,
 } from '../../../format_info.js';

--- a/src/webgpu/format_info.spec.ts
+++ b/src/webgpu/format_info.spec.ts
@@ -1,0 +1,34 @@
+export const description = `
+Unittests for helpers in format_info.ts.
+`;
+
+import { Fixture } from '../common/framework/fixture.js';
+import { makeTestGroup } from '../common/framework/test_group.js';
+import { assert, objectEquals } from '../common/util/util.js';
+
+import { kDepthStencilFormats, kTextureFormatInfo, resolvePerAspectFormat } from './format_info.js';
+
+export const g = makeTestGroup(Fixture);
+
+g.test('resolvePerAspectFormat')
+  .desc(
+    `Test that resolvePerAspectFormat works and kTextureFormatInfo contains identical
+    information for the combined and separate versions of that aspect.`
+  )
+  .fn(t => {
+    for (const format of kDepthStencilFormats) {
+      const info = kTextureFormatInfo[format];
+      if (info.depth) {
+        const depthFormatInfo = kTextureFormatInfo[resolvePerAspectFormat(format, 'depth-only')];
+        assert(objectEquals(info.depth, depthFormatInfo.depth), 'Error in texture format table');
+      }
+      if (info.stencil) {
+        const stencilFormatInfo =
+          kTextureFormatInfo[resolvePerAspectFormat(format, 'stencil-only')];
+        assert(
+          objectEquals(info.stencil, stencilFormatInfo.stencil),
+          'Error in texture format table'
+        );
+      }
+    }
+  });

--- a/src/webgpu/format_info.ts
+++ b/src/webgpu/format_info.ts
@@ -1558,6 +1558,31 @@ export const kValidTextureFormatsForCopyE2T = [
 // Other related stuff
 //
 
+/**
+ * Pass this to `expandWithParams` to expand a format list into a format+aspect list.
+ *
+ * In some cases, `aspect` will be unset, invoking the default (which is always `"all"`).
+ */
+export function* aspectParamsForTextureFormat(format: GPUTextureFormat): Generator<{
+  /** `GPUTextureAspect | undefined` to pass to WebGPU. */
+  aspect?: 'depth-only' | 'stencil-only';
+  /** Key for the aspect in the info table: `kTextureFormatInfo[format][_aspectKey]`. */
+  _aspectKey: 'color' | 'depth' | 'stencil';
+}> {
+  const info = kTextureFormatInfo[format];
+  if (info.color?.bytes) {
+    yield { _aspectKey: 'color' } as const;
+  }
+  if (info.depth?.bytes) {
+    yield { aspect: 'depth-only', _aspectKey: 'depth' } as const;
+    if (!info.stencil) yield { _aspectKey: 'depth' } as const;
+  }
+  if (info.stencil?.bytes) {
+    yield { aspect: 'stencil-only', _aspectKey: 'stencil' } as const;
+    if (!info.depth) yield { _aspectKey: 'stencil' } as const;
+  }
+}
+
 const kDepthStencilFormatCapabilityInBufferTextureCopy = {
   // kUnsizedDepthStencilFormats
   depth24plus: {

--- a/src/webgpu/format_info.ts
+++ b/src/webgpu/format_info.ts
@@ -1,5 +1,5 @@
 import { keysOf } from '../common/util/data_tables.js';
-import { assert, objectEquals, unreachable } from '../common/util/util.js';
+import { assert, unreachable } from '../common/util/util.js';
 
 import { align } from './util/math.js';
 import { ImageCopyType } from './util/texture/layout.js';

--- a/src/webgpu/format_info.ts
+++ b/src/webgpu/format_info.ts
@@ -1,5 +1,5 @@
 import { keysOf } from '../common/util/data_tables.js';
-import { assert, unreachable } from '../common/util/util.js';
+import { assert, objectEquals, unreachable } from '../common/util/util.js';
 
 import { align } from './util/math.js';
 import { ImageCopyType } from './util/texture/layout.js';


### PR DESCRIPTION
Removes two uses of the deprecated .bytesPerBlock.

- Test a few depth/stencil formats that weren't in kSizedTextureFormats
  (depth24plus-stencil8 stencil, depth32float-stencil8 depth+stencil)
- Parameterize over aspect (depth-only/stencil-only/all)
- Reduce some overparameterization to make up for it (net ~3x faster)

Issue: Part 7 of #2495

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
