### PR TITLE
Add WGSL validation return, value tests for textureSampleXXX builtins

### DIFF
--- a/src/webgpu/shader/validation/expression/call/builtin/textureSampleBaseClampToEdge.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/textureSampleBaseClampToEdge.spec.ts
@@ -3,6 +3,8 @@ export const description = `
 Validation tests for the ${builtin}() builtin.
 
 * test textureSampleBaseClampToEdge coords parameter must be correct type
+* test textureSampleBaseClampToEdge returns the correct type
+* test textureSampleBaseClampToEdge doesn't work with texture types it's not supposed to
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
@@ -15,10 +17,42 @@ import {
 } from '../../../../../util/conversion.js';
 import { ShaderValidationTest } from '../../../shader_validation_test.js';
 
-const kTextureSampleBaseClampToEdgeTextureTypes = ['texture_2d<f32>', 'texture_external'] as const;
+import { kTestTextureTypes } from './shader_builtin_utils.js';
+
+const kTextureSampleBaseClampToEdgeTextureTypes = ['texture_2d<f32>', 'texture_external'];
 const kValuesTypes = objectsToRecord(kAllScalarsAndVectors);
 
 export const g = makeTestGroup(ShaderValidationTest);
+
+g.test('return_type')
+  .specURL('https://gpuweb.github.io/gpuweb/wgsl/#texturesamplebaseclamptoedge')
+  .desc(
+    `
+Validates the return type of ${builtin} is the expected type.
+`
+  )
+  .params(u =>
+    u
+      .combine('returnType', keysOf(kValuesTypes))
+      .combine('textureType', kTextureSampleBaseClampToEdgeTextureTypes)
+  )
+  .fn(t => {
+    const { returnType, textureType } = t.params;
+    const returnVarType = kValuesTypes[returnType];
+
+    const varWGSL = returnVarType.toString();
+
+    const code = `
+@group(0) @binding(0) var s: sampler;
+@group(0) @binding(1) var t: ${textureType};
+@fragment fn fs() -> @location(0) vec4f {
+  let v: ${varWGSL} = textureSampleBaseClampToEdge(t, s, vec2f(0));
+  return vec4f(0);
+}
+`;
+    const expectSuccess = isConvertible(Type.vec4f, returnVarType);
+    t.expectCompileResult(expectSuccess, code);
+  });
 
 g.test('coords_argument')
   .specURL('https://gpuweb.github.io/gpuweb/wgsl/#texturesamplebaseclamptoedge')
@@ -50,5 +84,28 @@ Validates that only incorrect coords arguments are rejected by ${builtin}
 }
 `;
     const expectSuccess = isConvertible(coordArgType, Type.vec2f);
+    t.expectCompileResult(expectSuccess, code);
+  });
+
+g.test('texture_type')
+  .specURL('https://gpuweb.github.io/gpuweb/wgsl/#texturesamplebaseclamptoedge')
+  .desc(
+    `
+Validates that incompatible texture types don't work with ${builtin}
+`
+  )
+  .params(u => u.combine('testTextureType', kTestTextureTypes))
+  .fn(t => {
+    const { testTextureType } = t.params;
+
+    const code = `
+@group(0) @binding(0) var s: sampler;
+@group(0) @binding(1) var t: ${testTextureType};
+@fragment fn fs() -> @location(0) vec4f {
+  let v = textureSampleBaseClampToEdge(t, s, vec2f(0));
+  return vec4f(0);
+}
+`;
+    const expectSuccess = kTextureSampleBaseClampToEdgeTextureTypes.includes(testTextureType);
     t.expectCompileResult(expectSuccess, code);
   });

--- a/src/webgpu/shader/validation/expression/call/builtin/textureSampleBias.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/textureSampleBias.spec.ts
@@ -9,6 +9,8 @@ Validation tests for the ${builtin}() builtin.
 * test textureSampleBias offset parameter must be correct type
 * test textureSampleBias offset parameter must be a const-expression
 * test textureSampleBias offset parameter must be between -8 and +7 inclusive
+* test textureSampleBias returns the correct type
+* test textureSampleBias doesn't work with texture types it's not supposed to
 
 note: uniformity validation is covered in src/webgpu/shader/validation/uniformity/uniformity.spec.ts
 `;
@@ -27,7 +29,10 @@ import {
 } from '../../../../../util/conversion.js';
 import { ShaderValidationTest } from '../../../shader_validation_test.js';
 
-import { kEntryPointsToValidateFragmentOnlyBuiltins } from './shader_builtin_utils.js';
+import {
+  kEntryPointsToValidateFragmentOnlyBuiltins,
+  kTestTextureTypes,
+} from './shader_builtin_utils.js';
 
 type TextureSampleBiasArguments = {
   coordsArgType: ScalarType | VectorType;
@@ -51,6 +56,45 @@ const kTextureTypes = keysOf(kValidTextureSampleBiasParameterTypes);
 const kValuesTypes = objectsToRecord(kAllScalarsAndVectors);
 
 export const g = makeTestGroup(ShaderValidationTest);
+
+g.test('return_type')
+  .specURL('https://gpuweb.github.io/gpuweb/wgsl/#texturesamplebias')
+  .desc(
+    `
+Validates the return type of ${builtin} is the expected type.
+`
+  )
+  .params(u =>
+    u
+      .combine('returnType', keysOf(kValuesTypes))
+      .combine('textureType', keysOf(kValidTextureSampleBiasParameterTypes))
+      .beginSubcases()
+      .expand('offset', t =>
+        kValidTextureSampleBiasParameterTypes[t.textureType].offsetArgType ? [false, true] : [false]
+      )
+  )
+  .fn(t => {
+    const { returnType, textureType, offset } = t.params;
+    const returnVarType = kValuesTypes[returnType];
+    const { offsetArgType, coordsArgType, hasArrayIndexArg } =
+      kValidTextureSampleBiasParameterTypes[textureType];
+
+    const varWGSL = returnVarType.toString();
+    const coordWGSL = coordsArgType.create(0).wgsl();
+    const arrayWGSL = hasArrayIndexArg ? ', 0' : '';
+    const offsetWGSL = offset ? `, ${offsetArgType?.create(0).wgsl()}` : '';
+
+    const code = `
+@group(0) @binding(0) var s: sampler;
+@group(0) @binding(1) var t: ${textureType};
+@fragment fn fs() -> @location(0) vec4f {
+  let v: ${varWGSL} = textureSampleBias(t, s, ${coordWGSL}${arrayWGSL}, 0${offsetWGSL});
+  return vec4f(0);
+}
+`;
+    const expectSuccess = isConvertible(Type.vec4f, returnVarType);
+    t.expectCompileResult(expectSuccess, code);
+  });
 
 g.test('coords_argument')
   .specURL('https://gpuweb.github.io/gpuweb/wgsl/#texturesamplebias')
@@ -306,4 +350,49 @@ fn foo() {
   _ = textureSampleBias(t, s, ${coordWGSL}${arrayWGSL}, 0${offsetWGSL});
 }`;
     t.expectCompileResult(config.expectSuccess, code);
+  });
+
+g.test('texture_type')
+  .specURL('https://gpuweb.github.io/gpuweb/wgsl/#texturesamplebias')
+  .desc(
+    `
+Validates that incompatible texture types don't work with ${builtin}
+`
+  )
+  .params(u =>
+    u
+      .combine('testTextureType', kTestTextureTypes)
+      .combine('textureType', keysOf(kValidTextureSampleBiasParameterTypes))
+      .beginSubcases()
+      .expand('offset', t =>
+        kValidTextureSampleBiasParameterTypes[t.textureType].offsetArgType ? [false, true] : [false]
+      )
+  )
+  .fn(t => {
+    const { testTextureType, textureType, offset } = t.params;
+    const { coordsArgType, offsetArgType, hasArrayIndexArg } =
+      kValidTextureSampleBiasParameterTypes[textureType];
+
+    const coordWGSL = coordsArgType.create(0).wgsl();
+    const arrayWGSL = hasArrayIndexArg ? ', 0' : '';
+    const offsetWGSL = offset ? `, ${offsetArgType?.create(0).wgsl()}` : '';
+
+    const code = `
+@group(0) @binding(0) var s: sampler;
+@group(0) @binding(1) var t: ${testTextureType};
+@fragment fn fs() -> @location(0) vec4f {
+  let v = textureSampleBias(t, s, ${coordWGSL}${arrayWGSL}, 0${offsetWGSL});
+  return vec4f(0);
+}
+`;
+
+    const types = kValidTextureSampleBiasParameterTypes[testTextureType];
+    const typesMatch = types
+      ? types.coordsArgType === coordsArgType &&
+        types.hasArrayIndexArg === hasArrayIndexArg &&
+        (offset ? types.offsetArgType === offsetArgType : true)
+      : false;
+
+    const expectSuccess = testTextureType === textureType || typesMatch;
+    t.expectCompileResult(expectSuccess, code);
   });

--- a/src/webgpu/shader/validation/expression/call/builtin/textureSampleCompare.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/textureSampleCompare.spec.ts
@@ -8,7 +8,9 @@ Validation tests for the ${builtin}() builtin.
 * test textureSampleCompare offset parameter must be correct type
 * test textureSampleCompare offset parameter must be a const-expression
 * test textureSampleCompare offset parameter must be between -8 and +7 inclusive
-* test textureSample not usable in a compute or vertex shader
+* test textureSampleCompare not usable in a compute or vertex shader
+* test textureSampleCompare returns the correct type
+* test textureSampleCompare doesn't work with texture types it's not supposed to
 
 note: uniformity validation is covered in src/webgpu/shader/validation/uniformity/uniformity.spec.ts
 `;
@@ -25,7 +27,10 @@ import {
 } from '../../../../../util/conversion.js';
 import { ShaderValidationTest } from '../../../shader_validation_test.js';
 
-import { kEntryPointsToValidateFragmentOnlyBuiltins } from './shader_builtin_utils.js';
+import {
+  kEntryPointsToValidateFragmentOnlyBuiltins,
+  kTestTextureTypes,
+} from './shader_builtin_utils.js';
 
 type TextureSampleCompareArguments = {
   coordsArgType: ScalarType | VectorType;
@@ -48,6 +53,47 @@ const kTextureTypes = keysOf(kValidTextureSampleCompareParameterTypes);
 const kValuesTypes = objectsToRecord(kAllScalarsAndVectors);
 
 export const g = makeTestGroup(ShaderValidationTest);
+
+g.test('return_type')
+  .specURL('https://gpuweb.github.io/gpuweb/wgsl/#texturesamplecompare')
+  .desc(
+    `
+Validates the return type of ${builtin} is the expected type.
+`
+  )
+  .params(u =>
+    u
+      .combine('returnType', keysOf(kValuesTypes))
+      .combine('textureType', keysOf(kValidTextureSampleCompareParameterTypes))
+      .beginSubcases()
+      .expand('offset', t =>
+        kValidTextureSampleCompareParameterTypes[t.textureType].offsetArgType
+          ? [false, true]
+          : [false]
+      )
+  )
+  .fn(t => {
+    const { returnType, textureType, offset } = t.params;
+    const returnVarType = kValuesTypes[returnType];
+    const { offsetArgType, coordsArgType, hasArrayIndexArg } =
+      kValidTextureSampleCompareParameterTypes[textureType];
+
+    const varWGSL = returnVarType.toString();
+    const coordWGSL = coordsArgType.create(0).wgsl();
+    const arrayWGSL = hasArrayIndexArg ? ', 0' : '';
+    const offsetWGSL = offset ? `, ${offsetArgType?.create(0).wgsl()}` : '';
+
+    const code = `
+@group(0) @binding(0) var s: sampler_comparison;
+@group(0) @binding(1) var t: ${textureType};
+@fragment fn fs() -> @location(0) vec4f {
+  let v: ${varWGSL} = textureSampleCompare(t, s, ${coordWGSL}${arrayWGSL}, 0${offsetWGSL});
+  return vec4f(0);
+}
+`;
+    const expectSuccess = isConvertible(Type.f32, returnVarType);
+    t.expectCompileResult(expectSuccess, code);
+  });
 
 g.test('coords_argument')
   .specURL('https://gpuweb.github.io/gpuweb/wgsl/#texturesamplecompare')
@@ -305,4 +351,51 @@ fn foo() {
   _ = textureSampleCompare(t, s, ${coordWGSL}${arrayWGSL}, 0${offsetWGSL});
 }`;
     t.expectCompileResult(config.expectSuccess, code);
+  });
+
+g.test('texture_type')
+  .specURL('https://gpuweb.github.io/gpuweb/wgsl/#texturesamplecompare')
+  .desc(
+    `
+Validates that incompatible texture types don't work with ${builtin}
+`
+  )
+  .params(u =>
+    u
+      .combine('testTextureType', kTestTextureTypes)
+      .combine('textureType', keysOf(kValidTextureSampleCompareParameterTypes))
+      .beginSubcases()
+      .expand('offset', t =>
+        kValidTextureSampleCompareParameterTypes[t.textureType].offsetArgType
+          ? [false, true]
+          : [false]
+      )
+  )
+  .fn(t => {
+    const { testTextureType, textureType, offset } = t.params;
+    const { coordsArgType, offsetArgType, hasArrayIndexArg } =
+      kValidTextureSampleCompareParameterTypes[textureType];
+
+    const coordWGSL = coordsArgType.create(0).wgsl();
+    const arrayWGSL = hasArrayIndexArg ? ', 0' : '';
+    const offsetWGSL = offset ? `, ${offsetArgType?.create(0).wgsl()}` : '';
+
+    const code = `
+@group(0) @binding(0) var s: sampler_comparison;
+@group(0) @binding(1) var t: ${testTextureType};
+@fragment fn fs() -> @location(0) vec4f {
+  let v = textureSampleCompare(t, s, ${coordWGSL}${arrayWGSL}, 0${offsetWGSL});
+  return vec4f(0);
+}
+`;
+
+    const types = kValidTextureSampleCompareParameterTypes[testTextureType];
+    const typesMatch = types
+      ? types.coordsArgType === coordsArgType &&
+        types.hasArrayIndexArg === hasArrayIndexArg &&
+        (offset ? types.offsetArgType === offsetArgType : true)
+      : false;
+
+    const expectSuccess = testTextureType === textureType || typesMatch;
+    t.expectCompileResult(expectSuccess, code);
   });

--- a/src/webgpu/shader/validation/expression/call/builtin/textureSampleCompareLevel.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/textureSampleCompareLevel.spec.ts
@@ -8,6 +8,8 @@ Validation tests for the ${builtin}() builtin.
 * test textureSampleCompareLevel offset parameter must be correct type
 * test textureSampleCompareLevel offset parameter must be a const-expression
 * test textureSampleCompareLevel offset parameter must be between -8 and +7 inclusive
+* test textureSampleCompareLevel returns the correct type
+* test textureSampleCompareLevel doesn't work with texture types it's not supposed to
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
@@ -21,6 +23,8 @@ import {
   isUnsignedType,
 } from '../../../../../util/conversion.js';
 import { ShaderValidationTest } from '../../../shader_validation_test.js';
+
+import { kTestTextureTypes } from './shader_builtin_utils.js';
 
 type TextureSampleCompareLevelArguments = {
   coordsArgType: ScalarType | VectorType;
@@ -45,6 +49,47 @@ const kTextureTypes = keysOf(kValidTextureSampleCompareLevelParameterTypes);
 const kValuesTypes = objectsToRecord(kAllScalarsAndVectors);
 
 export const g = makeTestGroup(ShaderValidationTest);
+
+g.test('return_type')
+  .specURL('https://gpuweb.github.io/gpuweb/wgsl/#texturesamplecomparelevel')
+  .desc(
+    `
+Validates the return type of ${builtin} is the expected type.
+`
+  )
+  .params(u =>
+    u
+      .combine('returnType', keysOf(kValuesTypes))
+      .combine('textureType', keysOf(kValidTextureSampleCompareLevelParameterTypes))
+      .beginSubcases()
+      .expand('offset', t =>
+        kValidTextureSampleCompareLevelParameterTypes[t.textureType].offsetArgType
+          ? [false, true]
+          : [false]
+      )
+  )
+  .fn(t => {
+    const { returnType, textureType, offset } = t.params;
+    const returnVarType = kValuesTypes[returnType];
+    const { offsetArgType, coordsArgType, hasArrayIndexArg } =
+      kValidTextureSampleCompareLevelParameterTypes[textureType];
+
+    const varWGSL = returnVarType.toString();
+    const coordWGSL = coordsArgType.create(0).wgsl();
+    const arrayWGSL = hasArrayIndexArg ? ', 0' : '';
+    const offsetWGSL = offset ? `, ${offsetArgType?.create(0).wgsl()}` : '';
+
+    const code = `
+@group(0) @binding(0) var s: sampler_comparison;
+@group(0) @binding(1) var t: ${textureType};
+@fragment fn fs() -> @location(0) vec4f {
+  let v: ${varWGSL} = textureSampleCompareLevel(t, s, ${coordWGSL}${arrayWGSL}, 0${offsetWGSL});
+  return vec4f(0);
+}
+`;
+    const expectSuccess = isConvertible(Type.f32, returnVarType);
+    t.expectCompileResult(expectSuccess, code);
+  });
 
 g.test('coords_argument')
   .specURL('https://gpuweb.github.io/gpuweb/wgsl/#texturesamplecomparelevel')
@@ -264,5 +309,52 @@ Validates that only non-const offset arguments are rejected by ${builtin}
 }
 `;
     const expectSuccess = varType === 'c';
+    t.expectCompileResult(expectSuccess, code);
+  });
+
+g.test('texture_type')
+  .specURL('https://gpuweb.github.io/gpuweb/wgsl/#texturesamplecomparelevel')
+  .desc(
+    `
+Validates that incompatible texture types don't work with ${builtin}
+`
+  )
+  .params(u =>
+    u
+      .combine('testTextureType', kTestTextureTypes)
+      .combine('textureType', keysOf(kValidTextureSampleCompareLevelParameterTypes))
+      .beginSubcases()
+      .expand('offset', t =>
+        kValidTextureSampleCompareLevelParameterTypes[t.textureType].offsetArgType
+          ? [false, true]
+          : [false]
+      )
+  )
+  .fn(t => {
+    const { testTextureType, textureType, offset } = t.params;
+    const { coordsArgType, offsetArgType, hasArrayIndexArg } =
+      kValidTextureSampleCompareLevelParameterTypes[textureType];
+
+    const coordWGSL = coordsArgType.create(0).wgsl();
+    const arrayWGSL = hasArrayIndexArg ? ', 0' : '';
+    const offsetWGSL = offset ? `, ${offsetArgType?.create(0).wgsl()}` : '';
+
+    const code = `
+@group(0) @binding(0) var s: sampler_comparison;
+@group(0) @binding(1) var t: ${testTextureType};
+@fragment fn fs() -> @location(0) vec4f {
+  let v = textureSampleCompareLevel(t, s, ${coordWGSL}${arrayWGSL}, 0${offsetWGSL});
+  return vec4f(0);
+}
+`;
+
+    const types = kValidTextureSampleCompareLevelParameterTypes[testTextureType];
+    const typesMatch = types
+      ? types.coordsArgType === coordsArgType &&
+        types.hasArrayIndexArg === hasArrayIndexArg &&
+        (offset ? types.offsetArgType === offsetArgType : true)
+      : false;
+
+    const expectSuccess = testTextureType === textureType || typesMatch;
     t.expectCompileResult(expectSuccess, code);
   });

--- a/src/webgpu/shader/validation/expression/call/builtin/textureSampleGrad.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/textureSampleGrad.spec.ts
@@ -10,6 +10,8 @@ Validation tests for the ${builtin}() builtin.
 * test textureSampleGrad offset parameter must be correct type
 * test textureSampleGrad offset parameter must be a const-expression
 * test textureSampleGrad offset parameter must be between -8 and +7 inclusive
+* test textureSampleGrad returns the correct type
+* test textureSampleGrad doesn't work with texture types it's not supposed to
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
@@ -23,6 +25,8 @@ import {
   isUnsignedType,
 } from '../../../../../util/conversion.js';
 import { ShaderValidationTest } from '../../../shader_validation_test.js';
+
+import { kTestTextureTypes } from './shader_builtin_utils.js';
 
 // Note: ddX and ddy parameter types match coords so we'll use coordsArgType for ddX and ddY.
 type TextureSampleGradArguments = {
@@ -50,6 +54,46 @@ const kTextureTypes = keysOf(kValidTextureSampleGradParameterTypes);
 const kValuesTypes = objectsToRecord(kAllScalarsAndVectors);
 
 export const g = makeTestGroup(ShaderValidationTest);
+
+g.test('return_type')
+  .specURL('https://gpuweb.github.io/gpuweb/wgsl/#texturesamplegrad')
+  .desc(
+    `
+Validates the return type of ${builtin} is the expected type.
+`
+  )
+  .params(u =>
+    u
+      .combine('returnType', keysOf(kValuesTypes))
+      .combine('textureType', keysOf(kValidTextureSampleGradParameterTypes))
+      .beginSubcases()
+      .expand('offset', t =>
+        kValidTextureSampleGradParameterTypes[t.textureType].offsetArgType ? [false, true] : [false]
+      )
+  )
+  .fn(t => {
+    const { returnType, textureType, offset } = t.params;
+    const returnVarType = kValuesTypes[returnType];
+    const { offsetArgType, coordsArgType, hasArrayIndexArg } =
+      kValidTextureSampleGradParameterTypes[textureType];
+
+    const varWGSL = returnVarType.toString();
+    const coordWGSL = coordsArgType.create(0).wgsl();
+    const arrayWGSL = hasArrayIndexArg ? ', 0' : '';
+    const ddWGSL = coordsArgType.create(0).wgsl();
+    const offsetWGSL = offset ? `, ${offsetArgType?.create(0).wgsl()}` : '';
+
+    const code = `
+@group(0) @binding(0) var s: sampler;
+@group(0) @binding(1) var t: ${textureType};
+@fragment fn fs() -> @location(0) vec4f {
+  let v: ${varWGSL} = textureSampleGrad(t, s, ${coordWGSL}${arrayWGSL}, ${ddWGSL}, ${ddWGSL}${offsetWGSL});
+  return vec4f(0);
+}
+`;
+    const expectSuccess = isConvertible(Type.vec4f, returnVarType);
+    t.expectCompileResult(expectSuccess, code);
+  });
 
 g.test('coords_argument')
   .specURL('https://gpuweb.github.io/gpuweb/wgsl/#texturesamplegrad')
@@ -313,5 +357,51 @@ Validates that only non-const offset arguments are rejected by ${builtin}
 }
 `;
     const expectSuccess = varType === 'c';
+    t.expectCompileResult(expectSuccess, code);
+  });
+
+g.test('texture_type')
+  .specURL('https://gpuweb.github.io/gpuweb/wgsl/#texturesamplegrad')
+  .desc(
+    `
+Validates that incompatible texture types don't work with ${builtin}
+`
+  )
+  .params(u =>
+    u
+      .combine('testTextureType', kTestTextureTypes)
+      .combine('textureType', keysOf(kValidTextureSampleGradParameterTypes))
+      .beginSubcases()
+      .expand('offset', t =>
+        kValidTextureSampleGradParameterTypes[t.textureType].offsetArgType ? [false, true] : [false]
+      )
+  )
+  .fn(t => {
+    const { testTextureType, textureType, offset } = t.params;
+    const { coordsArgType, offsetArgType, hasArrayIndexArg } =
+      kValidTextureSampleGradParameterTypes[textureType];
+
+    const coordWGSL = coordsArgType.create(0).wgsl();
+    const arrayWGSL = hasArrayIndexArg ? ', 0' : '';
+    const ddWGSL = coordsArgType.create(0).wgsl();
+    const offsetWGSL = offset ? `, ${offsetArgType?.create(0).wgsl()}` : '';
+
+    const code = `
+@group(0) @binding(0) var s: sampler;
+@group(0) @binding(1) var t: ${testTextureType};
+@fragment fn fs() -> @location(0) vec4f {
+  let v = textureSampleGrad(t, s, ${coordWGSL}${arrayWGSL}, ${ddWGSL}, ${ddWGSL}${offsetWGSL});
+  return vec4f(0);
+}
+`;
+
+    const types = kValidTextureSampleGradParameterTypes[testTextureType];
+    const typesMatch = types
+      ? types.coordsArgType === coordsArgType &&
+        types.hasArrayIndexArg === hasArrayIndexArg &&
+        (offset ? types.offsetArgType === offsetArgType : true)
+      : false;
+
+    const expectSuccess = testTextureType === textureType || typesMatch;
     t.expectCompileResult(expectSuccess, code);
   });

--- a/src/webgpu/shader/validation/expression/call/builtin/textureSampleLevel.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/textureSampleLevel.spec.ts
@@ -8,6 +8,8 @@ Validation tests for the ${builtin}() builtin.
 * test textureSampleLevel offset parameter must be correct type
 * test textureSampleLevel offset parameter must be a const-expression
 * test textureSampleLevel offset parameter must be between -8 and +7 inclusive
+* test textureSampleLevel returns the correct type
+* test textureSampleLevel doesn't work with texture types it's not supposed to
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
@@ -21,6 +23,8 @@ import {
   isUnsignedType,
 } from '../../../../../util/conversion.js';
 import { ShaderValidationTest } from '../../../shader_validation_test.js';
+
+import { kTestTextureTypes } from './shader_builtin_utils.js';
 
 type TextureSampleLevelArguments = {
   coordsArgType: ScalarType | VectorType;
@@ -58,6 +62,48 @@ const kTextureTypes = keysOf(kValidTextureSampleLevelParameterTypes);
 const kValuesTypes = objectsToRecord(kAllScalarsAndVectors);
 
 export const g = makeTestGroup(ShaderValidationTest);
+
+g.test('return_type')
+  .specURL('https://gpuweb.github.io/gpuweb/wgsl/#texturesamplelevel')
+  .desc(
+    `
+Validates the return type of ${builtin} is the expected type.
+`
+  )
+  .params(u =>
+    u
+      .combine('returnType', keysOf(kValuesTypes))
+      .combine('textureType', keysOf(kValidTextureSampleLevelParameterTypes))
+      .beginSubcases()
+      .expand('offset', t =>
+        kValidTextureSampleLevelParameterTypes[t.textureType].offsetArgType
+          ? [false, true]
+          : [false]
+      )
+  )
+  .fn(t => {
+    const { returnType, textureType, offset } = t.params;
+    const returnVarType = kValuesTypes[returnType];
+    const { offsetArgType, coordsArgType, hasArrayIndexArg } =
+      kValidTextureSampleLevelParameterTypes[textureType];
+    const returnExpectedType = textureType.includes('depth') ? Type.f32 : Type.vec4f;
+
+    const varWGSL = returnVarType.toString();
+    const coordWGSL = coordsArgType.create(0).wgsl();
+    const arrayWGSL = hasArrayIndexArg ? ', 0' : '';
+    const offsetWGSL = offset ? `, ${offsetArgType?.create(0).wgsl()}` : '';
+
+    const code = `
+@group(0) @binding(0) var s: sampler;
+@group(0) @binding(1) var t: ${textureType};
+@fragment fn fs() -> @location(0) vec4f {
+  let v: ${varWGSL} = textureSampleLevel(t, s, ${coordWGSL}${arrayWGSL}, 0${offsetWGSL});
+  return vec4f(0);
+}
+`;
+    const expectSuccess = isConvertible(returnExpectedType, returnVarType);
+    t.expectCompileResult(expectSuccess, code);
+  });
 
 g.test('coords_argument')
   .specURL('https://gpuweb.github.io/gpuweb/wgsl/#texturesamplelevel')
@@ -278,5 +324,52 @@ Validates that only non-const offset arguments are rejected by ${builtin}
 }
 `;
     const expectSuccess = varType === 'c';
+    t.expectCompileResult(expectSuccess, code);
+  });
+
+g.test('texture_type')
+  .specURL('https://gpuweb.github.io/gpuweb/wgsl/#texturesamplelevel')
+  .desc(
+    `
+Validates that incompatible texture types don't work with ${builtin}
+`
+  )
+  .params(u =>
+    u
+      .combine('testTextureType', kTestTextureTypes)
+      .combine('textureType', keysOf(kValidTextureSampleLevelParameterTypes))
+      .beginSubcases()
+      .expand('offset', t =>
+        kValidTextureSampleLevelParameterTypes[t.textureType].offsetArgType
+          ? [false, true]
+          : [false]
+      )
+  )
+  .fn(t => {
+    const { testTextureType, textureType, offset } = t.params;
+    const { coordsArgType, offsetArgType, hasArrayIndexArg } =
+      kValidTextureSampleLevelParameterTypes[textureType];
+
+    const coordWGSL = coordsArgType.create(0).wgsl();
+    const arrayWGSL = hasArrayIndexArg ? ', 0' : '';
+    const offsetWGSL = offset ? `, ${offsetArgType?.create(0).wgsl()}` : '';
+
+    const code = `
+@group(0) @binding(0) var s: sampler;
+@group(0) @binding(1) var t: ${testTextureType};
+@fragment fn fs() -> @location(0) vec4f {
+  let v = textureSampleLevel(t, s, ${coordWGSL}${arrayWGSL}, 0${offsetWGSL});
+  return vec4f(0);
+}
+`;
+
+    const types = kValidTextureSampleLevelParameterTypes[testTextureType];
+    const typesMatch = types
+      ? types.coordsArgType === coordsArgType &&
+        types.hasArrayIndexArg === hasArrayIndexArg &&
+        (offset ? types.offsetArgType === offsetArgType : true)
+      : false;
+
+    const expectSuccess = testTextureType === textureType || typesMatch;
     t.expectCompileResult(expectSuccess, code);
   });


### PR DESCRIPTION


Issue: #3586 #3594

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [X] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
