### PR TITLE
Test that submit validates command buffers uniqueness

### DIFF
--- a/src/webgpu/api/validation/queue/submit.spec.ts
+++ b/src/webgpu/api/validation/queue/submit.spec.ts
@@ -45,3 +45,18 @@ g.test('command_buffer,device_mismatch')
       t.device.queue.submit([cb0, cb1]);
     }, mismatched);
   });
+
+g.test('command_buffer,duplicate_buffers')
+  .desc(
+    `
+    Tests submit cannot be called with the same command buffer listed multiple times:
+    `
+  )
+  .fn(t => {
+    const encoder0 = t.device.createCommandEncoder();
+    const cb = encoder0.finish();
+
+    t.expectValidationError(() => {
+      t.device.queue.submit([cb, cb]);
+    }, true);
+  });


### PR DESCRIPTION
Issue first raised in https://github.com/gpuweb/gpuweb/issues/4367 with proposed validation behavior added to the spec in https://github.com/gpuweb/gpuweb/pull/4593. This PR should probably not land until that spec change has landed.

Ensures that command buffers are validated for uniqueness when submitting. Prevents an edge case which may allow command buffers to be submitted twice.

This behavior is not yet implemented in Chrome. Other browsers have not been tested but given that the requirement didn't exist in the spec previously it would be unsurprising if they lacked it as well.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [ ] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
