### PR TITLE
Add more structure validation tests

### DIFF
--- a/src/webgpu/shader/validation/types/struct.spec.ts
+++ b/src/webgpu/shader/validation/types/struct.spec.ts
@@ -248,6 +248,38 @@ const kStructureCases: Record<string, StructureCase> = {
     alias S = u32;`,
     valid: false,
   },
+  member_collision: {
+    code: `struct S { x : u32, x : u32 }`,
+    valid: false,
+  },
+  no_name: {
+    code: `struct { x : u32 }`,
+    valid: false,
+  },
+  missing_l_brace: {
+    code: `struct S x : u32 }`,
+    valid: false,
+  },
+  missing_r_brace: {
+    code: `struct S { x : u32`,
+    valid: false,
+  },
+  bad_name: {
+    code: `struct 123 { x : u32 }`,
+    valid: false,
+  },
+  bad_delimiter: {
+    code: `struct S { x : u32; y : u32 }`,
+    valid: false,
+  },
+  missing_delimiter: {
+    code: `struct S { x : u32 y : u32 }`,
+    valid: false,
+  },
+  bad_member_decl: {
+    code: `struct S { x u32 }`,
+    valid: false,
+  },
 };
 
 g.test('structures')


### PR DESCRIPTION
Fixes #1501

Attributes are tested elsewhere.


Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [ ] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [ ] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [ ] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
