### PR TITLE
call unregisterAllServiceWorkers only if serviceWorker are actually available

### DIFF
--- a/src/common/runtime/helper/test_worker.ts
+++ b/src/common/runtime/helper/test_worker.ts
@@ -17,12 +17,16 @@ function unregisterAllServiceWorkers() {
   });
 }
 
-// NOTE: This code runs on startup for any runtime with worker support. Here, we use that chance to
-// delete any leaked service workers, and register to clean up after ourselves at shutdown.
-unregisterAllServiceWorkers();
-window.addEventListener('beforeunload', () => {
+// Firefox has serviceWorkers disabled in private mode
+// and Servo does not support serviceWorkers yet.
+if ('serviceWorker' in navigator) {
+  // NOTE: This code runs on startup for any runtime with worker support. Here, we use that chance to
+  // delete any leaked service workers, and register to clean up after ourselves at shutdown.
   unregisterAllServiceWorkers();
-});
+  window.addEventListener('beforeunload', () => {
+    unregisterAllServiceWorkers();
+  });
+}
 
 abstract class TestBaseWorker {
   protected readonly ctsOptions: CTSOptions;


### PR DESCRIPTION
Servo does not support serviceWorkers and also Firefox has serviceWorkers disabled in private window.

MDN: https://developer.mozilla.org/en-US/docs/Web/API/Navigator/serviceWorker#browser_compatibility

<hr>

**Requirements for PR author:**

- [ ] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [ ] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [ ] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
