### PR TITLE
Add more vertex shader res restrictions on tests

### DIFF
--- a/src/webgpu/shader/validation/shader_io/group_and_binding.spec.ts
+++ b/src/webgpu/shader/validation/shader_io/group_and_binding.spec.ts
@@ -96,6 +96,9 @@ g.test('single_entry_point')
       .combine('a_kind', kResourceKindsA)
       .combine('b_kind', kResourceKindsB)
       .combine('usage', ['direct', 'transitive'] as const)
+      .filter(t => {
+        return !(t.stage === 'vertex' && t.b_kind === 'texture_storage_1d');
+      })
       .beginSubcases()
       .combine('a_group', [0, 3] as const)
       .combine('b_group', [0, 3] as const)
@@ -140,6 +143,9 @@ g.test('different_entry_points')
       .combine('a_kind', kResourceKindsA)
       .combine('b_kind', kResourceKindsB)
       .combine('usage', ['direct', 'transitive'] as const)
+      .filter(t => {
+        return !(t.b_stage === 'vertex' && t.b_kind === 'texture_storage_1d');
+      })
       .beginSubcases()
   )
   .fn(t => {


### PR DESCRIPTION
Filter out more tests that result in use of a writable texture storage buffer in a vertex shader.

Spec change: gpuweb/gpuweb#3947
Tint change (in progress): https://dawn-review.googlesource.com/c/dawn/+/190781

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
