### PR TITLE
fix: specify `rgba8unorm` render target for `webgpu:api,operation,labels:wrappers_do_not_share_labels:*`

### DIFF
--- a/src/webgpu/api/operation/labels.spec.ts
+++ b/src/webgpu/api/operation/labels.spec.ts
@@ -267,6 +267,14 @@ g.test('wrappers_do_not_share_labels')
         module,
         entryPoint: 'main',
       },
+      // Specify a color attachment so we have at least one render target. Otherwise, details here
+      // are not relevant to this test.
+      fragment: {
+        targets: [{ format: 'rgba8unorm' }],
+        module: t.device.createShaderModule({
+          code: `@fragment fn main() -> @location(0) vec4f { return vec4f(0); }`,
+        }),
+      },
     });
     const layout1 = pipeline.getBindGroupLayout(0);
     const layout2 = pipeline.getBindGroupLayout(0);


### PR DESCRIPTION
Issue: #3754

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.** I'm actually going to punt missing coverage to #3755.
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
