### PR TITLE
WGSL builtin textureSample compressed formats

### DIFF
--- a/src/webgpu/listing_meta.json
+++ b/src/webgpu/listing_meta.json
@@ -1559,7 +1559,6 @@
   "webgpu:shader,execution,expression,call,builtin,textureNumLevels:sampled:*": { "subcaseMS": 6.201 },
   "webgpu:shader,execution,expression,call,builtin,textureNumSamples:depth:*": { "subcaseMS": 1.101 },
   "webgpu:shader,execution,expression,call,builtin,textureNumSamples:sampled:*": { "subcaseMS": 6.600 },
-  "webgpu:shader,execution,expression,call,builtin,textureSample:control_flow:*": { "subcaseMS": 0.375 },
   "webgpu:shader,execution,expression,call,builtin,textureSample:depth_2d_coords:*": { "subcaseMS": 12.301 },
   "webgpu:shader,execution,expression,call,builtin,textureSample:depth_3d_coords:*": { "subcaseMS": 2.101 },
   "webgpu:shader,execution,expression,call,builtin,textureSample:depth_array_2d_coords:*": { "subcaseMS": 92.601 },

--- a/src/webgpu/shader/execution/expression/call/builtin/texture_utils.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/texture_utils.ts
@@ -1,5 +1,10 @@
 import { assert, range, unreachable } from '../../../../../../common/util/util.js';
-import { EncodableTextureFormat } from '../../../../../format_info.js';
+import {
+  EncodableTextureFormat,
+  isCompressedTextureFormat,
+  kEncodableTextureFormats,
+  kTextureFormatInfo,
+} from '../../../../../format_info.js';
 import { GPUTest, TextureTestMixinType } from '../../../../../gpu_test.js';
 import { float32ToUint32 } from '../../../../../util/conversion.js';
 import {
@@ -10,17 +15,14 @@ import {
   lerp,
   quantizeToF32,
 } from '../../../../../util/math.js';
-import { virtualMipSize } from '../../../../../util/texture/base.js';
+import { physicalMipSizeFromTexture, virtualMipSize } from '../../../../../util/texture/base.js';
 import {
   kTexelRepresentationInfo,
   PerTexelComponent,
   TexelRepresentationInfo,
 } from '../../../../../util/texture/texel_data.js';
 import { TexelView } from '../../../../../util/texture/texel_view.js';
-import {
-  createTextureFromTexelView,
-  createTextureFromTexelViews,
-} from '../../../../../util/texture.js';
+import { createTextureFromTexelViews } from '../../../../../util/texture.js';
 import { reifyExtent3D } from '../../../../../util/unions.js';
 
 function getLimitValue(v: number) {
@@ -43,6 +45,16 @@ function getValueBetweenMinAndMaxTexelValueInclusive(
     getLimitValue(rep.numericRange!.max),
     normalized
   );
+}
+
+/**
+ * We need the software rendering to do the same interpolation as the hardware
+ * rendered so for -srgb formats we set the TexelView to an -srgb format as
+ * TexelView handles this case. Note: It might be nice to add rgba32float-srgb
+ * or something similar to TexelView.
+ */
+export function getTexelViewFormatForTextureFormat(format: GPUTextureFormat) {
+  return format.endsWith('-srgb') ? 'rgba8unorm-srgb' : 'rgba32float';
 }
 
 /**
@@ -146,7 +158,7 @@ export function softwareTextureReadMipLevel<T extends Dimensionality>(
   call: TextureCall<T>,
   texture: Texture,
   sampler: GPUSamplerDescriptor,
-  mipLevel = 0
+  mipLevel: number
 ): PerTexelComponent<number> {
   const rep = kTexelRepresentationInfo[texture.texels[mipLevel].format];
   const tSize = reifyExtent3D(texture.descriptor.size);
@@ -335,24 +347,21 @@ export type TextureTestOptions = {
 };
 
 /**
- * Puts random data in a texture, generates a shader that implements `calls`
- * such that each call's result is written to the next consecutive texel of
- * a rgba32float texture. It then checks the result of each call matches
- * the expected result.
+ * Checks the result of each call matches the expected result.
  */
-export async function putDataInTextureThenDrawAndCheckResults<T extends Dimensionality>(
+export async function checkCallResults<T extends Dimensionality>(
   device: GPUDevice,
   texture: Texture,
   sampler: GPUSamplerDescriptor,
-  calls: TextureCall<T>[]
+  calls: TextureCall<T>[],
+  results: PerTexelComponent<number>[]
 ) {
-  const results = await doTextureCalls(device, texture, sampler, calls);
   const errs: string[] = [];
   const rep = kTexelRepresentationInfo[texture.texels[0].format];
   for (let callIdx = 0; callIdx < calls.length; callIdx++) {
     const call = calls[callIdx];
     const got = results[callIdx];
-    const expect = softwareTextureReadMipLevel(call, texture, sampler);
+    const expect = softwareTextureReadMipLevel(call, texture, sampler, 0);
 
     const gULP = rep.bitsToULPFromZero(rep.numberToBits(got));
     const eULP = rep.bitsToULPFromZero(rep.numberToBits(expect));
@@ -381,25 +390,20 @@ export async function putDataInTextureThenDrawAndCheckResults<T extends Dimensio
               softwareTextureReadMipLevel(
                 call,
                 { texels: [texels], descriptor: texture.descriptor },
-                sampler
+                sampler,
+                0
               )
             );
           })),
         ];
         const gotSamplePoints = [
           'got:',
-          ...(await identifySamplePoints(
-            texture.descriptor,
-            async (texels: TexelView) =>
-              (
-                await doTextureCalls(
-                  device,
-                  { texels: [texels], descriptor: texture.descriptor },
-                  sampler,
-                  [call]
-                )
-              )[0]
-          )),
+          ...(await identifySamplePoints(texture.descriptor, async (texels: TexelView) => {
+            const gpuTexture = createTextureFromTexelViews(device, [texels], texture.descriptor);
+            const result = (await doTextureCalls(device, gpuTexture, sampler, [call]))[0];
+            gpuTexture.destroy();
+            return result;
+          })),
         ];
         errs.push(layoutTwoColumns(expectedSamplePoints, gotSamplePoints).join('\n'));
         errs.push('', '');
@@ -488,16 +492,12 @@ export function softwareRasterize<T extends Dimensionality>(
 }
 
 /**
- * Puts data in a texture. Renders a quad to a rgba32float. Then "software renders"
- * to a TexelView the expected result and compares the rendered texture to the
- * expected TexelView.
+ * Render textured quad to an rgba32float texture.
  */
-export function putDataInTextureThenDrawAndCheckResultsComparedToSoftwareRasterizer<
-  T extends Dimensionality,
->(
+export function drawTexture(
   t: GPUTest & TextureTestMixinType,
-  texture: Texture,
-  sampler: GPUSamplerDescriptor,
+  texture: GPUTexture,
+  samplerDesc: GPUSamplerDescriptor,
   options: TextureTestOptions
 ) {
   const device = t.device;
@@ -511,12 +511,10 @@ export function putDataInTextureThenDrawAndCheckResultsComparedToSoftwareRasteri
   });
   t.trackForCleanup(renderTarget);
 
-  const textureSize = reifyExtent3D(texture.descriptor.size);
-
   // Compute the amount we need to multiply the unitQuad by get the
   // derivatives we want.
-  const uMult = (ddx * renderTarget.width) / textureSize.width;
-  const vMult = (ddy * renderTarget.height) / textureSize.height;
+  const uMult = (ddx * renderTarget.width) / texture.width;
+  const vMult = (ddy * renderTarget.height) / texture.height;
 
   const offsetWGSL = offset ? `, vec2i(${offset[0]},${offset[1]})` : '';
 
@@ -558,15 +556,13 @@ struct InOut {
     primitive: { topology: 'triangle-strip' },
   });
 
-  const gpuTexture = createTextureFromTexelViews(device, texture.texels, texture.descriptor);
-  t.trackForCleanup(gpuTexture);
-  const gpuSampler = device.createSampler(sampler);
+  const sampler = device.createSampler(samplerDesc);
 
   const bindGroup = device.createBindGroup({
     layout: pipeline.getBindGroupLayout(0),
     entries: [
-      { binding: 0, resource: gpuTexture.createView() },
-      { binding: 1, resource: gpuSampler },
+      { binding: 0, resource: texture.createView() },
+      { binding: 1, resource: sampler },
     ],
   });
 
@@ -582,13 +578,15 @@ struct InOut {
   renderPass.end();
   device.queue.submit([encoder.finish()]);
 
-  const expTexelView = softwareRasterize<T>(
-    texture,
-    sampler,
-    [renderTarget.width, renderTarget.height],
-    options
-  );
+  return renderTarget;
+}
 
+export function checkTextureMatchesExpectedTexelView(
+  t: GPUTest & TextureTestMixinType,
+  format: GPUTextureFormat,
+  actualTexture: GPUTexture,
+  expectedTexelView: TexelView
+) {
   // Note: I'm not sure what we should do here. My assumption is, given texels
   // have random values, the difference between 2 texels can be very large. In
   // the current version, for a float texture they can be +/- 1000 difference.
@@ -629,32 +627,234 @@ struct InOut {
   // tolerances if possible.
 
   let maxFractionalDiff = 0;
-  if (texture.descriptor.format.includes('8unorm')) {
+  if (format.includes('8unorm')) {
     maxFractionalDiff = 7 / 255;
-  } else if (texture.descriptor.format.includes('8snorm')) {
+  } else if (format.includes('8snorm')) {
     maxFractionalDiff = 7.9 / 128;
-  } else if (texture.descriptor.format.includes('2unorm')) {
+  } else if (format.includes('2unorm')) {
     maxFractionalDiff = 9 / 512;
-  } else if (texture.descriptor.format.endsWith('ufloat')) {
+  } else if (format.endsWith('ufloat')) {
     maxFractionalDiff = 156.249;
-  } else if (texture.descriptor.format.endsWith('float')) {
+  } else if (format.endsWith('float')) {
     maxFractionalDiff = 44;
+  } else if (isCompressedTextureFormat(format)) {
+    maxFractionalDiff = 7 / 255;
   } else {
     unreachable();
   }
 
   t.expectTexelViewComparisonIsOkInTexture(
-    { texture: renderTarget },
-    expTexelView,
-    [renderTarget.width, renderTarget.height],
+    { texture: actualTexture },
+    expectedTexelView,
+    [actualTexture.width, actualTexture.height],
     { maxFractionalDiff }
   );
+}
+
+/**
+ * Puts data in a texture. Renders a quad to a rgba32float. Then "software renders"
+ * to a TexelView the expected result and compares the rendered texture to the
+ * expected TexelView.
+ */
+export async function putDataInTextureThenDrawAndCheckResultsComparedToSoftwareRasterizer<
+  T extends Dimensionality,
+>(
+  t: GPUTest & TextureTestMixinType,
+  descriptor: GPUTextureDescriptor,
+  samplerDesc: GPUSamplerDescriptor,
+  options: TextureTestOptions
+) {
+  const { texture, texels } = await createTextureWithRandomDataAndGetTexels(t, descriptor);
+
+  const actualTexture = drawTexture(t, texture, samplerDesc, options);
+  const expectedTexelView = softwareRasterize<T>(
+    { descriptor, texels },
+    samplerDesc,
+    [actualTexture.width, actualTexture.height],
+    options
+  );
+
+  checkTextureMatchesExpectedTexelView(t, texture.format, actualTexture, expectedTexelView);
+}
+
+/**
+ * Fills a texture with random data. Assumes all values are valid.
+ * so this function is not useful for floating point formats, where it would
+ * insert NaNs. This function mostly useful for compressed formats.
+ */
+export function fillTextureWithRandomBytes(device: GPUDevice, texture: GPUTexture) {
+  const info = kTextureFormatInfo[texture.format];
+  const hashBase = texture.format
+    .toString()
+    .split('')
+    .reduce((sum, c) => sum + c.charCodeAt(0), 0);
+  for (let mipLevel = 0; mipLevel < texture.mipLevelCount; ++mipLevel) {
+    const size = physicalMipSizeFromTexture(texture, mipLevel);
+    const blocksAcross = Math.ceil(size[0] / info.blockWidth);
+    const blocksDown = Math.ceil(size[1] / info.blockHeight);
+    const bytesPerRow = blocksAcross * info.color!.bytes;
+    const bytesNeeded = bytesPerRow * blocksDown * size[2];
+    const data = new Uint8Array(bytesNeeded);
+    for (let i = 0; i < bytesNeeded; ++i) {
+      data[i] = hashU32(hashBase, mipLevel, i);
+    }
+    device.queue.writeTexture(
+      { texture, mipLevel },
+      data,
+      { bytesPerRow, rowsPerImage: blocksDown },
+      size
+    );
+  }
+}
+
+const s_readTextureToRGBA32DeviceToPipeline = new WeakMap<GPUDevice, GPUComputePipeline>();
+
+export async function readTextureToTexelViews(
+  t: GPUTest,
+  texture: GPUTexture,
+  format: EncodableTextureFormat
+) {
+  const device = t.device;
+  let pipeline = s_readTextureToRGBA32DeviceToPipeline.get(device);
+  if (!pipeline) {
+    const module = device.createShaderModule({
+      code: `
+        @group(0) @binding(0) var<uniform> mipLevel: u32;
+        @group(0) @binding(1) var tex: texture_2d<f32>;
+        @group(0) @binding(2) var<storage, read_write> data: array<vec4f>;
+        @compute @workgroup_size(1) fn cs(
+          @builtin(global_invocation_id) global_invocation_id : vec3<u32>) {
+          let size = textureDimensions(tex, mipLevel);
+          let ndx = global_invocation_id.y * size.x + global_invocation_id.x;
+          data[ndx] = textureLoad(tex, global_invocation_id.xy, mipLevel);
+        }
+      `,
+    });
+    pipeline = device.createComputePipeline({ layout: 'auto', compute: { module } });
+    s_readTextureToRGBA32DeviceToPipeline.set(device, pipeline);
+  }
+
+  const encoder = device.createCommandEncoder();
+
+  const readBuffers = [];
+  const textureSize = [texture.width, texture.height, texture.depthOrArrayLayers] as const;
+  for (let mipLevel = 0; mipLevel < texture.mipLevelCount; ++mipLevel) {
+    const size = virtualMipSize(texture.dimension, textureSize, mipLevel);
+
+    const uniformValues = new Uint32Array([mipLevel, 0, 0, 0]); // min size is 16 bytes
+    const uniformBuffer = device.createBuffer({
+      size: uniformValues.byteLength,
+      usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+    });
+    t.trackForCleanup(uniformBuffer);
+    device.queue.writeBuffer(uniformBuffer, 0, uniformValues);
+
+    const storageBuffer = device.createBuffer({
+      size: size[0] * size[1] * size[2] * 4 * 4, // rgba32float
+      usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC,
+    });
+    t.trackForCleanup(storageBuffer);
+
+    const readBuffer = device.createBuffer({
+      size: storageBuffer.size,
+      usage: GPUBufferUsage.MAP_READ | GPUBufferUsage.COPY_DST,
+    });
+    t.trackForCleanup(readBuffer);
+    readBuffers.push({ size, readBuffer });
+
+    const bindGroup = device.createBindGroup({
+      layout: pipeline.getBindGroupLayout(0),
+      entries: [
+        { binding: 0, resource: { buffer: uniformBuffer } },
+        { binding: 1, resource: texture.createView() },
+        { binding: 2, resource: { buffer: storageBuffer } },
+      ],
+    });
+
+    const pass = encoder.beginComputePass();
+    pass.setPipeline(pipeline);
+    pass.setBindGroup(0, bindGroup);
+    pass.dispatchWorkgroups(...size);
+    pass.end();
+    encoder.copyBufferToBuffer(storageBuffer, 0, readBuffer, 0, readBuffer.size);
+  }
+
+  device.queue.submit([encoder.finish()]);
+
+  const texelViews: TexelView[] = [];
+
+  for (const { readBuffer, size } of readBuffers) {
+    await readBuffer.mapAsync(GPUMapMode.READ);
+
+    // need a copy of the data since unmapping will nullify the typedarray view.
+    const data = new Float32Array(readBuffer.getMappedRange()).slice();
+    readBuffer.unmap();
+
+    texelViews.push(
+      TexelView.fromTexelsAsColors(format, coord => {
+        const offset = (coord.z * size[0] * size[1] + coord.y * size[0] + coord.x) * 4;
+        return {
+          R: data[offset + 0],
+          G: data[offset + 1],
+          B: data[offset + 2],
+          A: data[offset + 3],
+        };
+      })
+    );
+  }
+
+  return texelViews;
+}
+
+/**
+ * Fills a texture with random data and returns that data as
+ * an array of TexelView.
+ *
+ * For compressed textures the texture is filled with random bytes
+ * and then read back from the GPU by sampling so the GPU decompressed
+ * the texture.
+ *
+ * For uncompressed textures the TexelViews are generated and then
+ * copied to the texture.
+ */
+export async function createTextureWithRandomDataAndGetTexels(
+  t: GPUTest,
+  descriptor: GPUTextureDescriptor
+) {
+  if (isCompressedTextureFormat(descriptor.format)) {
+    const texture = t.device.createTexture(descriptor);
+    t.trackForCleanup(texture);
+
+    fillTextureWithRandomBytes(t.device, texture);
+    const texels = await readTextureToTexelViews(
+      t,
+      texture,
+      getTexelViewFormatForTextureFormat(texture.format)
+    );
+    return { texture, texels };
+  } else {
+    const texels = createRandomTexelViewMipmap(descriptor);
+    const texture = createTextureFromTexelViews(t.device, texels, descriptor);
+    return { texture, texels };
+  }
 }
 
 /**
  * Generates a text art grid showing which texels were sampled
  * followed by a list of the samples and the weights used for each
  * component.
+ *
+ * It works by making an index for every pixel in the texture. Then,
+ * for each index it generates texture data using TexelView.fromTexelsAsColor
+ * with a single [1, 1, 1, 1] texel at the texel for the current index.
+ *
+ * In then calls 'run' which renders a single `call`. `run` uses either
+ * the software renderer or WebGPU. The result ends up being the weights
+ * used when sampling that pixel. 0 = that texel was not sampled. > 0 =
+ * it was sampled.
+ *
+ * This lets you see if the weights from the software renderer match the
+ * weights from WebGPU.
  *
  * Example:
  *
@@ -685,7 +885,25 @@ async function identifySamplePoints(
 ) {
   const textureSize = reifyExtent3D(info.size);
   const numTexels = textureSize.width * textureSize.height;
-  const rep = kTexelRepresentationInfo[info.format as EncodableTextureFormat];
+  // This isn't perfect. We already know there was an error. We're just
+  // generating info so it seems okay it's not perfect. This format will
+  // be used to generate weights by drawing with a texture of this format
+  // with a specific pixel set to [1, 1, 1, 1]. As such, if the result
+  // is > 0 then that pixel was sampled and the results are the weights.
+  //
+  // Ideally, this texture with a single pixel set to [1, 1, 1, 1] would
+  // be the same format we were originally testing, the one we already
+  // detected an error for. This way, whatever subtle issues there are
+  // from that format will affect the weight values we're computing. But,
+  // if that format is not encodable, for example if it's a compressed
+  // texture format, then we have no way to build a texture so we use
+  // rgba8unorm instead.
+  const format = (
+    kEncodableTextureFormats.includes(info.format as EncodableTextureFormat)
+      ? info.format
+      : 'rgba8unorm'
+  ) as EncodableTextureFormat;
+  const rep = kTexelRepresentationInfo[format];
 
   // Identify all the texels that are sampled, and their weights.
   const sampledTexelWeights = new Map<number, PerTexelComponent<number>>();
@@ -707,7 +925,7 @@ async function identifySamplePoints(
     // See if any of the texels in setA were sampled.
     const results = await run(
       TexelView.fromTexelsAsColors(
-        info.format as EncodableTextureFormat,
+        format,
         (coords: Required<GPUOrigin3DDict>): Readonly<PerTexelComponent<number>> => {
           const isCandidate = setA.has(coords.x + coords.y * textureSize.width);
           const texel: PerTexelComponent<number> = {};
@@ -746,7 +964,7 @@ async function identifySamplePoints(
   {
     let line = '  ';
     for (let x = 0; x < textureSize.width; x++) {
-      line += `  ${x} `;
+      line += `  ${x.toString().padEnd(2)}`;
     }
     lines.push(line);
   }
@@ -759,7 +977,7 @@ async function identifySamplePoints(
   }
   for (let y = 0; y < textureSize.height; y++) {
     {
-      let line = `${y} │`;
+      let line = `${y.toString().padEnd(2)}│`;
       for (let x = 0; x < textureSize.width; x++) {
         const texelIdx = x + y * textureSize.height;
         const weight = sampledTexelWeights.get(texelIdx);
@@ -1019,7 +1237,7 @@ export function describeTextureCall<T extends Dimensionality>(call: TextureCall<
  */
 export async function doTextureCalls<T extends Dimensionality>(
   device: GPUDevice,
-  texture: Texture,
+  gpuTexture: GPUTexture,
   sampler: GPUSamplerDescriptor,
   calls: TextureCall<T>[]
 ) {
@@ -1090,6 +1308,7 @@ ${body}
   return result;
 }
 `;
+
   const shaderModule = device.createShaderModule({ code });
 
   const pipeline = device.createRenderPipeline({
@@ -1102,7 +1321,6 @@ ${body}
     primitive: { topology: 'triangle-strip' },
   });
 
-  const gpuTexture = createTextureFromTexelView(device, texture.texels[0], texture.descriptor);
   const gpuSampler = device.createSampler(sampler);
 
   const bindGroup = device.createBindGroup({
@@ -1122,7 +1340,13 @@ ${body}
   const encoder = device.createCommandEncoder();
 
   const renderPass = encoder.beginRenderPass({
-    colorAttachments: [{ view: renderTarget.createView(), loadOp: 'clear', storeOp: 'store' }],
+    colorAttachments: [
+      {
+        view: renderTarget.createView(),
+        loadOp: 'clear',
+        storeOp: 'store',
+      },
+    ],
   });
 
   renderPass.setPipeline(pipeline);
@@ -1161,7 +1385,6 @@ ${body}
   }
 
   renderTarget.destroy();
-  gpuTexture.destroy();
   resultBuffer.destroy();
 
   return out;


### PR DESCRIPTION
I'm not sure these are needed or not but given we were testing so many other formats it seems like we should be testing compressed formats?

It does this by filling a compressed texture with random data. For compressed textures of type unorm or snorm this is fine. For float types this would fail since they random values might be large, Infinity, or NaN. We aren't converting from values to a compressed format. We're filling a buffer with binary random data and assuming the values that come out are in range.

After that, read that texture back to the GPU using a compute shader. This way we get WebGPU to decode the compressed texture to an uncompressed format.

Some places I got lost. I first put in the derivatives test and it passed. Then I put in non-derivatives test and it failed on srgb formats. This makes some sense I think because I was using only `rgba32float` as the format for pulling the data out of the texture.

That meant, when doing the software interpolation it was probably doing it wrong. I switched to using one of `rgba8unorm`, `rgba8snorm` or `rgba8unorm-srgb` as the format the texture is read back to `TexelView` as. I think ideally if I could have an `rgba32float-srgb` that would have been best but that format doesn't exist and I think hacking it into `TexelView` would have made `TexelView`'s list of formats not a subset of WebGPU's

One thing I'm wondering is if I should combine the compressed and uncompressed tests. They're very similar and it wouldn't take too much work to add some small amount of
`if compressed {x} else {y}` to consolidate them.

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [X] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
