### PR TITLE
Remove stale TODO

### DIFF
--- a/src/webgpu/shader/execution/shader_io/fragment_builtins.spec.ts
+++ b/src/webgpu/shader/execution/shader_io/fragment_builtins.spec.ts
@@ -15,10 +15,6 @@ is evaluated per-fragment or per-sample. With @interpolate(, sample) or usage of
 
 * frag_depth output is tested in
   src/webgpu/api/operation/rendering/depth_clip_clamp.spec.ts
-
-TODO:
-* test sample_mask in
-  Consider extending the sample_mask out test.
 `;
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';


### PR DESCRIPTION
The sample_mask fragment input is already tested, via PR #3404

https://github.com/gpuweb/cts/pull/3404

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
