### PR TITLE
Add discard in continuing block execution test

### DIFF
--- a/src/webgpu/listing_meta.json
+++ b/src/webgpu/listing_meta.json
@@ -1837,6 +1837,7 @@
   "webgpu:shader,execution,stage:basic_render:*": { "subcaseMS": 1.000 },
   "webgpu:shader,execution,statement,compound:decl:*": { "subcaseMS": 29.767 },
   "webgpu:shader,execution,statement,discard:all:*": { "subcaseMS": 36.094 },
+  "webgpu:shader,execution,statement,discard:continuing:*": { "subcaseMS": 276.268 },
   "webgpu:shader,execution,statement,discard:derivatives:*": { "subcaseMS": 15.287 },
   "webgpu:shader,execution,statement,discard:function_call:*": { "subcaseMS": 11.744 },
   "webgpu:shader,execution,statement,discard:loop:*": { "subcaseMS": 11.821 },

--- a/src/webgpu/shader/execution/statement/discard.spec.ts
+++ b/src/webgpu/shader/execution/statement/discard.spec.ts
@@ -495,6 +495,74 @@ fn fsMain(@builtin(position) pos : vec4f) -> @location(0) u32 {
     drawFullScreen(t, code, dataChecker, fbChecker);
   });
 
+g.test('continuing')
+  .desc('Test discards in a loop')
+  .fn(t => {
+    const code = `
+${kSharedCode}
+
+@fragment
+fn fsMain(@builtin(position) pos : vec4f) -> @location(0) u32 {
+  _ = uniformValues[0];
+  var i = 0;
+  loop {
+    continuing {
+      if i > 0 {
+        discard;
+      }
+      i++;
+      break if i >= 2;
+    }
+  }
+  let idx = atomicAdd(&atomicIndex, 1);
+  output[idx] = pos.xy;
+  return 1;
+}
+`;
+
+    // No storage writes occur.
+    const dataChecker = (a: Float32Array) => {
+      return checkElementsPassPredicate(
+        a,
+        (idx: number, value: number | bigint) => {
+          return value === 0;
+        },
+        {
+          predicatePrinter: [
+            {
+              leftHeader: 'data exp ==',
+              getValueForCell: (idx: number) => {
+                return 0;
+              },
+            },
+          ],
+        }
+      );
+    };
+
+    // No fragment outputs occur.
+    const fbChecker = (a: Uint32Array) => {
+      return checkElementsPassPredicate(
+        a,
+        (idx: number, value: number | bigint) => {
+          return value === kWidth * kHeight;
+        },
+        {
+          predicatePrinter: [
+            {
+              leftHeader: 'fb exp ==',
+              getValueForCell: (idx: number) => {
+                return kWidth * kHeight;
+              },
+            },
+          ],
+        }
+      );
+    };
+
+    drawFullScreen(t, code, dataChecker, fbChecker);
+  });
+
 g.test('uniform_read_loop')
   .desc('Test that helpers read a uniform value in a loop')
   .fn(t => {


### PR DESCRIPTION
Fixes #3317

* Add a loop variant that discards in the continuing block




Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
