### PR TITLE
Fix compound assignment storage_rw when resultType != storage(resultT…

### DIFF
--- a/src/webgpu/shader/execution/expression/expression.ts
+++ b/src/webgpu/shader/execution/expression/expression.ts
@@ -867,7 +867,7 @@ ${body}
       // Runtime eval
       //////////////////////////////////////////////////////////////////////////
       let operation = '';
-      if (inputSource === 'storage_rw') {
+      if (inputSource === 'storage_rw' && objectEquals(resultType, storageType(resultType))) {
         operation = `
         outputs[i].value = ${storageType(resultType)}(inputs[i].lhs);
         outputs[i].value ${op} ${rhsType}(inputs[i].rhs);`;


### PR DESCRIPTION
…ype)

In the storage_rw case, when the result type is not the same as storage(result type) then generate the full expansion (stylistically):

     var ret = LHSType(LHS);
     ret {op}= RHSType(RHS);
     outputs.value = ret;

instead of:

     outputs.value = {storageType}(LHS);
     outputs.value {op}= ret;

This situation occurs when the value type is bool or bool-vec. In that case the result type is u32, and there are no mixed overloads for & and | such as:

   u32 & bool
   u32 | bool

Fixes: #3845




Issue: #3845

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
