### PR TITLE
WGSL textureLoad exe tests 1d, 3d, and arrayed

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/textureLoad.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureLoad.spec.ts
@@ -25,6 +25,8 @@ import {
   isDepthTextureFormat,
   kCompressedTextureFormats,
   kEncodableTextureFormats,
+  kTextureFormatInfo,
+  textureDimensionAndFormatCompatible,
 } from '../../../../../format_info.js';
 import { GPUTest } from '../../../../../gpu_test.js';
 import {
@@ -34,6 +36,7 @@ import {
   pack4x8unorm,
   pack4x8snorm,
 } from '../../../../../util/conversion.js';
+import { maxMipLevelCount } from '../../../../../util/texture/base.js';
 import { TexelFormats } from '../../../../types.js';
 
 import {
@@ -44,14 +47,19 @@ import {
   doTextureCalls,
   appendComponentTypeForFormatToTextureType,
   vec2,
+  vec1,
+  vec3,
 } from './texture_utils.js';
 import {
   Boundary,
+  LayerSpec,
   LevelSpec,
   generateCoordBoundaries,
   getCoordinateForBoundaries,
+  getLayerFromLayerSpec,
   getMipLevelFromLevelSpec,
   isBoundaryNegative,
+  isLayerSpecNegative,
   isLevelSpecNegative,
 } from './utils.js';
 
@@ -65,8 +73,14 @@ function filterOutU32WithNegativeValues(t: {
   C: 'i32' | 'u32';
   level: LevelSpec;
   coordsBoundary: Boundary;
+  array_index?: LayerSpec;
 }) {
-  return t.C === 'i32' || (!isLevelSpecNegative(t.level) && !isBoundaryNegative(t.coordsBoundary));
+  return (
+    t.C === 'i32' ||
+    (!isLevelSpecNegative(t.level) &&
+      !isBoundaryNegative(t.coordsBoundary) &&
+      !isLayerSpecNegative(t.array_index ?? 0))
+  );
 }
 
 export const g = makeTestGroup(GPUTest);
@@ -87,11 +101,64 @@ Parameters:
   )
   .params(u =>
     u
+      .combine('format', kTestableColorFormats)
+      .filter(t => textureDimensionAndFormatCompatible('1d', t.format))
+      // 1d textures can't have a height !== 1
+      .filter(t => kTextureFormatInfo[t.format].blockHeight === 1)
+      .beginSubcases()
       .combine('C', ['i32', 'u32'] as const)
-      .combine('coords', generateCoordBoundaries(1))
-      .combine('level', [-1, 0, `numlevels-1`, `numlevels`] as const)
+      .combine('L', ['i32', 'u32'] as const)
+      .combine('coordsBoundary', generateCoordBoundaries(1))
+      .combine('level', [-1, 0, `numLevels-1`, `numLevels`] as const)
+      // Only test level out of bounds if coordBoundary is in-bounds
+      .filter(t => !(t.level !== 0 && t.coordsBoundary !== 'in-bounds'))
+      .filter(filterOutU32WithNegativeValues)
   )
-  .unimplemented();
+  .beforeAllSubcases(t => {
+    const { format } = t.params;
+    t.skipIfTextureFormatNotSupported(format);
+    t.selectDeviceForTextureFormatOrSkipTestCase(t.params.format);
+  })
+  .fn(async t => {
+    const { format, C, L, coordsBoundary, level } = t.params;
+
+    // We want at least 4 blocks or something wide enough for 3 mip levels.
+    const [width] = chooseTextureSize({ minSize: 8, minBlocks: 4, format });
+    const size = [width, 1];
+
+    const descriptor: GPUTextureDescriptor = {
+      format,
+      dimension: '1d',
+      size,
+      usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+    };
+    const { texels, texture } = await createTextureWithRandomDataAndGetTexels(t, descriptor);
+    const mipLevel = getMipLevelFromLevelSpec(texture.mipLevelCount, level);
+    const coords = getCoordinateForBoundaries<vec1>(texture, mipLevel, coordsBoundary);
+
+    const calls: TextureCall<vec1>[] = [
+      {
+        builtin: 'textureLoad',
+        coordType: C === 'i32' ? 'i' : 'u',
+        levelType: L === 'i32' ? 'i' : 'u',
+        mipLevel,
+        coords,
+      },
+    ];
+    const textureType = appendComponentTypeForFormatToTextureType('texture_1d', texture.format);
+    const viewDescriptor = {};
+    const sampler = undefined;
+    const results = await doTextureCalls(t, texture, viewDescriptor, textureType, sampler, calls);
+    const res = await checkCallResults(
+      t,
+      { texels, descriptor, viewDescriptor },
+      textureType,
+      sampler,
+      calls,
+      results
+    );
+    t.expectOK(res);
+  });
 
 g.test('sampled_2d')
   .specURL('https://www.w3.org/TR/WGSL/#textureload')
@@ -117,6 +184,8 @@ Parameters:
       .combine('L', ['i32', 'u32'] as const)
       .combine('coordsBoundary', generateCoordBoundaries(2))
       .combine('level', [-1, 0, `numLevels-1`, `numLevels`] as const)
+      // Only test level out of bounds if coordBoundary is in-bounds
+      .filter(t => !(t.level !== 0 && t.coordsBoundary !== 'in-bounds'))
       .filter(filterOutU32WithNegativeValues)
   )
   .beforeAllSubcases(t => {
@@ -128,12 +197,13 @@ Parameters:
     const { format, C, L, coordsBoundary, level } = t.params;
 
     // We want at least 4 blocks or something wide enough for 3 mip levels.
-    const [width, height] = chooseTextureSize({ minSize: 8, minBlocks: 4, format });
+    const size = chooseTextureSize({ minSize: 8, minBlocks: 4, format });
 
     const descriptor: GPUTextureDescriptor = {
       format,
-      size: { width, height },
+      size,
       usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+      mipLevelCount: maxMipLevelCount({ size }),
     };
     const { texels, texture } = await createTextureWithRandomDataAndGetTexels(t, descriptor);
     const mipLevel = getMipLevelFromLevelSpec(texture.mipLevelCount, level);
@@ -179,11 +249,62 @@ Parameters:
   )
   .params(u =>
     u
+      .combine('format', kTestableColorFormats)
+      .filter(t => textureDimensionAndFormatCompatible('3d', t.format))
+      .beginSubcases()
       .combine('C', ['i32', 'u32'] as const)
-      .combine('coords', generateCoordBoundaries(3))
+      .combine('L', ['i32', 'u32'] as const)
+      .combine('coordsBoundary', generateCoordBoundaries(3))
       .combine('level', [-1, 0, `numLevels-1`, `numLevels`] as const)
+      // Only test level out of bounds if coordBoundary is in-bounds
+      .filter(t => !(t.level !== 0 && t.coordsBoundary !== 'in-bounds'))
+      .filter(filterOutU32WithNegativeValues)
   )
-  .unimplemented();
+  .beforeAllSubcases(t => {
+    const { format } = t.params;
+    t.skipIfTextureFormatNotSupported(format);
+    t.selectDeviceForTextureFormatOrSkipTestCase(t.params.format);
+  })
+  .fn(async t => {
+    const { format, C, L, coordsBoundary, level } = t.params;
+
+    // We want at least 4 blocks or something wide enough for 3 mip levels.
+    const size = chooseTextureSize({ minSize: 8, minBlocks: 4, format, viewDimension: '3d' });
+
+    const descriptor: GPUTextureDescriptor = {
+      format,
+      dimension: '3d',
+      size,
+      usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+      mipLevelCount: maxMipLevelCount({ size }),
+    };
+    const { texels, texture } = await createTextureWithRandomDataAndGetTexels(t, descriptor);
+    const mipLevel = getMipLevelFromLevelSpec(texture.mipLevelCount, level);
+    const coords = getCoordinateForBoundaries<vec3>(texture, mipLevel, coordsBoundary);
+
+    const calls: TextureCall<vec3>[] = [
+      {
+        builtin: 'textureLoad',
+        coordType: C === 'i32' ? 'i' : 'u',
+        levelType: L === 'i32' ? 'i' : 'u',
+        mipLevel,
+        coords,
+      },
+    ];
+    const textureType = appendComponentTypeForFormatToTextureType('texture_3d', texture.format);
+    const viewDescriptor = {};
+    const sampler = undefined;
+    const results = await doTextureCalls(t, texture, viewDescriptor, textureType, sampler, calls);
+    const res = await checkCallResults(
+      t,
+      { texels, descriptor, viewDescriptor },
+      textureType,
+      sampler,
+      calls,
+      results
+    );
+    t.expectOK(res);
+  });
 
 g.test('multisampled')
   .specURL('https://www.w3.org/TR/WGSL/#textureload')
@@ -259,8 +380,8 @@ g.test('arrayed')
     `
 C is i32 or u32
 
-fn textureLoad(t: texture_2d_array<T>, coords: vec2<C>, array_index: C, level: C) -> vec4<T>
-fn textureLoad(t: texture_depth_2d_array, coords: vec2<C>, array_index: C, level: C) -> f32
+fn textureLoad(t: texture_2d_array<T>, coords: vec2<C>, array_index: A, level: L) -> vec4<T>
+fn textureLoad(t: texture_depth_2d_array, coords: vec2<C>, array_index: A, level: L) -> f32
 
 Parameters:
  * t: The sampled texture to read from
@@ -271,14 +392,73 @@ Parameters:
   )
   .params(u =>
     u
+      .combine('format', kTestableColorFormats)
+      // MAINTENANCE_TODO: Update createTextureFromTexelViews to support depth32float and remove this filter.
+      .filter(t => t.format !== 'depth32float' && !isCompressedFloatTextureFormat(t.format))
       .combine('texture_type', ['texture_2d_array', 'texture_depth_2d_array'] as const)
+      .filter(
+        t => !(t.texture_type === 'texture_depth_2d_array' && !isDepthTextureFormat(t.format))
+      )
       .beginSubcases()
       .combine('C', ['i32', 'u32'] as const)
-      .combine('coords', generateCoordBoundaries(2))
-      .combine('array_index', [-1, 0, `numlayers-1`, `numlayers`] as const)
+      .combine('A', ['i32', 'u32'] as const)
+      .combine('L', ['i32', 'u32'] as const)
+      .combine('coordsBoundary', generateCoordBoundaries(3))
+      .combine('array_index', [-1, 0, `numLayers-1`, `numLayers`] as const)
+      // Only test array_index out of bounds if coordBoundary is in bounds
+      .filter(t => !(t.array_index !== 0 && t.coordsBoundary !== 'in-bounds'))
       .combine('level', [-1, 0, `numLevels-1`, `numLevels`] as const)
+      // Only test level out of bounds if coordBoundary and array_index are in bounds
+      .filter(t => !(t.level !== 0 && (t.coordsBoundary !== 'in-bounds' || t.array_index !== 0)))
+      .filter(filterOutU32WithNegativeValues)
   )
-  .unimplemented();
+  .beforeAllSubcases(t => {
+    const { format } = t.params;
+    t.skipIfTextureFormatNotSupported(format);
+    t.selectDeviceForTextureFormatOrSkipTestCase(t.params.format);
+  })
+  .fn(async t => {
+    const { texture_type, format, C, A, L, coordsBoundary, level, array_index } = t.params;
+
+    // We want at least 4 blocks or something wide enough for 3 mip levels.
+    const size = chooseTextureSize({ minSize: 8, minBlocks: 4, format, viewDimension: '3d' });
+
+    const descriptor: GPUTextureDescriptor = {
+      format,
+      size,
+      usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+      mipLevelCount: maxMipLevelCount({ size }),
+    };
+    const { texels, texture } = await createTextureWithRandomDataAndGetTexels(t, descriptor);
+    const mipLevel = getMipLevelFromLevelSpec(texture.mipLevelCount, level);
+    const arrayIndex = getLayerFromLayerSpec(texture.depthOrArrayLayers, array_index);
+    const coords = getCoordinateForBoundaries<vec2>(texture, mipLevel, coordsBoundary);
+
+    const calls: TextureCall<vec2>[] = [
+      {
+        builtin: 'textureLoad',
+        coordType: C === 'i32' ? 'i' : 'u',
+        levelType: L === 'i32' ? 'i' : 'u',
+        arrayIndexType: A === 'i32' ? 'i' : 'u',
+        arrayIndex,
+        mipLevel,
+        coords,
+      },
+    ];
+    const textureType = appendComponentTypeForFormatToTextureType(texture_type, texture.format);
+    const viewDescriptor = {};
+    const sampler = undefined;
+    const results = await doTextureCalls(t, texture, viewDescriptor, textureType, sampler, calls);
+    const res = await checkCallResults(
+      t,
+      { texels, descriptor, viewDescriptor },
+      textureType,
+      sampler,
+      calls,
+      results
+    );
+    t.expectOK(res);
+  });
 
 // Returns texel values to use as inputs for textureLoad.
 // Values are kept simple to avoid rounding issues.

--- a/src/webgpu/shader/execution/expression/call/builtin/utils.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/utils.ts
@@ -67,6 +67,27 @@ export function isLevelSpecNegative(levelSpec: LevelSpec) {
   return levelSpec === -1;
 }
 
+export type LayerSpec = -1 | 0 | 'numLayers-1' | 'numLayers';
+
+export function getLayerFromLayerSpec(arrayLayerCount: number, layerSpec: LayerSpec): number {
+  switch (layerSpec) {
+    case -1:
+      return -1;
+    case 0:
+      return 0;
+    case 'numLayers':
+      return arrayLayerCount;
+    case 'numLayers-1':
+      return arrayLayerCount - 1;
+    default:
+      unreachable();
+  }
+}
+
+export function isLayerSpecNegative(layerSpec: LayerSpec) {
+  return layerSpec === -1;
+}
+
 function getCoordForSize(size: [number, number, number], boundary: Boundary) {
   const coord = size.map(v => Math.floor(v / 2));
   switch (boundary) {


### PR DESCRIPTION
<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [X] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
