### PR TITLE
Add `acosh` validation tests.

### DIFF
--- a/src/webgpu/listing_meta.json
+++ b/src/webgpu/listing_meta.json
@@ -1879,6 +1879,7 @@
   "webgpu:shader,validation,expression,call,builtin,acos:parameters:*": { "subcaseMS": 44.578 },
   "webgpu:shader,validation,expression,call,builtin,acos:values:*": { "subcaseMS": 0.342 },
   "webgpu:shader,validation,expression,call,builtin,acosh:integer_argument:*": { "subcaseMS": 1.234 },
+  "webgpu:shader,validation,expression,call,builtin,acosh:parameters:*": { "subcaseMS": 152.403 },
   "webgpu:shader,validation,expression,call,builtin,acosh:values:*": { "subcaseMS": 0.217 },
   "webgpu:shader,validation,expression,call,builtin,arrayLength:access_mode:*": { "subcaseMS": 0.000 },
   "webgpu:shader,validation,expression,call,builtin,arrayLength:bool_type:*": { "subcaseMS": 0.000 },

--- a/src/webgpu/shader/validation/expression/call/builtin/acosh.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/acosh.spec.ts
@@ -86,3 +86,127 @@ Validates that scalar and vector integer arguments are rejected by ${builtin}()
       'constant'
     );
   });
+
+const kTests = {
+  valid: {
+    src: `_ = acosh(1);`,
+    pass: true,
+  },
+  alias: {
+    src: `_ = acosh(f32_alias(1));`,
+    pass: true,
+  },
+
+  bool: {
+    src: `_ = acosh(false);`,
+    pass: false,
+  },
+  i32: {
+    src: `_ = acosh(1i);`,
+    pass: false,
+  },
+  u32: {
+    src: `_ = acosh(1u);`,
+    pass: false,
+  },
+  vec_bool: {
+    src: `_ = acosh(vec2<bool>(false, true));`,
+    pass: false,
+  },
+  vec_i32: {
+    src: `_ = acosh(vec2<i32>(1, 1));`,
+    pass: false,
+  },
+  vec_u32: {
+    src: `_ = acosh(vec2<u32>(1, 1));`,
+    pass: false,
+  },
+  matrix: {
+    src: `_ = acosh(mat2x2(1, 1, 1, 1));`,
+    pass: false,
+  },
+  atomic: {
+    src: ` _ = acosh(a);`,
+    pass: false,
+  },
+  array: {
+    src: `var a: array<u32, 5>;
+          _ = acosh(a);`,
+    pass: false,
+  },
+  array_runtime: {
+    src: `_ = acosh(k.arry);`,
+    pass: false,
+  },
+  struct: {
+    src: `var a: A;
+          _ = acosh(a);`,
+    pass: false,
+  },
+  enumerant: {
+    src: `_ = acosh(read_write);`,
+    pass: false,
+  },
+  ptr: {
+    src: `var<function> a = 1f;
+          let p: ptr<function, f32> = &a;
+          _ = acosh(p);`,
+    pass: false,
+  },
+  ptr_deref: {
+    src: `var<function> a = 1f;
+          let p: ptr<function, f32> = &a;
+          _ = acosh(*p);`,
+    pass: true,
+  },
+  sampler: {
+    src: `_ = acosh(s);`,
+    pass: false,
+  },
+  texture: {
+    src: `_ = acosh(t);`,
+    pass: false,
+  },
+  no_params: {
+    src: `_ = acosh();`,
+    pass: false,
+  },
+  too_many_params: {
+    src: `_ = acosh(1, 2);`,
+    pass: false,
+  },
+
+  less_then_one: {
+    src: `_ = acosh(.9f);`,
+    pass: false,
+  },
+};
+
+g.test('parameters')
+  .desc(`Test that ${builtin} is validated correctly.`)
+  .params(u => u.combine('test', keysOf(kTests)))
+  .fn(t => {
+    const src = kTests[t.params.test].src;
+    const code = `
+alias f32_alias = f32;
+
+@group(0) @binding(0) var s: sampler;
+@group(0) @binding(1) var t: texture_2d<f32>;
+
+var<workgroup> a: atomic<u32>;
+
+struct A {
+  i: u32,
+}
+struct B {
+  arry: array<u32>,
+}
+@group(0) @binding(3) var<storage> k: B;
+
+@vertex
+fn main() -> @builtin(position) vec4<f32> {
+  ${src}
+  return vec4<f32>(.4, .2, .3, .1);
+}`;
+    t.expectCompileResult(kTests[t.params.test].pass, code);
+  });


### PR DESCRIPTION
This CL adds validation for invalid parameters to the `acosh` builtin.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
