### PR TITLE
shader/exeuction: Fix abstract-numeric constructor tests

### DIFF
--- a/src/webgpu/shader/execution/expression/constructor/non_zero.spec.ts
+++ b/src/webgpu/shader/execution/expression/constructor/non_zero.spec.ts
@@ -191,7 +191,7 @@ g.test('abstract_vector_splat')
       basicExpressionBuilder(_ => `${fn}(${t.params.value * 0x100000000}${suffix}) / 0x100000000`),
       [],
       concreteVectorType,
-      { inputSource: 'const' },
+      { inputSource: 'const', constEvaluationMode: 'direct' },
       [{ input: [], expected: concreteVectorType.create(t.params.value) }]
     );
   });
@@ -269,7 +269,7 @@ g.test('abstract_vector_elements')
       ),
       [],
       concreteVectorType,
-      { inputSource: 'const' },
+      { inputSource: 'const', constEvaluationMode: 'direct' },
       [{ input: [], expected: concreteVectorType.create(elements) }]
     );
   });
@@ -391,7 +391,7 @@ g.test('abstract_vector_mix')
       basicExpressionBuilder(_ => `${fn}(${args.join(', ')}) / 0x100000000`),
       [],
       concreteVectorType,
-      { inputSource: 'const' },
+      { inputSource: 'const', constEvaluationMode: 'direct' },
       [
         {
           input: [],
@@ -514,7 +514,7 @@ g.test('abstract_matrix_elements')
       ),
       [],
       concreteMatrixType,
-      { inputSource: 'const' },
+      { inputSource: 'const', constEvaluationMode: 'direct' },
       [
         {
           input: [],
@@ -605,7 +605,7 @@ g.test('abstract_matrix_column_vectors')
       basicExpressionBuilder(_ => `${fn}(${columnVectors.join(', ')}) * (1.0 / 0x100000000)`),
       [],
       concreteMatrixType,
-      { inputSource: 'const' },
+      { inputSource: 'const', constEvaluationMode: 'direct' },
       [
         {
           input: [],

--- a/src/webgpu/shader/execution/expression/constructor/zero_value.spec.ts
+++ b/src/webgpu/shader/execution/expression/constructor/zero_value.spec.ts
@@ -72,7 +72,7 @@ g.test('vector_prefix')
       basicExpressionBuilder(ops => `vec${t.params.width}()`),
       [],
       type,
-      { inputSource: 'const' },
+      { inputSource: 'const', constEvaluationMode: 'direct' },
       [{ input: [], expected: type.create(0) }]
     );
   });


### PR DESCRIPTION
Specify `constEvaluationMode: 'direct'` for abstract-numeric constructor tests.

This CL extends #3677 to fix more tests that early concretize values when loops are not unrolled.

Depending on the platform, we either directly assign the expression evaluation to the output buffer, or go via a const array. The latter caused compilation failures as it would force a concretization of the abstract values in the array, which would become incompatible with the output type.

Fixes: #3743

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
