### PR TITLE
shader/validation: Expand tested statement condition types

### DIFF
--- a/src/webgpu/shader/validation/statement/break_if.spec.ts
+++ b/src/webgpu/shader/validation/statement/break_if.spec.ts
@@ -1,44 +1,32 @@
 export const description = `Validation tests for 'break if' statements'`;
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
-import { scalarTypeOf, Type } from '../../../util/conversion.js';
+import { keysOf } from '../../../../common/util/data_tables.js';
 import { ShaderValidationTest } from '../shader_validation_test.js';
+
+import { kTestTypes } from './test_types.js';
 
 export const g = makeTestGroup(ShaderValidationTest);
 
-const kTestTypes = [
-  'bool',
-  'i32',
-  'u32',
-  'f32',
-  'f16',
-  'vec2f',
-  'vec3h',
-  'vec4u',
-  'vec3b',
-  'mat2x3f',
-  'mat4x2h',
-  'abstract-int',
-  'abstract-float',
-] as const;
-
 g.test('condition_type')
   .desc(`Tests that an 'break if' condition must be a bool type`)
-  .params(u => u.combine('type', kTestTypes))
+  .params(u => u.combine('type', keysOf(kTestTypes)))
   .beforeAllSubcases(t => {
-    if (scalarTypeOf(Type[t.params.type]).kind === 'f16') {
+    if (kTestTypes[t.params.type].requires === 'f16') {
       t.selectDeviceOrSkipTestCase('shader-f16');
     }
   })
   .fn(t => {
-    const type = Type[t.params.type];
+    const type = kTestTypes[t.params.type];
     const code = `
-${scalarTypeOf(type).kind === 'f16' ? 'enable f16;' : ''}
+${type.requires ? `enable ${type.requires};` : ''}
+
+${type.header ?? ''}
 
 fn f() {
   loop {
     continuing {
-      break if ${type.create(1).wgsl()};
+      break if ${type.value};
     }
   }
 }

--- a/src/webgpu/shader/validation/statement/for.spec.ts
+++ b/src/webgpu/shader/validation/statement/for.spec.ts
@@ -1,42 +1,30 @@
 export const description = `Validation tests for 'for' statements'`;
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
-import { scalarTypeOf, Type } from '../../../util/conversion.js';
+import { keysOf } from '../../../../common/util/data_tables.js';
 import { ShaderValidationTest } from '../shader_validation_test.js';
+
+import { kTestTypes } from './test_types.js';
 
 export const g = makeTestGroup(ShaderValidationTest);
 
-const kTestTypes = [
-  'bool',
-  'i32',
-  'u32',
-  'f32',
-  'f16',
-  'vec2f',
-  'vec3h',
-  'vec4u',
-  'vec3b',
-  'mat2x3f',
-  'mat4x2h',
-  'abstract-int',
-  'abstract-float',
-] as const;
-
 g.test('condition_type')
   .desc(`Tests that a 'for' condition must be a bool type`)
-  .params(u => u.combine('type', kTestTypes))
+  .params(u => u.combine('type', keysOf(kTestTypes)))
   .beforeAllSubcases(t => {
-    if (scalarTypeOf(Type[t.params.type]).kind === 'f16') {
+    if (kTestTypes[t.params.type].requires === 'f16') {
       t.selectDeviceOrSkipTestCase('shader-f16');
     }
   })
   .fn(t => {
-    const type = Type[t.params.type];
+    const type = kTestTypes[t.params.type];
     const code = `
-${scalarTypeOf(type).kind === 'f16' ? 'enable f16;' : ''}
+${type.requires ? `enable ${type.requires};` : ''}
+
+${type.header ?? ''}
 
 fn f() -> bool {
-  for (; ${type.create(1).wgsl()};) {
+  for (; ${type.value};) {
     return true;
   }
   return false;

--- a/src/webgpu/shader/validation/statement/if.spec.ts
+++ b/src/webgpu/shader/validation/statement/if.spec.ts
@@ -1,42 +1,30 @@
 export const description = `Validation tests for 'if' statements'`;
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
-import { scalarTypeOf, Type } from '../../../util/conversion.js';
+import { keysOf } from '../../../../common/util/data_tables.js';
 import { ShaderValidationTest } from '../shader_validation_test.js';
+
+import { kTestTypes } from './test_types.js';
 
 export const g = makeTestGroup(ShaderValidationTest);
 
-const kTestTypes = [
-  'bool',
-  'i32',
-  'u32',
-  'f32',
-  'f16',
-  'vec2f',
-  'vec3h',
-  'vec4u',
-  'vec3b',
-  'mat2x3f',
-  'mat4x2h',
-  'abstract-int',
-  'abstract-float',
-] as const;
-
 g.test('condition_type')
   .desc(`Tests that an 'if' condition must be a bool type`)
-  .params(u => u.combine('type', kTestTypes))
+  .params(u => u.combine('type', keysOf(kTestTypes)))
   .beforeAllSubcases(t => {
-    if (scalarTypeOf(Type[t.params.type]).kind === 'f16') {
+    if (kTestTypes[t.params.type].requires === 'f16') {
       t.selectDeviceOrSkipTestCase('shader-f16');
     }
   })
   .fn(t => {
-    const type = Type[t.params.type];
+    const type = kTestTypes[t.params.type];
     const code = `
-${scalarTypeOf(type).kind === 'f16' ? 'enable f16;' : ''}
+${type.requires ? `enable ${type.requires};` : ''}
+
+${type.header ?? ''}
 
 fn f() -> bool {
-  if ${type.create(1).wgsl()} {
+  if ${type.value} {
     return true;
   }
   return false;
@@ -49,21 +37,23 @@ fn f() -> bool {
 
 g.test('else_condition_type')
   .desc(`Tests that an 'else if' condition must be a bool type`)
-  .params(u => u.combine('type', kTestTypes))
+  .params(u => u.combine('type', keysOf(kTestTypes)))
   .beforeAllSubcases(t => {
-    if (scalarTypeOf(Type[t.params.type]).kind === 'f16') {
+    if (kTestTypes[t.params.type].requires === 'f16') {
       t.selectDeviceOrSkipTestCase('shader-f16');
     }
   })
   .fn(t => {
-    const type = Type[t.params.type];
+    const type = kTestTypes[t.params.type];
     const code = `
-${scalarTypeOf(type).kind === 'f16' ? 'enable f16;' : ''}
+${type.requires ? `enable ${type.requires};` : ''}
+
+${type.header ?? ''}
 
 fn f(c : bool) -> bool {
   if (c) {
     return true;
-  } else if (${type.create(1).wgsl()}) {
+  } else if (${type.value}) {
     return true;
   }
   return false;

--- a/src/webgpu/shader/validation/statement/loop.spec.ts
+++ b/src/webgpu/shader/validation/statement/loop.spec.ts
@@ -1,44 +1,32 @@
 export const description = `Validation tests for 'loop' statements'`;
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
-import { scalarTypeOf, Type } from '../../../util/conversion.js';
+import { keysOf } from '../../../../common/util/data_tables.js';
 import { ShaderValidationTest } from '../shader_validation_test.js';
+
+import { kTestTypes } from './test_types.js';
 
 export const g = makeTestGroup(ShaderValidationTest);
 
-const kTestTypes = [
-  'bool',
-  'i32',
-  'u32',
-  'f32',
-  'f16',
-  'vec2f',
-  'vec3h',
-  'vec4u',
-  'vec3b',
-  'mat2x3f',
-  'mat4x2h',
-  'abstract-int',
-  'abstract-float',
-] as const;
-
 g.test('break_if_type')
   .desc(`Tests that a 'break if' condition must be a bool type`)
-  .params(u => u.combine('type', kTestTypes))
+  .params(u => u.combine('type', keysOf(kTestTypes)))
   .beforeAllSubcases(t => {
-    if (scalarTypeOf(Type[t.params.type]).kind === 'f16') {
+    if (kTestTypes[t.params.type].requires === 'f16') {
       t.selectDeviceOrSkipTestCase('shader-f16');
     }
   })
   .fn(t => {
-    const type = Type[t.params.type];
+    const type = kTestTypes[t.params.type];
     const code = `
-${scalarTypeOf(type).kind === 'f16' ? 'enable f16;' : ''}
+${type.requires ? `enable ${type.requires};` : ''}
+
+${type.header ?? ''}
 
 fn f() {
   loop {
     continuing {
-      break if ${type.create(1).wgsl()};
+      break if ${type.value};
     }
   }
 }

--- a/src/webgpu/shader/validation/statement/switch.spec.ts
+++ b/src/webgpu/shader/validation/statement/switch.spec.ts
@@ -1,42 +1,31 @@
 export const description = `Validation tests for 'switch' statements'`;
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
-import { scalarTypeOf, Type } from '../../../util/conversion.js';
+import { keysOf } from '../../../../common/util/data_tables.js';
+import { Type } from '../../../util/conversion.js';
 import { ShaderValidationTest } from '../shader_validation_test.js';
+
+import { kTestTypes } from './test_types.js';
 
 export const g = makeTestGroup(ShaderValidationTest);
 
-const kTestTypes = [
-  'bool',
-  'i32',
-  'u32',
-  'f32',
-  'f16',
-  'vec2f',
-  'vec3h',
-  'vec4u',
-  'vec3b',
-  'mat2x3f',
-  'mat4x2h',
-  'abstract-int',
-  'abstract-float',
-] as const;
-
 g.test('condition_type')
   .desc(`Tests that a 'switch' condition must be of an integer type`)
-  .params(u => u.combine('type', kTestTypes))
+  .params(u => u.combine('type', keysOf(kTestTypes)))
   .beforeAllSubcases(t => {
-    if (scalarTypeOf(Type[t.params.type]).kind === 'f16') {
+    if (kTestTypes[t.params.type].requires === 'f16') {
       t.selectDeviceOrSkipTestCase('shader-f16');
     }
   })
   .fn(t => {
-    const type = Type[t.params.type];
+    const type = kTestTypes[t.params.type];
     const code = `
-${scalarTypeOf(type).kind === 'f16' ? 'enable f16;' : ''}
+${type.requires ? `enable ${type.requires};` : ''}
+
+${type.header ?? ''}
 
 fn f() -> bool {
-  switch ${type.create(1).wgsl()} {
+  switch ${type.value} {
     case 1: {
       return true;
     }

--- a/src/webgpu/shader/validation/statement/test_types.ts
+++ b/src/webgpu/shader/validation/statement/test_types.ts
@@ -1,0 +1,36 @@
+export type TestType = {
+  /** A WGSL expression that produces a value of the given type */
+  value: string;
+  /** An optional shader enable required to use the type */
+  requires?: string;
+  /** An optional module-scope WGSL declaration required to use the type */
+  header?: string;
+};
+
+/** A selection of different types used by statement validation tests */
+export const kTestTypes: Record<string, TestType> = {
+  bool: { value: 'true' },
+  i32: { value: '1i' },
+  u32: { value: '1u' },
+  f32: { value: '1f' },
+  f16: { value: '1h', requires: 'f16' },
+  'abstract-int': { value: '1' },
+  'abstract-float': { value: '1.0' },
+  vec2af: { value: 'vec2(1.0)' },
+  vec3af: { value: 'vec3(1.0)' },
+  vec4af: { value: 'vec4(1.0)' },
+  vec2ai: { value: 'vec2(1)' },
+  vec3ai: { value: 'vec3(1)' },
+  vec4ai: { value: 'vec4(1)' },
+  vec2f: { value: 'vec2f(1)' },
+  vec3h: { value: 'vec3h(1)', requires: 'f16' },
+  vec4u: { value: 'vec4u(1)' },
+  vec3b: { value: 'vec3<bool>(true)' },
+  mat2x3f: { value: 'mat2x3f(1, 2, 3, 4, 5, 6)' },
+  mat4x2h: { value: 'mat4x2h(1, 2, 3, 4, 5, 6, 7, 8)', requires: 'f16' },
+  array: { value: 'array<i32, 4>(1, 2, 3, 4)' },
+  atomic: { value: 'A', header: 'var<workgroup> A : atomic<i32>;' },
+  struct: { value: 'Str(1)', header: 'struct Str{ i : i32 }' },
+  texture: { value: 'T', header: '@group(0) @binding(0) var T : texture_2d<f32>;' },
+  sampler: { value: 'S', header: '@group(0) @binding(1) var S : sampler;' },
+} as const;

--- a/src/webgpu/shader/validation/statement/while.spec.ts
+++ b/src/webgpu/shader/validation/statement/while.spec.ts
@@ -1,42 +1,30 @@
 export const description = `Validation tests for 'while' statements'`;
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
-import { scalarTypeOf, Type } from '../../../util/conversion.js';
+import { keysOf } from '../../../../common/util/data_tables.js';
 import { ShaderValidationTest } from '../shader_validation_test.js';
+
+import { kTestTypes } from './test_types.js';
 
 export const g = makeTestGroup(ShaderValidationTest);
 
-const kTestTypes = [
-  'bool',
-  'i32',
-  'u32',
-  'f32',
-  'f16',
-  'vec2f',
-  'vec3h',
-  'vec4u',
-  'vec3b',
-  'mat2x3f',
-  'mat4x2h',
-  'abstract-int',
-  'abstract-float',
-] as const;
-
 g.test('condition_type')
   .desc(`Tests that a 'while' condition must be a bool type`)
-  .params(u => u.combine('type', kTestTypes))
+  .params(u => u.combine('type', keysOf(kTestTypes)))
   .beforeAllSubcases(t => {
-    if (scalarTypeOf(Type[t.params.type]).kind === 'f16') {
+    if (kTestTypes[t.params.type].requires === 'f16') {
       t.selectDeviceOrSkipTestCase('shader-f16');
     }
   })
   .fn(t => {
-    const type = Type[t.params.type];
+    const type = kTestTypes[t.params.type];
     const code = `
-${scalarTypeOf(type).kind === 'f16' ? 'enable f16;' : ''}
+${type.requires ? `enable ${type.requires};` : ''}
+
+${type.header ?? ''}
 
 fn f() -> bool {
-  while (${type.create(1).wgsl()}) {
+  while (${type.value}) {
     return true;
   }
   return false;


### PR DESCRIPTION


Issue: #3685

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
