### PR TITLE
Test that lhs reference of increment decrement evaluated once

### DIFF
--- a/src/webgpu/listing_meta.json
+++ b/src/webgpu/listing_meta.json
@@ -1851,6 +1851,8 @@
   "webgpu:shader,execution,statement,increment_decrement:scalar_u32_decrement_underflow:*": { "subcaseMS": 21.600 },
   "webgpu:shader,execution,statement,increment_decrement:scalar_u32_increment:*": { "subcaseMS": 5.900 },
   "webgpu:shader,execution,statement,increment_decrement:scalar_u32_increment_overflow:*": { "subcaseMS": 4.700 },
+  "webgpu:shader,execution,statement,increment_decrement:single_eval_decrement:*": { "subcaseMS": 14.013 },
+  "webgpu:shader,execution,statement,increment_decrement:single_eval_increment:*": { "subcaseMS": 14.762 },
   "webgpu:shader,execution,statement,increment_decrement:vec2_element_decrement:*": { "subcaseMS": 5.200 },
   "webgpu:shader,execution,statement,increment_decrement:vec2_element_increment:*": { "subcaseMS": 5.000 },
   "webgpu:shader,execution,statement,increment_decrement:vec3_element_decrement:*": { "subcaseMS": 17.700 },

--- a/src/webgpu/shader/execution/statement/increment_decrement.spec.ts
+++ b/src/webgpu/shader/execution/statement/increment_decrement.spec.ts
@@ -22,7 +22,8 @@ export function runStatementTest(
   t: GPUTest,
   fmt: string,
   values: TypedArrayBufferView,
-  wgsl_main: string
+  wgsl_main: string,
+  extras: { global_decl?: string } = {}
 ) {
   const wgsl = `
 struct Outputs {
@@ -36,6 +37,8 @@ fn push_output(value : ${fmt}) {
   outputs.data[count] = value;
   count += 1;
 }
+
+${extras.global_decl ?? ''}
 
 @compute @workgroup_size(1)
 fn main() {
@@ -377,5 +380,69 @@ g.test('frexp_exp_increment')
     a.exp++;
     push_output(a.exp);
 `
+    );
+  });
+
+g.test('single_eval_increment')
+  .desc('Tests the left-hand-side reference of an increment is computed only once.')
+  .fn(t => {
+    runStatementTest(
+      t,
+      'i32',
+      new Int32Array([999, 0, 1, 2, 11, 21, 31]),
+      `
+    var a: array<i32,3> = array(10, 20, 30);
+
+    push_output(999);
+    a[bump()]++;
+    a[bump()]++;
+    a[bump()]++;
+    push_output(a[0]);
+    push_output(a[1]);
+    push_output(a[2]);
+`,
+      {
+        global_decl: `
+  var<private> index_counter: i32 = 0;
+  fn bump() -> i32 {
+    let result = index_counter;
+    push_output(result);
+    index_counter = index_counter + 1;
+    return result;
+  }
+  `,
+      }
+    );
+  });
+
+g.test('single_eval_decrement')
+  .desc('Tests the left-hand-side reference of a decrement is computed only once.')
+  .fn(t => {
+    runStatementTest(
+      t,
+      'i32',
+      new Int32Array([999, 0, 1, 2, 9, 19, 29]),
+      `
+    var a: array<i32,3> = array(10, 20, 30);
+
+    push_output(999);
+    a[bump()]--;
+    a[bump()]--;
+    a[bump()]--;
+    push_output(a[0]);
+    push_output(a[1]);
+    push_output(a[2]);
+`,
+      {
+        global_decl: `
+  var<private> index_counter: i32 = 0;
+  fn bump() -> i32 {
+    let result = index_counter;
+    push_output(result);
+    index_counter = index_counter + 1;
+    return result;
+  }
+  `,
+      }
     );
   });


### PR DESCRIPTION

<hr>
Issue: #1646 

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
