### PR TITLE
compat: fix more flat either issues

### DIFF
--- a/src/webgpu/shader/validation/decl/context_dependent_resolution.spec.ts
+++ b/src/webgpu/shader/validation/decl/context_dependent_resolution.spec.ts
@@ -28,7 +28,7 @@ const kAttributeCases = {
   // diagnostic is a keyword
   group: `@group(0) @binding(0) var s : sampler;`,
   id: `@id(1) override x : i32;`,
-  interpolate: `@fragment fn main(@location(0) @interpolate(flat) x : i32) { }`,
+  interpolate: `@fragment fn main(@location(0) @interpolate(flat, either) x : i32) { }`,
   invariant: `@fragment fn main(@builtin(position) @invariant pos : vec4f) { }`,
   location: `@fragment fn main(@location(0) x : f32) { }`,
   must_use: `@must_use fn foo() -> u32 { return 0; }`,
@@ -102,6 +102,17 @@ g.test('builtin_value_names')
       .beginSubcases()
       .combine('decl', ['override', 'const', 'var<private>'] as const)
   )
+  .beforeAllSubcases(t => {
+    const wgsl = kBuiltinCases[t.params.case];
+    t.skipIf(
+      t.isCompatibility && wgsl.includes('sample_mask'),
+      'sample_mask is not supported in compatibility mode'
+    );
+    t.skipIf(
+      t.isCompatibility && wgsl.includes('sample_index'),
+      'sample_index is not supported in compatibility mode'
+    );
+  })
   .fn(t => {
     const code = `
     ${t.params.decl} ${t.params.case} : u32 = 0;
@@ -325,6 +336,12 @@ g.test('interpolation_sampling_names')
       .beginSubcases()
       .combine('decl', ['override', 'const', 'var<private>'] as const)
   )
+  .beforeAllSubcases(t => {
+    t.skipIf(
+      t.isCompatibility && t.params.case === 'sample',
+      'compatibility mode does not support sample sampling'
+    );
+  })
   .fn(t => {
     const code = `
     ${t.params.decl} ${t.params.case} : u32 = 0;
@@ -347,6 +364,12 @@ g.test('interpolation_flat_names')
       .beginSubcases()
       .combine('decl', ['override', 'const', 'var<private>'] as const)
   )
+  .beforeAllSubcases(t => {
+    t.skipIf(
+      t.isCompatibility && t.params.case === 'first',
+      'compatibility mode does not support first sampling'
+    );
+  })
   .fn(t => {
     const code = `
     ${t.params.decl} ${t.params.case} : u32 = 0;


### PR DESCRIPTION

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [X] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
