### PR TITLE
Skip some context_dependent_resolution cases

### DIFF
--- a/src/webgpu/shader/validation/decl/context_dependent_resolution.spec.ts
+++ b/src/webgpu/shader/validation/decl/context_dependent_resolution.spec.ts
@@ -102,6 +102,12 @@ g.test('builtin_value_names')
       .beginSubcases()
       .combine('decl', ['override', 'const', 'var<private>'] as const)
   )
+  .beforeAllSubcases(t => {
+    t.skipIf(
+      t.isCompatibility && ['sample_index', 'sample_mask_input', 'sample_mask_output'].includes(t.params.case),
+      'compatibility mode does not support sample_index or sample_mask'
+    );
+  })
   .fn(t => {
     const code = `
     ${t.params.decl} ${t.params.case} : u32 = 0;


### PR DESCRIPTION
These cases of builtin value names are not supported in compatibility mode and should be skipped.

This is necessary for the implementation of condext dependent builtin values in Tint: https://dawn-review.googlesource.com/c/dawn/+/197477/

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
