### PR TITLE
WGSL validation test for textureSampleBaseClampToEdge

### DIFF
--- a/src/webgpu/listing_meta.json
+++ b/src/webgpu/listing_meta.json
@@ -1956,6 +1956,7 @@
   "webgpu:shader,validation,expression,call,builtin,textureSample:offset_argument,non_const:*": { "subcaseMS": 1.604 },
   "webgpu:shader,validation,expression,call,builtin,textureSample:offset_argument:*": { "subcaseMS": 1.401 },
   "webgpu:shader,validation,expression,call,builtin,textureSample:only_in_fragment:*": { "subcaseMS": 1.121 },
+  "webgpu:shader,validation,expression,call,builtin,textureSampleBaseClampToEdge:coords_argument:*": { "subcaseMS": 239.356 },
   "webgpu:shader,validation,expression,call,builtin,textureSampleBias:array_index_argument:*": { "subcaseMS": 1.630 },
   "webgpu:shader,validation,expression,call,builtin,textureSampleBias:bias_argument:*": { "subcaseMS": 1.102 },
   "webgpu:shader,validation,expression,call,builtin,textureSampleBias:coords_argument:*": { "subcaseMS": 1.938 },

--- a/src/webgpu/shader/validation/expression/call/builtin/textureSampleBaseClampToEdge.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/textureSampleBaseClampToEdge.spec.ts
@@ -1,0 +1,54 @@
+const builtin = 'textureSampleBaseClampToEdge';
+export const description = `
+Validation tests for the ${builtin}() builtin.
+
+* test textureSampleBaseClampToEdge coords parameter must be correct type
+`;
+
+import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
+import { keysOf, objectsToRecord } from '../../../../../../common/util/data_tables.js';
+import {
+  Type,
+  kAllScalarsAndVectors,
+  isConvertible,
+  isUnsignedType,
+} from '../../../../../util/conversion.js';
+import { ShaderValidationTest } from '../../../shader_validation_test.js';
+
+const kTextureSampleBaseClampToEdgeTextureTypes = ['texture_2d<f32>', 'texture_external'] as const;
+const kValuesTypes = objectsToRecord(kAllScalarsAndVectors);
+
+export const g = makeTestGroup(ShaderValidationTest);
+
+g.test('coords_argument')
+  .specURL('https://gpuweb.github.io/gpuweb/wgsl/#texturesamplebaseclamptoedge')
+  .desc(
+    `
+Validates that only incorrect coords arguments are rejected by ${builtin}
+`
+  )
+  .params(u =>
+    u
+      .combine('textureType', kTextureSampleBaseClampToEdgeTextureTypes)
+      .combine('coordType', keysOf(kValuesTypes))
+      .beginSubcases()
+      .combine('value', [-1, 0, 1] as const)
+      // filter out unsigned types with negative values
+      .filter(t => !isUnsignedType(kValuesTypes[t.coordType]) || t.value >= 0)
+  )
+  .fn(t => {
+    const { textureType, coordType, value } = t.params;
+    const coordArgType = kValuesTypes[coordType];
+    const coordWGSL = coordArgType.create(value).wgsl();
+
+    const code = `
+@group(0) @binding(0) var s: sampler;
+@group(0) @binding(1) var t: ${textureType};
+@fragment fn fs() -> @location(0) vec4f {
+  let v = textureSampleBaseClampToEdge(t, s, ${coordWGSL});
+  return vec4f(0);
+}
+`;
+    const expectSuccess = isConvertible(coordArgType, Type.vec2f);
+    t.expectCompileResult(expectSuccess, code);
+  });


### PR DESCRIPTION

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [X] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
