### PR TITLE
Fixup storage texture var restrictions in test

### DIFF
--- a/src/webgpu/api/validation/render_pipeline/resource_compatibility.spec.ts
+++ b/src/webgpu/api/validation/render_pipeline/resource_compatibility.spec.ts
@@ -51,7 +51,8 @@ g.test('resource_compatibility')
     t.skipIf(
       t.params.stage === 'vertex' &&
         ((wgslResource.buffer !== undefined && wgslResource.buffer.type === 'storage') ||
-          wgslResource.storageTexture !== undefined),
+          (wgslResource.storageTexture !== undefined &&
+            wgslResource.storageTexture.access !== 'read-only')),
       'Storage buffers and textures cannot be used in vertex shaders'
     );
     const emptyVS = `


### PR DESCRIPTION
Test cases for read-only storage textures should not be skipped as they are permitted in vertex shaders.

This is a followup from: https://github.com/gpuweb/cts/pull/3772#discussion_r1621161204

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
