### PR TITLE
WGSL builtin textureSample w/derivatives test

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/textureSample.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureSample.spec.ts
@@ -10,11 +10,12 @@ import { kTexelRepresentationInfo } from '../../../../../util/texture/texel_data
 
 import {
   vec2,
-  createRandomTexelView,
   TextureCall,
   putDataInTextureThenDrawAndCheckResults,
+  putDataInTextureThenDrawAndCheckResultsComparedToSoftwareRasterizer,
   generateSamplePoints,
   kSamplePointMethods,
+  createRandomTexelViewMipmap,
 } from './texture_utils.js';
 import { generateCoordBoundaries, generateOffsets } from './utils.js';
 
@@ -98,7 +99,7 @@ Parameters:
       size: { width: 8, height: 8 },
       usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
     };
-    const texelView = createRandomTexelView(descriptor);
+    const texelViews = createRandomTexelViewMipmap(descriptor);
     const calls: TextureCall<vec2>[] = generateSamplePoints(50, t.params.minFilter === 'nearest', {
       method: t.params.sample_points,
       textureWidth: 8,
@@ -120,7 +121,7 @@ Parameters:
     };
     const res = await putDataInTextureThenDrawAndCheckResults(
       t.device,
-      { texels: texelView, descriptor },
+      { texels: texelViews, descriptor },
       sampler,
       calls
     );
@@ -137,7 +138,65 @@ fn textureSample(t: texture_2d<f32>, s: sampler, coords: vec2<f32>, offset: vec2
 test mip level selection based on derivatives
     `
   )
-  .unimplemented();
+  .params(u =>
+    u
+      .combine('format', kEncodableTextureFormats)
+      .filter(t => {
+        const type = kTextureFormatInfo[t.format].color?.type;
+        return type === 'float' || type === 'unfilterable-float';
+      })
+      .combine('mipmapFilter', ['nearest', 'linear'] as const)
+      // note: this is the derivative we want at sample time. It is not the value
+      // passed directly to the shader. This way if we change the texture size
+      // or render target size we can compute the correct values to achieve the
+      // same results.
+      .combineWithParams([
+        { ddx: 0.5, ddy: 0.5 }, // test mag filter
+        { ddx: 1, ddy: 1 }, // test level 0
+        { ddx: 2, ddy: 1 }, // test level 1 via ddx
+        { ddx: 1, ddy: 4 }, // test level 2 via ddy
+        { ddx: 1.5, ddy: 1.5 }, // test mix between 1 and 2
+        { ddx: 6, ddy: 6 }, // test mix between 2 and 3 (there is no 3 so we should get just 2)
+        { ddx: 1.5, ddy: 1.5, offset: [7, -8] }, // test mix between 1 and 2 with offset
+        { ddx: 1.5, ddy: 1.5, offset: [3, -3] }, // test mix between 1 and 2 with offset
+        { ddx: 1.5, ddy: 1.5, ddxStart: -3, ddyStart: -4 }, // test mix between 1 and 2 with negative coords
+      ])
+  )
+  .beforeAllSubcases(t => {
+    const { format } = t.params;
+    const formatInfo = kTexelRepresentationInfo[format];
+    t.skipIfTextureFormatNotSupported(format);
+    const hasFloat32 = formatInfo.componentOrder.some(c => {
+      const info = formatInfo.componentInfo[c]!;
+      return info.dataType === 'float' && info.bitLength === 32;
+    });
+    if (hasFloat32) {
+      t.selectDeviceOrSkipTestCase('float32-filterable');
+    }
+  })
+  .fn(t => {
+    const { format, mipmapFilter, ddx, ddy, ddxStart, ddyStart, offset } = t.params;
+    const descriptor: GPUTextureDescriptor = {
+      format,
+      mipLevelCount: 3,
+      size: { width: 8, height: 8 },
+      usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+    };
+    const texelViews = createRandomTexelViewMipmap(descriptor);
+    const sampler: GPUSamplerDescriptor = {
+      addressModeU: 'repeat',
+      addressModeV: 'repeat',
+      minFilter: 'linear',
+      magFilter: 'linear',
+      mipmapFilter,
+    };
+    putDataInTextureThenDrawAndCheckResultsComparedToSoftwareRasterizer(
+      t,
+      { texels: texelViews, descriptor },
+      sampler,
+      { ddx, ddy, ddxStart, ddyStart, offset: offset as vec2 }
+    );
+  });
 
 g.test('sampled_3d_coords')
   .specURL('https://www.w3.org/TR/WGSL/#texturesample')

--- a/src/webgpu/shader/execution/expression/call/builtin/textureSample.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureSample.spec.ts
@@ -157,9 +157,9 @@ test mip level selection based on derivatives
         { ddx: 1, ddy: 4 }, // test level 2 via ddy
         { ddx: 1.5, ddy: 1.5 }, // test mix between 1 and 2
         { ddx: 6, ddy: 6 }, // test mix between 2 and 3 (there is no 3 so we should get just 2)
-        { ddx: 1.5, ddy: 1.5, offset: [7, -8] }, // test mix between 1 and 2 with offset
-        { ddx: 1.5, ddy: 1.5, offset: [3, -3] }, // test mix between 1 and 2 with offset
-        { ddx: 1.5, ddy: 1.5, ddxStart: -3, ddyStart: -4 }, // test mix between 1 and 2 with negative coords
+        { ddx: 1.5, ddy: 1.5, offset: [7, -8] as const }, // test mix between 1 and 2 with offset
+        { ddx: 1.5, ddy: 1.5, offset: [3, -3] as const }, // test mix between 1 and 2 with offset
+        { ddx: 1.5, ddy: 1.5, uvwStart: [-3.5, -4] as const }, // test mix between 1 and 2 with negative coords
       ])
   )
   .beforeAllSubcases(t => {
@@ -175,7 +175,7 @@ test mip level selection based on derivatives
     }
   })
   .fn(t => {
-    const { format, mipmapFilter, ddx, ddy, ddxStart, ddyStart, offset } = t.params;
+    const { format, mipmapFilter, ddx, ddy, uvwStart, offset } = t.params;
     const descriptor: GPUTextureDescriptor = {
       format,
       mipLevelCount: 3,
@@ -194,7 +194,7 @@ test mip level selection based on derivatives
       t,
       { texels: texelViews, descriptor },
       sampler,
-      { ddx, ddy, ddxStart, ddyStart, offset: offset as vec2 }
+      { ddx, ddy, uvwStart, offset }
     );
   });
 

--- a/src/webgpu/shader/execution/expression/call/builtin/texture_utils.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/texture_utils.ts
@@ -425,8 +425,8 @@ export function softwareRasterize<T extends Dimensionality>(
   const format = 'rgba32float';
 
   const textureSize = reifyExtent3D(texture.descriptor.size);
-  const screenSpaceDDX = (ddx * width) / textureSize.width;
-  const screenSpaceDDY = (ddy * height) / textureSize.height;
+  const screenSpaceUMult = (ddx * width) / textureSize.width;
+  const screenSpaceVMult = (ddy * height) / textureSize.height;
 
   const rep = kTexelRepresentationInfo[format];
 
@@ -453,8 +453,8 @@ export function softwareRasterize<T extends Dimensionality>(
       // pass those into the softwareTextureRead<T> as they would normally be
       // derived from the change in coord.
       const coords = [
-        (fragX / width) * screenSpaceDDX + uvwStart[0],
-        (fragY / height) * screenSpaceDDY + uvwStart[1],
+        (fragX / width) * screenSpaceUMult + uvwStart[0],
+        (fragY / height) * screenSpaceVMult + uvwStart[1],
       ] as T;
       const call: TextureCall<T> = {
         builtin: 'textureSample',

--- a/src/webgpu/shader/execution/expression/call/builtin/texture_utils.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/texture_utils.ts
@@ -425,6 +425,14 @@ export function softwareRasterize<T extends Dimensionality>(
   const format = 'rgba32float';
 
   const textureSize = reifyExtent3D(texture.descriptor.size);
+
+  // MAINTENANCE_TODO: Consider passing these in as a similar computation
+  // happens in putDataInTextureThenDrawAndCheckResultsComparedToSoftwareRasterizer.
+  // The issue is there, the calculation is "what do we need to multiply the unitQuad
+  // by to get the derivatives we want". The calculation here is "what coordinate
+  // will we get for a given frag coordinate". It turns out to be the same calculation
+  // but needs rephrasing them so they are more obviously the same would help
+  // consolidate them into one calculation.
   const screenSpaceUMult = (ddx * width) / textureSize.width;
   const screenSpaceVMult = (ddy * height) / textureSize.height;
 

--- a/src/webgpu/shader/execution/expression/call/builtin/texture_utils.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/texture_utils.ts
@@ -1,14 +1,26 @@
 import { assert, range, unreachable } from '../../../../../../common/util/util.js';
 import { EncodableTextureFormat } from '../../../../../format_info.js';
+import { GPUTest, TextureTestMixinType } from '../../../../../gpu_test.js';
 import { float32ToUint32 } from '../../../../../util/conversion.js';
-import { align, clamp, hashU32, lerp, quantizeToF32 } from '../../../../../util/math.js';
+import {
+  align,
+  clamp,
+  dotProduct,
+  hashU32,
+  lerp,
+  quantizeToF32,
+} from '../../../../../util/math.js';
+import { virtualMipSize } from '../../../../../util/texture/base.js';
 import {
   kTexelRepresentationInfo,
   PerTexelComponent,
   TexelRepresentationInfo,
 } from '../../../../../util/texture/texel_data.js';
 import { TexelView } from '../../../../../util/texture/texel_view.js';
-import { createTextureFromTexelView } from '../../../../../util/texture.js';
+import {
+  createTextureFromTexelView,
+  createTextureFromTexelViews,
+} from '../../../../../util/texture.js';
 import { reifyExtent3D } from '../../../../../util/unions.js';
 
 function getLimitValue(v: number) {
@@ -51,6 +63,27 @@ export function createRandomTexelView(info: {
     return quantize(texel, rep);
   };
   return TexelView.fromTexelsAsColors(info.format as EncodableTextureFormat, generator);
+}
+
+/**
+ * Creates a mip chain of TexelViews filled with random values
+ */
+export function createRandomTexelViewMipmap(info: {
+  format: GPUTextureFormat;
+  size: GPUExtent3D;
+  mipLevelCount?: number;
+  dimension?: GPUTextureDimension;
+}): TexelView[] {
+  const mipLevelCount = info.mipLevelCount ?? 1;
+  const dimension = info.dimension ?? '2d';
+  const size = reifyExtent3D(info.size);
+  const tSize = [size.width, size.height, size.depthOrArrayLayers] as const;
+  return range(mipLevelCount, i =>
+    createRandomTexelView({
+      format: info.format,
+      size: virtualMipSize(dimension, tSize, i),
+    })
+  );
 }
 
 export type vec2 = [number, number];
@@ -101,7 +134,7 @@ function apply(a: number[], b: number[], op: (x: number, y: number) => number) {
 const add = (a: number[], b: number[]) => apply(a, b, (x, y) => x + y);
 
 export interface Texture {
-  texels: TexelView;
+  texels: TexelView[];
   descriptor: GPUTextureDescriptor;
 }
 
@@ -111,11 +144,16 @@ export interface Texture {
 export function expected<T extends Dimensionality>(
   call: TextureCall<T>,
   texture: Texture,
-  sampler: GPUSamplerDescriptor
+  sampler: GPUSamplerDescriptor,
+  mipLevel = 0
 ): PerTexelComponent<number> {
-  const rep = kTexelRepresentationInfo[texture.texels.format];
-  const textureExtent = reifyExtent3D(texture.descriptor.size);
-  const textureSize = [textureExtent.width, textureExtent.height, textureExtent.depthOrArrayLayers];
+  const rep = kTexelRepresentationInfo[texture.texels[mipLevel].format];
+  const tSize = reifyExtent3D(texture.descriptor.size);
+  const textureSize = virtualMipSize(
+    texture.descriptor.dimension || '2d',
+    [tSize.width, tSize.height, tSize.depthOrArrayLayers],
+    mipLevel
+  );
   const addressMode = [
     sampler.addressModeU ?? 'clamp-to-edge',
     sampler.addressModeV ?? 'clamp-to-edge',
@@ -123,7 +161,7 @@ export function expected<T extends Dimensionality>(
   ];
 
   const load = (at: number[]) =>
-    texture.texels.color({
+    texture.texels[mipLevel].color({
       x: Math.floor(at[0]),
       y: Math.floor(at[1] ?? 0),
       z: Math.floor(at[2] ?? 0),
@@ -146,6 +184,8 @@ export function expected<T extends Dimensionality>(
       let at = coords.map((v, i) => v * textureSize[i] - 0.5);
 
       // Apply offset in whole texel units
+      // This means the offset is added at each mip level in texels. There's no
+      // scaling for each level.
       if (call.offset !== undefined) {
         at = add(at, toArray(call.offset));
       }
@@ -223,6 +263,73 @@ export function expected<T extends Dimensionality>(
 }
 
 /**
+ * The software version of a texture builtin (eg: textureSample)
+ * Note that this is not a complete implementation. Rather it's only
+ * what's needed to generate the correct expected value for the tests.
+ */
+export function softwareTextureRead<T extends Dimensionality>(
+  call: TextureCall<T>,
+  texture: Texture,
+  sampler: GPUSamplerDescriptor,
+  size: [number, number]
+): PerTexelComponent<number> {
+  assert(call.ddx !== undefined);
+  assert(call.ddy !== undefined);
+  const rep = kTexelRepresentationInfo[texture.texels[0].format];
+  const texSize = reifyExtent3D(texture.descriptor.size);
+  const textureSize = [texSize.width, texSize.height];
+
+  const ddx: readonly number[] = typeof call.ddx === 'number' ? [call.ddx] : call.ddx;
+  const ddy: readonly number[] = typeof call.ddy === 'number' ? [call.ddy] : call.ddy;
+  const sDdx = ddx.map((v, i) => (v * textureSize[i]) / size[i]);
+  const sDdy = ddy.map((v, i) => (v * textureSize[i]) / size[i]);
+  const dotDDX = dotProduct(sDdx, sDdx);
+  const dotDDY = dotProduct(sDdy, sDdy);
+  const deltaMax = Math.max(dotDDX, dotDDY);
+
+  // MAINTENANCE_TODO: handle texture view baseMipLevel and mipLevelCount?
+  const mipLevel = 0.5 * Math.log2(deltaMax);
+  const mipLevelCount = texture.texels.length;
+  const maxLevel = mipLevelCount - 1;
+
+  switch (sampler.mipmapFilter) {
+    case 'linear': {
+      const clampedMipLevel = clamp(mipLevel, { min: 0, max: maxLevel });
+      const baseMipLevel = Math.floor(clampedMipLevel);
+      const nextMipLevel = Math.ceil(clampedMipLevel);
+      const t0 = expected<T>(call, texture, sampler, baseMipLevel);
+      const t1 = expected<T>(call, texture, sampler, nextMipLevel);
+      const mix = mipLevel % 1;
+      const values = [
+        { v: t0, weight: 1 - mix },
+        { v: t1, weight: mix },
+      ];
+      const out: PerTexelComponent<number> = {};
+      for (const { v, weight } of values) {
+        for (const component of rep.componentOrder) {
+          out[component] = (out[component] ?? 0) + v[component]! * weight;
+        }
+      }
+      return out;
+    }
+    default: {
+      const baseMipLevel = Math.floor(
+        clamp(mipLevel + 0.5, { min: 0, max: texture.texels.length - 1 })
+      );
+      return expected<T>(call, texture, sampler, baseMipLevel);
+    }
+  }
+}
+
+export type TextureTestOptions = {
+  ddx?: number; // the derivative we want at sample time
+  ddy?: number;
+  ddxStart?: number; // the starting derivative value
+  ddyStart?: number;
+  offset?: [number, number]; // a constant offset
+};
+
+/**
  * Puts random data in a texture, generates a shader that implements `calls`
  * such that each call's result is written to the next consecutive texel of
  * a rgba32float texture. It then checks the result of each call matches
@@ -236,7 +343,7 @@ export async function putDataInTextureThenDrawAndCheckResults<T extends Dimensio
 ) {
   const results = await doTextureCalls(device, texture, sampler, calls);
   const errs: string[] = [];
-  const rep = kTexelRepresentationInfo[texture.texels.format];
+  const rep = kTexelRepresentationInfo[texture.texels[0].format];
   for (let callIdx = 0; callIdx < calls.length; callIdx++) {
     const call = calls[callIdx];
     const got = results[callIdx];
@@ -266,7 +373,7 @@ export async function putDataInTextureThenDrawAndCheckResults<T extends Dimensio
           'expected:',
           ...(await identifySamplePoints(texture.descriptor, (texels: TexelView) => {
             return Promise.resolve(
-              expected(call, { texels, descriptor: texture.descriptor }, sampler)
+              expected(call, { texels: [texels], descriptor: texture.descriptor }, sampler)
             );
           })),
         ];
@@ -276,9 +383,12 @@ export async function putDataInTextureThenDrawAndCheckResults<T extends Dimensio
             texture.descriptor,
             async (texels: TexelView) =>
               (
-                await doTextureCalls(device, { texels, descriptor: texture.descriptor }, sampler, [
-                  call,
-                ])
+                await doTextureCalls(
+                  device,
+                  { texels: [texels], descriptor: texture.descriptor },
+                  sampler,
+                  [call]
+                )
               )[0]
           )),
         ];
@@ -289,6 +399,212 @@ export async function putDataInTextureThenDrawAndCheckResults<T extends Dimensio
   }
 
   return errs.length > 0 ? new Error(errs.join('\n')) : undefined;
+}
+
+/**
+ * "Renders a quad" to a TexelView with the given parameters,
+ * sampling from the given Texture.
+ */
+export function softwareRasterize<T extends Dimensionality>(
+  texture: Texture,
+  sampler: GPUSamplerDescriptor,
+  targetSize: [number, number],
+  options: TextureTestOptions
+) {
+  const [width, height] = targetSize;
+  const { ddx = 1, ddy = 1, ddxStart = 0, ddyStart = 0 } = options;
+  const format = 'rgba32float';
+
+  const rep = kTexelRepresentationInfo[format];
+
+  const expData = new Float32Array(width * height * 4);
+  for (let y = 0; y < height; ++y) {
+    const fragY = height - y - 1 + 0.5;
+    for (let x = 0; x < width; ++x) {
+      const fragX = x + 0.5;
+      const coords = [(fragX / width) * ddx - ddxStart, (fragY / height) * ddy - ddyStart] as T;
+      const call: TextureCall<T> = {
+        builtin: 'textureSample',
+        coordType: 'f',
+        coords,
+        ddx: [ddx, 0] as T,
+        ddy: [0, ddy] as T,
+        offset: options.offset as T,
+      };
+      const sample = softwareTextureRead<T>(call, texture, sampler, targetSize);
+      const rgba = { R: 0, G: 0, B: 0, A: 1, ...sample };
+      const asRgba32Float = new Float32Array(rep.pack(rgba));
+      expData.set(asRgba32Float, (y * width + x) * 4);
+    }
+  }
+
+  return TexelView.fromTextureDataByReference(format, new Uint8Array(expData.buffer), {
+    bytesPerRow: width * 4 * 4,
+    rowsPerImage: height,
+    subrectOrigin: [0, 0, 0],
+    subrectSize: targetSize,
+  });
+}
+
+/**
+ * Puts data in a texture. Renders a quad to a rgba32float. Then "software renders"
+ * to a TexelView the expected result and compares the rendered texture to the
+ * expected TexelView.
+ */
+export function putDataInTextureThenDrawAndCheckResultsComparedToSoftwareRasterizer<
+  T extends Dimensionality,
+>(
+  t: GPUTest & TextureTestMixinType,
+  texture: Texture,
+  sampler: GPUSamplerDescriptor,
+  options: TextureTestOptions
+) {
+  const device = t.device;
+
+  const format = 'rgba32float';
+  const renderTarget = device.createTexture({
+    format,
+    size: [32, 32],
+    usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  });
+  t.trackForCleanup(renderTarget);
+
+  const size = reifyExtent3D(texture.descriptor.size);
+  const ddx = ((options.ddx ?? 1) * renderTarget.width) / size.width;
+  const ddy = ((options.ddy ?? 1) * renderTarget.height) / size.height;
+  const ddxStart = ((options.ddxStart ?? 0) * renderTarget.width) / size.width;
+  const ddyStart = ((options.ddyStart ?? 0) * renderTarget.height) / size.height;
+  const offset = options.offset;
+
+  const code = `
+struct InOut {
+  @builtin(position) pos: vec4f,
+  @location(0) uv: vec2f,
+};
+
+@vertex fn vs(@builtin(vertex_index) vertex_index : u32) -> InOut {
+  let positions = array(
+    vec2f(-1,  1), vec2f( 1,  1),
+    vec2f(-1, -1), vec2f( 1, -1),
+  );
+  let pos = positions[vertex_index];
+  return InOut(
+    vec4f(pos, 0, 1),
+    (pos * 0.5 + 0.5) * vec2f(${ddx}, ${ddy}) - vec2f(${ddxStart}, ${ddyStart}),
+  );
+}
+
+@group(0) @binding(0) var          T    : texture_2d<f32>;
+@group(0) @binding(1) var          S    : sampler;
+
+@fragment fn fs(v: InOut) -> @location(0) vec4f {
+  return textureSample(T, S, v.uv${offset ? `, vec2i(${offset[0]},${offset[1]})` : ''});
+}
+`;
+
+  const shaderModule = device.createShaderModule({ code });
+
+  const pipeline = device.createRenderPipeline({
+    layout: 'auto',
+    vertex: { module: shaderModule },
+    fragment: {
+      module: shaderModule,
+      targets: [{ format }],
+    },
+    primitive: { topology: 'triangle-strip' },
+  });
+
+  const gpuTexture = createTextureFromTexelViews(device, texture.texels, texture.descriptor);
+  t.trackForCleanup(gpuTexture);
+  const gpuSampler = device.createSampler(sampler);
+
+  const bindGroup = device.createBindGroup({
+    layout: pipeline.getBindGroupLayout(0),
+    entries: [
+      { binding: 0, resource: gpuTexture.createView() },
+      { binding: 1, resource: gpuSampler },
+    ],
+  });
+
+  const encoder = device.createCommandEncoder();
+
+  const renderPass = encoder.beginRenderPass({
+    colorAttachments: [{ view: renderTarget.createView(), loadOp: 'clear', storeOp: 'store' }],
+  });
+
+  renderPass.setPipeline(pipeline);
+  renderPass.setBindGroup(0, bindGroup);
+  renderPass.draw(4);
+  renderPass.end();
+  device.queue.submit([encoder.finish()]);
+
+  const expTexelView = softwareRasterize<T>(
+    texture,
+    sampler,
+    [renderTarget.width, renderTarget.height],
+    { ddx, ddy, ddxStart, ddyStart, offset }
+  );
+
+  // Note: I'm not sure what we should do here. My assumption is, given texels
+  // have random values, the difference between 2 texels can be very large. In
+  // the current version, for a float texture they can be +/- 1000 difference.
+  // Sampling is very GPU dependent. So if one pixel gets a random value of
+  // -1000 and the neighboring pixel gets +1000 then any slight variation in how
+  // sampling is applied will generate a large difference when interpolating
+  // between -1000 and +1000.
+  //
+  // We could make some entry for every format but for now I just put the
+  // tolerances here based on format texture suffix.
+  //
+  // It's possible the math in the software rasterizer is just bad but the
+  // results certainly seem close.
+  //
+  // These tolerances started from the OpenGL ES dEQP tests.
+  // Those tests always render to an rgba8unorm texture. The shaders do effectively
+  //
+  //   result = textureSample(...) * scale + bias
+  //
+  // to get the results in a 0.0 to 1.0 range. After reading the values back they
+  // expand them to their original ranges with
+  //
+  //   value = (result - bias) / scale;
+  //
+  // Tolerances from dEQP
+  // --------------------
+  // 8unorm: 3.9 / 255
+  // 8snorm: 7.9 / 128
+  // 2unorm: 7.9 / 512
+  // ufloat: 156.249
+  //  float: 31.2498
+  //
+  // The numbers below have been set empirically to get the tests to pass on all
+  // devices. The devices with the most divergence from the calculated expected
+  // values are MacOS Intel and AMD.
+  //
+  // MAINTENANCE_TODO: Double check the software rendering math and lower these
+  // tolerances if possible.
+
+  let maxFractionalDiff = 0;
+  if (texture.descriptor.format.includes('8unorm')) {
+    maxFractionalDiff = 7 / 255; // 3.9 / 255;
+  } else if (texture.descriptor.format.includes('8snorm')) {
+    maxFractionalDiff = 7.9 / 128;
+  } else if (texture.descriptor.format.includes('2unorm')) {
+    maxFractionalDiff = 9 / 512; // 7.9 / 512;
+  } else if (texture.descriptor.format.endsWith('ufloat')) {
+    maxFractionalDiff = 156.249;
+  } else if (texture.descriptor.format.endsWith('float')) {
+    maxFractionalDiff = 44; // 31.2498;
+  } else {
+    unreachable();
+  }
+
+  t.expectTexelViewComparisonIsOkInTexture(
+    { texture: renderTarget },
+    expTexelView,
+    [renderTarget.width, renderTarget.height],
+    { maxFractionalDiff }
+  );
 }
 
 /**
@@ -734,16 +1050,15 @@ ${body}
 
   const pipeline = device.createRenderPipeline({
     layout: 'auto',
-    vertex: { module: shaderModule, entryPoint: 'vs_main' },
+    vertex: { module: shaderModule },
     fragment: {
       module: shaderModule,
-      entryPoint: 'fs_main',
       targets: [{ format: renderTarget.format }],
     },
-    primitive: { topology: 'triangle-strip', cullMode: 'none' },
+    primitive: { topology: 'triangle-strip' },
   });
 
-  const gpuTexture = createTextureFromTexelView(device, texture.texels, texture.descriptor);
+  const gpuTexture = createTextureFromTexelView(device, texture.texels[0], texture.descriptor);
   const gpuSampler = device.createSampler(sampler);
 
   const bindGroup = device.createBindGroup({

--- a/src/webgpu/shader/execution/expression/call/builtin/texture_utils.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/texture_utils.ts
@@ -436,7 +436,8 @@ export function softwareRasterize<T extends Dimensionality>(
     for (let x = 0; x < width; ++x) {
       const fragX = x + 0.5;
       // This code calculates the same value that will be passed to
-      // `textureSample` in the fragment shader for a given frag coord. That
+      // `textureSample` in the fragment shader for a given frag coord (see the
+      // WGSL code which uses the same formula, but using interpolation). That
       // shader renders a clip space quad and includes a inter-stage "uv"
       // coordinates that start with a unit quad (0,0) to (1,1) and is
       // multiplied by ddx,ddy and as added in uStart and vStart


### PR DESCRIPTION
This test is different than the pattern set by the non-derivative test. The existing test renders an array of coordinates. The coordinates might come from data passed to the shader, or they might be hard coded with multiple `textureSample` calls. The results are written to a storage buffer and compared to computed expected values.

This test instead renders a quad (2 triangles) to an rgba32float texture given a simple shader. It then "software renders" the expected result and compares the 2 results.

There are a large number of permutations of parameters that affect texture sampling. The sampler itself has wrapping modes and sampling modes. `textureSample` is influenced by texture format, coordinates, derivatives and offsets. Testing all combinations X all texture formats would make the tests too slow so, these tests focus mostly on the effect of derivatives and assume the combinations in the non-derivative case give effective coverage of the other permutations.

The tolerances for whether the actual result match the expected result are rather large. They are influenced by the OpenGL dEQP test suite which has similar tolerances. The hope is these are a good starting point to get the tests written with a structure that can be adjusted later should it be decided to make these tests more strict.

There's a chromium run here: https://dawn-review.googlesource.com/c/dawn/+/188725/2?checksPatchset=2&tab=checks


Note: another possibility is I discard this PR and try to fit derivatives into the existing (rendering a list of coords) framework. I looked into that and it's certainly possible. I can use the fragment shader's `@builtin(position)` as the source of the changing value for the derivative. For any call into a texture builtin I subtract the expected frag position for that call as a constant. It has to be constant otherwise the calculation would affect the derivative. But, because it would have to be a constant, that would make every call unique which makes the shader very large.  If that's a better direction though I can switch.

The advantage to that direction is, testing other things that have to be constants gets more coverage. For example, if you check that test you'll see, for `offset`, the test parameter is `true`, `false` and if `true` then a bunch of pseudo random constants are used generating a shader with N calls to `textureSample`, one per offset. Where as in the derivatives test it just tests 2 pairs of constants and hopes that's good enough.

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [X] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
