### PR TITLE
Add early evaluation error tests for smoothstep

### DIFF
--- a/src/webgpu/listing_meta.json
+++ b/src/webgpu/listing_meta.json
@@ -2233,6 +2233,7 @@
   "webgpu:shader,validation,expression,call,builtin,sinh:values:*": { "subcaseMS": 0.357 },
   "webgpu:shader,validation,expression,call,builtin,smoothstep:argument_types:*": { "subcaseMS": 69163.359 },
   "webgpu:shader,validation,expression,call,builtin,smoothstep:arguments:*": { "subcaseMS": 131.134 },
+  "webgpu:shader,validation,expression,call,builtin,smoothstep:early_eval_errors:*": { "subcaseMS": 161.151 },
   "webgpu:shader,validation,expression,call,builtin,smoothstep:values:*": { "subcaseMS": 81643.500 },
   "webgpu:shader,validation,expression,call,builtin,sqrt:args:*": { "subcaseMS": 5.398 },
   "webgpu:shader,validation,expression,call,builtin,sqrt:integer_argument:*": { "subcaseMS": 1.356 },

--- a/src/webgpu/shader/validation/expression/call/builtin/smoothstep.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/smoothstep.spec.ts
@@ -254,7 +254,6 @@ g.test('early_eval_errors')
       .beginSubcases()
       .combineWithParams([
         { low: 1, high: 2 },
-        { low: 1, high: 2 },
         { low: 2, high: 1 },
         { low: 1, high: 1 },
       ] as const)

--- a/src/webgpu/shader/validation/expression/call/builtin/smoothstep.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/smoothstep.spec.ts
@@ -13,6 +13,7 @@ import {
   kAllScalarsAndVectors,
   kConvertableToFloatScalarsAndVectors,
   scalarTypeOf,
+  f32,
 } from '../../../../../util/conversion.js';
 import { ShaderValidationTest } from '../../../shader_validation_test.js';
 
@@ -243,4 +244,27 @@ g.test('arguments')
     return vec4<f32>(.4, .2, .3, .1);
   }`;
     t.expectCompileResult(kTests[t.params.test].pass, code);
+  });
+
+g.test('early_eval_errors')
+  .desc('Validates that high must be greater than low')
+  .params(u =>
+    u
+      .combine('stage', kConstantAndOverrideStages)
+      .beginSubcases()
+      .combineWithParams([
+        { low: 1, high: 2 },
+        { low: 1, high: 2 },
+        { low: 2, high: 1 },
+        { low: 1, high: 1 },
+      ] as const)
+  )
+  .fn(t => {
+    validateConstOrOverrideBuiltinEval(
+      t,
+      builtin,
+      /* expectedResult */ t.params.low < t.params.high,
+      [f32(0), f32(t.params.low), f32(t.params.high)],
+      t.params.stage
+    );
   });


### PR DESCRIPTION
Fixes #3722

* Test that const- and override-expressions where low >= high produce an error for smoothstep

Tint currently does not produce therse errors.


Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [ ] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [ ] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [ ] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
