### PR TITLE
Compat: Fix textureLoad WGSL validation tests for compat spec changes.

### DIFF
--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -262,6 +262,19 @@ export class GPUTestSubcaseBatchState extends SubcaseBatchState {
     }
   }
 
+  skipIfTextureLoadNotSupportedForTextureType(...types: (string | undefined | null)[]) {
+    if (this.isCompatibility) {
+      for (const type of types) {
+        switch (type) {
+          case 'texture_depth_2d':
+          case 'texture_depth_2d_array':
+          case 'texture_depth_multisampled_2d':
+            this.skip(`${type} is not supported by textureLoad in compatibility mode`);
+        }
+      }
+    }
+  }
+
   /**
    * Skips test if the given interpolation type or sampling is not supported.
    */

--- a/src/webgpu/shader/validation/expression/call/builtin/textureLoad.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/textureLoad.spec.ts
@@ -80,7 +80,7 @@ const kValidTextureLoadParameterTypesForNonStorageTextures: { [n: string]: Textu
       hasSampleIndexArg: true,
     },
     texture_external: { coordsArgTypes: kCoords2DTypes },
-  };
+  } as const;
 
 const kValidTextureLoadParameterTypesForStorageTextures: { [n: string]: TextureLoadArguments } = {
   texture_storage_1d: { coordsArgTypes: [Type.i32, Type.u32] },
@@ -114,6 +114,7 @@ Validates the return type of ${builtin} is the expected type.
         kNonStorageTextureTypeInfo[t.textureType].texelTypes.map(v => v.toString())
       )
   )
+  .beforeAllSubcases(t => t.skipIfTextureLoadNotSupportedForTextureType(t.params.textureType))
   .fn(t => {
     const { returnType, textureType, texelType } = t.params;
     const returnVarType = kValuesTypes[returnType];
@@ -158,6 +159,7 @@ Validates that only incorrect coords arguments are rejected by ${builtin}
       // filter out unsigned types with negative values
       .filter(t => !isUnsignedType(kValuesTypes[t.coordType]) || t.value >= 0)
   )
+  .beforeAllSubcases(t => t.skipIfTextureLoadNotSupportedForTextureType(t.params.textureType))
   .fn(t => {
     const { textureType, coordType, texelType, value } = t.params;
     const coordArgType = kValuesTypes[coordType];
@@ -251,6 +253,7 @@ Validates that only incorrect array_index arguments are rejected by ${builtin}
       // filter out unsigned types with negative values
       .filter(t => !isUnsignedType(kValuesTypes[t.arrayIndexType]) || t.value >= 0)
   )
+  .beforeAllSubcases(t => t.skipIfTextureLoadNotSupportedForTextureType(t.params.textureType))
   .fn(t => {
     const { textureType, arrayIndexType, texelType, value } = t.params;
     const arrayIndexArgType = kValuesTypes[arrayIndexType];
@@ -348,6 +351,7 @@ Validates that only incorrect level arguments are rejected by ${builtin}
       // filter out unsigned types with negative values
       .filter(t => !isUnsignedType(kValuesTypes[t.levelType]) || t.value >= 0)
   )
+  .beforeAllSubcases(t => t.skipIfTextureLoadNotSupportedForTextureType(t.params.textureType))
   .fn(t => {
     const { textureType, levelType, texelType, value } = t.params;
     const levelArgType = kValuesTypes[levelType];
@@ -395,6 +399,7 @@ Validates that only incorrect sample_index arguments are rejected by ${builtin}
       // filter out unsigned types with negative values
       .filter(t => !isUnsignedType(kValuesTypes[t.sampleIndexType]) || t.value >= 0)
   )
+  .beforeAllSubcases(t => t.skipIfTextureLoadNotSupportedForTextureType(t.params.textureType))
   .fn(t => {
     const { textureType, sampleIndexType, texelType, value } = t.params;
     const sampleIndexArgType = kValuesTypes[sampleIndexType];
@@ -431,8 +436,9 @@ Validates that incompatible texture types don't work with ${builtin}
     u
       .combine('testTextureType', kTestTextureTypes)
       .beginSubcases()
-      .combine('textureType', keysOf(kValidTextureLoadParameterTypesForNonStorageTextures))
+      .combine('textureType', kNonStorageTextureTypes)
   )
+  .beforeAllSubcases(t => t.skipIfTextureLoadNotSupportedForTextureType(t.params.testTextureType))
   .fn(t => {
     const { testTextureType, textureType } = t.params;
     const { coordsArgTypes, hasArrayIndexArg, hasLevelArg, hasSampleIndexArg } =
@@ -484,9 +490,10 @@ Validates that incompatible texture types don't work with ${builtin}
     u
       .combine('testTextureType', kTestTextureTypes)
       .beginSubcases()
-      .combine('textureType', keysOf(kValidTextureLoadParameterTypesForStorageTextures))
+      .combine('textureType', kStorageTextureTypes)
       .combine('format', kAllTextureFormats)
   )
+  .beforeAllSubcases(t => t.skipIfTextureLoadNotSupportedForTextureType(t.params.testTextureType))
   .fn(t => {
     const { testTextureType, textureType } = t.params;
     const { coordsArgTypes, hasArrayIndexArg, hasLevelArg, hasSampleIndexArg } =


### PR DESCRIPTION
Compat generates shader module creation errors instead of pipeline creation errors.

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [X] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
