### PR TITLE
wgsl: Add validation tests for continue statement

### DIFF
--- a/src/webgpu/listing_meta.json
+++ b/src/webgpu/listing_meta.json
@@ -2401,6 +2401,7 @@
   "webgpu:shader,validation,parse,compound:parse:*": { "subcaseMS": 4.315 },
   "webgpu:shader,validation,parse,const:placement:*": { "subcaseMS": 1.167 },
   "webgpu:shader,validation,parse,const_assert:parse:*": { "subcaseMS": 1.400 },
+  "webgpu:shader,validation,parse,continue:module_scope:*": { "subcaseMS": 0.278 },
   "webgpu:shader,validation,parse,continue:placement:*": { "subcaseMS": 53.998 },
   "webgpu:shader,validation,parse,continuing:placement:*": { "subcaseMS": 0.000 },
   "webgpu:shader,validation,parse,diagnostic:after_other_directives:*": { "subcaseMS": 1.000 },

--- a/src/webgpu/listing_meta.json
+++ b/src/webgpu/listing_meta.json
@@ -2401,6 +2401,7 @@
   "webgpu:shader,validation,parse,compound:parse:*": { "subcaseMS": 4.315 },
   "webgpu:shader,validation,parse,const:placement:*": { "subcaseMS": 1.167 },
   "webgpu:shader,validation,parse,const_assert:parse:*": { "subcaseMS": 1.400 },
+  "webgpu:shader,validation,parse,continue:placement:*": { "subcaseMS": 53.998 },
   "webgpu:shader,validation,parse,continuing:placement:*": { "subcaseMS": 0.000 },
   "webgpu:shader,validation,parse,diagnostic:after_other_directives:*": { "subcaseMS": 1.000 },
   "webgpu:shader,validation,parse,diagnostic:conflicting_attribute_different_location:*": { "subcaseMS": 2.257 },

--- a/src/webgpu/shader/validation/parse/continue.spec.ts
+++ b/src/webgpu/shader/validation/parse/continue.spec.ts
@@ -1,0 +1,88 @@
+export const description = `Validation tests for continue`;
+
+import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { keysOf } from '../../../../common/util/data_tables.js';
+import { ShaderValidationTest } from '../shader_validation_test.js';
+
+export const g = makeTestGroup(ShaderValidationTest);
+
+const kTests = {
+  continue: {
+    src: 'continue;',
+    pass: false,
+  },
+  compound_continue: {
+    src: '{ continue; }',
+    pass: false,
+  },
+  loop_continue: {
+    src: 'loop { if false { break; } continue; }',
+    pass: true,
+  },
+  while_continue: {
+    src: 'while true { continue; }',
+    pass: true,
+  },
+  for_continue: {
+    src: 'for (;true;) { continue; }',
+    pass: true,
+  },
+  continuing_continue: {
+    src: 'loop { continuing { continue; } }',
+    pass: false,
+  },
+  continuing_nested_loop_continue: {
+    src: 'loop { if false { break; } continuing { loop { if false { break; } continue; } } }',
+    pass: true,
+  },
+  if_continue: {
+    src: 'if true { continue; }',
+    pass: false,
+  },
+  nested_if_continue: {
+    src: 'while true { if true { continue; } }',
+    pass: true,
+  },
+  switch_case_continue: {
+    src: 'switch(1) { default: { continue; } }',
+    pass: false,
+  },
+  nested_switch_case_continue: {
+    src: 'while true { switch(1) { default: { continue; } } }',
+    pass: true,
+  },
+  return_continue: {
+    src: 'return continue;',
+    pass: false,
+  },
+  loop_continue_after_decl_used_in_continuing: {
+    src: 'loop { let cond = false; continue; continuing { break if cond; } }',
+    pass: true,
+  },
+  loop_continue_before_decl_used_in_continuing: {
+    src: 'loop { continue; let cond = false; continuing { break if cond; } }',
+    pass: false,
+  },
+  loop_continue_before_decl_not_used_in_continuing: {
+    src: 'loop { continue; let cond = false; continuing { break if false; } }',
+    pass: true,
+  },
+  loop_nested_continue_before_decl_used_in_continuing: {
+    src: 'loop { if false { continue; } let cond = false; continuing { break if cond; } }',
+    pass: false,
+  },
+};
+
+g.test('placement')
+  .desc('Test that continue placement is validated correctly')
+  .params(u => u.combine('stmt', keysOf(kTests)))
+  .fn(t => {
+    const code = `
+@vertex
+fn vtx() -> @builtin(position) vec4f {
+  ${kTests[t.params.stmt].src}
+  return vec4f(1);
+}
+    `;
+    t.expectCompileResult(kTests[t.params.stmt].pass, code);
+  });

--- a/src/webgpu/shader/validation/parse/continue.spec.ts
+++ b/src/webgpu/shader/validation/parse/continue.spec.ts
@@ -71,6 +71,22 @@ const kTests = {
     src: 'loop { if false { continue; } let cond = false; continuing { break if cond; } }',
     pass: false,
   },
+  loop_continue_expression: {
+    src: 'loop { if false { break; } continue true; }',
+    pass: false,
+  },
+  for_init_continue: {
+    src: 'for (continue;;) { break; }',
+    pass: false,
+  },
+  for_condition_continue: {
+    src: 'for (;continue;) { break; }',
+    pass: false,
+  },
+  for_continue_continue: {
+    src: 'for (;;continue) { break; }',
+    pass: false,
+  },
 };
 
 g.test('placement')
@@ -85,4 +101,13 @@ fn vtx() -> @builtin(position) vec4f {
 }
     `;
     t.expectCompileResult(kTests[t.params.stmt].pass, code);
+  });
+
+g.test('module_scope')
+  .desc('Test that continue is not valid at module-scope.')
+  .fn(t => {
+    const code = `
+continue;
+    `;
+    t.expectCompileResult(false, code);
   });


### PR DESCRIPTION
Issue #1681

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [X] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
