### PR TITLE
Rework extractBits count_offset tests to include runtime values

### DIFF
--- a/src/webgpu/shader/validation/expression/call/builtin/extractBits.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/extractBits.spec.ts
@@ -73,7 +73,8 @@ Validates that count and offset must be smaller than the size of the primitive.
   )
   .params(u =>
     u
-      .combine('stage', kConstantAndOverrideStages)
+      .combine('offsetStage', [...kConstantAndOverrideStages, 'runtime'] as const)
+      .combine('countStage', [...kConstantAndOverrideStages, 'runtime'] as const)
       .beginSubcases()
       .combineWithParams([
         // offset + count < 32
@@ -99,13 +100,57 @@ Validates that count and offset must be smaller than the size of the primitive.
       ] as const)
   )
   .fn(t => {
-    validateConstOrOverrideBuiltinEval(
-      t,
-      builtin,
-      /* expectedResult */ t.params.offset + t.params.count <= 32,
-      [u32(1), u32(t.params.offset), u32(t.params.count)],
-      t.params.stage
-    );
+    let offsetArg = '';
+    let countArg = '';
+    switch (t.params.offsetStage) {
+      case 'constant':
+        offsetArg = `${Type.u32.create(t.params.offset).wgsl()}`;
+        break;
+      case 'override':
+        offsetArg = `o_offset`;
+        break;
+      case 'runtime':
+        offsetArg = 'v_offset';
+        break;
+    }
+    switch (t.params.countStage) {
+      case 'constant':
+        countArg = `${Type.u32.create(t.params.count).wgsl()}`;
+        break;
+      case 'override':
+        countArg = `o_count`;
+        break;
+      case 'runtime':
+        countArg = 'v_count';
+        break;
+    }
+    const wgsl = `
+override o_offset : u32;
+override o_count : u32;
+fn foo() {
+  var v_offset : u32;
+  var v_count : u32;
+  var e : u32;
+  let tmp = extractBits(e, ${offsetArg}, ${countArg});
+}`;
+
+    const error = t.params.offset + t.params.count > 32;
+    const shader_error =
+      error && t.params.offsetStage === 'constant' && t.params.countStage === 'constant';
+    const pipeline_error =
+      error && t.params.offsetStage !== 'runtime' && t.params.countStage !== 'runtime';
+    t.expectCompileResult(!shader_error, wgsl);
+    if (!shader_error) {
+      const constants: Record<string, number> = {};
+      constants['o_offset'] = t.params.offset;
+      constants['o_count'] = t.params.count;
+      t.expectPipelineResult({
+        expectedResult: !pipeline_error,
+        code: wgsl,
+        constants,
+        reference: ['o_offset', 'o_count'],
+      });
+    }
   });
 
 interface Argument {


### PR DESCRIPTION
Contributes to #3778

* Reworks validation tests for extractBits `count_offset` to sweep all types of values
  * keeps base value as runtime value




Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [ ] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [ ] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [ ] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
