### PR TITLE
Validate invalidation of submitted command buffers

### DIFF
--- a/src/webgpu/api/validation/queue/submit.spec.ts
+++ b/src/webgpu/api/validation/queue/submit.spec.ts
@@ -8,7 +8,31 @@ Note: buffer map state is tested in ./buffer_mapped.spec.ts.
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { ValidationTest } from '../validation_test.js';
 
-export const g = makeTestGroup(ValidationTest);
+interface CommandBufferOptions {
+  device?: GPUDevice;
+  valid?: boolean;
+}
+
+class F extends ValidationTest {
+  createCommandBuffer(options: CommandBufferOptions = {}): GPUCommandBuffer {
+    const device = options.device ?? this.device;
+
+    let cb!: GPUCommandBuffer;
+
+    this.expectValidationError(() => {
+      const encoder = device.createCommandEncoder();
+      if (options.valid === false) {
+        // Popping a debug group when none are pushed results in an invalid command buffer.
+        encoder.popDebugGroup();
+      }
+      cb = encoder.finish();
+    }, options.valid === false);
+
+    return cb;
+  }
+}
+
+export const g = makeTestGroup(F);
 
 g.test('command_buffer,device_mismatch')
   .desc(
@@ -31,15 +55,8 @@ g.test('command_buffer,device_mismatch')
     const { cb0Mismatched, cb1Mismatched } = t.params;
     const mismatched = cb0Mismatched || cb1Mismatched;
 
-    const encoder0 = cb0Mismatched
-      ? t.mismatchedDevice.createCommandEncoder()
-      : t.device.createCommandEncoder();
-    const cb0 = encoder0.finish();
-
-    const encoder1 = cb1Mismatched
-      ? t.mismatchedDevice.createCommandEncoder()
-      : t.device.createCommandEncoder();
-    const cb1 = encoder1.finish();
+    const cb0 = t.createCommandBuffer({ device: cb0Mismatched ? t.mismatchedDevice : t.device });
+    const cb1 = t.createCommandBuffer({ device: cb1Mismatched ? t.mismatchedDevice : t.device });
 
     t.expectValidationError(() => {
       t.device.queue.submit([cb0, cb1]);
@@ -53,10 +70,52 @@ g.test('command_buffer,duplicate_buffers')
     `
   )
   .fn(t => {
-    const encoder0 = t.device.createCommandEncoder();
-    const cb = encoder0.finish();
+    const cb = t.createCommandBuffer();
 
     t.expectValidationError(() => {
       t.device.queue.submit([cb, cb]);
     }, true);
+  });
+
+g.test('command_buffer,submit_invalidates')
+  .desc(
+    `
+    Tests that calling submit invalidates the command buffers passed to it:
+    `
+  )
+  .fn(t => {
+    const cb0 = t.createCommandBuffer();
+
+    // Initial submit of a valid command buffer should pass.
+    t.device.queue.submit([cb0]);
+
+    // Subsequent submits of the same command buffer should fail.
+    t.expectValidationError(() => {
+      t.device.queue.submit([cb0]);
+    });
+
+    // Valid command buffers should be invalidated even if they're part of an invalid submit
+    const cb1 = t.createCommandBuffer();
+    const cb1_invalid = t.createCommandBuffer({ valid: false });
+
+    // Submit should fail because on of the command buffers is invalid
+    t.expectValidationError(() => {
+      t.device.queue.submit([cb1, cb1_invalid]);
+    });
+
+    // Subsequent submits of the previously valid command buffer should fail.
+    t.expectValidationError(() => {
+      t.device.queue.submit([cb1]);
+    });
+
+    // The order of the invalid and valid command buffers in the submit array should not matter.
+    const cb2 = t.createCommandBuffer();
+    const cb2_invalid = t.createCommandBuffer({ valid: false });
+
+    t.expectValidationError(() => {
+      t.device.queue.submit([cb2_invalid, cb2]);
+    });
+    t.expectValidationError(() => {
+      t.device.queue.submit([cb2]);
+    });
   });

--- a/src/webgpu/api/validation/queue/submit.spec.ts
+++ b/src/webgpu/api/validation/queue/submit.spec.ts
@@ -103,28 +103,20 @@ g.test('command_buffer,invalid_submit_invalidates')
     `
   )
   .fn(t => {
-    const cb = t.createCommandBuffer();
-    const cb_invalid = t.createCommandBuffer({ valid: false });
+    const cb1 = t.createCommandBuffer();
+    const cb1_invalid = t.createCommandBuffer({ valid: false });
 
     // Submit should fail because on of the command buffers is invalid
     t.expectValidationError(() => {
-      t.device.queue.submit([cb, cb_invalid]);
+      t.device.queue.submit([cb1, cb1_invalid]);
     });
 
     // Subsequent submits of the previously valid command buffer should fail.
     t.expectValidationError(() => {
-      t.device.queue.submit([cb]);
+      t.device.queue.submit([cb1]);
     });
-  });
 
-g.test('command_buffer,submit_invalidate_order')
-  .desc(
-    `
-    Tests that the order of the invalid and valid command buffers in the submit
-    array does not affect the command buffer invalidation.
-    `
-  )
-  .fn(t => {
+    // The order of the invalid and valid command buffers in the submit array should not matter.
     const cb2 = t.createCommandBuffer();
     const cb2_invalid = t.createCommandBuffer({ valid: false });
 

--- a/src/webgpu/api/validation/queue/submit.spec.ts
+++ b/src/webgpu/api/validation/queue/submit.spec.ts
@@ -84,31 +84,47 @@ g.test('command_buffer,submit_invalidates')
     `
   )
   .fn(t => {
-    const cb0 = t.createCommandBuffer();
+    const cb = t.createCommandBuffer();
 
     // Initial submit of a valid command buffer should pass.
-    t.device.queue.submit([cb0]);
+    t.device.queue.submit([cb]);
 
     // Subsequent submits of the same command buffer should fail.
     t.expectValidationError(() => {
-      t.device.queue.submit([cb0]);
+      t.device.queue.submit([cb]);
     });
+  });
 
-    // Valid command buffers should be invalidated even if they're part of an invalid submit
-    const cb1 = t.createCommandBuffer();
-    const cb1_invalid = t.createCommandBuffer({ valid: false });
+g.test('command_buffer,invalid_submit_invalidates')
+  .desc(
+    `
+    Tests that calling submit invalidates all command buffers passed to it, even
+    if they're part of an invalid submit.
+    `
+  )
+  .fn(t => {
+    const cb = t.createCommandBuffer();
+    const cb_invalid = t.createCommandBuffer({ valid: false });
 
     // Submit should fail because on of the command buffers is invalid
     t.expectValidationError(() => {
-      t.device.queue.submit([cb1, cb1_invalid]);
+      t.device.queue.submit([cb, cb_invalid]);
     });
 
     // Subsequent submits of the previously valid command buffer should fail.
     t.expectValidationError(() => {
-      t.device.queue.submit([cb1]);
+      t.device.queue.submit([cb]);
     });
+  });
 
-    // The order of the invalid and valid command buffers in the submit array should not matter.
+g.test('command_buffer,submit_invalidate_order')
+  .desc(
+    `
+    Tests that the order of the invalid and valid command buffers in the submit
+    array does not affect the command buffer invalidation.
+    `
+  )
+  .fn(t => {
     const cb2 = t.createCommandBuffer();
     const cb2_invalid = t.createCommandBuffer({ valid: false });
 


### PR DESCRIPTION
Adds validation to ensure that submit invalidates command buffers. I'm surprised this didn't exist before, but I'm unable to find any tests that attempt that specifically. Also makes a small utility for creating command buffers to make these tests a bit more terse and easy to write.

Last two checks in this test assume that we change the spec for `submit()` as proposed in https://github.com/gpuweb/gpuweb/pull/4608 and discussed in https://github.com/gpuweb/gpuweb/issues/4599.

<hr>

**Requirements for PR author:**

- [ ] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [ ] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [ ] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
