### PR TITLE
Add vertex variable resource restrictions to test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3086,10 +3086,8 @@
       }
     },
     "node_modules/eslint-plugin-gpuweb-cts": {
-      "version": "0.0.0",
-      "resolved": "file:tools/eslint-plugin-gpuweb-cts",
-      "dev": true,
-      "license": "BSD-3-Clause"
+      "resolved": "tools/eslint-plugin-gpuweb-cts",
+      "link": true
     },
     "node_modules/eslint-plugin-import": {
       "version": "2.29.0",
@@ -8958,6 +8956,11 @@
       "version": "0.0.0",
       "extraneous": true,
       "license": "BSD-3-Clause"
+    },
+    "tools/eslint-plugin-gpuweb-cts": {
+      "version": "0.0.0",
+      "dev": true,
+      "license": "BSD-3-Clause"
     }
   },
   "dependencies": {
@@ -11289,8 +11292,7 @@
       }
     },
     "eslint-plugin-gpuweb-cts": {
-      "version": "0.0.0",
-      "dev": true
+      "version": "file:tools/eslint-plugin-gpuweb-cts"
     },
     "eslint-plugin-import": {
       "version": "2.29.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3086,8 +3086,10 @@
       }
     },
     "node_modules/eslint-plugin-gpuweb-cts": {
-      "resolved": "tools/eslint-plugin-gpuweb-cts",
-      "link": true
+      "version": "0.0.0",
+      "resolved": "file:tools/eslint-plugin-gpuweb-cts",
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/eslint-plugin-import": {
       "version": "2.29.0",
@@ -8956,11 +8958,6 @@
       "version": "0.0.0",
       "extraneous": true,
       "license": "BSD-3-Clause"
-    },
-    "tools/eslint-plugin-gpuweb-cts": {
-      "version": "0.0.0",
-      "dev": true,
-      "license": "BSD-3-Clause"
     }
   },
   "dependencies": {
@@ -11292,7 +11289,8 @@
       }
     },
     "eslint-plugin-gpuweb-cts": {
-      "version": "file:tools/eslint-plugin-gpuweb-cts"
+      "version": "0.0.0",
+      "dev": true
     },
     "eslint-plugin-import": {
       "version": "2.29.0",

--- a/src/webgpu/api/validation/render_pipeline/resource_compatibility.spec.ts
+++ b/src/webgpu/api/validation/render_pipeline/resource_compatibility.spec.ts
@@ -48,6 +48,11 @@ g.test('resource_compatibility')
         !t.hasLanguageFeature('readonly_and_readwrite_storage_textures'),
       'Storage textures require language feature'
     );
+    t.skipIf(t.params.stage === 'vertex' &&
+                 ((wgslResource.buffer !== undefined &&
+                   wgslResource.buffer.type === 'storage') ||
+                  (wgslResource.storageTexture !== undefined)),
+             'Storage buffers and textures cannot be used in vertex shaders');
     const emptyVS = `
 @vertex
 fn main() -> @builtin(position) vec4f {

--- a/src/webgpu/api/validation/render_pipeline/resource_compatibility.spec.ts
+++ b/src/webgpu/api/validation/render_pipeline/resource_compatibility.spec.ts
@@ -48,11 +48,12 @@ g.test('resource_compatibility')
         !t.hasLanguageFeature('readonly_and_readwrite_storage_textures'),
       'Storage textures require language feature'
     );
-    t.skipIf(t.params.stage === 'vertex' &&
-                 ((wgslResource.buffer !== undefined &&
-                   wgslResource.buffer.type === 'storage') ||
-                  (wgslResource.storageTexture !== undefined)),
-             'Storage buffers and textures cannot be used in vertex shaders');
+    t.skipIf(
+      t.params.stage === 'vertex' &&
+        ((wgslResource.buffer !== undefined && wgslResource.buffer.type === 'storage') ||
+          wgslResource.storageTexture !== undefined),
+      'Storage buffers and textures cannot be used in vertex shaders'
+    );
     const emptyVS = `
 @vertex
 fn main() -> @builtin(position) vec4f {


### PR DESCRIPTION
Skip render pipeline resource compatibility test subcases where a vertex shader would have a storage or texture buffer. As per gpuweb/gpuweb#3947, neither storage buffers with non-read-only access nor storage textures can be used in vertex shaders. This test fix is necessary for:
https://dawn-review.googlesource.com/c/dawn/+/190781

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
