### PR TITLE
Add validation tests for smoothstep partial eval errors

### DIFF
--- a/src/webgpu/listing_meta.json
+++ b/src/webgpu/listing_meta.json
@@ -2235,6 +2235,7 @@
   "webgpu:shader,validation,expression,call,builtin,smoothstep:argument_types:*": { "subcaseMS": 69163.359 },
   "webgpu:shader,validation,expression,call,builtin,smoothstep:arguments:*": { "subcaseMS": 131.134 },
   "webgpu:shader,validation,expression,call,builtin,smoothstep:early_eval_errors:*": { "subcaseMS": 161.151 },
+  "webgpu:shader,validation,expression,call,builtin,smoothstep:partial_eval_errors:*": { "subcaseMS": 1656.114 },
   "webgpu:shader,validation,expression,call,builtin,smoothstep:values:*": { "subcaseMS": 81643.500 },
   "webgpu:shader,validation,expression,call,builtin,sqrt:args:*": { "subcaseMS": 5.398 },
   "webgpu:shader,validation,expression,call,builtin,sqrt:integer_argument:*": { "subcaseMS": 1.356 },

--- a/src/webgpu/shader/validation/expression/call/builtin/smoothstep.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/smoothstep.spec.ts
@@ -51,8 +51,8 @@ Validates that constant evaluation and override evaluation of ${builtin}() rejec
   .fn(t => {
     const type = kValuesTypes[t.params.type];
 
-    // We expect to fail if low == high as it results in a DBZ
-    const expectedResult = t.params.value1 !== t.params.value2;
+    // We expect to fail if low >= high as it results in a DBZ
+    const expectedResult = t.params.value1 >= t.params.value2;
 
     validateConstOrOverrideBuiltinEval(
       t,
@@ -62,6 +62,87 @@ Validates that constant evaluation and override evaluation of ${builtin}() rejec
       t.params.stage,
       /* returnType */ concreteTypeOf(type, [Type.f32])
     );
+  });
+
+const kStages = [...kConstantAndOverrideStages, 'runtime'] as const
+
+g.test('partial_eval_errors')
+  .desc('Validates that low < high')
+  .params(u =>
+    u
+      .combine('lowStage', kStages)
+      .combine('highStage', kStages)
+      .combine('type', keysOf(kValuesTypes))
+      .filter(t => {
+        const type = kValuesTypes[t.type];
+        const scalarTy = scalarTypeOf(type);
+        return scalarTy !== Type.abstractInt && scalarTy !== Type.abstractFloat;
+      })
+      .beginSubcases()
+      .expand('low', u => [0,10])
+      .expand('high', u => [0,10])
+  )
+  .beforeAllSubcases(t => {
+    if (scalarTypeOf(kValuesTypes[t.params.type]) === Type.f16) {
+      t.selectDeviceOrSkipTestCase('shader-f16');
+    }
+  })
+  .fn(t => {
+    const type = kValuesTypes[t.params.type];
+    const scalarTy = scalarTypeOf(type);
+    const enable = `${type.requiresF16() ? 'enable f16;' : ''}`;
+    let lowArg = '';
+    let highArg = '';
+    switch (t.params.lowStage) {
+      case 'constant':
+        lowArg = `${type.create(t.params.low).wgsl()}`;
+        break;
+      case 'override':
+        lowArg = `${type.toString()}(o_low)`;
+        break;
+      case 'runtime':
+        lowArg = `v_low`;
+        break;
+    }
+    switch (t.params.highStage) {
+      case 'constant':
+        highArg = `${type.create(t.params.high).wgsl()}`;
+        break;
+      case 'override':
+        highArg = `${type.toString()}(o_high)`;
+        break;
+      case 'runtime':
+        highArg = `v_high`;
+        break;
+    }
+    const wgsl = `
+${enable}
+override o_low : ${scalarTy.toString()};
+override o_high : ${scalarTy.toString()};
+fn foo() {
+  var x : ${type.toString()};
+  var v_low : ${type.toString()};
+  var v_high : ${type.toString()};
+  let tmp = smoothstep(${lowArg}, ${highArg}, x);
+}`;
+
+  const error = t.params.low >= t.params.high;
+  const shader_error =
+    error && t.params.lowStage === 'constant' && t.params.highStage === 'constant';
+  const pipeline_error =
+    error && t.params.lowStage !== 'runtime' && t.params.highStage !== 'runtime';
+  t.expectCompileResult(!shader_error, wgsl);
+  if (!shader_error) {
+    const constants: Record<string, number> = {};
+    constants['o_low'] = t.params.low;
+    constants['o_high'] = t.params.high;
+    t.expectPipelineResult({
+      expectedResult: !pipeline_error,
+      code: wgsl,
+      constants,
+      reference: ['o_low', 'o_high'],
+    });
+  }
   });
 
 g.test('argument_types')

--- a/src/webgpu/shader/validation/expression/call/builtin/smoothstep.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/smoothstep.spec.ts
@@ -64,7 +64,7 @@ Validates that constant evaluation and override evaluation of ${builtin}() rejec
     );
   });
 
-const kStages = [...kConstantAndOverrideStages, 'runtime'] as const
+const kStages = [...kConstantAndOverrideStages, 'runtime'] as const;
 
 g.test('partial_eval_errors')
   .desc('Validates that low < high')
@@ -79,8 +79,8 @@ g.test('partial_eval_errors')
         return scalarTy !== Type.abstractInt && scalarTy !== Type.abstractFloat;
       })
       .beginSubcases()
-      .expand('low', u => [0,10])
-      .expand('high', u => [0,10])
+      .expand('low', u => [0, 10])
+      .expand('high', u => [0, 10])
   )
   .beforeAllSubcases(t => {
     if (scalarTypeOf(kValuesTypes[t.params.type]) === Type.f16) {
@@ -126,23 +126,23 @@ fn foo() {
   let tmp = smoothstep(${lowArg}, ${highArg}, x);
 }`;
 
-  const error = t.params.low >= t.params.high;
-  const shader_error =
-    error && t.params.lowStage === 'constant' && t.params.highStage === 'constant';
-  const pipeline_error =
-    error && t.params.lowStage !== 'runtime' && t.params.highStage !== 'runtime';
-  t.expectCompileResult(!shader_error, wgsl);
-  if (!shader_error) {
-    const constants: Record<string, number> = {};
-    constants['o_low'] = t.params.low;
-    constants['o_high'] = t.params.high;
-    t.expectPipelineResult({
-      expectedResult: !pipeline_error,
-      code: wgsl,
-      constants,
-      reference: ['o_low', 'o_high'],
-    });
-  }
+    const error = t.params.low >= t.params.high;
+    const shader_error =
+      error && t.params.lowStage === 'constant' && t.params.highStage === 'constant';
+    const pipeline_error =
+      error && t.params.lowStage !== 'runtime' && t.params.highStage !== 'runtime';
+    t.expectCompileResult(!shader_error, wgsl);
+    if (!shader_error) {
+      const constants: Record<string, number> = {};
+      constants['o_low'] = t.params.low;
+      constants['o_high'] = t.params.high;
+      t.expectPipelineResult({
+        expectedResult: !pipeline_error,
+        code: wgsl,
+        constants,
+        reference: ['o_low', 'o_high'],
+      });
+    }
   });
 
 g.test('argument_types')


### PR DESCRIPTION
Contributes to #3778

* Add tests for smoothstep when x is a runtime value
  * sweep low and high as const, override or runtime
  * sweep low and high values




Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [ ] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [ ] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [ ] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
