### PR TITLE
Add test for atomicSub with i32 min value

### DIFF
--- a/src/webgpu/listing_meta.json
+++ b/src/webgpu/listing_meta.json
@@ -1210,6 +1210,7 @@
   "webgpu:shader,execution,expression,call,builtin,atomics,atomicStore:store_storage_basic:*": { "subcaseMS": 5.524 },
   "webgpu:shader,execution,expression,call,builtin,atomics,atomicStore:store_workgroup_advanced:*": { "subcaseMS": 6.029 },
   "webgpu:shader,execution,expression,call,builtin,atomics,atomicStore:store_workgroup_basic:*": { "subcaseMS": 6.632 },
+  "webgpu:shader,execution,expression,call,builtin,atomics,atomicSub:sub_i32_min:*": { "subcaseMS": 2.756 },
   "webgpu:shader,execution,expression,call,builtin,atomics,atomicSub:sub_storage:*": { "subcaseMS": 5.757 },
   "webgpu:shader,execution,expression,call,builtin,atomics,atomicSub:sub_workgroup:*": { "subcaseMS": 7.238 },
   "webgpu:shader,execution,expression,call,builtin,atomics,atomicXor:xor_storage:*": { "subcaseMS": 6.807 },

--- a/src/webgpu/shader/execution/expression/call/builtin/atomics/atomicSub.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atomics/atomicSub.spec.ts
@@ -99,3 +99,27 @@ fn atomicSub(atomic_ptr: ptr<AS, atomic<T>, read_write>, v: T) -> T
       expected,
     });
   });
+
+g.test('sub_i32_min')
+  .desc('Test atomicSub with i32 minimum value')
+  .fn(t => {
+    // Allocate one extra element to ensure it doesn't get modified
+    const bufferNumElements = 2;
+
+    const initValue = 0xffff;
+    const op = `atomicSub(&output[0], -2147483648)`;
+    const expected = new (typedArrayCtor('i32'))(bufferNumElements);
+    expected[0] = -0x7fff0001;
+    expected[1] = 0xffff;
+
+    runStorageVariableTest({
+      t,
+      workgroupSize: 1,
+      dispatchSize: 1,
+      bufferNumElements,
+      initValue,
+      op,
+      expected,
+    });
+  });
+

--- a/src/webgpu/shader/execution/expression/call/builtin/atomics/atomicSub.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/atomics/atomicSub.spec.ts
@@ -122,4 +122,3 @@ g.test('sub_i32_min')
       expected,
     });
   });
-


### PR DESCRIPTION
Fixes #3100

* Add an atomicSub test that uses i32 minimum values (-2147483648) to cover polyfills




Issue: #3100

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
