### PR TITLE
wgsl: Add utility to help check for ambiguous overflows

### DIFF
--- a/src/webgpu/shader/validation/expression/call/builtin/const_override_validation.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/const_override_validation.ts
@@ -1,6 +1,7 @@
 import { assert, unreachable } from '../../../../../../common/util/util.js';
 import { kValue } from '../../../../../util/constants.js';
 import {
+  ScalarType,
   Type,
   Value,
   elementTypeOf,
@@ -14,6 +15,9 @@ import {
   scalarF64Range,
   linearRange,
   linearRangeBigInt,
+  quantizeToF32,
+  quantizeToF16,
+  QuantizeFunc,
 } from '../../../../../util/math.js';
 import { ShaderValidationTest } from '../../../shader_validation_test.js';
 
@@ -311,4 +315,75 @@ export function unique<T>(...arrays: Array<readonly T[]>): T[] {
     }
   }
   return [...set];
+}
+
+interface FloatLimits {
+  positive: {
+    max: number;
+  },
+  negative: {
+    min: number;
+  },
+  emax: number;
+}
+
+/**
+ * Provides an easy way to validate steps in an equation that will trigger a validation error with
+ * constant or override values due to overflow/underflow. Typical call pattern is:
+ * 
+ * const vCheck = new ConstantOrOverrideValueChecker(t, Type.f32);
+ * const c = vCheck.checkedResult(a + b);
+ * const d = vCheck.checkedResult(c * c);
+ * const expectedResult = vCheck.allChecksPassed();
+ */
+export class ConstantOrOverrideValueChecker {
+  #allChecksPassed = true;
+  #floatLimits?: FloatLimits;
+  #quantizeFn: QuantizeFunc<number>;
+
+  constructor(private t: ShaderValidationTest, type: ScalarType) {
+    switch (type) {
+      case Type.f32:
+        this.#quantizeFn = quantizeToF32;
+        this.#floatLimits = kValue.f32;
+        break;
+      case Type.f16:
+        this.#quantizeFn = quantizeToF16;
+        this.#floatLimits = kValue.f16;
+        break;
+      default:
+        this.#quantizeFn = (v: number) => v;
+        break;
+    }
+  }
+
+  quantize(value: number): number {
+    return this.#quantizeFn(value);
+  }
+
+  // Some overflow floating point values may fall into an abiguously rounded scenario, where they
+  // can either round up to Infinity or down to the maximum representable value. In these cases the
+  // test should be skipped, because it's valid for implementations to differ.
+  isAmbiguousOverflow(value: number): boolean {
+    if (!this.#floatLimits ||
+        (value <= this.#floatLimits.positive.max &&
+          value >= this.#floatLimits.negative.min)) {
+          return false;
+    }
+    return Math.abs(value) < Math.pow(2, this.#floatLimits.emax+1);
+  }
+
+  checkedResult(value: number): number {
+    if (this.isAmbiguousOverflow(value)) {
+      this.t.skip(`Checked value, ${value}, was within the ambiguous overflow rounding range.`);
+    }
+    
+    const quantizedValue = this.quantize(value);
+    if (!Number.isFinite(quantizedValue)) {
+      this.#allChecksPassed = false;
+    }
+    return value;
+  }
+
+  allChecksPassed(): boolean { return this.#allChecksPassed; }
 }

--- a/src/webgpu/shader/validation/expression/call/builtin/distance.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/distance.spec.ts
@@ -9,12 +9,11 @@ import {
   Type,
   kConvertableToFloatScalarsAndVectors,
   scalarTypeOf,
-  ScalarType,
 } from '../../../../../util/conversion.js';
-import { QuantizeFunc, quantizeToF16, quantizeToF32 } from '../../../../../util/math.js';
 import { ShaderValidationTest } from '../../../shader_validation_test.js';
 
 import {
+  ConstantOrOverrideValueChecker,
   fullRangeForType,
   kConstantAndOverrideStages,
   stageSupportsType,
@@ -24,17 +23,6 @@ import {
 export const g = makeTestGroup(ShaderValidationTest);
 
 const kValidArgumentTypes = objectsToRecord(kConvertableToFloatScalarsAndVectors);
-
-function quantizeFunctionForScalarType(type: ScalarType): QuantizeFunc<number> {
-  switch (type) {
-    case Type.f32:
-      return quantizeToF32;
-    case Type.f16:
-      return quantizeToF16;
-    default:
-      return (v: number) => v;
-  }
-}
 
 g.test('values')
   .desc(
@@ -57,32 +45,22 @@ Validates that constant evaluation and override evaluation of ${builtin}() never
     }
   })
   .fn(t => {
-    let expectedResult = true;
-
     const scalarType = scalarTypeOf(kValidArgumentTypes[t.params.type]);
-    const quantizeFn = quantizeFunctionForScalarType(scalarType);
+    const vCheck = new ConstantOrOverrideValueChecker(t, scalarType);
 
     // Distance equation: length(a - b)
     // Should be invalid if the calculations result in intermediate values that
     // exceed the maximum representable float value for the given type.
     const a = Number(t.params.a);
     const b = Number(t.params.b);
-    const ab = quantizeFn(a - b);
-
-    if (!Number.isFinite(ab)) {
-      expectedResult = false;
-    }
+    const ab = vCheck.checkedResult(a - b);
 
     // Only calculates the full length if the type is a vector. Otherwise abs(a-b) is used.
     if (kValidArgumentTypes[t.params.type].width > 1) {
-      const ab2 = quantizeFn(ab * ab);
-      const sqrLen = quantizeFn(ab2 * kValidArgumentTypes[t.params.type].width);
+      const ab2 = vCheck.checkedResult(ab * ab);
+      const sqrLen = vCheck.checkedResult(ab2 * kValidArgumentTypes[t.params.type].width);
       // Square root does not need to be calculated because it can never fail if
       // the previous results are finite.
-
-      if (!Number.isFinite(ab2) || !Number.isFinite(sqrLen)) {
-        expectedResult = false;
-      }
     }
 
     const type = kValidArgumentTypes[t.params.type];
@@ -91,7 +69,7 @@ Validates that constant evaluation and override evaluation of ${builtin}() never
     validateConstOrOverrideBuiltinEval(
       t,
       builtin,
-      expectedResult,
+      vCheck.allChecksPassed(),
       [type.create(t.params.a), type.create(t.params.b)],
       t.params.stage
     );

--- a/src/webgpu/shader/validation/expression/call/builtin/distance.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/distance.spec.ts
@@ -59,8 +59,10 @@ Validates that constant evaluation and override evaluation of ${builtin}() never
     if (kValidArgumentTypes[t.params.type].width > 1) {
       const ab2 = vCheck.checkedResult(ab * ab);
       const sqrLen = vCheck.checkedResult(ab2 * kValidArgumentTypes[t.params.type].width);
-      // Square root does not need to be calculated because it can never fail if
-      // the previous results are finite.
+      // If the squared length is near zero it may fail on some implementations, so skip the test.
+      if (vCheck.isNearZero(sqrLen)) {
+        t.skip(`Squared length of ${sqrLen} is at or near 0.`);
+      }
     }
 
     const type = kValidArgumentTypes[t.params.type];


### PR DESCRIPTION
Fixes #3623

Primary thing to pay attention to is the new `ConstantOrOverrideValueChecker` utility class (rolls off the tongue, huh?) This is performing the same quantization step as before but now has the opportunity to force a subcase to be skipped if the checked value is found to be in a range where the overflow rounding behavior is ambiguous.

If we think this is a good direction then I'll go back and update a bunch of the tests I've already completed to use the new utility class for consistency/completeness.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
