### PR TITLE
Revert #3469 and #3466

### DIFF
--- a/src/webgpu/api/operation/rendering/draw.spec.ts
+++ b/src/webgpu/api/operation/rendering/draw.spec.ts
@@ -11,10 +11,10 @@ import {
   TypedArrayBufferView,
   TypedArrayBufferViewConstructor,
 } from '../../../../common/util/util.js';
-import { AdapterLimitsGPUTest, TextureTestMixin } from '../../../gpu_test.js';
+import { GPUTest, TextureTestMixin } from '../../../gpu_test.js';
 import { PerPixelComparison } from '../../../util/texture/texture_ok.js';
 
-class DrawTest extends TextureTestMixin(AdapterLimitsGPUTest) {
+class DrawTest extends TextureTestMixin(GPUTest) {
   checkTriangleDraw(opts: {
     firstIndex: number | undefined;
     count: number;

--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -93,47 +93,11 @@ export function initUncanonicalizedDeviceDescriptor(
   }
 }
 
-/**
- * Gets the adapter limits as a standard JavaScript object.
- */
-function getAdapterLimitsAsDeviceRequiredLimits(adapter: GPUAdapter) {
-  const requiredLimits: Record<string, GPUSize64> = {};
-  const adapterLimits = adapter.limits as unknown as Record<string, GPUSize64>;
-  for (const key in adapter.limits) {
-    requiredLimits[key] = adapterLimits[key];
-  }
-  return requiredLimits;
-}
-
-/**
- * Conditionally applies adapter limits to device descriptor
- * but does not overwrite existing requested limits.
- */
-function conditionallyApplyAdapterLimitsToDeviceDescriptor(
-  adapter: GPUAdapter,
-  useAdapterLimits: boolean,
-  descriptor: UncanonicalizedDeviceDescriptor | undefined
-): UncanonicalizedDeviceDescriptor {
-  return {
-    ...(descriptor || {}),
-    requiredLimits: {
-      ...(useAdapterLimits && getAdapterLimitsAsDeviceRequiredLimits(adapter)),
-      ...(descriptor?.requiredLimits || {}),
-    },
-  };
-}
-
 export class GPUTestSubcaseBatchState extends SubcaseBatchState {
   /** Provider for default device. */
   private provider: Promise<DeviceProvider> | undefined;
   /** Provider for mismatched device. */
   private mismatchedProvider: Promise<DeviceProvider> | undefined;
-  /** True if device should be created with adapter limits */
-  private useAdapterLimits = false;
-
-  constructor(recorder: TestCaseRecorder, params: TestParams) {
-    super(recorder, params);
-  }
 
   override async postInit(): Promise<void> {
     // Skip all subcases if there's no device.
@@ -159,14 +123,6 @@ export class GPUTestSubcaseBatchState extends SubcaseBatchState {
     return this.provider;
   }
 
-  useAdapterLimitsForDevice() {
-    assert(
-      this.provider === undefined,
-      'useAdapterLimits must be called before getting the device'
-    );
-    this.useAdapterLimits = true;
-  }
-
   get isCompatibility() {
     return globalTestConfig.compatibility;
   }
@@ -184,18 +140,10 @@ export class GPUTestSubcaseBatchState extends SubcaseBatchState {
    */
   selectDeviceOrSkipTestCase(descriptor: DeviceSelectionDescriptor): void {
     assert(this.provider === undefined, "Can't selectDeviceOrSkipTestCase() multiple times");
-    this.provider = devicePool
-      .requestAdapter(this.recorder)
-      .then(adapter =>
-        devicePool.acquire(
-          adapter,
-          conditionallyApplyAdapterLimitsToDeviceDescriptor(
-            adapter,
-            this.useAdapterLimits,
-            initUncanonicalizedDeviceDescriptor(descriptor)
-          )
-        )
-      );
+    this.provider = devicePool.acquire(
+      this.recorder,
+      initUncanonicalizedDeviceDescriptor(descriptor)
+    );
     // Suppress uncaught promise rejection (we'll catch it later).
     this.provider.catch(() => {});
   }
@@ -253,18 +201,10 @@ export class GPUTestSubcaseBatchState extends SubcaseBatchState {
       "Can't selectMismatchedDeviceOrSkipTestCase() multiple times"
     );
 
-    this.mismatchedProvider = mismatchedDevicePool
-      .requestAdapter(this.recorder)
-      .then(adapter =>
-        mismatchedDevicePool.acquire(
-          adapter,
-          conditionallyApplyAdapterLimitsToDeviceDescriptor(
-            adapter,
-            this.useAdapterLimits,
-            initUncanonicalizedDeviceDescriptor(descriptor)
-          )
-        )
-      );
+    this.mismatchedProvider = mismatchedDevicePool.acquire(
+      this.recorder,
+      initUncanonicalizedDeviceDescriptor(descriptor)
+    );
     // Suppress uncaught promise rejection (we'll catch it later).
     this.mismatchedProvider.catch(() => {});
   }
@@ -1260,20 +1200,6 @@ export class GPUTest extends GPUTestBase {
   expectDeviceLost(reason: GPUDeviceLostReason): void {
     assert(this.provider !== undefined, 'internal error: GPUDevice missing?');
     this.provider.expectDeviceLost(reason);
-  }
-}
-
-/**
- * A version of GPUTest that requires the adapter limits.
- */
-export class AdapterLimitsGPUTest extends GPUTest {
-  public static override MakeSharedState(
-    recorder: TestCaseRecorder,
-    params: TestParams
-  ): GPUTestSubcaseBatchState {
-    const state = new GPUTestSubcaseBatchState(recorder, params);
-    state.useAdapterLimitsForDevice();
-    return state;
   }
 }
 

--- a/src/webgpu/util/device_pool.ts
+++ b/src/webgpu/util/device_pool.ts
@@ -22,21 +22,33 @@ class FeaturesNotSupported extends Error {}
 export class TestOOMedShouldAttemptGC extends Error {}
 
 export class DevicePool {
-  private holders = new DescriptorToHolderMap();
-
-  async requestAdapter(recorder: TestCaseRecorder) {
-    const gpu = getGPU(recorder);
-    const adapter = await gpu.requestAdapter();
-    assert(adapter !== null, 'requestAdapter returned null');
-    return adapter;
-  }
+  private holders: 'uninitialized' | 'failed' | DescriptorToHolderMap = 'uninitialized';
 
   /** Acquire a device from the pool and begin the error scopes. */
   async acquire(
-    adapter: GPUAdapter,
+    recorder: TestCaseRecorder,
     descriptor?: UncanonicalizedDeviceDescriptor
   ): Promise<DeviceProvider> {
-    const holder = await this.holders.getOrCreate(adapter, descriptor);
+    let errorMessage = '';
+    if (this.holders === 'uninitialized') {
+      this.holders = new DescriptorToHolderMap();
+      try {
+        await this.holders.getOrCreate(recorder, undefined);
+      } catch (ex) {
+        this.holders = 'failed';
+        if (ex instanceof Error) {
+          errorMessage = ` with ${ex.name} "${ex.message}"`;
+        }
+      }
+    }
+
+    assert(
+      this.holders !== 'failed',
+      `WebGPU device failed to initialize${errorMessage}; not retrying`
+    );
+
+    const holder = await this.holders.getOrCreate(recorder, descriptor);
+
     assert(holder.state === 'free', 'Device was in use on DevicePool.acquire');
     holder.state = 'acquired';
     holder.beginTestScope();
@@ -126,7 +138,7 @@ class DescriptorToHolderMap {
    * Throws SkipTestCase if devices with this descriptor are unsupported.
    */
   async getOrCreate(
-    adapter: GPUAdapter,
+    recorder: TestCaseRecorder,
     uncanonicalizedDescriptor: UncanonicalizedDeviceDescriptor | undefined
   ): Promise<DeviceHolder> {
     const [descriptor, key] = canonicalizeDescriptor(uncanonicalizedDescriptor);
@@ -151,7 +163,7 @@ class DescriptorToHolderMap {
     // No existing item was found; add a new one.
     let value;
     try {
-      value = await DeviceHolder.create(adapter, descriptor);
+      value = await DeviceHolder.create(recorder, descriptor);
     } catch (ex) {
       if (ex instanceof FeaturesNotSupported) {
         this.unsupported.add(key);
@@ -286,14 +298,15 @@ class DeviceHolder implements DeviceProvider {
   // Gets a device and creates a DeviceHolder.
   // If the device is lost, DeviceHolder.lost gets set.
   static async create(
-    adapter: GPUAdapter,
+    recorder: TestCaseRecorder,
     descriptor: CanonicalDeviceDescriptor | undefined
   ): Promise<DeviceHolder> {
-    assert(adapter !== null, 'requestAdapter is null');
+    const gpu = getGPU(recorder);
+    const adapter = await gpu.requestAdapter();
+    assert(adapter !== null, 'requestAdapter returned null');
     if (!supportsFeature(adapter, descriptor)) {
       throw new FeaturesNotSupported('One or more features are not supported');
     }
-
     const device = await adapter.requestDevice(descriptor);
     assert(device !== null, 'requestDevice returned null');
 


### PR DESCRIPTION
This reverts commits:
* f71a8343c3b4ea23eddf0cf35b9957a0b45b0cf3 - `Fix device_pool refactor`
* 0a68bf71fb07b7ecd117d84d919fbaf81e302403 - `Add AdapterLimitsGPUTest that sets all limits to the adapter's`

These changes have been idenitified as causing a large collection of CTS failures with `webgpu:web_platform,copyToTexture,ImageBitmap` (and possibly others).

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
