### PR TITLE
Fix matrix overflow test case

### DIFF
--- a/src/webgpu/shader/validation/expression/matrix/mul.spec.ts
+++ b/src/webgpu/shader/validation/expression/matrix/mul.spec.ts
@@ -524,7 +524,7 @@ g.test('overflow_vec_f16')
       }
     }
     lhs += ')';
-    const rhs = `vec${t.params.c}h(${t.params.rhs})`;
+    const rhs = `vec${t.params.c}h(${t.params.rhs}/${t.params.c})`;
 
     const code = `
 enable f16;
@@ -534,7 +534,7 @@ fn main() {
 }
 `;
 
-    t.expectCompileResult(t.params.rhs === 1, code);
+    t.expectCompileResult(t.params.rhs !== kValue.f16.positive.max, code);
   });
 
 g.test('overflow_vec_f16_internal')


### PR DESCRIPTION
This PR fixes up the test for successful non-overflow cases of f16 matrix vector multiplication. For example, for a mat2x2 * vec2, this will now result in:
MAX_FLOAT * 0.5 + MAX_FLOAT * 0.5
instead of the overflowing:
MAX_FLOAT * 1 + MAX_FLOAT * 1




Issue: #3765

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
