### PR TITLE
Add validation tests on the types of `blend_src(0)` and `blend_src(1)`

### DIFF
--- a/src/webgpu/shader/validation/extension/dual_source_blending.spec.ts
+++ b/src/webgpu/shader/validation/extension/dual_source_blending.spec.ts
@@ -560,3 +560,64 @@ ${
 `;
     t.expectCompileResult(kUsageValidationTests[t.params.attr].pass, code);
   });
+
+const kValidLocationTypes = [
+  'f16',
+  'f32',
+  'i32',
+  'u32',
+  'vec2h',
+  'vec2f',
+  'vec2i',
+  'vec2u',
+  'vec3h',
+  'vec3f',
+  'vec3i',
+  'vec3u',
+  'vec4h',
+  'vec4f',
+  'vec4i',
+  'vec4u',
+] as const;
+
+const kF16TypesSet = new Set(['f16', 'vec2h', 'vec3h', 'vec4h']);
+
+g.test('blend_src_same_type')
+  .desc(`Test that the struct member with @blend_src(0) and @blend_src(1) must have same type.`)
+  .params(u =>
+    u.combine('blendSrc0Type', kValidLocationTypes).combine('blendSrc1Type', kValidLocationTypes)
+  )
+  .beforeAllSubcases(t => {
+    const requiredFeatures: GPUFeatureName[] = ['dual-source-blending'];
+    const needF16Extension =
+      kF16TypesSet.has(t.params.blendSrc0Type) || kF16TypesSet.has(t.params.blendSrc1Type);
+    if (needF16Extension) {
+      requiredFeatures.push('shader-f16');
+    }
+    t.selectDeviceOrSkipTestCase({ requiredFeatures });
+  })
+  .fn(t => {
+    const { blendSrc0Type, blendSrc1Type } = t.params;
+
+    const needF16Extension = kF16TypesSet.has(blendSrc0Type) || kF16TypesSet.has(blendSrc1Type);
+    const code = `
+enable dual_source_blending;
+
+${needF16Extension ? 'enable f16;' : ''}
+
+struct BlendSrcOutput {
+  @location(0) @blend_src(0) color : ${blendSrc0Type},
+  @location(0) @blend_src(1) blend : ${blendSrc1Type},
+}
+
+@fragment fn main() -> BlendSrcOutput {
+  var output : BlendSrcOutput;
+  output.color = ${blendSrc0Type}();
+  output.blend = ${blendSrc1Type}();
+  return output;
+}
+`;
+
+    const success = blendSrc0Type === blendSrc1Type;
+    t.expectCompileResult(success, code);
+  });


### PR DESCRIPTION
This patch adds shader validation tests to verify the type of the struct member with `@blend_src(0)` is equal to the one with `@blend_src(1)` in one struct.




Issue: #3810

<hr>

**Requirements for PR author:**

- [*] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [*] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [*] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [*] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
