### PR TITLE
wgsl: valdate dot4I8Packed, dot4U8Packed on bool and bool vec

### DIFF
--- a/src/webgpu/shader/validation/expression/call/builtin/dot4I8Packed.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/dot4I8Packed.spec.ts
@@ -19,6 +19,8 @@ const kBadArgs = {
   '1f32': '(1u,2f)',
   '1bool': '(1u,true)',
   '1vec2u': '(1u,vec2u())',
+  bool_bool: '(false,true)',
+  bool2_bool2: '(vec2<bool>(),vec2(false,true))',
 };
 
 export const g = makeTestGroup(ShaderValidationTest);

--- a/src/webgpu/shader/validation/expression/call/builtin/dot4U8Packed.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/dot4U8Packed.spec.ts
@@ -19,6 +19,8 @@ const kBadArgs = {
   '1f32': '(1u,2f)',
   '1bool': '(1u,true)',
   '1vec2u': '(1u,vec2u())',
+  bool_bool: '(false,true)',
+  bool2_bool2: '(vec2<bool>(),vec2(false,true))',
 };
 
 export const g = makeTestGroup(ShaderValidationTest);


### PR DESCRIPTION


Issue: #3180

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
