### PR TITLE
shader/execution: Fix `f16` structure member access tests

### DIFF
--- a/src/webgpu/shader/execution/expression/access/structure/index.spec.ts
+++ b/src/webgpu/shader/execution/expression/access/structure/index.spec.ts
@@ -30,9 +30,14 @@ async function run(
   input: Value[] | ArrayBufferLike | null,
   inputSource: InputSource
 ) {
-  const outputBufferSize = structStride(
-    expected.map(v => v.type),
-    'storage_rw'
+  const kMinStorageBufferSize = 4;
+
+  const outputBufferSize = Math.max(
+    kMinStorageBufferSize,
+    structStride(
+      expected.map(v => v.type),
+      'storage_rw'
+    )
   );
 
   const outputBuffer = t.device.createBuffer({
@@ -51,7 +56,10 @@ async function run(
     let inputData: Uint8Array;
     if (input instanceof Array) {
       const inputTypes = input.map(v => v.type);
-      const inputBufferSize = structStride(inputTypes, inputSource);
+      const inputBufferSize = Math.max(
+        kMinStorageBufferSize,
+        structStride(inputTypes, inputSource)
+      );
       inputData = new Uint8Array(inputBufferSize);
       structLayout(inputTypes, inputSource, m => {
         input[m.index].copyTo(inputData, m.offset);


### PR DESCRIPTION
The output buffer must be at least 4 bytes in size.

Issue: #3654

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
