### PR TITLE
Rework clamp low_high tests to support partial evaluation

### DIFF
--- a/src/webgpu/listing_meta.json
+++ b/src/webgpu/listing_meta.json
@@ -2028,6 +2028,7 @@
   "webgpu:shader,validation,expression,call,builtin,ceil:values:*": { "subcaseMS": 1.539 },
   "webgpu:shader,validation,expression,call,builtin,clamp:arguments:*": { "subcaseMS": 63.628 },
   "webgpu:shader,validation,expression,call,builtin,clamp:low_high:*": { "subcaseMS": 52.347 },
+  "webgpu:shader,validation,expression,call,builtin,clamp:low_high_abstract:*": { "subcaseMS": 33.348 },
   "webgpu:shader,validation,expression,call,builtin,clamp:mismatched:*": { "subcaseMS": 19292.911 },
   "webgpu:shader,validation,expression,call,builtin,clamp:must_use:*": { "subcaseMS": 5.207 },
   "webgpu:shader,validation,expression,call,builtin,clamp:values:*": { "subcaseMS": 0.377 },


### PR DESCRIPTION
Contributes to #3778

* Rework `low_high`
  * e is always runtime
  * low and high are swept through constant, override and runtime values
* Added `low_high_abstract` to cover abstract type cases that were removed from `low_high`




Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [ ] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [ ] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [ ] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
