### PR TITLE
Move more tests into subcases

### DIFF
--- a/src/webgpu/api/operation/rendering/color_target_state.spec.ts
+++ b/src/webgpu/api/operation/rendering/color_target_state.spec.ts
@@ -165,6 +165,7 @@ g.test('blending,GPUBlendComponent')
       .combine('component', ['color', 'alpha'] as const)
       .combine('srcFactor', kBlendFactors)
       .combine('dstFactor', kBlendFactors)
+      .beginSubcases()
       .combine('operation', kBlendOperations)
       .filter(t => {
         if (t.operation === 'min' || t.operation === 'max') {
@@ -172,7 +173,6 @@ g.test('blending,GPUBlendComponent')
         }
         return true;
       })
-      .beginSubcases()
       .combine('srcColor', [{ r: 0.11, g: 0.61, b: 0.81, a: 0.44 }])
       .combine('dstColor', [
         { r: 0.51, g: 0.22, b: 0.71, a: 0.33 },

--- a/src/webgpu/shader/validation/expression/binary/add_sub_mul.spec.ts
+++ b/src/webgpu/shader/validation/expression/binary/add_sub_mul.spec.ts
@@ -33,7 +33,6 @@ g.test('scalar_vector')
   )
   .params(u =>
     u
-      .combine('op', keysOf(kOperators))
       .combine('lhs', keysOf(kScalarAndVectorTypes))
       .combine(
         'rhs',
@@ -44,6 +43,7 @@ g.test('scalar_vector')
         )
       )
       .beginSubcases()
+      .combine('op', keysOf(kOperators))
   )
   .beforeAllSubcases(t => {
     if (

--- a/src/webgpu/shader/validation/expression/binary/and_or_xor.spec.ts
+++ b/src/webgpu/shader/validation/expression/binary/and_or_xor.spec.ts
@@ -33,7 +33,6 @@ g.test('scalar_vector')
   )
   .params(u =>
     u
-      .combine('op', keysOf(kOperators))
       .combine('lhs', keysOf(kScalarAndVectorTypes))
       .combine(
         'rhs',
@@ -44,6 +43,7 @@ g.test('scalar_vector')
         )
       )
       .beginSubcases()
+      .combine('op', keysOf(kOperators))
   )
   .beforeAllSubcases(t => {
     if (

--- a/src/webgpu/shader/validation/expression/binary/bitwise_shift.spec.ts
+++ b/src/webgpu/shader/validation/expression/binary/bitwise_shift.spec.ts
@@ -39,7 +39,6 @@ g.test('scalar_vector')
   )
   .params(u =>
     u
-      .combine('op', ['<<', '>>'])
       .combine('lhs', keysOf(kScalarAndVectorTypes))
       .combine(
         'rhs',
@@ -49,6 +48,7 @@ g.test('scalar_vector')
         )
       )
       .beginSubcases()
+      .combine('op', ['<<', '>>'])
   )
   .beforeAllSubcases(t => {
     if (

--- a/src/webgpu/shader/validation/expression/binary/comparison.spec.ts
+++ b/src/webgpu/shader/validation/expression/binary/comparison.spec.ts
@@ -37,7 +37,6 @@ g.test('scalar_vector')
   )
   .params(u =>
     u
-      .combine('op', keysOf(kComparisonOperators))
       .combine('lhs', keysOf(kScalarAndVectorTypes))
       .combine(
         'rhs',
@@ -47,6 +46,7 @@ g.test('scalar_vector')
         )
       )
       .beginSubcases()
+      .combine('op', keysOf(kComparisonOperators))
   )
   .beforeAllSubcases(t => {
     if (

--- a/src/webgpu/shader/validation/expression/unary/address_of_and_indirection.spec.ts
+++ b/src/webgpu/shader/validation/expression/unary/address_of_and_indirection.spec.ts
@@ -99,10 +99,11 @@ g.test('composite')
   .params(u =>
     u
       .combine('addressSpace', kAddressSpaces)
-      .combine('accessMode', kAccessModes)
-      .combine('storageType', kStorageTypes)
       .combine('compositeType', kCompositeTypes)
+      .combine('storageType', kStorageTypes)
+      .beginSubcases()
       .combine('derefType', keysOf(kDerefTypes))
+      .combine('accessMode', kAccessModes)
       .filter(t => {
         if (t.storageType === 'bool') {
           return t.addressSpace === 'function' || t.addressSpace === 'private';


### PR DESCRIPTION
Reduces the number of tests by ~5000, speeding up testing harnesses.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
