### PR TITLE
Revert "Update validation tests for 3D textures with BC compression"

### DIFF
--- a/src/webgpu/api/validation/createTexture.spec.ts
+++ b/src/webgpu/api/validation/createTexture.spec.ts
@@ -101,8 +101,7 @@ g.test('zero_size_and_usage')
 
 g.test('dimension_type_and_format_compatibility')
   .desc(
-    `Test every dimension type on every format. Depth/stencil formats only support 2d;
-    compressed formats support either 2d or 2d+3d.`
+    `Test every dimension type on every format. Note that compressed formats and depth/stencil formats are not valid for 1D/3D dimension types.`
   )
   .params(u =>
     u //
@@ -221,6 +220,7 @@ g.test('mipLevelCount,bound_check')
         ({ format, size, dimension }) =>
           format === 'bc1-rgba-unorm' &&
           (dimension === '1d' ||
+            dimension === '3d' ||
             size[0] % kTextureFormatInfo[format].blockWidth !== 0 ||
             size[1] % kTextureFormatInfo[format].blockHeight !== 0)
       )
@@ -459,8 +459,8 @@ g.test('texture_size,default_value_and_smallest_size,compressed_format')
   )
   .params(u =>
     u
-      // Compressed formats are invalid for 1D.
-      .combine('dimension', [undefined, '2d', '3d'] as const)
+      // Compressed formats are invalid for 1D and 3D.
+      .combine('dimension', [undefined, '2d'] as const)
       .combine('format', kCompressedTextureFormats)
       .beginSubcases()
       .expandWithParams(p => {
@@ -474,10 +474,6 @@ g.test('texture_size,default_value_and_smallest_size,compressed_format')
           { size: [blockWidth, blockHeight, 1], _success: true },
         ];
       })
-      // Filter if the dimension is 3D and format is not compatible
-      .unless(
-        ({ dimension, format }) => dimension === '3d' && !kTextureFormatInfo[format].texture3D
-      )
   )
   .beforeAllSubcases(t => {
     const { format } = t.params;

--- a/src/webgpu/format_info.ts
+++ b/src/webgpu/format_info.ts
@@ -30,8 +30,6 @@ const kFormatUniversalDefaults = {
   feature: undefined,
   /** The base format for srgb formats. Specified on both srgb and equivalent non-srgb formats. */
   baseFormat: undefined,
-  /** Whether the format can be used in textures with 3D dimension. */
-  texture3D: undefined,
 
   /** @deprecated Use `.color.bytes`, `.depth.bytes`, or `.stencil.bytes`. */
   bytesPerBlock: undefined,
@@ -70,7 +68,7 @@ function formatTableWithDefaults<Defaults extends {}, Table extends { readonly [
 
 /** "plain color formats", plus rgb9e5ufloat. */
 const kRegularTextureFormatInfo = formatTableWithDefaults({
-  defaults: { blockWidth: 1, blockHeight: 1, texture3D: true },
+  defaults: { blockWidth: 1, blockHeight: 1 },
   table: {
     // plain, 8 bits per component
 
@@ -579,7 +577,7 @@ const kRegularTextureFormatInfo = formatTableWithDefaults({
 // because one aspect can be sized and one can be unsized. This should be cleaned up, but is kept
 // this way during a migration phase.
 const kSizedDepthStencilFormatInfo = formatTableWithDefaults({
-  defaults: { blockWidth: 1, blockHeight: 1, multisample: true, texture3D: false },
+  defaults: { blockWidth: 1, blockHeight: 1, multisample: true },
   table: {
     stencil8: {
       stencil: {
@@ -617,7 +615,7 @@ const kSizedDepthStencilFormatInfo = formatTableWithDefaults({
   },
 } as const);
 const kUnsizedDepthStencilFormatInfo = formatTableWithDefaults({
-  defaults: { blockWidth: 1, blockHeight: 1, multisample: true, texture3D: false },
+  defaults: { blockWidth: 1, blockHeight: 1, multisample: true },
   table: {
     depth24plus: {
       depth: {
@@ -675,7 +673,6 @@ const kBCTextureFormatInfo = formatTableWithDefaults({
     blockHeight: 4,
     multisample: false,
     feature: 'texture-compression-bc',
-    texture3D: true,
   },
   table: {
     'bc1-rgba-unorm': {
@@ -855,7 +852,6 @@ const kETC2TextureFormatInfo = formatTableWithDefaults({
     blockHeight: 4,
     multisample: false,
     feature: 'texture-compression-etc2',
-    texture3D: false,
   },
   table: {
     'etc2-rgb8unorm': {
@@ -985,7 +981,6 @@ const kASTCTextureFormatInfo = formatTableWithDefaults({
   defaults: {
     multisample: false,
     feature: 'texture-compression-astc',
-    texture3D: false,
   },
   table: {
     'astc-4x4-unorm': {
@@ -1742,9 +1737,9 @@ export function textureDimensionAndFormatCompatible(
   format: GPUTextureFormat
 ): boolean {
   const info = kAllTextureFormatInfo[format];
-  return (
-    !(dimension === '1d' && (info.blockWidth > 1 || info.depth || info.stencil)) &&
-    !(dimension === '3d' && !info.texture3D)
+  return !(
+    (dimension === '1d' || dimension === '3d') &&
+    (info.blockWidth > 1 || info.depth || info.stencil)
   );
 }
 


### PR DESCRIPTION
Reverts gpuweb/cts#3777

Changing a helper affected some other tests. Those tests need to be fixed, or changed temporarily to skip the affected cases temporarily (with a TODO).