### PR TITLE
Fix depth_clamp_and_clip test

### DIFF
--- a/src/webgpu/api/operation/rendering/depth_clip_clamp.spec.ts
+++ b/src/webgpu/api/operation/rendering/depth_clip_clamp.spec.ts
@@ -272,7 +272,9 @@ have unexpected values then get drawn to the color buffer, which is later checke
       pass.end();
     }
     if (dsActual) {
-      enc.copyTextureToBuffer({ texture: dsTexture }, { buffer: dsActual }, [kNumTestPoints]);
+      enc.copyTextureToBuffer({ texture: dsTexture, aspect: 'depth-only' }, { buffer: dsActual }, [
+        kNumTestPoints,
+      ]);
     }
     {
       const clearValue = [0, 0, 0, 0]; // Will see this color if the check passed.
@@ -304,7 +306,11 @@ have unexpected values then get drawn to the color buffer, which is later checke
     }
     enc.copyTextureToBuffer({ texture: checkTexture }, { buffer: checkBuffer }, [kNumTestPoints]);
     if (dsExpected) {
-      enc.copyTextureToBuffer({ texture: dsTexture }, { buffer: dsExpected }, [kNumTestPoints]);
+      enc.copyTextureToBuffer(
+        { texture: dsTexture, aspect: 'depth-only' },
+        { buffer: dsExpected },
+        [kNumTestPoints]
+      );
     }
     t.device.queue.submit([enc.finish()]);
 


### PR DESCRIPTION
Broken in #3412. Prior to this, some copies were being skipped for some formats because bytesPerBlock was undefined for those copies.
This doesn't change the coverage of the test though, as the actual check that used those copies is still skipped.

I missed the regressions before because they were a bit buried in existing failures on my machine.

Issue: #2495

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
