### PR TITLE
wgsl: Refactor existing bitwise shift execution tests

### DIFF
--- a/src/webgpu/shader/execution/expression/binary/bitwise_shift.spec.ts
+++ b/src/webgpu/shader/execution/expression/binary/bitwise_shift.spec.ts
@@ -4,7 +4,7 @@ Execution Tests for the bitwise shift binary expression operations
 
 import { makeTestGroup } from '../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../gpu_test.js';
-import { i32, scalarType, ScalarType, Type, u32 } from '../../../../util/conversion.js';
+import { scalarType, ScalarType, Type, u32 } from '../../../../util/conversion.js';
 import { Case } from '../case.js';
 import { allInputSources, run } from '../expression.js';
 
@@ -12,25 +12,20 @@ import { binary, compoundBinary } from './binary.js';
 
 export const g = makeTestGroup(GPUTest);
 
-function is_unsiged(type: string) {
-  return type === 'u32';
-}
-
-const bitwidth = 32;
-
 // Returns true if e1 << e2 is valid for const evaluation
-function is_valid_const_shift_left(e1: number, e1Type: string, e2: number) {
+function isValidConstShiftLeft(e1: number, e1_type: ScalarType, e2: number) {
   // Shift by 0 is always valid
   if (e2 === 0) {
     return true;
   }
 
+  const bitwidth = e1_type.size * 8;
   // Cannot shift by bitwidth or greater
   if (e2 >= bitwidth) {
     return false;
   }
 
-  if (is_unsiged(e1Type)) {
+  if (!e1_type.signed) {
     // If T is an unsigned integer type, and any of the e2 most significant bits of e1 are 1, then invalid.
     const must_be_zero_msb = e2;
     const mask = ~0 << (bitwidth - must_be_zero_msb);
@@ -50,12 +45,13 @@ function is_valid_const_shift_left(e1: number, e1Type: string, e2: number) {
 }
 
 // Returns true if e1 >> e2 is valid for const evaluation
-function is_valid_const_shift_right(e1: number, e1Type: string, e2: number) {
+function isValidConstShiftRight(_e1: number, e1_type: ScalarType, e2: number) {
   // Shift by 0 is always valid
   if (e2 === 0) {
     return true;
   }
 
+  const bitwidth = e1_type.size * 8;
   // Cannot shift by bitwidth or greater
   if (e2 >= bitwidth) {
     return false;
@@ -66,33 +62,34 @@ function is_valid_const_shift_right(e1: number, e1Type: string, e2: number) {
 
 // Returns all cases of shifting e1 left by [0,63]. If `is_const` is true, cases that are
 // invalid for const eval are not returned.
-function generate_shift_left_cases(e1: number, e1Type: string, is_const: boolean): Case[] {
-  const V = e1Type === 'i32' ? i32 : u32;
+function generateShiftLeftCases(e1: number, e1_type: ScalarType, is_const: boolean): Case[] {
+  const V = e1_type.create.bind(e1_type);
+  const bitwidth = e1_type.size * 8;
   const cases: Case[] = [];
   for (let shift = 0; shift < 64; ++shift) {
     const e2 = shift;
-    if (is_const && !is_valid_const_shift_left(e1, e1Type, e2)) {
+    if (is_const && !isValidConstShiftLeft(e1, e1_type, e2)) {
       continue;
     }
     const expected = e1 << e2 % bitwidth;
-    cases.push({ input: [V(e1), u32(e2)], expected: V(expected) });
+    cases.push({ input: [e1_type.create(e1), u32(e2)], expected: V(expected) });
   }
   return cases;
 }
 
 // Returns all cases of shifting e1 right by [0,63]. If `is_const` is true, cases that are
 // invalid for const eval are not returned.
-function generate_shift_right_cases(e1: number, e1Type: string, is_const: boolean): Case[] {
-  const V = e1Type === 'i32' ? i32 : u32;
+function generateShiftRightCases(e1: number, e1_type: ScalarType, is_const: boolean): Case[] {
+  const V = e1_type.create.bind(e1_type);
   const cases: Case[] = [];
   for (let shift = 0; shift < 64; ++shift) {
     const e2 = shift;
-    if (is_const && !is_valid_const_shift_right(e1, e1Type, e2)) {
+    if (is_const && !isValidConstShiftRight(e1, e1_type, e2)) {
       continue;
     }
 
     let expected: number = 0;
-    if (is_unsiged(e1Type)) {
+    if (!e1_type.signed) {
       // zero-fill right shift
       expected = e1 >>> e2;
     } else {
@@ -104,9 +101,10 @@ function generate_shift_right_cases(e1: number, e1Type: string, is_const: boolea
   return cases;
 }
 
-function makeShiftLeftConcreteCases(inputType: string, inputSource: string, type: ScalarType) {
-  const V = inputType === 'i32' ? i32 : u32;
-  const is_const = inputSource === 'const';
+function makeShiftLeftConcreteCases(input_source: string, type: ScalarType) {
+  const V = type.create.bind(type);
+  const is_const = input_source === 'const';
+  const is_unsigned = !type.signed;
 
   const cases: Case[] = [
     {
@@ -119,8 +117,8 @@ function makeShiftLeftConcreteCases(inputType: string, inputSource: string, type
     },
   ];
 
-  const add_unsigned_overflow_cases = !is_const || is_unsiged(inputType);
-  const add_signed_overflow_cases = !is_const || !is_unsiged(inputType);
+  const add_unsigned_overflow_cases = !is_const || is_unsigned;
+  const add_signed_overflow_cases = !is_const || !is_unsigned;
 
   if (add_unsigned_overflow_cases) {
     // Cases that are fine for unsigned values, but would overflow (sign change) signed
@@ -164,15 +162,15 @@ function makeShiftLeftConcreteCases(inputType: string, inputSource: string, type
   }
 
   // Generate cases that shift input value by [0,63] (invalid const eval cases are not returned).
-  cases.push(...generate_shift_left_cases(0b00000000000000000000000000000000, inputType, is_const));
-  cases.push(...generate_shift_left_cases(0b00000000000000000000000000000001, inputType, is_const));
-  cases.push(...generate_shift_left_cases(0b00000000000000000000000000000010, inputType, is_const));
-  cases.push(...generate_shift_left_cases(0b00000000000000000000000000000011, inputType, is_const));
-  cases.push(...generate_shift_left_cases(0b10000000000000000000000000000000, inputType, is_const));
-  cases.push(...generate_shift_left_cases(0b01000000000000000000000000000000, inputType, is_const));
-  cases.push(...generate_shift_left_cases(0b11000000000000000000000000000000, inputType, is_const));
-  cases.push(...generate_shift_left_cases(0b00010000001000001000010001010101, inputType, is_const));
-  cases.push(...generate_shift_left_cases(0b11101111110111110111101110101010, inputType, is_const));
+  cases.push(...generateShiftLeftCases(0b00000000000000000000000000000000, type, is_const));
+  cases.push(...generateShiftLeftCases(0b00000000000000000000000000000001, type, is_const));
+  cases.push(...generateShiftLeftCases(0b00000000000000000000000000000010, type, is_const));
+  cases.push(...generateShiftLeftCases(0b00000000000000000000000000000011, type, is_const));
+  cases.push(...generateShiftLeftCases(0b10000000000000000000000000000000, type, is_const));
+  cases.push(...generateShiftLeftCases(0b01000000000000000000000000000000, type, is_const));
+  cases.push(...generateShiftLeftCases(0b11000000000000000000000000000000, type, is_const));
+  cases.push(...generateShiftLeftCases(0b00010000001000001000010001010101, type, is_const));
+  cases.push(...generateShiftLeftCases(0b11101111110111110111101110101010, type, is_const));
   return cases;
 }
 
@@ -193,7 +191,7 @@ Shift left (shifted value is concrete)
   )
   .fn(async t => {
     const type = scalarType(t.params.type);
-    const cases = makeShiftLeftConcreteCases(t.params.type, t.params.inputSource, type);
+    const cases = makeShiftLeftConcreteCases(t.params.inputSource, type);
     await run(t, binary('<<'), [type, Type.u32], type, t.params, cases);
   });
 
@@ -214,13 +212,13 @@ Shift left (shifted value is concrete)
   )
   .fn(async t => {
     const type = scalarType(t.params.type);
-    const cases = makeShiftLeftConcreteCases(t.params.type, t.params.inputSource, type);
+    const cases = makeShiftLeftConcreteCases(t.params.inputSource, type);
     await run(t, compoundBinary('<<='), [type, Type.u32], type, t.params, cases);
   });
 
-function makeShiftRightConcreteCases(inputType: string, inputSource: string, type: ScalarType) {
-  const V = inputType === 'i32' ? i32 : u32;
-  const is_const = inputSource === 'const';
+function makeShiftRightConcreteCases(input_source: string, type: ScalarType) {
+  const V = type.create.bind(type);
+  const is_const = input_source === 'const';
 
   const cases: Case[] = [
     {
@@ -240,7 +238,7 @@ function makeShiftRightConcreteCases(inputType: string, inputSource: string, typ
       expected: /**/ V(0b00110000000000000000000000000000),
     },
   ];
-  if (is_unsiged(inputType)) {
+  if (!type.signed) {
     // No sign extension
     cases.push(
       ...[
@@ -271,33 +269,15 @@ function makeShiftRightConcreteCases(inputType: string, inputSource: string, typ
   }
 
   // Generate cases that shift input value by [0,63] (invalid const eval cases are not returned).
-  cases.push(
-    ...generate_shift_right_cases(0b00000000000000000000000000000000, inputType, is_const)
-  );
-  cases.push(
-    ...generate_shift_right_cases(0b00000000000000000000000000000001, inputType, is_const)
-  );
-  cases.push(
-    ...generate_shift_right_cases(0b00000000000000000000000000000010, inputType, is_const)
-  );
-  cases.push(
-    ...generate_shift_right_cases(0b00000000000000000000000000000011, inputType, is_const)
-  );
-  cases.push(
-    ...generate_shift_right_cases(0b10000000000000000000000000000000, inputType, is_const)
-  );
-  cases.push(
-    ...generate_shift_right_cases(0b01000000000000000000000000000000, inputType, is_const)
-  );
-  cases.push(
-    ...generate_shift_right_cases(0b11000000000000000000000000000000, inputType, is_const)
-  );
-  cases.push(
-    ...generate_shift_right_cases(0b00010000001000001000010001010101, inputType, is_const)
-  );
-  cases.push(
-    ...generate_shift_right_cases(0b11101111110111110111101110101010, inputType, is_const)
-  );
+  cases.push(...generateShiftRightCases(0b00000000000000000000000000000000, type, is_const));
+  cases.push(...generateShiftRightCases(0b00000000000000000000000000000001, type, is_const));
+  cases.push(...generateShiftRightCases(0b00000000000000000000000000000010, type, is_const));
+  cases.push(...generateShiftRightCases(0b00000000000000000000000000000011, type, is_const));
+  cases.push(...generateShiftRightCases(0b10000000000000000000000000000000, type, is_const));
+  cases.push(...generateShiftRightCases(0b01000000000000000000000000000000, type, is_const));
+  cases.push(...generateShiftRightCases(0b11000000000000000000000000000000, type, is_const));
+  cases.push(...generateShiftRightCases(0b00010000001000001000010001010101, type, is_const));
+  cases.push(...generateShiftRightCases(0b11101111110111110111101110101010, type, is_const));
   return cases;
 }
 
@@ -318,7 +298,7 @@ Shift right (shifted value is concrete)
   )
   .fn(async t => {
     const type = scalarType(t.params.type);
-    const cases = makeShiftRightConcreteCases(t.params.type, t.params.inputSource, type);
+    const cases = makeShiftRightConcreteCases(t.params.inputSource, type);
     await run(t, binary('>>'), [type, Type.u32], type, t.params, cases);
   });
 
@@ -339,6 +319,6 @@ Shift right (shifted value is concrete)
   )
   .fn(async t => {
     const type = scalarType(t.params.type);
-    const cases = makeShiftRightConcreteCases(t.params.type, t.params.inputSource, type);
+    const cases = makeShiftRightConcreteCases(t.params.inputSource, type);
     await run(t, compoundBinary('>>='), [type, Type.u32], type, t.params, cases);
   });

--- a/src/webgpu/shader/execution/expression/binary/bitwise_shift.spec.ts
+++ b/src/webgpu/shader/execution/expression/binary/bitwise_shift.spec.ts
@@ -3,8 +3,9 @@ Execution Tests for the bitwise shift binary expression operations
 `;
 
 import { makeTestGroup } from '../../../../../common/framework/test_group.js';
+import { assert } from '../../../../../common/util/util.js';
 import { GPUTest } from '../../../../gpu_test.js';
-import { scalarType, ScalarType, Type, u32 } from '../../../../util/conversion.js';
+import { ScalarBuilder, ScalarValue, Type, u32 } from '../../../../util/conversion.js';
 import { Case } from '../case.js';
 import { allInputSources, run } from '../expression.js';
 
@@ -13,23 +14,26 @@ import { binary, compoundBinary } from './binary.js';
 export const g = makeTestGroup(GPUTest);
 
 // Returns true if e1 << e2 is valid for const evaluation
-function isValidConstShiftLeft(e1: number, e1_type: ScalarType, e2: number) {
+function isValidConstShiftLeft(e1: ScalarValue, e2: number) {
+  // This will need to change when AbstractInts are added in
+  assert(typeof e1.value === 'number');
+
   // Shift by 0 is always valid
   if (e2 === 0) {
     return true;
   }
 
-  const bitwidth = e1_type.size * 8;
+  const bitwidth = e1.type.size * 8;
   // Cannot shift by bitwidth or greater
   if (e2 >= bitwidth) {
     return false;
   }
 
-  if (!e1_type.signed) {
+  if (!e1.type.signed) {
     // If T is an unsigned integer type, and any of the e2 most significant bits of e1 are 1, then invalid.
     const must_be_zero_msb = e2;
     const mask = ~0 << (bitwidth - must_be_zero_msb);
-    if ((e1 & mask) !== 0) {
+    if ((e1.value & mask) !== 0) {
       return false;
     }
   } else {
@@ -37,7 +41,7 @@ function isValidConstShiftLeft(e1: number, e1_type: ScalarType, e2: number) {
     // not have the same bit value, then error.
     const must_match_msb = e2 + 1;
     const mask = ~0 << (bitwidth - must_match_msb);
-    if ((e1 & mask) !== 0 && (e1 & mask) !== mask) {
+    if ((e1.value & mask) !== 0 && (e1.value & mask) !== mask) {
       return false;
     }
   }
@@ -45,13 +49,13 @@ function isValidConstShiftLeft(e1: number, e1_type: ScalarType, e2: number) {
 }
 
 // Returns true if e1 >> e2 is valid for const evaluation
-function isValidConstShiftRight(_e1: number, e1_type: ScalarType, e2: number) {
+function isValidConstShiftRight(e1: ScalarValue, e2: number) {
   // Shift by 0 is always valid
   if (e2 === 0) {
     return true;
   }
 
-  const bitwidth = e1_type.size * 8;
+  const bitwidth = e1.type.size * 8;
   // Cannot shift by bitwidth or greater
   if (e2 >= bitwidth) {
     return false;
@@ -60,65 +64,70 @@ function isValidConstShiftRight(_e1: number, e1_type: ScalarType, e2: number) {
   return true;
 }
 
-// Returns all cases of shifting e1 left by [0,63]. If `is_const` is true, cases that are
+// Returns all cases of shifting e1 left by [0,63]. If `isConst` is true, cases that are
 // invalid for const eval are not returned.
-function generateShiftLeftCases(e1: number, e1_type: ScalarType, is_const: boolean): Case[] {
-  const V = e1_type.create.bind(e1_type);
-  const bitwidth = e1_type.size * 8;
+function generateShiftLeftCases(e1: ScalarValue, isConst: boolean): Case[] {
+  // This will need to change when AbstractInts are added in
+  assert(typeof e1.value === 'number');
+
+  const bitwidth = e1.type.size * 8;
   const cases: Case[] = [];
   for (let shift = 0; shift < 64; ++shift) {
     const e2 = shift;
-    if (is_const && !isValidConstShiftLeft(e1, e1_type, e2)) {
+    if (isConst && !isValidConstShiftLeft(e1, e2)) {
       continue;
     }
-    const expected = e1 << e2 % bitwidth;
-    cases.push({ input: [e1_type.create(e1), u32(e2)], expected: V(expected) });
+    const expected = e1.value << e2 % bitwidth;
+    cases.push({ input: [e1, u32(e2)], expected: e1.type.create(expected) });
   }
   return cases;
 }
 
 // Returns all cases of shifting e1 right by [0,63]. If `is_const` is true, cases that are
 // invalid for const eval are not returned.
-function generateShiftRightCases(e1: number, e1_type: ScalarType, is_const: boolean): Case[] {
-  const V = e1_type.create.bind(e1_type);
+function generateShiftRightCases(e1: ScalarValue, isConst: boolean): Case[] {
+  // This will need to change when AbstractInts are added in
+  assert(typeof e1.value === 'number');
+
   const cases: Case[] = [];
   for (let shift = 0; shift < 64; ++shift) {
     const e2 = shift;
-    if (is_const && !isValidConstShiftRight(e1, e1_type, e2)) {
+    if (isConst && !isValidConstShiftRight(e1, e2)) {
       continue;
     }
 
     let expected: number = 0;
-    if (!e1_type.signed) {
+    if (!e1.type.signed) {
       // zero-fill right shift
-      expected = e1 >>> e2;
+      expected = e1.value >>> e2;
     } else {
       // arithmetic right shift
-      expected = e1 >> e2;
+      expected = e1.value >> e2;
     }
-    cases.push({ input: [V(e1), u32(e2)], expected: V(expected) });
+    cases.push({ input: [e1, u32(e2)], expected: e1.type.create(expected) });
   }
   return cases;
 }
 
-function makeShiftLeftConcreteCases(input_source: string, type: ScalarType) {
-  const V = type.create.bind(type);
-  const is_const = input_source === 'const';
-  const is_unsigned = !type.signed;
-
+// ScalarBuilder<number> will need to be updated to support AbstractInt
+function makeShiftLeftConcreteCases(
+  isConst: boolean,
+  isUnsigned: boolean,
+  B: ScalarBuilder<number>
+) {
   const cases: Case[] = [
     {
-      input: /*  */ [V(0b00000000000000000000000000000001), u32(1)],
-      expected: /**/ V(0b00000000000000000000000000000010),
+      input: /*  */ [B(0b00000000000000000000000000000001), u32(1)],
+      expected: /**/ B(0b00000000000000000000000000000010),
     },
     {
-      input: /*  */ [V(0b00000000000000000000000000000011), u32(1)],
-      expected: /**/ V(0b00000000000000000000000000000110),
+      input: /*  */ [B(0b00000000000000000000000000000011), u32(1)],
+      expected: /**/ B(0b00000000000000000000000000000110),
     },
   ];
 
-  const add_unsigned_overflow_cases = !is_const || is_unsigned;
-  const add_signed_overflow_cases = !is_const || !is_unsigned;
+  const add_unsigned_overflow_cases = !isConst || isUnsigned;
+  const add_signed_overflow_cases = !isConst || !isUnsigned;
 
   if (add_unsigned_overflow_cases) {
     // Cases that are fine for unsigned values, but would overflow (sign change) signed
@@ -126,16 +135,16 @@ function makeShiftLeftConcreteCases(input_source: string, type: ScalarType) {
     cases.push(
       ...[
         {
-          input: [/*  */ V(0b01000000000000000000000000000000), u32(1)],
-          expected: /**/ V(0b10000000000000000000000000000000),
+          input: [/*  */ B(0b01000000000000000000000000000000), u32(1)],
+          expected: /**/ B(0b10000000000000000000000000000000),
         },
         {
-          input: [/*  */ V(0b01111111111111111111111111111111), u32(1)],
-          expected: /**/ V(0b11111111111111111111111111111110),
+          input: [/*  */ B(0b01111111111111111111111111111111), u32(1)],
+          expected: /**/ B(0b11111111111111111111111111111110),
         },
         {
-          input: [/*  */ V(0b00000000000000000000000000000001), u32(31)],
-          expected: /**/ V(0b10000000000000000000000000000000),
+          input: [/*  */ B(0b00000000000000000000000000000001), u32(31)],
+          expected: /**/ B(0b10000000000000000000000000000000),
         },
       ]
     );
@@ -146,31 +155,31 @@ function makeShiftLeftConcreteCases(input_source: string, type: ScalarType) {
     cases.push(
       ...[
         {
-          input: [/*  */ V(0b11000000000000000000000000000000), u32(1)],
-          expected: /**/ V(0b10000000000000000000000000000000),
+          input: [/*  */ B(0b11000000000000000000000000000000), u32(1)],
+          expected: /**/ B(0b10000000000000000000000000000000),
         },
         {
-          input: [/*  */ V(0b11111111111111111111111111111111), u32(1)],
-          expected: /**/ V(0b11111111111111111111111111111110),
+          input: [/*  */ B(0b11111111111111111111111111111111), u32(1)],
+          expected: /**/ B(0b11111111111111111111111111111110),
         },
         {
-          input: [/*  */ V(0b11111111111111111111111111111111), u32(31)],
-          expected: /**/ V(0b10000000000000000000000000000000),
+          input: [/*  */ B(0b11111111111111111111111111111111), u32(31)],
+          expected: /**/ B(0b10000000000000000000000000000000),
         },
       ]
     );
   }
 
   // Generate cases that shift input value by [0,63] (invalid const eval cases are not returned).
-  cases.push(...generateShiftLeftCases(0b00000000000000000000000000000000, type, is_const));
-  cases.push(...generateShiftLeftCases(0b00000000000000000000000000000001, type, is_const));
-  cases.push(...generateShiftLeftCases(0b00000000000000000000000000000010, type, is_const));
-  cases.push(...generateShiftLeftCases(0b00000000000000000000000000000011, type, is_const));
-  cases.push(...generateShiftLeftCases(0b10000000000000000000000000000000, type, is_const));
-  cases.push(...generateShiftLeftCases(0b01000000000000000000000000000000, type, is_const));
-  cases.push(...generateShiftLeftCases(0b11000000000000000000000000000000, type, is_const));
-  cases.push(...generateShiftLeftCases(0b00010000001000001000010001010101, type, is_const));
-  cases.push(...generateShiftLeftCases(0b11101111110111110111101110101010, type, is_const));
+  cases.push(...generateShiftLeftCases(B(0b00000000000000000000000000000000), isConst));
+  cases.push(...generateShiftLeftCases(B(0b00000000000000000000000000000001), isConst));
+  cases.push(...generateShiftLeftCases(B(0b00000000000000000000000000000010), isConst));
+  cases.push(...generateShiftLeftCases(B(0b00000000000000000000000000000011), isConst));
+  cases.push(...generateShiftLeftCases(B(0b10000000000000000000000000000000), isConst));
+  cases.push(...generateShiftLeftCases(B(0b01000000000000000000000000000000), isConst));
+  cases.push(...generateShiftLeftCases(B(0b11000000000000000000000000000000), isConst));
+  cases.push(...generateShiftLeftCases(B(0b00010000001000001000010001010101), isConst));
+  cases.push(...generateShiftLeftCases(B(0b11101111110111110111101110101010), isConst));
   return cases;
 }
 
@@ -190,8 +199,14 @@ Shift left (shifted value is concrete)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
-    const type = scalarType(t.params.type);
-    const cases = makeShiftLeftConcreteCases(t.params.inputSource, type);
+    const type = Type[t.params.type];
+    const builder = type.create.bind(type);
+
+    const cases = makeShiftLeftConcreteCases(
+      t.params.inputSource === 'const',
+      !type.signed,
+      builder
+    );
     await run(t, binary('<<'), [type, Type.u32], type, t.params, cases);
   });
 
@@ -211,44 +226,52 @@ Shift left (shifted value is concrete)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
-    const type = scalarType(t.params.type);
-    const cases = makeShiftLeftConcreteCases(t.params.inputSource, type);
+    const type = Type[t.params.type];
+    const builder = type.create.bind(type);
+
+    const cases = makeShiftLeftConcreteCases(
+      t.params.inputSource === 'const',
+      !type.signed,
+      builder
+    );
     await run(t, compoundBinary('<<='), [type, Type.u32], type, t.params, cases);
   });
 
-function makeShiftRightConcreteCases(input_source: string, type: ScalarType) {
-  const V = type.create.bind(type);
-  const is_const = input_source === 'const';
-
+// ScalarBuilder<number> will need to be updated to support AbstractInt
+function makeShiftRightConcreteCases(
+  isConst: boolean,
+  isUnsigned: boolean,
+  B: ScalarBuilder<number>
+) {
   const cases: Case[] = [
     {
-      input: /*  */ [V(0b00000000000000000000000000000001), u32(1)],
-      expected: /**/ V(0b00000000000000000000000000000000),
+      input: /*  */ [B(0b00000000000000000000000000000001), u32(1)],
+      expected: /**/ B(0b00000000000000000000000000000000),
     },
     {
-      input: /*  */ [V(0b00000000000000000000000000000011), u32(1)],
-      expected: /**/ V(0b00000000000000000000000000000001),
+      input: /*  */ [B(0b00000000000000000000000000000011), u32(1)],
+      expected: /**/ B(0b00000000000000000000000000000001),
     },
     {
-      input: /*  */ [V(0b01000000000000000000000000000000), u32(1)],
-      expected: /**/ V(0b00100000000000000000000000000000),
+      input: /*  */ [B(0b01000000000000000000000000000000), u32(1)],
+      expected: /**/ B(0b00100000000000000000000000000000),
     },
     {
-      input: /*  */ [V(0b01100000000000000000000000000000), u32(1)],
-      expected: /**/ V(0b00110000000000000000000000000000),
+      input: /*  */ [B(0b01100000000000000000000000000000), u32(1)],
+      expected: /**/ B(0b00110000000000000000000000000000),
     },
   ];
-  if (!type.signed) {
+  if (isUnsigned) {
     // No sign extension
     cases.push(
       ...[
         {
-          input: /*  */ [V(0b10000000000000000000000000000000), u32(1)],
-          expected: /**/ V(0b01000000000000000000000000000000),
+          input: /*  */ [B(0b10000000000000000000000000000000), u32(1)],
+          expected: /**/ B(0b01000000000000000000000000000000),
         },
         {
-          input: /*  */ [V(0b11000000000000000000000000000000), u32(1)],
-          expected: /**/ V(0b01100000000000000000000000000000),
+          input: /*  */ [B(0b11000000000000000000000000000000), u32(1)],
+          expected: /**/ B(0b01100000000000000000000000000000),
         },
       ]
     );
@@ -257,27 +280,27 @@ function makeShiftRightConcreteCases(input_source: string, type: ScalarType) {
       // Sign extension if msb is 1
       ...[
         {
-          input: /*  */ [V(0b10000000000000000000000000000000), u32(1)],
-          expected: /**/ V(0b11000000000000000000000000000000),
+          input: /*  */ [B(0b10000000000000000000000000000000), u32(1)],
+          expected: /**/ B(0b11000000000000000000000000000000),
         },
         {
-          input: /*  */ [V(0b11000000000000000000000000000000), u32(1)],
-          expected: /**/ V(0b11100000000000000000000000000000),
+          input: /*  */ [B(0b11000000000000000000000000000000), u32(1)],
+          expected: /**/ B(0b11100000000000000000000000000000),
         },
       ]
     );
   }
 
   // Generate cases that shift input value by [0,63] (invalid const eval cases are not returned).
-  cases.push(...generateShiftRightCases(0b00000000000000000000000000000000, type, is_const));
-  cases.push(...generateShiftRightCases(0b00000000000000000000000000000001, type, is_const));
-  cases.push(...generateShiftRightCases(0b00000000000000000000000000000010, type, is_const));
-  cases.push(...generateShiftRightCases(0b00000000000000000000000000000011, type, is_const));
-  cases.push(...generateShiftRightCases(0b10000000000000000000000000000000, type, is_const));
-  cases.push(...generateShiftRightCases(0b01000000000000000000000000000000, type, is_const));
-  cases.push(...generateShiftRightCases(0b11000000000000000000000000000000, type, is_const));
-  cases.push(...generateShiftRightCases(0b00010000001000001000010001010101, type, is_const));
-  cases.push(...generateShiftRightCases(0b11101111110111110111101110101010, type, is_const));
+  cases.push(...generateShiftRightCases(B(0b00000000000000000000000000000000), isConst));
+  cases.push(...generateShiftRightCases(B(0b00000000000000000000000000000001), isConst));
+  cases.push(...generateShiftRightCases(B(0b00000000000000000000000000000010), isConst));
+  cases.push(...generateShiftRightCases(B(0b00000000000000000000000000000011), isConst));
+  cases.push(...generateShiftRightCases(B(0b10000000000000000000000000000000), isConst));
+  cases.push(...generateShiftRightCases(B(0b01000000000000000000000000000000), isConst));
+  cases.push(...generateShiftRightCases(B(0b11000000000000000000000000000000), isConst));
+  cases.push(...generateShiftRightCases(B(0b00010000001000001000010001010101), isConst));
+  cases.push(...generateShiftRightCases(B(0b11101111110111110111101110101010), isConst));
   return cases;
 }
 
@@ -297,8 +320,14 @@ Shift right (shifted value is concrete)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
-    const type = scalarType(t.params.type);
-    const cases = makeShiftRightConcreteCases(t.params.inputSource, type);
+    const type = Type[t.params.type];
+    const builder = type.create.bind(type);
+
+    const cases = makeShiftRightConcreteCases(
+      t.params.inputSource === 'const',
+      !type.signed,
+      builder
+    );
     await run(t, binary('>>'), [type, Type.u32], type, t.params, cases);
   });
 
@@ -318,7 +347,13 @@ Shift right (shifted value is concrete)
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
-    const type = scalarType(t.params.type);
-    const cases = makeShiftRightConcreteCases(t.params.inputSource, type);
+    const type = Type[t.params.type];
+    const builder = type.create.bind(type);
+
+    const cases = makeShiftRightConcreteCases(
+      t.params.inputSource === 'const',
+      !type.signed,
+      builder
+    );
     await run(t, compoundBinary('>>='), [type, Type.u32], type, t.params, cases);
   });


### PR DESCRIPTION
Bunch of cleanup to this code, mosty removing local utility functions and constants by using ScalarType instead of ScalarKind. Broadly prepping this code for the addition AbstractInt testing.

<hr>

**Requirements for PR author:**

- [ ] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [ ] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [ ] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
