### PR TITLE
Fix type costruction of RHS in storage_rw compoundAssignmentBuilder

### DIFF
--- a/src/webgpu/shader/execution/expression/expression.ts
+++ b/src/webgpu/shader/execution/expression/expression.ts
@@ -870,7 +870,7 @@ ${body}
       if (inputSource === 'storage_rw') {
         operation = `
         outputs[i].value = ${storageType(resultType)}(inputs[i].lhs);
-        outputs[i].value ${op} ${storageType(resultType)}(inputs[i].rhs);`;
+        outputs[i].value ${op} ${rhsType}(inputs[i].rhs);`;
       } else {
         operation = `
         var ret = ${lhsType}(inputs[i].lhs);


### PR DESCRIPTION
Fixed: #3842




Issue: #3842
<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
