### PR TITLE
More override validation tests

### DIFF
--- a/src/webgpu/shader/validation/decl/override.spec.ts
+++ b/src/webgpu/shader/validation/decl/override.spec.ts
@@ -169,6 +169,10 @@ const kInitCases = {
     code: `override x : u32 = 1i;`,
     valid: false,
   },
+  init_mismatch_vector: {
+    code: `override x : u32 = vec2i();`,
+    valid: false,
+  },
   abs_int_init_convert: {
     code: `override x : f32 = 1;`,
     valid: true,
@@ -188,6 +192,20 @@ const kInitCases = {
   init_runtime_expr: {
     code: `var<private> x = 2;\noverride y = x;`,
     valid: false,
+  },
+  const_func_init: {
+    code: `override x = max(1, 2);`,
+    valid: true,
+  },
+  non_const_func_init: {
+    code: `override x = foo(1);
+    fn foo(p : i32) -> i32 { return p; }`,
+    valid: false,
+  },
+  mix_order_init: {
+    code: `override x = y;
+    override y : i32;`,
+    valid: true,
   },
 };
 


### PR DESCRIPTION
Fixes #1557

* Remaining cases
  * scalar decl, vector init failure
  * mixed order init success
  * const function init success
  * non-const function init failure




Issue: #1557

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
