### PR TITLE
Test variable address space restrictions for shader stages

### DIFF
--- a/src/webgpu/listing_meta.json
+++ b/src/webgpu/listing_meta.json
@@ -1937,6 +1937,7 @@
   "webgpu:shader,validation,decl,var:module_scope_initializers:*": { "subcaseMS": 1.000 },
   "webgpu:shader,validation,decl,var:module_scope_types:*": { "subcaseMS": 1.000 },
   "webgpu:shader,validation,decl,var:read_access:*": { "subcaseMS": 20.792 },
+  "webgpu:shader,validation,decl,var:shader_stage:*": { "subcaseMS": 18.095 },
   "webgpu:shader,validation,decl,var:var_access_mode_bad_other_template_contents:*": { "subcaseMS": 54.257 },
   "webgpu:shader,validation,decl,var:var_access_mode_bad_template_delim:*": { "subcaseMS": 49.467 },
   "webgpu:shader,validation,decl,var:write_access:*": { "subcaseMS": 21.476 },

--- a/src/webgpu/shader/validation/decl/var.spec.ts
+++ b/src/webgpu/shader/validation/decl/var.spec.ts
@@ -776,6 +776,7 @@ g.test('shader_stage')
       .combine('stage', ['compute', 'vertex', 'fragment'] as const)
       .combine('kind', [
         'handle_ro',
+        'handle_wo',
         'handle_rw',
         'function',
         'private',
@@ -786,12 +787,21 @@ g.test('shader_stage')
       ])
   )
   .fn(t => {
+    t.skipIf(
+      !t.hasLanguageFeature('readonly_and_readwrite_storage_textures') &&
+        t.params.kind === 'handle_rw',
+      'Unsupported language feature'
+    );
     let mdecl = ``;
     let fdecl = ``;
     let expect = true;
     switch (t.params.kind) {
       case 'handle_ro':
         mdecl = `@group(0) @binding(0) var v : sampler;`;
+        break;
+      case 'handle_wo':
+        mdecl = `@group(0) @binding(0) var v : texture_storage_2d<r32uint, write>;`;
+        expect = t.params.stage !== 'vertex';
         break;
       case 'handle_rw':
         mdecl = `@group(0) @binding(0) var v : texture_storage_2d<r32uint, read_write>;`;

--- a/src/webgpu/shader/validation/decl/var.spec.ts
+++ b/src/webgpu/shader/validation/decl/var.spec.ts
@@ -768,3 +768,84 @@ g.test('var_access_mode_bad_template_delim')
     const ok = t.params.prefix === '<' && t.params.suffix === '>';
     t.expectCompileResult(ok, prog);
   });
+
+g.test('shader_stage')
+  .desc('Test the limitations of address space and shader stage')
+  .params(u =>
+    u
+      .combine('stage', ['compute', 'vertex', 'fragment'] as const)
+      .combine('kind', [
+        'handle_ro',
+        'handle_rw',
+        'function',
+        'private',
+        'storage_ro',
+        'storage_rw',
+        'uniform',
+        'workgroup',
+      ])
+  )
+  .fn(t => {
+    let mdecl = ``;
+    let fdecl = ``;
+    let expect = true;
+    switch (t.params.kind) {
+      case 'handle_ro':
+        mdecl = `@group(0) @binding(0) var v : sampler;`;
+        break;
+      case 'handle_rw':
+        mdecl = `@group(0) @binding(0) var v : texture_storage_2d<r32uint, read_write>;`;
+        expect = t.params.stage !== 'vertex';
+        break;
+      case 'function':
+        fdecl = `var v : u32;`;
+        break;
+      case 'private':
+        mdecl = `var<private> v : i32;`;
+        break;
+      case 'storage_ro':
+        mdecl = `@group(0) @binding(0) var<storage> v : u32;`;
+        break;
+      case 'storage_rw':
+        mdecl = `@group(0) @binding(0) var<storage, read_write> v : u32;`;
+        expect = t.params.stage !== 'vertex';
+        break;
+      case 'uniform':
+        mdecl = `@group(0) @binding(0) var<uniform> v : u32;`;
+        break;
+      case 'workgroup':
+        mdecl = `var<workgroup> v : u32;`;
+        expect = t.params.stage === 'compute';
+        break;
+    }
+    let func = ``;
+    switch (t.params.stage) {
+      case 'compute':
+        func = `@compute @workgroup_size(1)
+        fn main() {
+          ${fdecl}
+          _ = v;
+        }`;
+        break;
+      case 'vertex':
+        func = `@vertex
+        fn main() -> @builtin(position) vec4f {
+          ${fdecl}
+          _ = v;
+          return vec4f();
+        }`;
+        break;
+      case 'fragment':
+        func = `@fragment
+        fn main() {
+          ${fdecl}
+          _ = v;
+        }`;
+        break;
+    }
+
+    const code = `
+    ${mdecl}
+    ${func}`;
+    t.expectCompileResult(expect, code);
+  });


### PR DESCRIPTION
Fixes #2398

* Test the restrictions for each address space per shader stage
  * workgroup only in compute
  * RW buffer and texture not in vertex


Tint fails the RW buffer and textures by allowing them in the vertex stage.

Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [ ] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [ ] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [ ] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
