### PR TITLE
Partial evaluation error tests for bit shifts

### DIFF
--- a/src/webgpu/listing_meta.json
+++ b/src/webgpu/listing_meta.json
@@ -1962,6 +1962,7 @@
   "webgpu:shader,validation,expression,binary,and_or_xor:invalid_types:*": { "subcaseMS": 24.069 },
   "webgpu:shader,validation,expression,binary,and_or_xor:scalar_vector:*": { "subcaseMS": 666.807 },
   "webgpu:shader,validation,expression,binary,bitwise_shift:invalid_types:*": { "subcaseMS": 22.058 },
+  "webgpu:shader,validation,expression,binary,bitwise_shift:partial_eval_errors:*": { "subcaseMS": 116.339 },
   "webgpu:shader,validation,expression,binary,bitwise_shift:scalar_vector:*": { "subcaseMS": 525.052 },
   "webgpu:shader,validation,expression,binary,bitwise_shift:shift_left_concrete:*": { "subcaseMS": 1.216 },
   "webgpu:shader,validation,expression,binary,bitwise_shift:shift_right_concrete:*": { "subcaseMS": 1.237 },

--- a/src/webgpu/shader/validation/expression/binary/bitwise_shift.spec.ts
+++ b/src/webgpu/shader/validation/expression/binary/bitwise_shift.spec.ts
@@ -267,3 +267,42 @@ fn main() {
     `;
     t.expectCompileResult(t.params.case.pass, code);
   });
+
+g.test('partial_eval_errors')
+  .desc('Tests partial evaluation errors for left shift')
+  .params(u =>
+    u
+      .combine('op', ['<<', '>>'] as const)
+      .combine('type', ['i32', 'u32'] as const)
+      .beginSubcases()
+      .combine('stage', ['shader', 'pipeline'] as const)
+      .combine('value', [32, 33, 64] as const)
+  )
+  .fn(t => {
+    const type = Type[t.params.type];
+    const u32 = Type.u32;
+    let rhs = 'o';
+    if (t.params.stage === 'shader') {
+      rhs = `${u32.create(t.params.value).wgsl()}`;
+    }
+    const wgsl = `
+override o = 0u;
+fn foo() {
+  var v : ${t.params.type} = 0;
+  let tmp = v ${t.params.op} ${rhs};
+}`;
+
+    const expect = t.params.value <= 32;
+    if (t.params.stage === 'shader') {
+      t.expectCompileResult(expect, wgsl);
+    } else {
+      const constants: Record<string, number> = {};
+      constants['o'] = t.params.value;
+      t.expectPipelineResult({
+        expectedResult: expect,
+        code: wgsl,
+        constants,
+        reference: ['o'],
+      });
+    }
+  });

--- a/src/webgpu/shader/validation/expression/binary/bitwise_shift.spec.ts
+++ b/src/webgpu/shader/validation/expression/binary/bitwise_shift.spec.ts
@@ -279,7 +279,6 @@ g.test('partial_eval_errors')
       .combine('value', [32, 33, 64] as const)
   )
   .fn(t => {
-    const type = Type[t.params.type];
     const u32 = Type.u32;
     let rhs = 'o';
     if (t.params.stage === 'shader') {


### PR DESCRIPTION
Contributes to #3778

* Tests that runtime shifted by an early evaluation expression is an error when shift value is greater or equal than value's width




Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [ ] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [ ] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [ ] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
