### PR TITLE
Compat: Skip more tests for sample_* validation

### DIFF
--- a/src/webgpu/api/validation/render_pipeline/inter_stage.spec.ts
+++ b/src/webgpu/api/validation/render_pipeline/inter_stage.spec.ts
@@ -335,12 +335,12 @@ g.test('max_components_count,input')
     }
 
     if (useExtraBuiltinInputs) {
-      inputs.push(
-        '@builtin(front_facing) front_facing_in: bool',
-        '@builtin(sample_mask) sample_mask_in: u32'
-      );
+      inputs.push('@builtin(front_facing) front_facing_in: bool');
       if (!t.isCompatibility) {
-        inputs.push('@builtin(sample_index) sample_index_in: u32');
+        inputs.push(
+          '@builtin(sample_mask) sample_mask_in: u32',
+          '@builtin(sample_index) sample_index_in: u32'
+        );
       }
     }
 

--- a/src/webgpu/shader/execution/shader_io/fragment_builtins.spec.ts
+++ b/src/webgpu/shader/execution/shader_io/fragment_builtins.spec.ts
@@ -1351,6 +1351,7 @@ g.test('inputs,sample_mask')
       interpolation: { type, sampling },
     } = t.params;
     t.skipIfInterpolationTypeOrSamplingNotSupported({ type, sampling });
+    t.skipIf(t.isCompatibility, 'sample_mask is not supported in compatibility mode');
   })
   .fn(async t => {
     const {

--- a/src/webgpu/shader/validation/shader_io/builtins.spec.ts
+++ b/src/webgpu/shader/validation/shader_io/builtins.spec.ts
@@ -76,6 +76,12 @@ g.test('stage_inout')
       .combine('target_io', ['in', 'out'] as const)
       .beginSubcases()
   )
+  .beforeAllSubcases(t => {
+    t.skipIf(
+      t.isCompatibility && ['sample_index', 'sample_mask'].includes(t.params.name),
+      'compatibility mode does not support sample_index or sample_mask'
+    );
+  })
   .fn(t => {
     const code = generateShader({
       attribute: `@builtin(${t.params.name})`,
@@ -108,6 +114,12 @@ g.test('type')
       .combine('target_type', kTestTypes)
       .combine('use_struct', [true, false] as const)
   )
+  .beforeAllSubcases(t => {
+    t.skipIf(
+      t.isCompatibility && ['sample_index', 'sample_mask'].includes(t.params.name),
+      'compatibility mode does not support sample_index or sample_mask'
+    );
+  })
   .fn(t => {
     let code = '';
 
@@ -146,10 +158,10 @@ g.test('nesting')
       .beginSubcases()
   )
   .fn(t => {
-    // Generate a struct that contains a sample_mask builtin, nested inside another struct.
+    // Generate a struct that contains a frag_depth builtin, nested inside another struct.
     let code = `
     struct Inner {
-      @builtin(sample_mask) value : u32
+      @builtin(frag_depth) value : f32
     };
     struct Outer {
       inner : Inner
@@ -182,6 +194,9 @@ g.test('duplicates')
       .combine('second', ['p2', 's1b', 's2b', 'rb'] as const)
       .beginSubcases()
   )
+  .beforeAllSubcases(t => {
+    t.skipIf(t.isCompatibility, 'compatibility mode does not support sample_mask');
+  })
   .fn(t => {
     const p1 =
       t.params.first === 'p1' ? '@builtin(sample_mask)' : '@location(1) @interpolate(flat)';

--- a/src/webgpu/shader/validation/uniformity/uniformity.spec.ts
+++ b/src/webgpu/shader/validation/uniformity/uniformity.spec.ts
@@ -268,6 +268,12 @@ const kFragmentBuiltinValues = [
 g.test('fragment_builtin_values')
   .desc(`Test uniformity of fragment built-in values`)
   .params(u => u.combineWithParams(kFragmentBuiltinValues).beginSubcases())
+  .beforeAllSubcases(t => {
+    t.skipIf(
+      t.isCompatibility && ['sample_index', 'sample_mask'].includes(t.params.builtin),
+      'compatibility mode does not support sample_index or sample_mask'
+    );
+  })
   .fn(t => {
     let cond = ``;
     switch (t.params.type) {


### PR DESCRIPTION
<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [X] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
