### PR TITLE
Cleanup for virtualMipSize usage

### DIFF
--- a/src/webgpu/api/operation/resource_init/check_texture/texture_zero_init_test.ts
+++ b/src/webgpu/api/operation/resource_init/check_texture/texture_zero_init_test.ts
@@ -353,9 +353,10 @@ export class TextureZeroInitTest extends GPUTest {
     const firstSubresource = subresourceRange.each().next().value;
     assert(typeof firstSubresource !== 'undefined');
 
+    const textureSize = [this.textureWidth, this.textureHeight, this.textureDepth];
     const [largestWidth, largestHeight, largestDepth] = virtualMipSize(
       this.p.dimension,
-      [this.textureWidth, this.textureHeight, this.textureDepth],
+      textureSize,
       firstSubresource.level
     );
 
@@ -372,11 +373,7 @@ export class TextureZeroInitTest extends GPUTest {
     const commandEncoder = this.device.createCommandEncoder();
 
     for (const { level, layer } of subresourceRange.each()) {
-      const [width, height, depth] = virtualMipSize(
-        this.p.dimension,
-        [this.textureWidth, this.textureHeight, this.textureDepth],
-        level
-      );
+      const [width, height, depth] = virtualMipSize(this.p.dimension, textureSize, level);
 
       commandEncoder.copyBufferToTexture(
         {

--- a/src/webgpu/api/validation/image_copy/texture_related.spec.ts
+++ b/src/webgpu/api/validation/image_copy/texture_related.spec.ts
@@ -303,11 +303,7 @@ Test the copy must be a full subresource if the texture's format is depth/stenci
       success = false;
     }
 
-    const levelSize = virtualMipSize(
-      dimension,
-      [size.width, size.height, size.depthOrArrayLayers],
-      mipLevel
-    );
+    const levelSize = virtualMipSize(dimension, size, mipLevel);
     const copySize = [
       levelSize[0] + copyWidthModifier * info.blockWidth,
       levelSize[1] + copyHeightModifier * info.blockHeight,

--- a/src/webgpu/shader/execution/expression/call/builtin/texture_utils.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/texture_utils.ts
@@ -94,12 +94,10 @@ export function createRandomTexelViewMipmap(info: {
 }): TexelView[] {
   const mipLevelCount = info.mipLevelCount ?? 1;
   const dimension = info.dimension ?? '2d';
-  const size = reifyExtent3D(info.size);
-  const tSize = [size.width, size.height, size.depthOrArrayLayers] as const;
   return range(mipLevelCount, i =>
     createRandomTexelView({
       format: info.format,
-      size: virtualMipSize(dimension, tSize, i),
+      size: virtualMipSize(dimension, info.size, i),
     })
   );
 }
@@ -202,10 +200,9 @@ export function softwareTextureReadMipLevel<T extends Dimensionality>(
   mipLevel: number
 ): PerTexelComponent<number> {
   const rep = kTexelRepresentationInfo[texture.texels[mipLevel].format];
-  const tSize = reifyExtent3D(texture.descriptor.size);
   const textureSize = virtualMipSize(
     texture.descriptor.dimension || '2d',
-    [tSize.width, tSize.height, tSize.depthOrArrayLayers],
+    texture.descriptor.size,
     mipLevel
   );
   const addressMode = [
@@ -1005,9 +1002,8 @@ export async function readTextureToTexelViews(
   const encoder = device.createCommandEncoder();
 
   const readBuffers = [];
-  const textureSize = [texture.width, texture.height, texture.depthOrArrayLayers] as const;
   for (let mipLevel = 0; mipLevel < texture.mipLevelCount; ++mipLevel) {
-    const size = virtualMipSize(texture.dimension, textureSize, mipLevel);
+    const size = virtualMipSize(texture.dimension, texture, mipLevel);
 
     const uniformValues = new Uint32Array([mipLevel, 0, 0, 0]); // min size is 16 bytes
     const uniformBuffer = device.createBuffer({


### PR DESCRIPTION
Now that virtualMipSize usage takes a
GPUExtent3D some code can be simplified.

