### PR TITLE
Test * and [] precendence on LHS

### DIFF
--- a/src/webgpu/listing_meta.json
+++ b/src/webgpu/listing_meta.json
@@ -2438,6 +2438,7 @@
   "webgpu:shader,validation,expression,precedence:binary_requires_parentheses:*": { "subcaseMS": 149.921 },
   "webgpu:shader,validation,expression,precedence:mixed_logical_requires_parentheses:*": { "subcaseMS": 6.107 },
   "webgpu:shader,validation,expression,precedence:other:*": { "subcaseMS": 5.459 },
+  "webgpu:shader,validation,expression,precedence:other_lhs:*": { "subcaseMS": 6.156 },
   "webgpu:shader,validation,expression,unary,address_of_and_indirection:basic:*": { "subcaseMS": 0.000 },
   "webgpu:shader,validation,expression,unary,address_of_and_indirection:composite:*": { "subcaseMS": 0.000 },
   "webgpu:shader,validation,expression,unary,address_of_and_indirection:invalid:*": { "subcaseMS": 0.000 },

--- a/src/webgpu/shader/validation/expression/precedence.spec.ts
+++ b/src/webgpu/shader/validation/expression/precedence.spec.ts
@@ -186,3 +186,34 @@ g.test('other')
 
     t.expectCompileResult(expr.result, wgsl);
   });
+
+const kLHSExpressions = {
+  deref_invalid1: { expr: `*p.b`, result: false },
+  deref_invalid2: { expr: `*p.a[0]`, result: false },
+  deref_valid1: { expr: `(*p).b`, result: true },
+  deref_valid2: { expr: `(*p).a[2]`, result: true },
+  addr_valid1: { expr: `*&v.b`, result: true },
+  addr_valid2: { expr: `(*&v).b`, result: true },
+  addr_valid3: { expr: `*&(v.b)`, result: true },
+};
+
+g.test('other_lhs')
+  .desc('Test precedence of * and [] in LHS')
+  .params(u => u.combine('expr', keysOf(kLHSExpressions)))
+  .fn(t => {
+    const expr = kLHSExpressions[t.params.expr];
+    const code = `
+    struct S {
+      a : array<i32, 4>,
+      b : i32,
+    }
+    fn main() {
+      var v : S;
+      let p = &v;
+      let q = &v.a;
+
+      ${expr.expr} = 1i;
+    }`;
+
+    t.expectCompileResult(expr.result, code);
+  });


### PR DESCRIPTION
Fixes #1981




Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [ ] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [ ] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [ ] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
