### PR TITLE
Add vec2(), vec3(), and vec4() execution tests

### DIFF
--- a/src/webgpu/listing_meta.json
+++ b/src/webgpu/listing_meta.json
@@ -1644,6 +1644,7 @@
   "webgpu:shader,execution,expression,constructor,zero_value:scalar:*": { "subcaseMS": 39.484 },
   "webgpu:shader,execution,expression,constructor,zero_value:structure:*": { "subcaseMS": 0.650 },
   "webgpu:shader,execution,expression,constructor,zero_value:vector:*": { "subcaseMS": 159.975 },
+  "webgpu:shader,execution,expression,constructor,zero_value:vector_prefix:*": { "subcaseMS": 23.267 },
   "webgpu:shader,execution,expression,precedence:precedence:*": { "subcaseMS": 531.048 },
   "webgpu:shader,execution,expression,unary,address_of_and_indirection:deref:*": { "subcaseMS": 0.000 },
   "webgpu:shader,execution,expression,unary,address_of_and_indirection:deref_index:*": { "subcaseMS": 0.000 },

--- a/src/webgpu/shader/execution/expression/constructor/zero_value.spec.ts
+++ b/src/webgpu/shader/execution/expression/constructor/zero_value.spec.ts
@@ -58,9 +58,7 @@ g.test('vector')
 g.test('vector_prefix')
   .desc(`Test that a zero value vector constructor produces the expected zero value`)
   .params(u =>
-    u
-      .combine('type', ['i32', 'u32', 'f32', 'f16'] as const)
-      .combine('width', [2, 3, 4] as const)
+    u.combine('type', ['i32', 'u32', 'f32', 'f16'] as const).combine('width', [2, 3, 4] as const)
   )
   .beforeAllSubcases(t => {
     if (t.params.type === 'f16') {

--- a/src/webgpu/shader/execution/expression/constructor/zero_value.spec.ts
+++ b/src/webgpu/shader/execution/expression/constructor/zero_value.spec.ts
@@ -55,6 +55,30 @@ g.test('vector')
     );
   });
 
+g.test('vector_prefix')
+  .desc(`Test that a zero value vector constructor produces the expected zero value`)
+  .params(u =>
+    u
+      .combine('type', ['i32', 'u32', 'f32', 'f16'] as const)
+      .combine('width', [2, 3, 4] as const)
+  )
+  .beforeAllSubcases(t => {
+    if (t.params.type === 'f16') {
+      t.selectDeviceOrSkipTestCase('shader-f16');
+    }
+  })
+  .fn(async t => {
+    const type = Type.vec(t.params.width, Type[t.params.type]);
+    await run(
+      t,
+      basicExpressionBuilder(ops => `vec${t.params.width}()`),
+      [],
+      type,
+      { inputSource: 'const' },
+      [{ input: [], expected: type.create(0) }]
+    );
+  });
+
 g.test('matrix')
   .specURL('https://www.w3.org/TR/WGSL/#zero-value-builtin-function')
   .desc(`Test that a zero value matrix constructor produces the expected zero value`)


### PR DESCRIPTION
Fixes #2481




Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
