### PR TITLE
Add validation tests for type aliases

### DIFF
--- a/src/webgpu/listing_meta.json
+++ b/src/webgpu/listing_meta.json
@@ -2406,6 +2406,8 @@
   "webgpu:shader,validation,shader_io,workgroup_size:workgroup_size_function:*": { "subcaseMS": 0.800 },
   "webgpu:shader,validation,shader_io,workgroup_size:workgroup_size_var:*": { "subcaseMS": 2.101 },
   "webgpu:shader,validation,shader_io,workgroup_size:workgroup_size_vertex_shader:*": { "subcaseMS": 1.000 },
+  "webgpu:shader,validation,types,alias:any_type:*": { "subcaseMS": 42.329 },
+  "webgpu:shader,validation,types,alias:match_non_alias:*": { "subcaseMS": 3.767 },
   "webgpu:shader,validation,types,alias:no_direct_recursion:*": { "subcaseMS": 1.450 },
   "webgpu:shader,validation,types,alias:no_indirect_recursion:*": { "subcaseMS": 1.000 },
   "webgpu:shader,validation,types,alias:no_indirect_recursion_via_array_element:*": { "subcaseMS": 1.050 },

--- a/src/webgpu/shader/validation/types/alias.spec.ts
+++ b/src/webgpu/shader/validation/types/alias.spec.ts
@@ -3,6 +3,7 @@ Validation tests for type aliases
 `;
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { keysOf } from '../../../../common/util/data_tables.js';
 import { ShaderValidationTest } from '../shader_validation_test.js';
 
 export const g = makeTestGroup(ShaderValidationTest);
@@ -120,4 +121,125 @@ struct S {
 alias T = ${t.params.target};
 `;
     t.expectCompileResult(t.params.target === 'i32', wgsl);
+  });
+
+const kTypes = [
+  'bool',
+  'i32',
+  'u32',
+  'f32',
+  'f16',
+  'vec2<i32>',
+  'vec3<u32>',
+  'vec4<f32>',
+  'mat2x2<f32>',
+  'mat2x3<f32>',
+  'mat2x4<f32>',
+  'mat3x2<f32>',
+  'mat3x3<f32>',
+  'mat3x4<f32>',
+  'mat4x2<f32>',
+  'mat4x3<f32>',
+  'mat4x4<f32>',
+  'array<u32>',
+  'array<i32, 4>',
+  'array<vec2<u32>, 8>',
+  'S',
+  'T',
+  'atomic<u32>',
+  'atomic<i32>',
+  'ptr<function, u32>',
+  'ptr<private, i32>',
+  'ptr<workgroup, f32>',
+  'ptr<uniform, vec2f>',
+  'ptr<storage, vec2u>',
+  'ptr<storage, vec3i, read>',
+  'ptr<storage, vec4f, read_write>',
+  'sampler',
+  'sampler_comparison',
+  'texture_1d<f32>',
+  'texture_2d<u32>',
+  'texture_2d_array<i32>',
+  'texture_3d<f32>',
+  'texture_cube<i32>',
+  'texture_cube_array<u32>',
+  'texture_multisampled_2d<f32>',
+  'texture_depth_multisampled_2d',
+  'texture_external',
+  'texture_storage_1d<rgba8snorm, write>',
+  'texture_storage_1d<r32uint, write>',
+  'texture_storage_1d<r32sint, read_write>',
+  'texture_storage_1d<r32float, read>',
+  'texture_storage_2d<rgba16uint, write>',
+  'texture_storage_2d_array<rg32float, write>',
+  'texture_storage_3d<bgra8unorm, write>',
+  'texture_depth_2d',
+  'texture_depth_2d_array',
+  'texture_depth_cube',
+  'texture_depth_cube_array',
+
+  // Pre-declared aliases (spot check)
+  'vec2f',
+  'vec3u',
+  'vec4i',
+  'mat2x2f',
+
+  // User-defined aliases
+  'anotherAlias',
+  'random_alias',
+];
+
+g.test('any_type')
+  .desc('Test that any type can be aliased')
+  .params(u => u.combine('type', kTypes))
+  .beforeAllSubcases(t => {
+    if (t.params.type === 'f16') {
+      t.selectDeviceOrSkipTestCase('shader-f16');
+    }
+  })
+  .fn(t => {
+    const ty = t.params.type;
+    t.skipIf(
+      ty.includes('texture_storage') &&
+        ty.includes('read') &&
+        !t.hasLanguageFeature('readonly_and_readwrite_storage_textures'),
+      'Missing language feature'
+    );
+    const enable = ty === 'f16' ? 'enable f16;' : '';
+    const code = `
+    ${enable}
+    struct S { x : u32 }
+    struct T { y : S }
+    alias anotherAlias = u32;
+    alias random_alias = i32;
+    alias myType = ${ty};`;
+    t.expectCompileResult(true, code);
+  });
+
+const kMatchCases = {
+  function_param: `
+    fn foo(x : u32) { }
+    fn bar() {
+      var x : alias_alias_u32;
+      foo(x);
+    }`,
+  constructor: `var<private> v : u32 = alias_u32(1);`,
+  template_param: `var<private> v : vec2<alias_u32> = vec2<u32>();`,
+  predeclared_alias: `var<private> v : vec2<alias_alias_u32> = vec2u();`,
+  struct_element: `
+    struct S { x : alias_u32 }
+    const c_u32 = 0u;
+    const c = S(c_u32);`,
+};
+
+g.test('match_non_alias')
+  .desc('Test that type checking succeeds using aliased and unaliased type')
+  .params(u => u.combine('case', keysOf(kMatchCases)))
+  .fn(t => {
+    const testcase = kMatchCases[t.params.case];
+    const code = `
+    alias alias_u32 = u32;
+    alias alias_alias_u32 = alias_u32;
+    ${testcase}`;
+    t.expectCompileResult(true, code);
   });


### PR DESCRIPTION


Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
