### PR TITLE
Buildfix: use correct include for 'assert'

### DIFF
--- a/src/resources/cache/hashes.json
+++ b/src/resources/cache/hashes.json
@@ -56,7 +56,7 @@
   "webgpu/shader/execution/faceForward.bin": "93106b04",
   "webgpu/shader/execution/floor.bin": "f423ef94",
   "webgpu/shader/execution/fma.bin": "49a0df16",
-  "webgpu/shader/execution/fract.bin": "1f75776f",
+  "webgpu/shader/execution/fract.bin": "c8b0ffb3",
   "webgpu/shader/execution/frexp.bin": "4d768906",
   "webgpu/shader/execution/inverseSqrt.bin": "6521f865",
   "webgpu/shader/execution/ldexp.bin": "75d2dc8b",

--- a/src/webgpu/shader/execution/expression/call/builtin/fract.cache.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/fract.cache.ts
@@ -1,5 +1,4 @@
-import { assert } from 'console';
-
+import { assert } from '../../../../../../common/util/util.js';
 import { FP, FPInterval } from '../../../../../util/floating_point.js';
 import { kFractTable } from '../../binary/af_data.js';
 import { makeCaseCache } from '../../case_cache.js';


### PR DESCRIPTION

Issue: #none, standalone page doesn't load, e.g. <https://gpuweb.github.io/cts/standalone/?q=webgpu:shader,execution,expression,call,builtin,*>

<hr>

**Requirements for PR author:**

- [ ] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [ ] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [ ] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
