### PR TITLE
Make `virtualMipSize` take a `GPUExtent3D`

### DIFF
--- a/src/webgpu/util/texture/base.ts
+++ b/src/webgpu/util/texture/base.ts
@@ -110,22 +110,22 @@ export function physicalMipSizeFromTexture(
 /**
  * Compute the "virtual size" of a mip level of a texture (not accounting for texel block rounding).
  *
- * MAINTENANCE_TODO: Change input/output to Required<GPUExtent3DDict> for consistency.
+ * MAINTENANCE_TODO: Change output to Required<GPUExtent3DDict> for consistency.
  */
 export function virtualMipSize(
   dimension: GPUTextureDimension,
-  size: readonly [number, number, number],
+  size: GPUExtent3D,
   mipLevel: number
 ): [number, number, number] {
+  const { width, height, depthOrArrayLayers } = reifyExtent3D(size);
   const shiftMinOne = (n: number) => Math.max(1, n >> mipLevel);
   switch (dimension) {
     case '1d':
-      assert(size[2] === 1);
-      return [shiftMinOne(size[0]), size[1], size[2]];
+      return [shiftMinOne(width), height, depthOrArrayLayers];
     case '2d':
-      return [shiftMinOne(size[0]), shiftMinOne(size[1]), size[2]];
+      return [shiftMinOne(width), shiftMinOne(height), depthOrArrayLayers];
     case '3d':
-      return [shiftMinOne(size[0]), shiftMinOne(size[1]), shiftMinOne(size[2])];
+      return [shiftMinOne(width), shiftMinOne(height), shiftMinOne(depthOrArrayLayers)];
     default:
       unreachable();
   }


### PR DESCRIPTION
Updated the TODO for making it return a GPUExtent3DDict

Note: I'm torn on which is better, 3 numbers or the object. The object seems verbose. The object is also inconsistent with `workgroup_size`

Being able to compute the number of texels with

```js
numTexels = size.reduce((acc, v) => acc * v);
```

Seems nice though I admit it's hardly that different than

```js
numTexls = size.width * size.height * size.depthOrArrayLayers;
```

It's also nice to be able to pass the size. For example algos which take a size of texture passed to a compute shader

```js
pass.dispatchWorkgroups(...size);
```

vs

```js
pass.dispatchWorkgroups(size.width, size.height, size.depthOrArrayLayers);
```

Or putting it into a uniform/storage buffer with 

```js
someTypedArray.set(size, offset);
```

Though again it's not that big if a deal. I get that it's kind of more readable to see the names but if that's the case the same argument applies to `workgroup_size` so 🤷‍ 😅

Size as an array also matches `textureDimensions` which returns a `vec2u` or `vec3u` which can be indexed with `[0]`, `[1]`, `[2]` and which is often useful directly in texture coordinate calculations `texelCoord = uv * size`

anyway, I'm not suggesting changing more now. Mostly voicing that I'd mildly prefer it not be changed to return a `GPUExtent3DDict` in the future.
