### PR TITLE
Compat: fix rgXXX format as storage texture issues

### DIFF
--- a/src/webgpu/format_info.ts
+++ b/src/webgpu/format_info.ts
@@ -1782,13 +1782,14 @@ export const kCompatModeUnsupportedStorageTextureFormats: readonly GPUTextureFor
 export function isTextureFormatUsableAsStorageFormat(
   format: GPUTextureFormat,
   isCompatibilityMode: boolean
-) {
+): boolean {
   if (isCompatibilityMode) {
     if (kCompatModeUnsupportedStorageTextureFormats.indexOf(format) >= 0) {
       return false;
     }
   }
-  return !!kTextureFormatInfo[format].color?.storage;
+  const info = kTextureFormatInfo[format];
+  return !!(info.color?.storage || info.depth?.storage || info.stencil?.storage);
 }
 
 export function isRegularTextureFormat(format: GPUTextureFormat) {

--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -491,6 +491,14 @@ export class GPUTestBase extends Fixture<GPUTestSubcaseBatchState> {
     }
   }
 
+  skipIfTextureFormatNotUsableAsStorageTexture(...formats: (GPUTextureFormat | undefined)[]) {
+    for (const format of formats) {
+      if (format && !isTextureFormatUsableAsStorageFormat(format, this.isCompatibility)) {
+        this.skip(`Texture with ${format} is not usable as a storage texture`);
+      }
+    }
+  }
+
   /** Skips this test case if the `langFeature` is *not* supported. */
   skipIfLanguageFeatureNotSupported(langFeature: WGSLLanguageFeature) {
     if (!this.hasLanguageFeature(langFeature)) {

--- a/src/webgpu/shader/validation/expression/call/builtin/textureDimensions.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/textureDimensions.spec.ts
@@ -162,6 +162,8 @@ Validates the return type of ${builtin} is the expected type.
   )
   .fn(t => {
     const { returnType, textureType, format } = t.params;
+    t.skipIfTextureFormatNotUsableAsStorageTexture(format);
+
     const returnVarType = kValuesTypes[returnType];
     const { returnType: returnRequiredType, hasLevelArg } =
       kValidTextureDimensionParameterTypesForStorageTextures[textureType];

--- a/src/webgpu/shader/validation/expression/call/builtin/textureLoad.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/textureLoad.spec.ts
@@ -210,6 +210,8 @@ Validates that only incorrect coords arguments are rejected by ${builtin}
   )
   .fn(t => {
     const { textureType, coordType, format, value } = t.params;
+    t.skipIfTextureFormatNotUsableAsStorageTexture(format);
+
     const coordArgType = kValuesTypes[coordType];
     const { coordsArgTypes, hasArrayIndexArg } =
       kValidTextureLoadParameterTypesForStorageTextures[textureType];
@@ -307,6 +309,8 @@ Validates that only incorrect array_index arguments are rejected by ${builtin}
   )
   .fn(t => {
     const { textureType, arrayIndexType, format, value } = t.params;
+    t.skipIfTextureFormatNotUsableAsStorageTexture(format);
+
     const arrayIndexArgType = kValuesTypes[arrayIndexType];
     const args = [arrayIndexArgType.create(value)];
     const { coordsArgTypes, hasLevelArg } =

--- a/src/webgpu/shader/validation/expression/call/builtin/textureNumLayers.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/textureNumLayers.spec.ts
@@ -89,6 +89,8 @@ Validates the return type of ${builtin} is the expected type.
   )
   .fn(t => {
     const { returnType, textureType, format } = t.params;
+    t.skipIfTextureFormatNotUsableAsStorageTexture(format);
+
     const returnVarType = kValuesTypes[returnType];
 
     const varWGSL = returnVarType.toString();

--- a/src/webgpu/shader/validation/expression/call/builtin/textureStore.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/textureStore.spec.ts
@@ -152,6 +152,8 @@ Validates that only incorrect value arguments are rejected by ${builtin}
   )
   .fn(t => {
     const { textureType, valueType, format, value } = t.params;
+    t.skipIfTextureFormatNotUsableAsStorageTexture(format);
+
     const valueArgType = kValuesTypes[valueType];
     const args = [valueArgType.create(value)];
     const { coordsArgTypes, hasArrayIndexArg } = kValidTextureStoreParameterTypes[textureType];

--- a/src/webgpu/shader/validation/extension/readonly_and_readwrite_storage_textures.spec.ts
+++ b/src/webgpu/shader/validation/extension/readonly_and_readwrite_storage_textures.spec.ts
@@ -27,6 +27,8 @@ g.test('var_decl')
   )
   .fn(t => {
     const { type, format, access } = t.params;
+    t.skipIfTextureFormatNotUsableAsStorageTexture(format.format);
+
     const source = `@group(0) @binding(0) var t : ${type}<${format.format}, ${access}>;`;
     const requiresFeature = access !== 'write';
     t.expectCompileResult(t.hasLanguageFeature(kFeatureName) || !requiresFeature, source);

--- a/src/webgpu/shader/validation/shader_io/util.ts
+++ b/src/webgpu/shader/validation/shader_io/util.ts
@@ -111,7 +111,7 @@ export const kResourceEmitters = new Map<string, ResourceDeclarationEmitter>([
   ['texture_storage_1d', basicEmitter('texture_storage_1d<rgba8unorm, write>')],
   ['texture_storage_2d', basicEmitter('texture_storage_2d<rgba8sint, write>')],
   ['texture_storage_2d_array', basicEmitter('texture_storage_2d_array<r32uint, write>')],
-  ['texture_storage_3d', basicEmitter('texture_storage_3d<rg32uint, write>')],
+  ['texture_storage_3d', basicEmitter('texture_storage_3d<rgba32uint, write>')],
   ['texture_depth_2d', basicEmitter('texture_depth_2d')],
   ['texture_depth_2d_array', basicEmitter('texture_depth_2d_array')],
   ['texture_depth_cube', basicEmitter('texture_depth_cube')],

--- a/src/webgpu/shader/validation/types/alias.spec.ts
+++ b/src/webgpu/shader/validation/types/alias.spec.ts
@@ -171,7 +171,7 @@ const kTypes = [
   'texture_storage_1d<r32sint, read_write>',
   'texture_storage_1d<r32float, read>',
   'texture_storage_2d<rgba16uint, write>',
-  'texture_storage_2d_array<rg32float, write>',
+  'texture_storage_2d_array<rgba32float, write>',
   'texture_storage_3d<bgra8unorm, write>',
   'texture_depth_2d',
   'texture_depth_2d_array',

--- a/src/webgpu/shader/validation/types/textures.spec.ts
+++ b/src/webgpu/shader/validation/types/textures.spec.ts
@@ -91,7 +91,7 @@ g.test('sampled_texture_types')
 
 g.test('external_sampled_texture_types')
   .desc(
-    `Test that texture_extenal compiles and cannot specify address space
+    `Test that texture_external compiles and cannot specify address space
 `
   )
   .fn(t => {
@@ -118,13 +118,9 @@ Besides, the shader compilation should always pass regardless of whether the for
   )
   .fn(t => {
     const { format, access, comma } = t.params;
-    const info = kTextureFormatInfo[format];
     // bgra8unorm is considered a valid storage format at shader compilation stage
     const isFormatValid =
-      info.color?.storage ||
-      info.depth?.storage ||
-      info.stencil?.storage ||
-      format === 'bgra8unorm';
+      isTextureFormatUsableAsStorageFormat(format, t.isCompatibility) || format === 'bgra8unorm';
     const isAccessValid = kAccessModes.includes(access);
     const wgsl = `@group(0) @binding(0) var tex: texture_storage_2d<${format}, ${access}${comma}>;`;
     t.expectCompileResult(isFormatValid && isAccessValid, wgsl);


### PR DESCRIPTION
Spec changed so that usage of rgXXX format textures as storage textures should generate a shader module creation error.

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [X] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
