### PR TITLE
Modernizes ceil/clamp tests to cover remaining types

### DIFF
--- a/src/webgpu/shader/validation/expression/call/builtin/ceil.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/ceil.spec.ts
@@ -54,6 +54,7 @@ Validates that constant evaluation and override evaluation of ${builtin}() never
     );
   });
 
+// f32 is included here to confirm that validation is failing due to a type issue and not something else.
 const kIntegerArgumentTypes = objectsToRecord([Type.f32, ...kConcreteIntegerScalarsAndVectors]);
 
 g.test('integer_argument')
@@ -72,4 +73,132 @@ Validates that scalar and vector integer arguments are rejected by ${builtin}()
       [type.create(0)],
       'constant'
     );
+  });
+
+const kTests: {
+  readonly [name: string]: {
+    /** Arguments to pass to the builtin with parentheses. */
+    readonly args: string;
+    /** Should the test case pass. */
+    readonly pass: boolean;
+    /** Additional setup code in the function scope. */
+    readonly preamble?: string;
+  };
+} = {
+  valid: {
+    args: '(1.0f)',
+    pass: true,
+  },
+  // Number of arguments.
+  no_parens: {
+    args: '',
+    pass: false,
+  },
+  too_few_args: {
+    args: '()',
+    pass: false,
+  },
+  too_many_args: {
+    args: '(1.f,2.f)',
+    pass: false,
+  },
+  // Arguments types (only 1 argument for this builtin).
+  alias: {
+    args: '(f32_alias(1.f))',
+    pass: true,
+  },
+  bool: {
+    args: '(false)',
+    pass: false,
+  },
+  vec_bool: {
+    args: '(vec2<bool>(false,true))',
+    pass: false,
+  },
+  matrix: {
+    args: '(mat2x2(1.f,1.f,1.f,1.f))',
+    pass: false,
+  },
+  atomic: {
+    args: '(a)',
+    pass: false,
+  },
+  array: {
+    preamble: 'var arry: array<f32, 5>;',
+    args: '(arry)',
+    pass: false,
+  },
+  array_runtime: {
+    args: '(k.arry)',
+    pass: false,
+  },
+  struct: {
+    preamble: 'var x: A;',
+    args: '(x)',
+    pass: false,
+  },
+  enumerant: {
+    args: '(read_write)',
+    pass: false,
+  },
+  ptr: {
+    preamble: `var<function> f = 1.f;
+                 let p: ptr<function, f32> = &f;`,
+    args: '(p)',
+    pass: false,
+  },
+  ptr_deref: {
+    preamble: `var<function> f = 1.f;
+                 let p: ptr<function, f32> = &f;`,
+    args: '(*p)',
+    pass: true,
+  },
+  sampler: {
+    args: '(s)',
+    pass: false,
+  },
+  texture: {
+    args: '(t)',
+    pass: false,
+  },
+};
+
+g.test('arguments')
+  .desc(`Test compilation validation of ${builtin} with variously shaped and typed arguments`)
+  .params(u => u.combine('test', keysOf(kTests)))
+  .fn(t => {
+    const test = kTests[t.params.test];
+    t.expectCompileResult(
+      test.pass,
+      `alias f32_alias = f32;
+
+        @group(0) @binding(0) var s: sampler;
+        @group(0) @binding(1) var t: texture_2d<f32>;
+
+        var<workgroup> a: atomic<u32>;
+
+        struct A {
+          i: f32,
+        }
+        struct B {
+          arry: array<f32>,
+        }
+        @group(0) @binding(3) var<storage> k: B;
+
+
+        @vertex
+        fn main() -> @builtin(position) vec4<f32> {
+          ${test.preamble ? test.preamble : ''}
+          _ = ${builtin}${test.args};
+          return vec4<f32>(.4, .2, .3, .1);
+        }`
+    );
+  });
+
+g.test('must_use')
+  .desc(`Result of ${builtin} must be used`)
+  .params(u => u.combine('use', [true, false]))
+  .fn(t => {
+    const use_it = t.params.use ? '_ = ' : '';
+    t.expectCompileResult(t.params.use, `fn f() { ${use_it}${builtin}(1.0f); }`);
   });

--- a/src/webgpu/shader/validation/expression/call/builtin/clamp.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/clamp.spec.ts
@@ -7,9 +7,11 @@ import { makeTestGroup } from '../../../../../../common/framework/test_group.js'
 import { keysOf, objectsToRecord } from '../../../../../../common/util/data_tables.js';
 import {
   Type,
-  kFloatScalarsAndVectors,
+  kConvertableToFloatScalarsAndVectors,
   kConcreteIntegerScalarsAndVectors,
   scalarTypeOf,
+  f32,
+  isConvertible,
 } from '../../../../../util/conversion.js';
 import { ShaderValidationTest } from '../../../shader_validation_test.js';
 
@@ -23,7 +25,7 @@ import {
 export const g = makeTestGroup(ShaderValidationTest);
 
 const kValuesTypes = objectsToRecord([
-  ...kFloatScalarsAndVectors,
+  ...kConvertableToFloatScalarsAndVectors,
   ...kConcreteIntegerScalarsAndVectors,
 ]);
 
@@ -58,4 +60,170 @@ Validates that constant evaluation and override evaluation of ${builtin}() rejec
       [type.create(t.params.e), type.create(t.params.low), type.create(t.params.high)],
       t.params.stage
     );
+  });
+
+g.test('mismatched')
+  .desc(
+    `
+Validates that even with valid types, if arg0 and arg1 do not match types ${builtin}() errors
+`
+  )
+  .params(u =>
+    u
+      .combine('e', keysOf(kValuesTypes))
+      .beginSubcases()
+      .combine('low', keysOf(kValuesTypes))
+      .combine('high', keysOf(kValuesTypes))
+  )
+  .beforeAllSubcases(t => {
+    if (scalarTypeOf(kValuesTypes[t.params.e]) === Type.f16) {
+      t.selectDeviceOrSkipTestCase('shader-f16');
+    }
+  })
+  .fn(t => {
+    const e = kValuesTypes[t.params.e];
+    const low = kValuesTypes[t.params.low];
+    const high = kValuesTypes[t.params.high];
+
+    // Skip if shader-16 isn't available.
+    t.skipIf(scalarTypeOf(low) === Type.f16 || scalarTypeOf(high) === Type.f16);
+
+    // If there exists 1 type of the 3 args that the other 2 can be converted into, then the args
+    // are valid.
+    const expectedResult =
+      (isConvertible(low, e) && isConvertible(high, e)) ||
+      (isConvertible(e, low) && isConvertible(high, low)) ||
+      (isConvertible(e, high) && isConvertible(low, high));
+    validateConstOrOverrideBuiltinEval(
+      t,
+      builtin,
+      expectedResult,
+      [e.create(1), low.create(0), high.create(2)],
+      'constant'
+    );
+  });
+
+g.test('low_high')
+  .desc(
+    `
+Validates that low <= high.
+`
+  )
+  .params(u =>
+    u
+      .combine('stage', kConstantAndOverrideStages)
+      .beginSubcases()
+      .combineWithParams([
+        { low: 0, high: 1 },
+        { low: 1, high: 1 },
+        { low: 1, high: 0 },
+      ] as const)
+  )
+  .fn(t => {
+    validateConstOrOverrideBuiltinEval(
+      t,
+      builtin,
+      /* expectedResult */ t.params.low <= t.params.high,
+      [f32(1), f32(t.params.low), f32(t.params.high)],
+      t.params.stage
+    );
+  });
+
+interface Argument {
+  /** Argument as a string. */
+  readonly arg: string;
+  /** Is this a valid argument type. Note that all args must be valid for the call to be valid. */
+  readonly pass: boolean;
+  /** Additional setup code necessary for this arg in the function scope. */
+  readonly preamble?: string;
+}
+
+function typesToArguments(types: readonly Type[], pass: boolean): Record<string, Argument> {
+  return types.reduce(
+    (res, type) => ({
+      ...res,
+      [type.toString()]: { arg: type.create(0).wgsl(), pass },
+    }),
+    {}
+  );
+}
+
+// f32 is included here to confirm that validation is failing due to a type issue and not something else.
+const kInputArgTypes: { readonly [name: string]: Argument } = {
+  ...typesToArguments([Type.f32], true),
+  ...typesToArguments([Type.bool, Type.mat2x2f], false),
+  alias: { arg: 'f32_alias(1.f)', pass: true },
+  vec_bool: { arg: 'vec2<bool>(false,true)', pass: false },
+  atomic: { arg: 'a', pass: false },
+  array: {
+    preamble: 'var arry: array<f32, 5>;',
+    arg: 'arry',
+    pass: false,
+  },
+  array_runtime: { arg: 'k.arry', pass: false },
+  struct: {
+    preamble: 'var x: A;',
+    arg: 'x',
+    pass: false,
+  },
+  enumerant: { arg: 'read_write', pass: false },
+  ptr: {
+    preamble: `var<function> f = 1.f;
+               let p: ptr<function, f32> = &f;`,
+    arg: 'p',
+    pass: false,
+  },
+  ptr_deref: {
+    preamble: `var<function> f = 1.f;
+               let p: ptr<function, f32> = &f;`,
+    arg: '*p',
+    pass: true,
+  },
+  sampler: { arg: 's', pass: false },
+  texture: { arg: 't', pass: false },
+};
+
+g.test('arguments')
+  .desc(
+    `
+Test compilation validation of ${builtin} with variously typed arguments
+  - Note that this passes the same type for all args. Mismatching types are tested separately above.
+`
+  )
+  .params(u => u.combine('type', keysOf(kInputArgTypes)))
+  .fn(t => {
+    const type = kInputArgTypes[t.params.type];
+    t.expectCompileResult(
+      type.pass,
+      `alias f32_alias = f32;
+
+      @group(0) @binding(0) var s: sampler;
+      @group(0) @binding(1) var t: texture_2d<f32>;
+
+      var<workgroup> a: atomic<u32>;
+
+      struct A {
+        i: u32,
+      }
+      struct B {
+        arry: array<u32>,
+      }
+      @group(0) @binding(3) var<storage> k: B;
+
+
+      @vertex
+      fn main() -> @builtin(position) vec4<f32> {
+        ${type.preamble ? type.preamble : ''}
+        _ = ${builtin}(${type.arg},${type.arg},${type.arg});
+        return vec4<f32>(.4, .2, .3, .1);
+      }`
+    );
+  });
+
+g.test('must_use')
+  .desc(`Result of ${builtin} must be used`)
+  .params(u => u.combine('use', [true, false]))
+  .fn(t => {
+    const use_it = t.params.use ? '_ = ' : '';
+    t.expectCompileResult(t.params.use, `fn f() { ${use_it}${builtin}(1.f,0.f,1.f); }`);
   });


### PR DESCRIPTION
<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
