### PR TITLE
Add layout tests for matrices in arrays

### DIFF
--- a/src/webgpu/shader/execution/memory_layout.spec.ts
+++ b/src/webgpu/shader/execution/memory_layout.spec.ts
@@ -785,6 +785,142 @@ const kLayoutCases: Record<string, LayoutCase> = {
     write_assign: `out[2].x = in`,
     offset: 32,
   },
+  array_mat2x2f_stride: {
+    type: `array<mat2x2f, 4>`,
+    read_assign: `out = u32(in[1][0][0])`,
+    write_assign: `out[1][0][0] = f32(in)`,
+    offset: 16,
+    f32: true,
+  },
+  array_mat2x2h_stride: {
+    type: `array<mat2x2h, 2>`,
+    read_assign: `out = u32(in[1][0][0])`,
+    write_assign: `out[1][0][0] = f16(in)`,
+    offset: 8,
+    f16: true,
+    skip_uniform: true,
+  },
+  array_mat3x2f_stride: {
+    type: `array<mat3x2f, 3>`,
+    read_assign: `out = u32(in[2][0][0])`,
+    write_assign: `out[2][0][0] = f32(in)`,
+    offset: 48,
+    f32: true,
+    skip_uniform: true,
+  },
+  array_mat3x2h_stride: {
+    type: `array<mat3x2h, 2>`,
+    read_assign: `out = u32(in[1][0][0])`,
+    write_assign: `out[1][0][0] = f16(in)`,
+    offset: 12,
+    f16: true,
+    skip_uniform: true,
+  },
+  array_mat4x2f_stride: {
+    type: `array<mat4x2f, 4>`,
+    read_assign: `out = u32(in[1][0][0])`,
+    write_assign: `out[1][0][0] = f32(in)`,
+    offset: 32,
+    f32: true,
+  },
+  array_mat4x2h_stride: {
+    type: `array<mat4x2h, 2>`,
+    read_assign: `out = u32(in[1][0][0])`,
+    write_assign: `out[1][0][0] = f16(in)`,
+    offset: 16,
+    f16: true,
+    skip_uniform: true,
+  },
+  array_mat2x3f_stride: {
+    type: `array<mat2x3f, 4>`,
+    read_assign: `out = u32(in[1][0][0])`,
+    write_assign: `out[1][0][0] = f32(in)`,
+    offset: 32,
+    f32: true,
+  },
+  array_mat2x3h_stride: {
+    type: `array<mat2x3h, 2>`,
+    read_assign: `out = u32(in[1][0][0])`,
+    write_assign: `out[1][0][0] = f16(in)`,
+    offset: 16,
+    f16: true,
+    skip_uniform: true,
+  },
+  array_mat3x3f_stride: {
+    type: `array<mat3x3f, 3>`,
+    read_assign: `out = u32(in[2][0][0])`,
+    write_assign: `out[2][0][0] = f32(in)`,
+    offset: 96,
+    f32: true,
+  },
+  array_mat3x3h_stride: {
+    type: `array<mat3x3h, 2>`,
+    read_assign: `out = u32(in[1][0][0])`,
+    write_assign: `out[1][0][0] = f16(in)`,
+    offset: 24,
+    f16: true,
+    skip_uniform: true,
+  },
+  array_mat4x3f_stride: {
+    type: `array<mat4x3f, 4>`,
+    read_assign: `out = u32(in[1][0][0])`,
+    write_assign: `out[1][0][0] = f32(in)`,
+    offset: 64,
+    f32: true,
+  },
+  array_mat4x3h_stride: {
+    type: `array<mat4x3h, 2>`,
+    read_assign: `out = u32(in[1][0][0])`,
+    write_assign: `out[1][0][0] = f16(in)`,
+    offset: 32,
+    f16: true,
+    skip_uniform: true,
+  },
+  array_mat2x4f_stride: {
+    type: `array<mat2x4f, 4>`,
+    read_assign: `out = u32(in[1][0][0])`,
+    write_assign: `out[1][0][0] = f32(in)`,
+    offset: 32,
+    f32: true,
+  },
+  array_mat2x4h_stride: {
+    type: `array<mat2x4h, 2>`,
+    read_assign: `out = u32(in[1][0][0])`,
+    write_assign: `out[1][0][0] = f16(in)`,
+    offset: 16,
+    f16: true,
+    skip_uniform: true,
+  },
+  array_mat3x4f_stride: {
+    type: `array<mat3x4f, 3>`,
+    read_assign: `out = u32(in[2][0][0])`,
+    write_assign: `out[2][0][0] = f32(in)`,
+    offset: 96,
+    f32: true,
+  },
+  array_mat3x4h_stride: {
+    type: `array<mat3x4h, 2>`,
+    read_assign: `out = u32(in[1][0][0])`,
+    write_assign: `out[1][0][0] = f16(in)`,
+    offset: 24,
+    f16: true,
+    skip_uniform: true,
+  },
+  array_mat4x4f_stride: {
+    type: `array<mat4x4f, 4>`,
+    read_assign: `out = u32(in[1][0][0])`,
+    write_assign: `out[1][0][0] = f32(in)`,
+    offset: 64,
+    f32: true,
+  },
+  array_mat4x4h_stride: {
+    type: `array<mat4x4h, 2>`,
+    read_assign: `out = u32(in[1][0][0])`,
+    write_assign: `out[1][0][0] = f16(in)`,
+    offset: 32,
+    f16: true,
+    skip_uniform: true,
+  },
 };
 
 g.test('read_layout')
@@ -815,7 +951,7 @@ g.test('read_layout')
     const testcase = kLayoutCases[t.params.case];
     let code = `
 ${testcase.f16 ? 'enable f16;' : ''}
-${testcase.decl}
+${testcase.decl ?? ''}
 
 @group(0) @binding(1)
 var<storage, read_write> out : u32;
@@ -952,7 +1088,7 @@ g.test('write_layout')
     const testcase = kLayoutCases[t.params.case];
     let code = `
 ${testcase.f16 ? 'enable f16;' : ''}
-${testcase.decl}
+${testcase.decl ?? ''}
 
 @group(0) @binding(0)
 var<storage> in : u32;

--- a/src/webgpu/shader/execution/memory_layout.spec.ts
+++ b/src/webgpu/shader/execution/memory_layout.spec.ts
@@ -829,7 +829,6 @@ const kLayoutCases: Record<string, LayoutCase> = {
     write_assign: `out[1][0][0] = f16(in)`,
     offset: 16,
     f16: true,
-    skip_uniform: true,
   },
   array_mat2x3f_stride: {
     type: `array<mat2x3f, 4>`,
@@ -844,7 +843,6 @@ const kLayoutCases: Record<string, LayoutCase> = {
     write_assign: `out[1][0][0] = f16(in)`,
     offset: 16,
     f16: true,
-    skip_uniform: true,
   },
   array_mat3x3f_stride: {
     type: `array<mat3x3f, 3>`,
@@ -874,7 +872,6 @@ const kLayoutCases: Record<string, LayoutCase> = {
     write_assign: `out[1][0][0] = f16(in)`,
     offset: 32,
     f16: true,
-    skip_uniform: true,
   },
   array_mat2x4f_stride: {
     type: `array<mat2x4f, 4>`,
@@ -889,7 +886,6 @@ const kLayoutCases: Record<string, LayoutCase> = {
     write_assign: `out[1][0][0] = f16(in)`,
     offset: 16,
     f16: true,
-    skip_uniform: true,
   },
   array_mat3x4f_stride: {
     type: `array<mat3x4f, 3>`,
@@ -919,7 +915,6 @@ const kLayoutCases: Record<string, LayoutCase> = {
     write_assign: `out[1][0][0] = f16(in)`,
     offset: 32,
     f16: true,
-    skip_uniform: true,
   },
 };
 


### PR DESCRIPTION
Fixes #3735

* Add cases to layout execution tests to cover matrices in an array




Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
