### PR TITLE
[compat] Fix or skip context dependent res cases

### DIFF
--- a/src/webgpu/shader/validation/decl/context_dependent_resolution.spec.ts
+++ b/src/webgpu/shader/validation/decl/context_dependent_resolution.spec.ts
@@ -314,10 +314,20 @@ g.test('interpolation_type_names')
       .beginSubcases()
       .combine('decl', ['override', 'const', 'var<private>'] as const)
   )
+  .beforeAllSubcases(t => {
+    t.skipIf(
+      t.isCompatibility && t.params.case === 'linear',
+      'compatibility mode does not support linear interpolation type'
+    );
+  })
   .fn(t => {
+    const attr =
+      t.isCompatibility && t.params.case === 'flat'
+        ? `@interpolate(flat, either)`
+        : `@interpolate(${t.params.case})`;
     const code = `
     ${t.params.decl} ${t.params.case} : u32 = 0;
-    @fragment fn main(@location(0) @interpolate(${t.params.case}) x : f32) { }
+    @fragment fn main(@location(0) ${attr} x : f32) { }
     fn use_var() -> u32 {
       return ${t.params.case};
     }


### PR DESCRIPTION
These tests should pass in Tint following the implementation of context dependent resolution of the interpolate attribute, but there are a couple cases that need fixing or skipping in compat mode.

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
