### PR TITLE
Include offset variants for textureSample and textureSampleCompare

### DIFF
--- a/src/webgpu/shader/validation/expression/call/builtin/textureSample.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/textureSample.spec.ts
@@ -124,14 +124,14 @@ Validates that only incorrect array_index arguments are rejected by ${builtin}
       )
   )
   .fn(t => {
-    const { textureType, arrayIndexType, value } = t.params;
+    const { textureType, arrayIndexType, value, offset } = t.params;
     const arrayIndexArgType = kValuesTypes[arrayIndexType];
     const args = [arrayIndexArgType.create(value)];
     const { coordsArgType, offsetArgType } = kValidTextureSampleParameterTypes[textureType];
 
     const coordWGSL = coordsArgType.create(0).wgsl();
     const arrayWGSL = args.map(arg => arg.wgsl()).join(', ');
-    const offsetWGSL = offsetArgType ? `, ${offsetArgType.create(0).wgsl()}` : '';
+    const offsetWGSL = offset ? `, ${offsetArgType!.create(0).wgsl()}` : '';
 
     const code = `
 @group(0) @binding(0) var s: sampler;

--- a/src/webgpu/shader/validation/expression/call/builtin/textureSampleCompare.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/textureSampleCompare.spec.ts
@@ -118,14 +118,14 @@ Validates that only incorrect array_index arguments are rejected by ${builtin}
       )
   )
   .fn(t => {
-    const { textureType, arrayIndexType, value } = t.params;
+    const { textureType, arrayIndexType, value, offset } = t.params;
     const arrayIndexArgType = kValuesTypes[arrayIndexType];
     const args = [arrayIndexArgType.create(value)];
     const { coordsArgType, offsetArgType } = kValidTextureSampleCompareParameterTypes[textureType];
 
     const coordWGSL = coordsArgType.create(0).wgsl();
     const arrayWGSL = args.map(arg => arg.wgsl()).join(', ');
-    const offsetWGSL = offsetArgType ? `, ${offsetArgType.create(0).wgsl()}` : '';
+    const offsetWGSL = offset ? `, ${offsetArgType!.create(0).wgsl()}` : '';
 
     const code = `
 @group(0) @binding(0) var s: sampler_comparison;
@@ -162,7 +162,7 @@ Validates that only incorrect depth_ref arguments are rejected by ${builtin}
       )
   )
   .fn(t => {
-    const { textureType, depthRefType, value } = t.params;
+    const { textureType, depthRefType, value, offset } = t.params;
     const depthRefArgType = kValuesTypes[depthRefType];
     const args = [depthRefArgType.create(value)];
     const { coordsArgType, hasArrayIndexArg, offsetArgType } =
@@ -171,7 +171,7 @@ Validates that only incorrect depth_ref arguments are rejected by ${builtin}
     const coordWGSL = coordsArgType.create(0).wgsl();
     const arrayWGSL = hasArrayIndexArg ? ', 0' : '';
     const depthRefWGSL = args.map(arg => arg.wgsl()).join(', ');
-    const offsetWGSL = offsetArgType ? `, ${offsetArgType.create(0).wgsl()}` : '';
+    const offsetWGSL = offset ? `, ${offsetArgType!.create(0).wgsl()}` : '';
 
     const code = `
 @group(0) @binding(0) var s: sampler_comparison;


### PR DESCRIPTION
I missed these 


<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [X] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
