### PR TITLE
Validation for address space and access mode in var decls

### DIFF
--- a/src/webgpu/listing_meta.json
+++ b/src/webgpu/listing_meta.json
@@ -1901,6 +1901,7 @@
   "webgpu:shader,validation,decl,ptr_spelling:ptr_bad_store_type:*": { "subcaseMS": 0.967 },
   "webgpu:shader,validation,decl,ptr_spelling:ptr_handle_space_invalid:*": { "subcaseMS": 1.000 },
   "webgpu:shader,validation,decl,ptr_spelling:ptr_not_instantiable:*": { "subcaseMS": 1.310 },
+  "webgpu:shader,validation,decl,var:address_space_access_mode:*": { "subcaseMS": 14.399 },
   "webgpu:shader,validation,decl,var:binding_collision_unused_helper:*": { "subcaseMS": 1.000 },
   "webgpu:shader,validation,decl,var:binding_collisions:*": { "subcaseMS": 1.000 },
   "webgpu:shader,validation,decl,var:binding_point_on_function_var:*": { "subcaseMS": 1.000 },

--- a/src/webgpu/shader/validation/decl/var.spec.ts
+++ b/src/webgpu/shader/validation/decl/var.spec.ts
@@ -533,31 +533,39 @@ g.test('address_space_access_mode')
   .params(u =>
     u
       .combine('address_space', ['private', 'storage', 'uniform', 'function', 'workgroup'] as const)
-      .combine('access_mode', ['', ',', ',read', ',write', ',read_write'] as const)
+      .combine('access_mode', ['', 'read', 'write', 'read_write'] as const)
+      .combine('trailing_comma', [true, false] as const)
   )
   .fn(t => {
     let fdecl = ``;
     let mdecl = ``;
     // Most address spaces do not accept an access mode, but should accept no
     // template argument or a trailing comma.
-    let shouldPass = t.params.access_mode === '' || t.params.access_mode === ',';
+    let shouldPass = t.params.access_mode === '';
+    let suffix = ``;
+    if (t.params.access_mode === '') {
+      suffix += t.params.trailing_comma ? ',' : '';
+    } else {
+      suffix += `,${t.params.access_mode}`;
+      suffix += t.params.trailing_comma ? ',' : '';
+    }
     // 'handle' unchecked since it is untypable.
     switch (t.params.address_space) {
       case 'private':
-        mdecl = `var<private${t.params.access_mode}> x : u32;`;
+        mdecl = `var<private${suffix}> x : u32;`;
         break;
       case 'storage':
-        mdecl = `@group(0) @binding(0) var<storage${t.params.access_mode}> x : u32;`;
-        shouldPass = t.params.access_mode !== ',write';
+        mdecl = `@group(0) @binding(0) var<storage${suffix}> x : u32;`;
+        shouldPass = t.params.access_mode !== 'write';
         break;
       case 'uniform':
-        mdecl = `@group(0) @binding(0) var<uniform${t.params.access_mode}> x : u32;`;
+        mdecl = `@group(0) @binding(0) var<uniform${suffix}> x : u32;`;
         break;
       case 'workgroup':
-        mdecl = `var<private${t.params.access_mode}> x : u32;`;
+        mdecl = `var<workgroup${suffix}> x : u32;`;
         break;
       case 'function':
-        fdecl = `var<function${t.params.access_mode}> x : u32;`;
+        fdecl = `var<function${suffix}> x : u32;`;
         break;
     }
     const code = `${mdecl}


### PR DESCRIPTION
* Check that only storage allows an access mode (read or read_write)
* Tests no access mode parameter and a trailing comma after address space separately

Tint currently fails `webgpu:shader,validation,decl,var:address_space_access_mode:address_space="*";access_mode="";trailing_comma=true` (see https://crbug.com/tint/2233).
`webgpu:shader,validation,decl,var:address_space_access_mode:address_space="storage";access_mode="read";trailing_comma=true` 
`webgpu:shader,validation,decl,var:address_space_access_mode:address_space="storage";access_mode="read_write";trailing_comma=true` 

Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
