### PR TITLE
Add partial evaluation validation tests for ldexp

### DIFF
--- a/src/webgpu/listing_meta.json
+++ b/src/webgpu/listing_meta.json
@@ -2122,6 +2122,7 @@
   "webgpu:shader,validation,expression,call,builtin,inverseSqrt:values:*": { "subcaseMS": 0.315 },
   "webgpu:shader,validation,expression,call,builtin,ldexp:args:*": { "subcaseMS": 86.955 },
   "webgpu:shader,validation,expression,call,builtin,ldexp:must_use:*": { "subcaseMS": 6.088 },
+  "webgpu:shader,validation,expression,call,builtin,ldexp:partial_values:*": { "subcaseMS": 102.253 },
   "webgpu:shader,validation,expression,call,builtin,ldexp:values:*": { "subcaseMS": 7707.260 },
   "webgpu:shader,validation,expression,call,builtin,length:args:*": { "subcaseMS": 5.046 },
   "webgpu:shader,validation,expression,call,builtin,length:integer_argument:*": { "subcaseMS": 2.011 },


### PR DESCRIPTION
Contributes to #3778

* Adds tests for ldexp where e1 is a runtime value, but e2 might be invalid




Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [ ] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [ ] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [ ] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
