### PR TITLE
Set document.title to query in standalone CTS

### DIFF
--- a/src/common/runtime/standalone.ts
+++ b/src/common/runtime/standalone.ts
@@ -676,6 +676,8 @@ void (async () => {
     return;
   }
 
+  document.title = `${document.title} ${compatibility ? '(compat)' : ''} - ${rootQuery.toString()}`;
+
   tree.dissolveSingleChildTrees();
 
   const { runSubtree, generateSubtreeHTML } = makeSubtreeHTML(tree.root, 1);


### PR DESCRIPTION
This means history, like long pressing on the back button, will show preivous tests vs now where they all just say 'WebGPU CTS'


