### PR TITLE
Compat: Refactor tests to use @interpolate(flat, either)

### DIFF
--- a/src/webgpu/api/operation/memory_sync/buffer/buffer_sync_test.ts
+++ b/src/webgpu/api/operation/memory_sync/buffer/buffer_sync_test.ts
@@ -544,7 +544,7 @@ export class BufferSyncTest extends GPUTest {
       vertex: `
       struct VertexOutput {
         @builtin(position) position : vec4<f32>,
-        @location(0) @interpolate(flat) data : u32,
+        @location(0) @interpolate(flat, either) data : u32,
       };
 
       @vertex fn vert_main(@location(0) input: u32) -> VertexOutput {
@@ -561,7 +561,7 @@ export class BufferSyncTest extends GPUTest {
 
       @group(0) @binding(0) var<storage, read_write> data : Data;
 
-      @fragment fn frag_main(@location(0) @interpolate(flat) input : u32) -> @location(0) vec4<f32> {
+      @fragment fn frag_main(@location(0) @interpolate(flat, either) input : u32) -> @location(0) vec4<f32> {
         data.a = input;
         return vec4<f32>();  // result does't matter
       }

--- a/src/webgpu/api/operation/render_pipeline/sample_mask.spec.ts
+++ b/src/webgpu/api/operation/render_pipeline/sample_mask.spec.ts
@@ -129,7 +129,7 @@ function getExpectedStencilData(
 const kSampleMaskTestShader = `
 struct Varyings {
   @builtin(position) Position : vec4<f32>,
-  @location(0) @interpolate(flat) uvFlat : vec2<f32>,
+  @location(0) @interpolate(flat, either) uvFlat : vec2<f32>,
   @location(1) @interpolate(perspective, sample) uvInterpolated : vec2<f32>,
 }
 

--- a/src/webgpu/api/operation/rendering/depth_clip_clamp.spec.ts
+++ b/src/webgpu/api/operation/rendering/depth_clip_clamp.spec.ts
@@ -92,7 +92,7 @@ have unexpected values then get drawn to the color buffer, which is later checke
 
       struct VFTest {
         @builtin(position) pos: vec4<f32>,
-        @location(0) @interpolate(flat) vertexIndex: u32,
+        @location(0) @interpolate(flat, either) vertexIndex: u32,
       };
 
       @vertex
@@ -129,7 +129,7 @@ have unexpected values then get drawn to the color buffer, which is later checke
 
       struct VFCheck {
         @builtin(position) pos: vec4<f32>,
-        @location(0) @interpolate(flat) vertexIndex: u32,
+        @location(0) @interpolate(flat, either) vertexIndex: u32,
       };
 
       @vertex
@@ -395,7 +395,7 @@ to be empty.`
 
       struct VF {
         @builtin(position) pos: vec4<f32>,
-        @location(0) @interpolate(flat) vertexIndex: u32,
+        @location(0) @interpolate(flat, either) vertexIndex: u32,
       };
 
       @vertex

--- a/src/webgpu/api/operation/rendering/draw.spec.ts
+++ b/src/webgpu/api/operation/rendering/draw.spec.ts
@@ -579,14 +579,14 @@ g.test('vertex_attributes,basic')
     // The remaining 3 vertex attributes
     if (numAttributes === 16) {
       accumulateVariableDeclarationsInVertexShader = `
-        @location(13) @interpolate(flat) outAttrib13 : vec4<${wgslFormat}>,
+        @location(13) @interpolate(flat, either) outAttrib13 : vec4<${wgslFormat}>,
       `;
       accumulateVariableAssignmentsInVertexShader = `
       output.outAttrib13 =
           vec4<${wgslFormat}>(input.attrib12, input.attrib13, input.attrib14, input.attrib15);
       `;
       accumulateVariableDeclarationsInFragmentShader = `
-      @location(13) @interpolate(flat) attrib13 : vec4<${wgslFormat}>,
+      @location(13) @interpolate(flat, either) attrib13 : vec4<${wgslFormat}>,
       `;
       accumulateVariableAssignmentsInFragmentShader = `
       outBuffer.primitives[input.primitiveId].attrib12 = input.attrib13.x;
@@ -596,14 +596,14 @@ g.test('vertex_attributes,basic')
       `;
     } else if (numAttributes === 14) {
       accumulateVariableDeclarationsInVertexShader = `
-        @location(13) @interpolate(flat) outAttrib13 : vec4<${wgslFormat}>,
+        @location(13) @interpolate(flat, either) outAttrib13 : vec4<${wgslFormat}>,
       `;
       accumulateVariableAssignmentsInVertexShader = `
       output.outAttrib13 =
           vec4<${wgslFormat}>(input.attrib12, input.attrib13, 0, 0);
       `;
       accumulateVariableDeclarationsInFragmentShader = `
-      @location(13) @interpolate(flat) attrib13 : vec4<${wgslFormat}>,
+      @location(13) @interpolate(flat, either) attrib13 : vec4<${wgslFormat}>,
       `;
       accumulateVariableAssignmentsInFragmentShader = `
       outBuffer.primitives[input.primitiveId].attrib12 = input.attrib13.x;
@@ -625,9 +625,9 @@ ${vertexInputShaderLocations.map(i => `  @location(${i}) attrib${i} : ${wgslForm
 struct Outputs {
   @builtin(position) Position : vec4<f32>,
 ${interStageScalarShaderLocations
-  .map(i => `  @location(${i}) @interpolate(flat) outAttrib${i} : ${wgslFormat},`)
+  .map(i => `  @location(${i}) @interpolate(flat, either) outAttrib${i} : ${wgslFormat},`)
   .join('\n')}
-  @location(${interStageScalarShaderLocations.length}) @interpolate(flat) primitiveId : u32,
+  @location(${interStageScalarShaderLocations.length}) @interpolate(flat, either) primitiveId : u32,
 ${accumulateVariableDeclarationsInVertexShader}
 };
 
@@ -650,9 +650,9 @@ ${accumulateVariableAssignmentsInVertexShader}
           code: `
 struct Inputs {
 ${interStageScalarShaderLocations
-  .map(i => `  @location(${i}) @interpolate(flat) attrib${i} : ${wgslFormat},`)
+  .map(i => `  @location(${i}) @interpolate(flat, either) attrib${i} : ${wgslFormat},`)
   .join('\n')}
-  @location(${interStageScalarShaderLocations.length}) @interpolate(flat) primitiveId : u32,
+  @location(${interStageScalarShaderLocations.length}) @interpolate(flat, either) primitiveId : u32,
 ${accumulateVariableDeclarationsInFragmentShader}
 };
 

--- a/src/webgpu/api/operation/storage_texture/read_only.spec.ts
+++ b/src/webgpu/api/operation/storage_texture/read_only.spec.ts
@@ -428,7 +428,7 @@ class F extends GPUTest {
         for (let layer = 0; layer < storageTexture.depthOrArrayLayers; ++layer) {
           vertexOutputs = vertexOutputs.concat(
             `
-            @location(${layer + 1}) @interpolate(flat)
+            @location(${layer + 1}) @interpolate(flat, either)
             vertex_out${layer}: ${this.GetOutputBufferWGSLType(format)},`
           );
         }
@@ -474,7 +474,7 @@ class F extends GPUTest {
         ${bindingResourceDeclaration}
         struct VertexOutput {
           @builtin(position) my_pos: vec4f,
-          @location(0) @interpolate(flat) tex_coord: vec2u,
+          @location(0) @interpolate(flat, either) tex_coord: vec2u,
           ${vertexOutputs}
         }
         @vertex

--- a/src/webgpu/api/operation/vertex_state/correctness.spec.ts
+++ b/src/webgpu/api/operation/vertex_state/correctness.spec.ts
@@ -202,7 +202,7 @@ ${vsChecks}
 }
 
 struct VSOutputs {
-  @location(0) @interpolate(flat) result : i32,
+  @location(0) @interpolate(flat, either) result : i32,
   @builtin(position) position : vec4<f32>,
 };
 
@@ -221,7 +221,7 @@ struct VSOutputs {
   return output;
 }
 
-@fragment fn fsMain(@location(0) @interpolate(flat) result : i32)
+@fragment fn fsMain(@location(0) @interpolate(flat, either) result : i32)
   -> @location(0) i32 {
   return result;
 }

--- a/src/webgpu/api/validation/render_pipeline/inter_stage.spec.ts
+++ b/src/webgpu/api/validation/render_pipeline/inter_stage.spec.ts
@@ -157,8 +157,8 @@ g.test('type')
     const { isAsync, output, input } = t.params;
 
     const descriptor = t.getDescriptorWithStates(
-      t.getVertexStateWithOutputs([`@location(0) @interpolate(flat) vout0: ${output}`]),
-      t.getFragmentStateWithInputs([`@location(0) @interpolate(flat) fin0: ${input}`])
+      t.getVertexStateWithOutputs([`@location(0) @interpolate(flat, either) vout0: ${output}`]),
+      t.getFragmentStateWithInputs([`@location(0) @interpolate(flat, either) fin0: ${input}`])
     );
 
     t.doCreateRenderPipelineTest(isAsync, output === input, descriptor);
@@ -178,8 +178,8 @@ g.test('interpolation_type')
       { output: '', input: '@interpolate(linear)' },
       { output: '@interpolate(perspective)', input: '@interpolate(perspective)' },
       { output: '@interpolate(linear)', input: '@interpolate(perspective)' },
-      { output: '@interpolate(flat)', input: '@interpolate(perspective)' },
-      { output: '@interpolate(linear)', input: '@interpolate(flat)' },
+      { output: '@interpolate(flat, either)', input: '@interpolate(perspective)' },
+      { output: '@interpolate(linear)', input: '@interpolate(flat, either)' },
       {
         output: '@interpolate(linear, center)',
         input: '@interpolate(linear, center)',
@@ -223,7 +223,7 @@ g.test('interpolation_sampling')
         _success: true,
         _compat_success: false,
       },
-      { output: '@interpolate(flat)', input: '@interpolate(flat)' },
+      { output: '@interpolate(flat, either)', input: '@interpolate(flat, either)' },
       { output: '@interpolate(perspective)', input: '@interpolate(perspective, sample)' },
       { output: '@interpolate(perspective, center)', input: '@interpolate(perspective, sample)' },
       {

--- a/src/webgpu/compat/api/validation/shader_module/shader_module.spec.ts
+++ b/src/webgpu/compat/api/validation/shader_module/shader_module.spec.ts
@@ -66,7 +66,7 @@ g.test('interpolate')
   .params(u =>
     u.combineWithParams([
       { success: true, interpolate: '' },
-      { success: true, interpolate: '@interpolate(linear)' },
+      { success: false, interpolate: '@interpolate(linear)' },
       { success: false, interpolate: '@interpolate(linear, sample)' },
       { success: false, interpolate: '@interpolate(perspective, sample)' },
       { success: false, interpolate: '@interpolate(flat)' },

--- a/src/webgpu/constants.ts
+++ b/src/webgpu/constants.ts
@@ -61,7 +61,7 @@ export const GPUConst = {
 export const kMaxUnsignedLongValue = 4294967295;
 export const kMaxUnsignedLongLongValue = Number.MAX_SAFE_INTEGER;
 
-export const kInterpolationSampling = ['center', 'centroid', 'sample'] as const;
+export const kInterpolationSampling = ['center', 'centroid', 'sample', 'first', 'either'] as const;
 export const kInterpolationType = ['perspective', 'linear', 'flat'] as const;
 export type InterpolationType = (typeof kInterpolationType)[number];
 export type InterpolationSampling = (typeof kInterpolationSampling)[number];

--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -294,6 +294,10 @@ export class GPUTestSubcaseBatchState extends SubcaseBatchState {
         sampling === 'sample',
         'interpolation type linear is not supported in compatibility mode'
       );
+      this.skipIf(
+        type === 'flat' && (!sampling || sampling === 'first'),
+        'interpolation type flat with sampling not set to either is not supported in compatibility mode'
+      );
     }
   }
 

--- a/src/webgpu/shader/execution/expression/call/builtin/derivatives.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/derivatives.ts
@@ -70,7 +70,7 @@ export function runDerivativeTest(
   const code = `
 struct CaseInfo {
   @builtin(position) position: vec4f,
-  @location(0) @interpolate(flat) quad_idx: u32,
+  @location(0) @interpolate(flat, either) quad_idx: u32,
 }
 
 @vertex

--- a/src/webgpu/shader/execution/expression/call/builtin/fwidth.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/fwidth.ts
@@ -62,7 +62,7 @@ export function runFWidthTest(
   const code = `
 struct CaseInfo {
   @builtin(position) position: vec4f,
-  @location(0) @interpolate(flat) quad_idx: u32,
+  @location(0) @interpolate(flat, either) quad_idx: u32,
 }
 
 @vertex

--- a/src/webgpu/shader/execution/shader_io/fragment_builtins.spec.ts
+++ b/src/webgpu/shader/execution/shader_io/fragment_builtins.spec.ts
@@ -758,7 +758,8 @@ g.test('inputs,position')
         { type: 'linear', sampling: 'center' },
         { type: 'linear', sampling: 'centroid' },
         { type: 'linear', sampling: 'sample' },
-        { type: 'flat' },
+        { type: 'flat', sampling: 'first' },
+        { type: 'flat', sampling: 'either' },
       ] as const)
   )
   .beforeAllSubcases(t => {
@@ -832,6 +833,8 @@ g.test('inputs,interStage')
   .desc(
     `
     Test fragment shader inter-stage variable values except for centroid interpolation.
+
+    * TODO: Test @interpolation(flat, either)
   `
   )
   .params(u =>
@@ -843,7 +846,7 @@ g.test('inputs,interStage')
         { type: 'perspective', sampling: 'sample' },
         { type: 'linear', sampling: 'center' },
         { type: 'linear', sampling: 'sample' },
-        { type: 'flat' },
+        { type: 'flat', sampling: 'first' },
       ] as const)
   )
   .beforeAllSubcases(t => {
@@ -1062,7 +1065,8 @@ g.test('inputs,sample_index')
         { type: 'linear', sampling: 'center' },
         { type: 'linear', sampling: 'centroid' },
         { type: 'linear', sampling: 'sample' },
-        { type: 'flat' },
+        { type: 'flat', sampling: 'first' },
+        { type: 'flat', sampling: 'either' },
       ] as const)
   )
   .beforeAllSubcases(t => {
@@ -1146,7 +1150,8 @@ g.test('inputs,front_facing')
         { type: 'linear', sampling: 'center' },
         { type: 'linear', sampling: 'centroid' },
         { type: 'linear', sampling: 'sample' },
-        { type: 'flat' },
+        { type: 'flat', sampling: 'first' },
+        { type: 'flat', sampling: 'either' },
       ] as const)
   )
   .beforeAllSubcases(t => {
@@ -1318,7 +1323,8 @@ g.test('inputs,sample_mask')
         { type: 'linear', sampling: 'center' },
         { type: 'linear', sampling: 'centroid' },
         { type: 'linear', sampling: 'sample' },
-        { type: 'flat' },
+        { type: 'flat', sampling: 'first' },
+        { type: 'flat', sampling: 'either' },
       ] as const)
       .beginSubcases()
       .combineWithParams([

--- a/src/webgpu/shader/execution/shader_io/user_io.spec.ts
+++ b/src/webgpu/shader/execution/shader_io/user_io.spec.ts
@@ -18,9 +18,9 @@ function generateInterstagePassthroughCode(type: string): string {
 ${type === 'f16' ? 'enable f16;' : ''}
 struct IOData {
   @builtin(position) pos : vec4f,
-  @location(0) @interpolate(flat) user0 : ${type},
-  @location(1) @interpolate(flat) user1 : vec2<${type}>,
-  @location(2) @interpolate(flat) user2 : vec4<${type}>,
+  @location(0) @interpolate(flat, either) user0 : ${type},
+  @location(1) @interpolate(flat, either) user1 : vec2<${type}>,
+  @location(2) @interpolate(flat, either) user2 : vec4<${type}>,
 }
 
 struct VertexInput {

--- a/src/webgpu/shader/validation/shader_io/builtins.spec.ts
+++ b/src/webgpu/shader/validation/shader_io/builtins.spec.ts
@@ -199,21 +199,25 @@ g.test('duplicates')
   })
   .fn(t => {
     const p1 =
-      t.params.first === 'p1' ? '@builtin(sample_mask)' : '@location(1) @interpolate(flat)';
+      t.params.first === 'p1' ? '@builtin(sample_mask)' : '@location(1) @interpolate(perspective)';
     const p2 =
-      t.params.second === 'p2' ? '@builtin(sample_mask)' : '@location(2) @interpolate(flat)';
+      t.params.second === 'p2' ? '@builtin(sample_mask)' : '@location(2) @interpolate(perspective)';
     const s1a =
-      t.params.first === 's1a' ? '@builtin(sample_mask)' : '@location(3) @interpolate(flat)';
+      t.params.first === 's1a' ? '@builtin(sample_mask)' : '@location(3) @interpolate(perspective)';
     const s1b =
-      t.params.second === 's1b' ? '@builtin(sample_mask)' : '@location(4) @interpolate(flat)';
+      t.params.second === 's1b'
+        ? '@builtin(sample_mask)'
+        : '@location(4) @interpolate(perspective)';
     const s2a =
-      t.params.first === 's2a' ? '@builtin(sample_mask)' : '@location(5) @interpolate(flat)';
+      t.params.first === 's2a' ? '@builtin(sample_mask)' : '@location(5) @interpolate(perspective)';
     const s2b =
-      t.params.second === 's2b' ? '@builtin(sample_mask)' : '@location(6) @interpolate(flat)';
+      t.params.second === 's2b'
+        ? '@builtin(sample_mask)'
+        : '@location(6) @interpolate(perspective)';
     const ra =
-      t.params.first === 'ra' ? '@builtin(sample_mask)' : '@location(1) @interpolate(flat)';
+      t.params.first === 'ra' ? '@builtin(sample_mask)' : '@location(1) @interpolate(perspective)';
     const rb =
-      t.params.second === 'rb' ? '@builtin(sample_mask)' : '@location(2) @interpolate(flat)';
+      t.params.second === 'rb' ? '@builtin(sample_mask)' : '@location(2) @interpolate(perspective)';
     const code = `
     struct S1 {
       ${s1a} a : u32,

--- a/src/webgpu/shader/validation/shader_io/builtins.spec.ts
+++ b/src/webgpu/shader/validation/shader_io/builtins.spec.ts
@@ -199,25 +199,33 @@ g.test('duplicates')
   })
   .fn(t => {
     const p1 =
-      t.params.first === 'p1' ? '@builtin(sample_mask)' : '@location(1) @interpolate(perspective)';
+      t.params.first === 'p1' ? '@builtin(sample_mask)' : '@location(1) @interpolate(flat, either)';
     const p2 =
-      t.params.second === 'p2' ? '@builtin(sample_mask)' : '@location(2) @interpolate(perspective)';
+      t.params.second === 'p2'
+        ? '@builtin(sample_mask)'
+        : '@location(2) @interpolate(flat, either)';
     const s1a =
-      t.params.first === 's1a' ? '@builtin(sample_mask)' : '@location(3) @interpolate(perspective)';
+      t.params.first === 's1a'
+        ? '@builtin(sample_mask)'
+        : '@location(3) @interpolate(flat, either)';
     const s1b =
       t.params.second === 's1b'
         ? '@builtin(sample_mask)'
-        : '@location(4) @interpolate(perspective)';
+        : '@location(4) @interpolate(flat, either)';
     const s2a =
-      t.params.first === 's2a' ? '@builtin(sample_mask)' : '@location(5) @interpolate(perspective)';
+      t.params.first === 's2a'
+        ? '@builtin(sample_mask)'
+        : '@location(5) @interpolate(flat, either)';
     const s2b =
       t.params.second === 's2b'
         ? '@builtin(sample_mask)'
-        : '@location(6) @interpolate(perspective)';
+        : '@location(6) @interpolate(flat, either)';
     const ra =
-      t.params.first === 'ra' ? '@builtin(sample_mask)' : '@location(1) @interpolate(perspective)';
+      t.params.first === 'ra' ? '@builtin(sample_mask)' : '@location(1) @interpolate(flat, either)';
     const rb =
-      t.params.second === 'rb' ? '@builtin(sample_mask)' : '@location(2) @interpolate(perspective)';
+      t.params.second === 'rb'
+        ? '@builtin(sample_mask)'
+        : '@location(2) @interpolate(flat, either)';
     const code = `
     struct S1 {
       ${s1a} a : u32,

--- a/src/webgpu/shader/validation/shader_io/interpolate.spec.ts
+++ b/src/webgpu/shader/validation/shader_io/interpolate.spec.ts
@@ -11,7 +11,7 @@ export const g = makeTestGroup(ShaderValidationTest);
 // List of valid interpolation attributes.
 const kValidCompatInterpolationAttributes = new Set([
   '',
-  '@interpolate(flat)',
+  '@interpolate(flat, either)',
   '@interpolate(perspective)',
   '@interpolate(perspective, center)',
   '@interpolate(perspective, centroid)',
@@ -19,6 +19,8 @@ const kValidCompatInterpolationAttributes = new Set([
 const kValidInterpolationAttributes = new Set([
   ...kValidCompatInterpolationAttributes,
   '@interpolate(flat)',
+  '@interpolate(flat, first)',
+  '@interpolate(flat, either)',
   '@interpolate(perspective)',
   '@interpolate(perspective, center)',
   '@interpolate(perspective, centroid)',
@@ -44,6 +46,8 @@ g.test('type_and_sampling')
         'center', // Invalid as first param
         'centroid', // Invalid as first param
         'sample', // Invalid as first param
+        'first', // Invalid as first param
+        'either', // Invalid as first param
       ] as const)
       // vertex output must include a position builtin, so must use a struct
       .filter(t => !(t.stage === 'vertex' && t.use_struct === false))
@@ -52,6 +56,8 @@ g.test('type_and_sampling')
         'center',
         'centroid',
         'sample',
+        'first',
+        'either',
         'flat', // Invalid as second param
         'perspective', // Invalid as second param
         'linear', // Invalid as second param
@@ -153,7 +159,7 @@ g.test('duplicate')
 
 const kValidationTests = {
   valid: {
-    src: `@interpolate(flat)`,
+    src: `@interpolate(perspective)`,
     pass: true,
   },
   no_space: {
@@ -169,11 +175,11 @@ const kValidationTests = {
     pass: true,
   },
   newline: {
-    src: '@\ninterpolate(flat)',
+    src: '@\ninterpolate(perspective)',
     pass: true,
   },
   comment: {
-    src: `@/* comment */interpolate(flat)`,
+    src: `@/* comment */interpolate(perspective)`,
     pass: true,
   },
 
@@ -182,7 +188,7 @@ const kValidationTests = {
     pass: false,
   },
   missing_left_paren: {
-    src: `@interpolate flat)`,
+    src: `@interpolate perspective)`,
     pass: false,
   },
   missing_value_and_left_paren: {
@@ -190,7 +196,7 @@ const kValidationTests = {
     pass: false,
   },
   missing_right_paren: {
-    src: `@interpolate(flat`,
+    src: `@interpolate(perspective`,
     pass: false,
   },
   missing_parens: {

--- a/src/webgpu/shader/validation/shader_io/locations.spec.ts
+++ b/src/webgpu/shader/validation/shader_io/locations.spec.ts
@@ -163,7 +163,7 @@ g.test('type')
     }
 
     code += generateShader({
-      attribute: '@location(0) @interpolate(perspective)',
+      attribute: '@location(0) @interpolate(flat, either)',
       type: t.params.type,
       stage: 'fragment',
       io: 'in',

--- a/src/webgpu/shader/validation/shader_io/locations.spec.ts
+++ b/src/webgpu/shader/validation/shader_io/locations.spec.ts
@@ -163,7 +163,7 @@ g.test('type')
     }
 
     code += generateShader({
-      attribute: '@location(0) @interpolate(flat)',
+      attribute: '@location(0) @interpolate(perspective)',
       type: t.params.type,
       stage: 'fragment',
       io: 'in',


### PR DESCRIPTION
These tests need `@interpolate(flat, either)` to be able to run on compat mode.

Note that they will all start failing on core if core is missing support for `'either'` sampling.

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [X] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
