### PR TITLE
Add overflow cases for left shift of abstract int

### DIFF
--- a/src/webgpu/shader/validation/expression/binary/bitwise_shift.spec.ts
+++ b/src/webgpu/shader/validation/expression/binary/bitwise_shift.spec.ts
@@ -204,6 +204,15 @@ const kLeftShiftCases = [
   { lhs: `1`, rhs: `-1`, pass: false },
   { lhs: `1i`, rhs: `-1`, pass: false },
   { lhs: `1u`, rhs: `-1`, pass: false },
+
+  // Signed overflow (sign change) for abstract
+  { lhs: `1`, rhs: `63`, pass: false },
+  { lhs: `2`, rhs: `62`, pass: false },
+  {
+    lhs: `${0b0100000000000000000000000000000000000000000000000000000000000000}`,
+    rhs: `1u`,
+    pass: false,
+  },
 ];
 
 g.test('shift_left_concrete')


### PR DESCRIPTION
Fixes #1631

* Add cases to cover overflow of abstract int left shift




Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [ ] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [ ] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [ ] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
