### PR TITLE
Add invalid function parameter validation.

### DIFF
--- a/src/webgpu/shader/validation/functions/restrictions.spec.ts
+++ b/src/webgpu/shader/validation/functions/restrictions.spec.ts
@@ -292,6 +292,7 @@ const kFunctionParamTypeCases: Record<string, ParamTypeCase> = {
   invalid_ptr5: { name: `ptr<private,u32,write>`, valid: false }, // Can't specify access mode
   invalid_ptr6: { name: `ptr<private,u32,read_write>`, valid: false }, // Can't specify access mode
   invalid_ptr7: { name: `ptr<private,clamp>`, valid: false }, // Invalid store type
+  invalid_ptr8: { name: `ptr<function, texture_external>`, valid: false }, // non-constructable pointer type
 };
 
 g.test('function_parameter_types')


### PR DESCRIPTION
This CL adds a test for a function which takes a `ptr<function, texture_external>` as a parameter. This parameter is invalid because a pointer must be able to be created in a program and it is invalid to take the address of a `handle` type object.

This test currently fails in Tint as covers a bug which is not yet fixed.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
