### PR TITLE
Add return and value validation tests for textureLoad/textureStore

### DIFF
--- a/src/webgpu/shader/validation/expression/call/builtin/textureLoad.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/textureLoad.spec.ts
@@ -6,6 +6,8 @@ Validation tests for the ${builtin}() builtin.
 * test textureLoad array_index parameter must be correct type
 * test textureLoad level parameter must be correct type
 * test textureLoad sample_index parameter must be correct type
+* test textureLoad returns the correct type
+* test textureLoad doesn't work with texture types it's not supposed to
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
@@ -19,12 +21,19 @@ import {
   ScalarType,
   VectorType,
   isUnsignedType,
+  stringToType,
 } from '../../../../../util/conversion.js';
 import { ShaderValidationTest } from '../../../shader_validation_test.js';
 
+import {
+  getNonStorageTextureTypeWGSL,
+  getSampleAndBaseTextureTypeForTextureType,
+  kNonStorageTextureTypeInfo,
+  kTestTextureTypes,
+} from './shader_builtin_utils.js';
+
 type TextureLoadArguments = {
   coordsArgTypes: readonly [ScalarType | VectorType, ScalarType | VectorType];
-  usesMultipleTypes?: boolean; // texture can use f32, i32, u32
   hasArrayIndexArg?: boolean;
   hasLevelArg?: boolean;
   hasSampleIndexArg?: boolean;
@@ -36,27 +45,40 @@ const kCoords3DTypes = [Type.vec3i, Type.vec3u] as const;
 
 const kValidTextureLoadParameterTypesForNonStorageTextures: { [n: string]: TextureLoadArguments } =
   {
-    texture_1d: { usesMultipleTypes: true, coordsArgTypes: kCoords1DTypes, hasLevelArg: true },
-    texture_2d: { usesMultipleTypes: true, coordsArgTypes: kCoords2DTypes, hasLevelArg: true },
+    texture_1d: {
+      coordsArgTypes: kCoords1DTypes,
+      hasLevelArg: true,
+    },
+    texture_2d: {
+      coordsArgTypes: kCoords2DTypes,
+      hasLevelArg: true,
+    },
     texture_2d_array: {
-      usesMultipleTypes: true,
       coordsArgTypes: kCoords2DTypes,
       hasArrayIndexArg: true,
       hasLevelArg: true,
     },
-    texture_3d: { usesMultipleTypes: true, coordsArgTypes: kCoords3DTypes, hasLevelArg: true },
+    texture_3d: {
+      coordsArgTypes: kCoords3DTypes,
+      hasLevelArg: true,
+    },
     texture_multisampled_2d: {
-      usesMultipleTypes: true,
       coordsArgTypes: kCoords2DTypes,
       hasSampleIndexArg: true,
     },
-    texture_depth_2d: { coordsArgTypes: kCoords2DTypes, hasLevelArg: true },
+    texture_depth_2d: {
+      coordsArgTypes: kCoords2DTypes,
+      hasLevelArg: true,
+    },
     texture_depth_2d_array: {
       coordsArgTypes: kCoords2DTypes,
       hasArrayIndexArg: true,
       hasLevelArg: true,
     },
-    texture_depth_multisampled_2d: { coordsArgTypes: kCoords2DTypes, hasSampleIndexArg: true },
+    texture_depth_multisampled_2d: {
+      coordsArgTypes: kCoords2DTypes,
+      hasSampleIndexArg: true,
+    },
     texture_external: { coordsArgTypes: kCoords2DTypes },
   };
 
@@ -74,15 +96,48 @@ const kNonStorageTextureTypes = keysOf(kValidTextureLoadParameterTypesForNonStor
 const kStorageTextureTypes = keysOf(kValidTextureLoadParameterTypesForStorageTextures);
 const kValuesTypes = objectsToRecord(kAllScalarsAndVectors);
 
-const kTexelType: { [n: string]: Type } = {
-  f32: Type.vec4f,
-  i32: Type.vec4i,
-  u32: Type.vec4u,
-} as const;
-
-const kTexelTypes = keysOf(kTexelType);
-
 export const g = makeTestGroup(ShaderValidationTest);
+
+g.test('return_type,non_storage')
+  .specURL('https://gpuweb.github.io/gpuweb/wgsl/#textureload')
+  .desc(
+    `
+Validates the return type of ${builtin} is the expected type.
+`
+  )
+  .params(u =>
+    u
+      .combine('returnType', keysOf(kValuesTypes))
+      .combine('textureType', kNonStorageTextureTypes)
+      .beginSubcases()
+      .expand('texelType', t =>
+        kNonStorageTextureTypeInfo[t.textureType].texelTypes.map(v => v.toString())
+      )
+  )
+  .fn(t => {
+    const { returnType, textureType, texelType } = t.params;
+    const returnVarType = kValuesTypes[returnType];
+    const { coordsArgTypes, hasArrayIndexArg, hasLevelArg, hasSampleIndexArg } =
+      kValidTextureLoadParameterTypesForNonStorageTextures[textureType];
+
+    const varWGSL = returnVarType.toString();
+    const texelArgType = stringToType(texelType);
+    const textureWGSL = getNonStorageTextureTypeWGSL(textureType, texelArgType);
+    const coordWGSL = coordsArgTypes[0].create(0).wgsl();
+    const arrayWGSL = hasArrayIndexArg ? ', 0' : '';
+    const levelWGSL = hasLevelArg ? ', 0' : '';
+    const sampleIndexWGSL = hasSampleIndexArg ? ', 0' : '';
+
+    const code = `
+@group(0) @binding(0) var t: ${textureWGSL};
+@fragment fn fs() -> @location(0) vec4f {
+  let v: ${varWGSL} = textureLoad(t, ${coordWGSL}${arrayWGSL}${levelWGSL}${sampleIndexWGSL});
+  return vec4f(0);
+}
+`;
+    const expectSuccess = isConvertible(texelArgType, returnVarType);
+    t.expectCompileResult(expectSuccess, code);
+  });
 
 g.test('coords_argument,non_storage')
   .specURL('https://gpuweb.github.io/gpuweb/wgsl/#textureload')
@@ -97,9 +152,7 @@ Validates that only incorrect coords arguments are rejected by ${builtin}
       .combine('coordType', keysOf(kValuesTypes))
       .beginSubcases()
       .expand('texelType', t =>
-        kValidTextureLoadParameterTypesForNonStorageTextures[t.textureType].usesMultipleTypes
-          ? kTexelTypes
-          : ['']
+        kNonStorageTextureTypeInfo[t.textureType].texelTypes.map(v => v.toString())
       )
       .combine('value', [-1, 0, 1] as const)
       // filter out unsigned types with negative values
@@ -111,14 +164,15 @@ Validates that only incorrect coords arguments are rejected by ${builtin}
     const { coordsArgTypes, hasArrayIndexArg, hasLevelArg, hasSampleIndexArg } =
       kValidTextureLoadParameterTypesForNonStorageTextures[textureType];
 
-    const texelTypeWGSL = texelType ? `<${texelType}>` : '';
+    const texelArgType = stringToType(texelType);
+    const textureWGSL = getNonStorageTextureTypeWGSL(textureType, texelArgType);
     const coordWGSL = coordArgType.create(value).wgsl();
     const arrayWGSL = hasArrayIndexArg ? ', 0' : '';
     const levelWGSL = hasLevelArg ? ', 0' : '';
     const sampleIndexWGSL = hasSampleIndexArg ? ', 0' : '';
 
     const code = `
-@group(0) @binding(0) var t: ${textureType}${texelTypeWGSL};
+@group(0) @binding(0) var t: ${textureWGSL};
 @fragment fn fs() -> @location(0) vec4f {
   _ = textureLoad(t, ${coordWGSL}${arrayWGSL}${levelWGSL}${sampleIndexWGSL});
   return vec4f(0);
@@ -191,9 +245,7 @@ Validates that only incorrect array_index arguments are rejected by ${builtin}
       .combine('arrayIndexType', keysOf(kValuesTypes))
       .beginSubcases()
       .expand('texelType', t =>
-        kValidTextureLoadParameterTypesForNonStorageTextures[t.textureType].usesMultipleTypes
-          ? kTexelTypes
-          : ['']
+        kNonStorageTextureTypeInfo[t.textureType].texelTypes.map(v => v.toString())
       )
       .combine('value', [-1, 0, 1])
       // filter out unsigned types with negative values
@@ -206,13 +258,14 @@ Validates that only incorrect array_index arguments are rejected by ${builtin}
     const { coordsArgTypes, hasLevelArg } =
       kValidTextureLoadParameterTypesForNonStorageTextures[textureType];
 
-    const texelTypeWGSL = texelType ? `<${texelType}>` : '';
+    const texelArgType = stringToType(texelType);
+    const textureWGSL = getNonStorageTextureTypeWGSL(textureType, texelArgType);
     const coordWGSL = coordsArgTypes[0].create(0).wgsl();
     const arrayWGSL = args.map(arg => arg.wgsl()).join(', ');
     const levelWGSL = hasLevelArg ? ', 0' : '';
 
     const code = `
-@group(0) @binding(0) var t: ${textureType}${texelTypeWGSL};
+@group(0) @binding(0) var t: ${textureWGSL};
 @fragment fn fs() -> @location(0) vec4f {
   _ = textureLoad(t, ${coordWGSL}, ${arrayWGSL}${levelWGSL});
   return vec4f(0);
@@ -289,9 +342,7 @@ Validates that only incorrect level arguments are rejected by ${builtin}
       .combine('levelType', keysOf(kValuesTypes))
       .beginSubcases()
       .expand('texelType', t =>
-        kValidTextureLoadParameterTypesForNonStorageTextures[t.textureType].usesMultipleTypes
-          ? kTexelTypes
-          : ['']
+        kNonStorageTextureTypeInfo[t.textureType].texelTypes.map(v => v.toString())
       )
       .combine('value', [-1, 0, 1])
       // filter out unsigned types with negative values
@@ -303,13 +354,14 @@ Validates that only incorrect level arguments are rejected by ${builtin}
     const { coordsArgTypes, hasArrayIndexArg } =
       kValidTextureLoadParameterTypesForNonStorageTextures[textureType];
 
-    const texelTypeWGSL = texelType ? `<${texelType}>` : '';
+    const texelArgType = stringToType(texelType);
+    const textureWGSL = getNonStorageTextureTypeWGSL(textureType, texelArgType);
     const coordWGSL = coordsArgTypes[0].create(0).wgsl();
     const arrayWGSL = hasArrayIndexArg ? ', 0' : '';
     const levelWGSL = levelArgType.create(value).wgsl();
 
     const code = `
-@group(0) @binding(0) var t: ${textureType}${texelTypeWGSL};
+@group(0) @binding(0) var t: ${textureWGSL};
 @fragment fn fs() -> @location(0) vec4f {
   _ = textureLoad(t, ${coordWGSL}${arrayWGSL}, ${levelWGSL});
   return vec4f(0);
@@ -337,9 +389,7 @@ Validates that only incorrect sample_index arguments are rejected by ${builtin}
       .combine('sampleIndexType', keysOf(kValuesTypes))
       .beginSubcases()
       .expand('texelType', t =>
-        kValidTextureLoadParameterTypesForNonStorageTextures[t.textureType].usesMultipleTypes
-          ? kTexelTypes
-          : ['']
+        kNonStorageTextureTypeInfo[t.textureType].texelTypes.map(v => v.toString())
       )
       .combine('value', [-1, 0, 1])
       // filter out unsigned types with negative values
@@ -352,13 +402,14 @@ Validates that only incorrect sample_index arguments are rejected by ${builtin}
       kValidTextureLoadParameterTypesForNonStorageTextures[textureType];
     assert(!hasLevelArg);
 
-    const texelTypeWGSL = texelType ? `<${texelType}>` : '';
+    const texelArgType = stringToType(texelType);
+    const textureWGSL = getNonStorageTextureTypeWGSL(textureType, texelArgType);
     const coordWGSL = coordsArgTypes[0].create(0).wgsl();
     const arrayWGSL = hasArrayIndexArg ? ', 0' : '';
     const sampleIndexWGSL = sampleIndexArgType.create(value).wgsl();
 
     const code = `
-@group(0) @binding(0) var t: ${textureType}${texelTypeWGSL};
+@group(0) @binding(0) var t: ${textureWGSL};
 @fragment fn fs() -> @location(0) vec4f {
   _ = textureLoad(t, ${coordWGSL}${arrayWGSL}, ${sampleIndexWGSL});
   return vec4f(0);
@@ -366,5 +417,111 @@ Validates that only incorrect sample_index arguments are rejected by ${builtin}
 `;
     const expectSuccess =
       isConvertible(sampleIndexArgType, Type.i32) || isConvertible(sampleIndexArgType, Type.u32);
+    t.expectCompileResult(expectSuccess, code);
+  });
+
+g.test('texture_type,non_storage')
+  .specURL('https://gpuweb.github.io/gpuweb/wgsl/#textureload')
+  .desc(
+    `
+Validates that incompatible texture types don't work with ${builtin}
+`
+  )
+  .params(u =>
+    u
+      .combine('testTextureType', kTestTextureTypes)
+      .combine('textureType', keysOf(kValidTextureLoadParameterTypesForNonStorageTextures))
+  )
+  .fn(t => {
+    const { testTextureType, textureType } = t.params;
+    const { coordsArgTypes, hasArrayIndexArg, hasLevelArg, hasSampleIndexArg } =
+      kValidTextureLoadParameterTypesForNonStorageTextures[textureType];
+
+    const coordWGSL = coordsArgTypes[0].create(0).wgsl();
+    const arrayWGSL = hasArrayIndexArg ? ', 0' : '';
+    const levelWGSL = hasLevelArg ? ', 0' : '';
+    const sampleIndexWGSL = hasSampleIndexArg ? ', 0' : '';
+
+    const code = `
+@group(0) @binding(1) var t: ${testTextureType};
+@fragment fn fs() -> @location(0) vec4f {
+  let v = textureLoad(t, ${coordWGSL}${arrayWGSL}${levelWGSL}${sampleIndexWGSL});
+  return vec4f(0);
+}
+`;
+
+    const [baseTestTextureType] = getSampleAndBaseTextureTypeForTextureType(testTextureType);
+
+    let expectSuccess = false;
+    const types =
+      kValidTextureLoadParameterTypesForNonStorageTextures[baseTestTextureType] ||
+      kValidTextureLoadParameterTypesForStorageTextures[baseTestTextureType];
+    if (types) {
+      const numTestNumberArgs =
+        (types.hasArrayIndexArg ? 1 : 0) +
+        (types.hasLevelArg ? 1 : 0) +
+        (types.hasSampleIndexArg ? 1 : 0);
+      const numExpectNumberArgs =
+        (hasArrayIndexArg ? 1 : 0) + (hasLevelArg ? 1 : 0) + (hasSampleIndexArg ? 1 : 0);
+      const typesMatch = types
+        ? types.coordsArgTypes[0] === coordsArgTypes[0] && numTestNumberArgs === numExpectNumberArgs
+        : false;
+      expectSuccess = typesMatch;
+    }
+
+    t.expectCompileResult(expectSuccess, code);
+  });
+
+g.test('texture_type,storage')
+  .specURL('https://gpuweb.github.io/gpuweb/wgsl/#textureload')
+  .desc(
+    `
+Validates that incompatible texture types don't work with ${builtin}
+`
+  )
+  .params(u =>
+    u
+      .combine('testTextureType', kTestTextureTypes)
+      .combine('textureType', keysOf(kValidTextureLoadParameterTypesForStorageTextures))
+      .beginSubcases()
+      .combine('format', kAllTextureFormats)
+  )
+  .fn(t => {
+    const { testTextureType, textureType } = t.params;
+    const { coordsArgTypes, hasArrayIndexArg, hasLevelArg, hasSampleIndexArg } =
+      kValidTextureLoadParameterTypesForStorageTextures[textureType];
+
+    const coordWGSL = coordsArgTypes[0].create(0).wgsl();
+    const arrayWGSL = hasArrayIndexArg ? ', 0' : '';
+    const levelWGSL = hasLevelArg ? ', 0' : '';
+    const sampleIndexWGSL = hasSampleIndexArg ? ', 0' : '';
+
+    const code = `
+@group(0) @binding(1) var t: ${testTextureType};
+@fragment fn fs() -> @location(0) vec4f {
+  let v = textureLoad(t, ${coordWGSL}${arrayWGSL}${levelWGSL}${sampleIndexWGSL});
+  return vec4f(0);
+}
+`;
+
+    const [baseTestTextureType] = getSampleAndBaseTextureTypeForTextureType(testTextureType);
+
+    let expectSuccess = false;
+    const types =
+      kValidTextureLoadParameterTypesForNonStorageTextures[baseTestTextureType] ||
+      kValidTextureLoadParameterTypesForStorageTextures[baseTestTextureType];
+    if (types) {
+      const numTestNumberArgs =
+        (types.hasArrayIndexArg ? 1 : 0) +
+        (types.hasLevelArg ? 1 : 0) +
+        (types.hasSampleIndexArg ? 1 : 0);
+      const numExpectNumberArgs =
+        (hasArrayIndexArg ? 1 : 0) + (hasLevelArg ? 1 : 0) + (hasSampleIndexArg ? 1 : 0);
+      const typesMatch = types
+        ? types.coordsArgTypes[0] === coordsArgTypes[0] && numTestNumberArgs === numExpectNumberArgs
+        : false;
+      expectSuccess = typesMatch;
+    }
+
     t.expectCompileResult(expectSuccess, code);
   });

--- a/src/webgpu/shader/validation/expression/call/builtin/textureStore.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/textureStore.spec.ts
@@ -5,6 +5,7 @@ Validation tests for the ${builtin}() builtin.
 * test textureStore coords parameter must be correct type
 * test textureStore array_index parameter must be correct type
 * test textureStore value parameter must be correct type
+* test textureStore doesn't work with texture types it's not supposed to
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
@@ -19,6 +20,11 @@ import {
   isUnsignedType,
 } from '../../../../../util/conversion.js';
 import { ShaderValidationTest } from '../../../shader_validation_test.js';
+
+import {
+  getSampleAndBaseTextureTypeForTextureType,
+  kTestTextureTypes,
+} from './shader_builtin_utils.js';
 
 const kTextureColorTypeToType = {
   sint: Type.vec4i,
@@ -164,5 +170,56 @@ Validates that only incorrect value arguments are rejected by ${builtin}
     const colorType = kTextureFormatInfo[format].color?.type;
     const requiredValueType = kTextureColorTypeToType[colorType!];
     const expectSuccess = isConvertible(valueArgType, requiredValueType);
+    t.expectCompileResult(expectSuccess, code);
+  });
+
+g.test('texture_type,storage')
+  .specURL('https://gpuweb.github.io/gpuweb/wgsl/#texturestore')
+  .desc(
+    `
+Validates that incompatible texture types don't work with ${builtin}
+`
+  )
+  .params(u =>
+    u
+      .combine('testTextureType', kTestTextureTypes)
+      .combine('textureType', keysOf(kValidTextureStoreParameterTypes))
+      .beginSubcases()
+      .combine('format', kAllTextureFormats)
+      // filter to only storage texture formats.
+      .filter(t => !!kTextureFormatInfo[t.format].color?.storage)
+  )
+  .fn(t => {
+    const { testTextureType, textureType, format } = t.params;
+    const { coordsArgTypes, hasArrayIndexArg } = kValidTextureStoreParameterTypes[textureType];
+
+    const coordWGSL = coordsArgTypes[0].create(0).wgsl();
+    const arrayWGSL = hasArrayIndexArg ? ', 0' : '';
+    const colorType = kTextureFormatInfo[format].color?.type;
+    const valueType = kTextureColorTypeToType[colorType!];
+    const valueWGSL = valueType.create(0).wgsl();
+
+    const code = `
+@group(0) @binding(1) var t: ${testTextureType.replace(', read', ', write')};
+@fragment fn fs() -> @location(0) vec4f {
+  textureStore(t, ${coordWGSL}${arrayWGSL}, ${valueWGSL});
+  return vec4f(0);
+}
+`;
+
+    const [baseTestTextureType, sampleType] =
+      getSampleAndBaseTextureTypeForTextureType(testTextureType);
+
+    let expectSuccess = false;
+    const types = kValidTextureStoreParameterTypes[baseTestTextureType];
+    if (types) {
+      const typesMatch = types
+        ? types.coordsArgTypes[0] === coordsArgTypes[0] &&
+          types.hasArrayIndexArg === hasArrayIndexArg &&
+          isConvertible(valueType, sampleType)
+        : false;
+      expectSuccess = typesMatch;
+    }
+
     t.expectCompileResult(expectSuccess, code);
   });


### PR DESCRIPTION


Issue: #3586 #3594 

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [X] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
