### PR TITLE
Add a test which does override evaluation.

### DIFF
--- a/src/webgpu/api/operation/compute_pipeline/overrides.spec.ts
+++ b/src/webgpu/api/operation/compute_pipeline/overrides.spec.ts
@@ -146,6 +146,74 @@ g.test('numeric_id')
     );
   });
 
+g.test('computed')
+  .desc(`Test that computed overrides work correctly`)
+  .fn(async t => {
+    const module = t.device.createShaderModule({
+      code: `
+      override c0: f32 = 0.;
+      override c1: f32 = 0.;
+      override c2: f32 = c0 * c1;
+
+      struct Buf {
+          data : array<u32, 3>,
+      }
+
+      @group(0) @binding(0) var<storage, read_write> buf : Buf;
+
+      @compute @workgroup_size(1) fn main() {
+          buf.data[0] = u32(c0);
+          buf.data[1] = u32(c1);
+          buf.data[2] = u32(c2);
+      }
+    `,
+    });
+
+    const expected = new Uint32Array([2, 4, 8]);
+
+    const buffer = t.device.createBuffer({
+      size: 3 * Uint32Array.BYTES_PER_ELEMENT,
+      usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE,
+    });
+
+    const descriptors: GPUComputePipelineDescriptor[] = [
+      {
+        layout: 'auto',
+        compute: {
+          module,
+          entryPoint: 'main',
+          constants: {
+            c0: 2,
+            c1: 4,
+          },
+        },
+      },
+    ];
+
+    const pipeline = await t.device.createComputePipelineAsync(descriptors[0]);
+    const bindGroups = [
+      t.device.createBindGroup({
+        entries: [
+          {
+            binding: 0,
+            resource: { buffer, offset: 0, size: 3 * Uint32Array.BYTES_PER_ELEMENT },
+          },
+        ],
+        layout: pipeline.getBindGroupLayout(0),
+      }),
+    ];
+
+    const encoder = t.device.createCommandEncoder();
+    const pass = encoder.beginComputePass();
+    pass.setPipeline(pipeline);
+    pass.setBindGroup(0, bindGroups[0]);
+    pass.dispatchWorkgroups(1);
+    pass.end();
+    t.device.queue.submit([encoder.finish()]);
+
+    t.expectGPUBufferValuesEqual(buffer, expected);
+  });
+
 g.test('precision')
   .desc(
     `Test that float number precision is preserved for constants as they are used for compute shader output of the storage buffer.`

--- a/src/webgpu/listing_meta.json
+++ b/src/webgpu/listing_meta.json
@@ -72,6 +72,7 @@
   "webgpu:api,operation,compute,basic:large_dispatch:*": { "subcaseMS": 9.237 },
   "webgpu:api,operation,compute,basic:memcpy:*": { "subcaseMS": 16.901 },
   "webgpu:api,operation,compute_pipeline,overrides:basic:*": { "subcaseMS": 15.100 },
+  "webgpu:api,operation,compute_pipeline,overrides:computed:*": { "subcaseMS": 508.356 },
   "webgpu:api,operation,compute_pipeline,overrides:multi_entry_points:*": { "subcaseMS": 15.900 },
   "webgpu:api,operation,compute_pipeline,overrides:numeric_id:*": { "subcaseMS": 14.300 },
   "webgpu:api,operation,compute_pipeline,overrides:precision:*": { "subcaseMS": 16.151 },


### PR DESCRIPTION
This CL adds a test which returns the computed value of two overrides which have default values and are provided by the API.

Issue: https://github.com/gpuweb/gpuweb/issues/4680

<hr>

**Requirements for PR author:**

- [ ] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [ ] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [ ] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
