### PR TITLE
Fix intra-invocation coherence 3d tests

### DIFF
--- a/src/webgpu/shader/execution/memory_model/texture_intra_invocation_coherence.spec.ts
+++ b/src/webgpu/shader/execution/memory_model/texture_intra_invocation_coherence.spec.ts
@@ -39,7 +39,7 @@ fn indexToCoord(idx : u32) -> vec2u {
     case '3d': {
       return `
 fn indexToCoord(idx : u32) -> vec3u {
-  return vec3u(idx % (wgx * num_wgs_x), idx / (wgx * num_wgs_x), 1);
+  return vec3u(idx % (wgx * num_wgs_x), idx / (wgx * num_wgs_x), 0);
 }`;
     }
     default: {


### PR DESCRIPTION
* Coordinates for 3D textures currently use 1 for the z component instead of 0, but the texutre is always created with a depth of 1 so this is out of bounds




Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
