### PR TITLE
More matrix validation

### DIFF
--- a/src/webgpu/shader/validation/types/matrix.spec.ts
+++ b/src/webgpu/shader/validation/types/matrix.spec.ts
@@ -86,6 +86,9 @@ const kValidCases = {
   shadow_mat4x2h: `enable f16;\nalias mat4x2h = mat4x2<f16>;`,
   shadow_mat4x3h: `enable f16;\nalias mat4x3h = mat4x3<f16>;`,
   shadow_mat4x4h: `enable f16;\nalias mat4x4h = mat4x4<f16>;`,
+
+  // Alias
+  alias: `alias E = f32; alias T = mat2x2<E>;`,
 };
 
 g.test('valid')
@@ -116,6 +119,11 @@ const kInvalidCases = {
   mat2x1: `alias T = mat2x1<f32>;`,
   mat2x5: `alias T = mat2x5<f32>;`,
   mat5x5: `alias T = mat5x5<f32>;`,
+  mat2x: `alias T = mat2x<f32>;`,
+  matx2: `alias T = matx2<f32>;`,
+  mat2: `alias T = mat2<f32>;`,
+  mat: `alias T = mat;`,
+  mat_f32: `alias T = mat<f32>;`,
 
   // Half-precision aliases require enable
   no_enable_mat2x2h: `alias T = mat2x2h;`,


### PR DESCRIPTION
Fixes #1494

* Tests:
  * more invalid specifiers (dimensions)
  * aliased element type




Issue: #1494

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
