### PR TITLE
Compat: Fix interpolation tests for compat spec changes

### DIFF
--- a/src/webgpu/api/validation/render_pipeline/inter_stage.spec.ts
+++ b/src/webgpu/api/validation/render_pipeline/inter_stage.spec.ts
@@ -4,11 +4,22 @@ Interface matching between vertex and fragment shader validation for createRende
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { range } from '../../../../common/util/util.js';
+import { GPUTestSubcaseBatchState } from '../../../gpu_test.js';
 
 import { CreateRenderPipelineValidationTest } from './common.js';
 
 function getVarName(i: number) {
   return `v${i}`;
+}
+
+function skipIfDisallowedInterpolationParameter(t: GPUTestSubcaseBatchState, ...wgsl: string[]) {
+  if (t.isCompatibility) {
+    for (const s of wgsl) {
+      if (s.includes('linear') || s.includes('sample')) {
+        t.skip(`unsupported interpolation parameter in compat: ${wgsl}`);
+      }
+    }
+  }
 }
 
 class InterStageMatchingValidationTest extends CreateRenderPipelineValidationTest {
@@ -176,6 +187,9 @@ g.test('interpolation_type')
       },
     ])
   )
+  .beforeAllSubcases(t => {
+    skipIfDisallowedInterpolationParameter(t, t.params.output, t.params.input);
+  })
   .fn(t => {
     const { isAsync, output, input, _success, _compat_success } = t.params;
 
@@ -219,6 +233,9 @@ g.test('interpolation_sampling')
       { output: '@interpolate(perspective, centroid)', input: '@interpolate(perspective)' },
     ])
   )
+  .beforeAllSubcases(t => {
+    skipIfDisallowedInterpolationParameter(t, t.params.output, t.params.input);
+  })
   .fn(t => {
     const { isAsync, output, input, _success, _compat_success } = t.params;
 

--- a/src/webgpu/shader/validation/shader_io/interpolate.spec.ts
+++ b/src/webgpu/shader/validation/shader_io/interpolate.spec.ts
@@ -9,8 +9,15 @@ import { generateShader } from './util.js';
 export const g = makeTestGroup(ShaderValidationTest);
 
 // List of valid interpolation attributes.
-const kValidInterpolationAttributes = new Set([
+const kValidCompatInterpolationAttributes = new Set([
   '',
+  '@interpolate(flat)',
+  '@interpolate(perspective)',
+  '@interpolate(perspective, center)',
+  '@interpolate(perspective, centroid)',
+]);
+const kValidInterpolationAttributes = new Set([
+  ...kValidCompatInterpolationAttributes,
   '@interpolate(flat)',
   '@interpolate(perspective)',
   '@interpolate(perspective, center)',
@@ -38,6 +45,8 @@ g.test('type_and_sampling')
         'centroid', // Invalid as first param
         'sample', // Invalid as first param
       ] as const)
+      // vertex output must include a position builtin, so must use a struct
+      .filter(t => !(t.stage === 'vertex' && t.use_struct === false))
       .combine('sampling', [
         '',
         'center',
@@ -50,10 +59,6 @@ g.test('type_and_sampling')
       .beginSubcases()
   )
   .fn(t => {
-    if (t.params.stage === 'vertex' && t.params.use_struct === false) {
-      t.skip('vertex output must include a position builtin, so must use a struct');
-    }
-
     let interpolate = '';
     if (t.params.type !== '' || t.params.sampling !== '') {
       interpolate = '@interpolate(';
@@ -72,8 +77,10 @@ g.test('type_and_sampling')
       io: t.params.io,
       use_struct: t.params.use_struct,
     });
-
-    t.expectCompileResult(kValidInterpolationAttributes.has(interpolate), code);
+    const validInterpolationAttributes = t.isCompatibility
+      ? kValidCompatInterpolationAttributes
+      : kValidInterpolationAttributes;
+    t.expectCompileResult(validInterpolationAttributes.has(interpolate), code);
   });
 
 g.test('require_location')


### PR DESCRIPTION
Compat generates shader module creation errors instead of pipeline creation errors.



<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [X] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
