### PR TITLE
[wgsl] Add `@size` const eval test

### DIFF
--- a/src/webgpu/shader/validation/shader_io/size.spec.ts
+++ b/src/webgpu/shader/validation/shader_io/size.spec.ts
@@ -27,6 +27,10 @@ const kSizeTests = {
     src: `@size(z)`,
     pass: true,
   },
+  const_expr: {
+    src: `@size(z + 4)`,
+    pass: true,
+  },
   trailing_comma: {
     src: `@size(4,)`,
     pass: true,


### PR DESCRIPTION
Add a test for an `@size` parameter which is calculated at compile time.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
