### PR TITLE
Expand context dependent name test to include flat sampling

### DIFF
--- a/src/webgpu/listing_meta.json
+++ b/src/webgpu/listing_meta.json
@@ -1911,6 +1911,7 @@
   "webgpu:shader,validation,decl,context_dependent_resolution:diagnostic_rule_names:*": { "subcaseMS": 6.860 },
   "webgpu:shader,validation,decl,context_dependent_resolution:diagnostic_severity_names:*": { "subcaseMS": 6.252 },
   "webgpu:shader,validation,decl,context_dependent_resolution:enable_names:*": { "subcaseMS": 2.226 },
+  "webgpu:shader,validation,decl,context_dependent_resolution:interpolation_flat_names:*": { "subcaseMS": 4.425 },
   "webgpu:shader,validation,decl,context_dependent_resolution:interpolation_sampling_names:*": { "subcaseMS": 4.971 },
   "webgpu:shader,validation,decl,context_dependent_resolution:interpolation_type_names:*": { "subcaseMS": 4.687 },
   "webgpu:shader,validation,decl,context_dependent_resolution:language_names:*": { "subcaseMS": 4.920 },

--- a/src/webgpu/shader/validation/decl/context_dependent_resolution.spec.ts
+++ b/src/webgpu/shader/validation/decl/context_dependent_resolution.spec.ts
@@ -339,7 +339,6 @@ g.test('interpolation_sampling_names')
 
 const kInterpolationFlatCases = ['first', 'either'] as const;
 
-
 g.test('interpolation_flat_names')
   .desc('Tests interpolation type names do not use name resolution')
   .params(u =>

--- a/src/webgpu/shader/validation/decl/context_dependent_resolution.spec.ts
+++ b/src/webgpu/shader/validation/decl/context_dependent_resolution.spec.ts
@@ -336,3 +336,26 @@ g.test('interpolation_sampling_names')
 
     t.expectCompileResult(true, code);
   });
+
+const kInterpolationFlatCases = ['first', 'either'] as const;
+
+
+g.test('interpolation_flat_names')
+  .desc('Tests interpolation type names do not use name resolution')
+  .params(u =>
+    u
+      .combine('case', kInterpolationFlatCases)
+      .beginSubcases()
+      .combine('decl', ['override', 'const', 'var<private>'] as const)
+  )
+  .fn(t => {
+    const code = `
+    ${t.params.decl} ${t.params.case} : u32 = 0;
+    @fragment fn main(@location(0) @interpolate(flat, ${t.params.case}) x : u32) { }
+    fn use_var() -> u32 {
+      return ${t.params.case};
+    }
+    `;
+
+    t.expectCompileResult(true, code);
+  });


### PR DESCRIPTION
Contributes to #3818

* Add tests that `first` and `either` in interpolation do not use name resolution




Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [ ] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [ ] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [ ] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
