### PR TITLE
Out-of-bounds textureStore tests

### DIFF
--- a/src/webgpu/listing_meta.json
+++ b/src/webgpu/listing_meta.json
@@ -1594,6 +1594,7 @@
   "webgpu:shader,execution,expression,call,builtin,textureSampleLevel:sampled_array_2d_coords:*": { "subcaseMS": 822.400 },
   "webgpu:shader,execution,expression,call,builtin,textureSampleLevel:sampled_array_3d_coords:*": { "subcaseMS": 817.200 },
   "webgpu:shader,execution,expression,call,builtin,textureStore:out_of_bounds:*": { "subcaseMS": 942.418 },
+  "webgpu:shader,execution,expression,call,builtin,textureStore:out_of_bounds_array:*": { "subcaseMS": 609.565 },
   "webgpu:shader,execution,expression,call,builtin,textureStore:store_1d_coords:*": { "subcaseMS": 19.907 },
   "webgpu:shader,execution,expression,call,builtin,textureStore:store_2d_coords:*": { "subcaseMS": 28.809 },
   "webgpu:shader,execution,expression,call,builtin,textureStore:store_3d_coords:*": { "subcaseMS": 37.206 },

--- a/src/webgpu/listing_meta.json
+++ b/src/webgpu/listing_meta.json
@@ -1593,6 +1593,7 @@
   "webgpu:shader,execution,expression,call,builtin,textureSampleLevel:sampled_3d_coords:*": { "subcaseMS": 118.901 },
   "webgpu:shader,execution,expression,call,builtin,textureSampleLevel:sampled_array_2d_coords:*": { "subcaseMS": 822.400 },
   "webgpu:shader,execution,expression,call,builtin,textureSampleLevel:sampled_array_3d_coords:*": { "subcaseMS": 817.200 },
+  "webgpu:shader,execution,expression,call,builtin,textureStore:out_of_bounds:*": { "subcaseMS": 942.418 },
   "webgpu:shader,execution,expression,call,builtin,textureStore:store_1d_coords:*": { "subcaseMS": 19.907 },
   "webgpu:shader,execution,expression,call,builtin,textureStore:store_2d_coords:*": { "subcaseMS": 28.809 },
   "webgpu:shader,execution,expression,call,builtin,textureStore:store_3d_coords:*": { "subcaseMS": 37.206 },

--- a/src/webgpu/shader/execution/expression/call/builtin/textureStore.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureStore.spec.ts
@@ -225,8 +225,7 @@ g.test('out_of_bounds')
       })
   )
   .fn(t => {
-    const format = 'r32uint';
-    const bytes_per_texel = 4;
+    const texel_format = 'r32uint';
     const num_texels = 4096;
     const view_texels = num_texels / (t.params.mip === 0 ? 1 : 1 << (t.params.mip * 2));
 
@@ -235,7 +234,7 @@ g.test('out_of_bounds')
     mip_size.width = (texture_size as GPUExtent3DDict).width / (1 << t.params.mip);
     mip_size.height = ((texture_size as GPUExtent3DDict).height ?? 1) / (1 << t.params.mip);
     const texture = t.device.createTexture({
-      format: format,
+      format: texel_format,
       dimension: t.params.dim,
       size: texture_size,
       mipLevelCount: t.params.mipCount,
@@ -279,7 +278,7 @@ fn main(@builtin(global_invocation_id) gid : vec3u) {
         {
           binding: 0,
           resource: texture.createView({
-            format: format,
+            format: texel_format,
             dimension: t.params.dim,
             baseArrayLayer: 0,
             arrayLayerCount: 1,

--- a/src/webgpu/shader/execution/expression/call/builtin/textureStore.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureStore.spec.ts
@@ -503,7 +503,7 @@ fn main(@builtin(global_invocation_id) gid : vec3u) {
         if (base_texels * (t.params.baseLevel + t.params.arrayLevels) <= x) {
           return 0;
         }
-        if (x % 2 == 1) {
+        if (x % 2 === 1) {
           return 0;
         }
         return x - baseOffset;

--- a/src/webgpu/shader/execution/expression/call/builtin/textureStore.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureStore.spec.ts
@@ -278,17 +278,7 @@ g.test('out_of_bounds')
     const view_texels = getMipTexels(num_texels, t.params.dim, t.params.mip);
 
     const texture_size = getTextureSize(num_texels, t.params.dim, 1);
-    const t_sizes: [number, number, number] = [
-      (texture_size as GPUExtent3DDict).width,
-      (texture_size as GPUExtent3DDict).height ?? 1,
-      (texture_size as GPUExtent3DDict).depthOrArrayLayers ?? 1,
-    ];
-    const mip_sizes = virtualMipSize(t.params.dim, t_sizes, t.params.mip);
-    const mip_size: GPUExtent3DDict = {
-      width: mip_sizes[0],
-      height: mip_sizes[1],
-      depthOrArrayLayers: mip_sizes[2],
-    };
+    const mip_size = virtualMipSize(t.params.dim, texture_size, t.params.mip);
     const texture = t.device.createTexture({
       format: texel_format,
       dimension: t.params.dim,
@@ -306,9 +296,9 @@ g.test('out_of_bounds')
 @group(0) @binding(0) var tex : ${textureType(t.params.dim)};
 
 const numTexels = ${view_texels};
-const width = ${mip_sizes[0]};
-const height = ${mip_sizes[1]};
-const depth = ${mip_sizes[2]};
+const width = ${mip_size[0]};
+const height = ${mip_size[1]};
+const depth = ${mip_size[2]};
 
 ${indexToCoord(t.params.dim, t.params.coords)}
 

--- a/src/webgpu/shader/execution/expression/call/builtin/textureStore.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureStore.spec.ts
@@ -168,6 +168,12 @@ fn indexToCoord(id : u32) -> vec2<${type}> {
 }`;
       break;
     case '3d':
+      return `
+fn indexToCoord(id : u32) -> vec3<${type}> {
+  const half = numTexels / depth;
+  let half_id = id % half;
+  return vec3<${type}>(${type}(half_id % width), ${type}(half_id / width), ${type}(id / half));
+}`;
       break;
   }
   return ``;
@@ -179,7 +185,7 @@ function outOfBoundsValue(dim: string, type: string): string {
   switch (dim) {
     case '1d': {
       if (type === 'i32') {
-        return `if gid.x % 3 == 1 {
+        return `if gid.x % 3 == 0 {
           coords = -coords;
         } else {
           coords = coords + numTexels;
@@ -191,16 +197,36 @@ function outOfBoundsValue(dim: string, type: string): string {
     }
     case '2d': {
       if (type === 'i32') {
-        return `if gid.x % 3 == 1 {
+        return `if gid.x % 3 == 0 {
           coords.x = -coords.x;
         } else {
-          coords.y = coords.y + numTexels;
+          coords.y = coords.y + height;
         }`;
       } else {
         return `if gid.x % 3 == 1 {
-          coords.x = coords.x + numTexels;
+          coords.x = coords.x + width;
         } else {
-          coords.y = coords.y + numTexels;
+          coords.y = coords.y + height;
+        }`;
+      }
+      break;
+    }
+    case '3d': {
+      if (type === 'i32') {
+        return `if gid.x % 3 == 0 {
+          coords.x = -coords.x;
+        } else if gid.x % 5 == 0 {
+          coords.y = coords.y + height;
+        } else {
+          coords.z = coords.z + depth;
+        }`;
+      } else {
+        return `if gid.x % 3 == 1 {
+          coords.x = coords.x + width;
+        } else if gid.x % 5 == 1 {
+          coords.y = coords.y + height;
+        } else {
+          coords.z = 2 * depth;
         }`;
       }
       break;
@@ -209,11 +235,47 @@ function outOfBoundsValue(dim: string, type: string): string {
   return ``;
 }
 
+function getMipTexels(numTexels: number, dim: string, mip: number): number {
+  let texels = numTexels;
+  if (mip === 0) {
+    return texels;
+  }
+  if (dim === '2d') {
+    texels /= 1 << mip;
+    texels /= 1 << mip;
+  } else if (dim === '3d') {
+    texels /= 1 << mip;
+    texels /= 1 << mip;
+    texels /= 1 << mip;
+  }
+  return texels;
+}
+
+function getMipSize(baseSize: GPUExtent3D, dim: string, mip: number): GPUExtent3D {
+  const size: GPUExtent3D = {
+    width: (baseSize as GPUExtent3DDict).width,
+    height: (baseSize as GPUExtent3DDict).height ?? 1,
+    depthOrArrayLayers: (baseSize as GPUExtent3DDict).depthOrArrayLayers ?? 1,
+  };
+  if (mip === 0) {
+    return size;
+  }
+  if (dim === '2d') {
+    size.width = size.width / (1 << mip);
+    size.height = (size.height ?? 1) / (1 << mip);
+  } else if (dim === '3d') {
+    size.width = size.width / (1 << mip);
+    size.height = (size.height ?? 1) / (1 << mip);
+    size.depthOrArrayLayers = (size.depthOrArrayLayers ?? 1) / (1 << mip);
+  }
+  return size;
+}
+
 g.test('out_of_bounds')
   .desc('Test that textureStore on out-of-bounds coordinates have no effect')
   .params(u =>
     u
-      .combine('dim', ['1d', '2d'] as const)
+      .combine('dim', ['1d', '2d', '3d'] as const)
       .combine('coords', ['i32', 'u32'] as const)
       .combine('mipCount', [1, 2, 3] as const)
       .combine('mip', [0, 1, 2] as const)
@@ -221,18 +283,19 @@ g.test('out_of_bounds')
         if (t.dim === '1d') {
           return t.mipCount === 1 && t.mip === 0;
         }
+        if (t.dim === '3d') {
+          return t.mipCount <= 2 && t.mip < t.mipCount;
+        }
         return t.mip < t.mipCount;
       })
   )
   .fn(t => {
     const texel_format = 'r32uint';
     const num_texels = 4096;
-    const view_texels = num_texels / (t.params.mip === 0 ? 1 : 1 << (t.params.mip * 2));
+    const view_texels = getMipTexels(num_texels, t.params.dim, t.params.mip);
 
     const texture_size = getTextureSize(num_texels, t.params.dim, 1);
-    const mip_size: GPUExtent3D = { width: 1, height: 1, depthOrArrayLayers: 1 };
-    mip_size.width = (texture_size as GPUExtent3DDict).width / (1 << t.params.mip);
-    mip_size.height = ((texture_size as GPUExtent3DDict).height ?? 1) / (1 << t.params.mip);
+    const mip_size = getMipSize(texture_size, t.params.dim, t.params.mip);
     const texture = t.device.createTexture({
       format: texel_format,
       dimension: t.params.dim,
@@ -243,14 +306,16 @@ g.test('out_of_bounds')
     t.trackForCleanup(texture);
 
     const oob_value = outOfBoundsValue(t.params.dim, t.params.coords);
-    const wgx_size = 16;
+    const wgx_size = 32;
     const num_wgs_x = view_texels / wgx_size;
 
     const wgsl = `
 @group(0) @binding(0) var tex : ${textureType(t.params.dim)};
 
 const numTexels = ${view_texels};
-const width = ${mip_size.width};
+const width = ${(mip_size as GPUExtent3DDict).width};
+const height = ${(mip_size as GPUExtent3DDict).height ?? 1};
+const depth = ${(mip_size as GPUExtent3DDict).depthOrArrayLayers ?? 1};
 
 ${indexToCoord(t.params.dim, t.params.coords)}
 
@@ -297,17 +362,151 @@ fn main(@builtin(global_invocation_id) gid : vec3u) {
     pass.end();
     t.queue.submit([encoder.finish()]);
 
-    const buffer = t.copyWholeTextureToNewBufferSimple(texture, t.params.mip);
+    for (let m = 0; m < t.params.mipCount; m++) {
+      const buffer = t.copyWholeTextureToNewBufferSimple(texture, m);
+      if (m === t.params.mip) {
+        const expectedOutput = new Uint32Array([
+          ...iterRange(view_texels, x => {
+            if (x >= view_texels) {
+              return 0;
+            }
+            if (x % 2 === 1) {
+              return 0;
+            }
+            return x;
+          }),
+        ]);
+        t.expectGPUBufferValuesEqual(buffer, expectedOutput);
+      } else {
+        const expectedOutput = new Uint32Array([
+          ...iterRange(getMipTexels(num_texels, t.params.dim, m), x => 0),
+        ]);
+        t.expectGPUBufferValuesEqual(buffer, expectedOutput);
+      }
+    }
+  });
 
+const kArrayLevels = 4;
+
+g.test('out_of_bounds_array')
+  .desc('Test that out-of-bounds array coordinates to textureStore have no effect')
+  .params(u =>
+    u
+      .combine('baseLevel', [0, 1, 2, 3] as const)
+      .combine('arrayLevels', [1, 2, 3, 4] as const)
+      .combine('type', ['i32', 'u32'] as const)
+      .filter(t => {
+        if (t.arrayLevels <= t.baseLevel) {
+          return false;
+        }
+        if (kArrayLevels < t.baseLevel + t.arrayLevels) {
+          return false;
+        }
+        return true;
+      })
+  )
+  .fn(t => {
+    const dim = '2d';
+    const view_dim = '2d-array';
+    const texel_format = 'r32uint';
+    const width = 64;
+    const height = 64;
+    const base_texels = width * height;
+    const num_texels = base_texels * kArrayLevels;
+    const view_texels = base_texels * t.params.arrayLevels;
+    const texture_size: GPUExtent3D = { width, height, depthOrArrayLayers: kArrayLevels };
+    const view_size: GPUExtent3D = { width, height, depthOrArrayLayers: t.params.arrayLevels };
+
+    const texture = t.device.createTexture({
+      format: texel_format,
+      dimension: dim,
+      size: texture_size,
+      mipLevelCount: 1,
+      usage: GPUTextureUsage.STORAGE_BINDING | GPUTextureUsage.COPY_SRC,
+    });
+    t.trackForCleanup(texture);
+
+    const wgx_size = 32;
+    const num_wgs_x = num_texels / wgx_size;
+
+    let oob_value = `layer = layer + layers;`;
+    if (t.params.type === 'i32') {
+      oob_value = `if gid.x % 3 == 0 {
+        layer = -(layer + layers);
+      } else {
+        layer = layer + layers;
+      }`;
+    }
+
+    const wgsl = `
+@group(0) @binding(0) var tex : texture_storage_2d_array<r32uint, write>;
+
+const numTexels = ${view_texels};
+const width = ${view_size.width};
+const height = ${view_size.height ?? 1};
+const layers = ${view_size.depthOrArrayLayers ?? 1};
+const layerTexels = numTexels / layers;
+
+@compute @workgroup_size(${wgx_size})
+fn main(@builtin(global_invocation_id) gid : vec3u) {
+  let layer_id = gid.x % layerTexels;
+  var x = ${t.params.type}(layer_id % width);
+  var y = ${t.params.type}(layer_id / width);
+  var layer = ${t.params.type}(gid.x / layerTexels);
+  if gid.x % 2 == 1 {
+    ${oob_value}
+  }
+  textureStore(tex, vec2(x, y), layer, vec4u(gid.x));
+}`;
+
+    const pipeline = t.device.createComputePipeline({
+      layout: 'auto',
+      compute: {
+        module: t.device.createShaderModule({
+          code: wgsl,
+        }),
+        entryPoint: 'main',
+      },
+    });
+    const bg = t.device.createBindGroup({
+      layout: pipeline.getBindGroupLayout(0),
+      entries: [
+        {
+          binding: 0,
+          resource: texture.createView({
+            format: texel_format,
+            dimension: view_dim,
+            baseArrayLayer: t.params.baseLevel,
+            arrayLayerCount: t.params.arrayLevels,
+            baseMipLevel: 0,
+            mipLevelCount: 1,
+          }),
+        },
+      ],
+    });
+
+    const encoder = t.device.createCommandEncoder();
+    const pass = encoder.beginComputePass();
+    pass.setPipeline(pipeline);
+    pass.setBindGroup(0, bg);
+    pass.dispatchWorkgroups(num_wgs_x, 1, 1);
+    pass.end();
+    t.queue.submit([encoder.finish()]);
+
+    const buffer = t.copyWholeTextureToNewBufferSimple(texture, 0);
     const expectedOutput = new Uint32Array([
-      ...iterRange(view_texels, x => {
-        if (x >= view_texels) {
+      ...iterRange(num_texels, x => {
+        const baseOffset = base_texels * t.params.baseLevel;
+        if (x < baseOffset) {
           return 0;
         }
-        if (x % 2 === 1) {
+        if (base_texels * (t.params.baseLevel + t.params.arrayLevels) <= x) {
           return 0;
         }
-        return x;
+        if (x % 2 == 1) {
+          return 0;
+        }
+        return x - baseOffset;
       }),
     ]);
     t.expectGPUBufferValuesEqual(buffer, expectedOutput);

--- a/src/webgpu/shader/execution/expression/call/builtin/textureStore.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureStore.spec.ts
@@ -252,7 +252,7 @@ function getMipTexels(numTexels: number, dim: GPUTextureDimension, mip: number):
   return texels;
 }
 
-const kDims: GPUTextureDimension[] = ['1d', '2d', '3d'];
+const kDims = ['1d', '2d', '3d'] as const;
 
 g.test('out_of_bounds')
   .desc('Test that textureStore on out-of-bounds coordinates have no effect')
@@ -327,7 +327,7 @@ fn main(@builtin(global_invocation_id) gid : vec3u) {
           binding: 0,
           resource: texture.createView({
             format: texel_format,
-            dimension: t.params.dim as GPUTextureViewDimension,
+            dimension: t.params.dim,
             baseArrayLayer: 0,
             arrayLayerCount: 1,
             baseMipLevel: t.params.mip,


### PR DESCRIPTION
* Checks that textureStore with out-of-bounds coordinates do not execute





Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [ ] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [ ] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [ ] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
