### PR TITLE
Add CTS test for new depthBias validation

### DIFF
--- a/src/webgpu/api/validation/render_pipeline/depth_stencil_state.spec.ts
+++ b/src/webgpu/api/validation/render_pipeline/depth_stencil_state.spec.ts
@@ -218,9 +218,15 @@ g.test('depth_bias')
       .beginSubcases()
       .combineWithParams([
         {},
-        ...u.combine('depthBias', [-1, 0, 1]),
-        ...u.combine('depthBiasSlopeScale', [-1, 0, 1]),
-        ...u.combine('depthBiasClamp', [-1, 0, 1]),
+        { depthBias: -1 },
+        { depthBias: 0 },
+        { depthBias: 1 },
+        { depthBiasSlopeScale: -1 },
+        { depthBiasSlopeScale: 0 },
+        { depthBiasSlopeScale: 1 },
+        { depthBiasClamp: -1 },
+        { depthBiasClamp: 0 },
+        { depthBiasClamp: 1 },
       ])
   )
   .fn(t => {

--- a/src/webgpu/api/validation/render_pipeline/depth_stencil_state.spec.ts
+++ b/src/webgpu/api/validation/render_pipeline/depth_stencil_state.spec.ts
@@ -4,7 +4,11 @@ This test dedicatedly tests validation of GPUDepthStencilState of createRenderPi
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { unreachable } from '../../../../common/util/util.js';
-import { kCompareFunctions, kPrimitiveTopology, kStencilOperations } from '../../../capability_info.js';
+import {
+  kCompareFunctions,
+  kPrimitiveTopology,
+  kStencilOperations,
+} from '../../../capability_info.js';
 import {
   kAllTextureFormats,
   kTextureFormatInfo,
@@ -206,9 +210,7 @@ g.test('depth_write,frag_depth')
   });
 
 g.test('depth_bias')
-  .desc(
-    `Depth bias parameters are only valid with triangle topologies.`
-  )
+  .desc(`Depth bias parameters are only valid with triangle topologies.`)
   .params(u =>
     u
       .combine('isAsync', [false, true])
@@ -221,7 +223,7 @@ g.test('depth_bias')
   .fn(t => {
     const { isAsync, topology, depthBias, depthBiasSlopeScale, depthBiasClamp } = t.params;
 
-    const isTriangleTopology = topology == 'triangle-list' || topology == 'triangle-strip';
+    const isTriangleTopology = topology === 'triangle-list' || topology === 'triangle-strip';
     const hasDepthBias = !!depthBias || !!depthBiasSlopeScale || !!depthBiasClamp;
 
     const descriptor = t.getDescriptor({
@@ -230,7 +232,9 @@ g.test('depth_bias')
         format: 'depth24plus',
         depthWriteEnabled: true,
         depthCompare: 'less-equal',
-        depthBias, depthBiasSlopeScale, depthBiasClamp
+        depthBias,
+        depthBiasSlopeScale,
+        depthBiasClamp,
       },
     });
     t.doCreateRenderPipelineTest(isAsync, !hasDepthBias || isTriangleTopology, descriptor);

--- a/src/webgpu/api/validation/render_pipeline/depth_stencil_state.spec.ts
+++ b/src/webgpu/api/validation/render_pipeline/depth_stencil_state.spec.ts
@@ -216,15 +216,19 @@ g.test('depth_bias')
       .combine('isAsync', [false, true])
       .combine('topology', kPrimitiveTopology)
       .beginSubcases()
-      .combine('depthBias', [undefined, 0, 1])
-      .combine('depthBiasSlopeScale', [undefined, 0, 1])
-      .combine('depthBiasClamp', [undefined, 0, 1])
+      .combineWithParams([
+        {},
+        ...u.combine('depthBias', [-1, 0, 1]),
+        ...u.combine('depthBiasSlopeScale', [-1, 0, 1]),
+        ...u.combine('depthBiasClamp', [-1, 0, 1]),
+      ])
   )
   .fn(t => {
     const { isAsync, topology, depthBias, depthBiasSlopeScale, depthBiasClamp } = t.params;
 
     const isTriangleTopology = topology === 'triangle-list' || topology === 'triangle-strip';
     const hasDepthBias = !!depthBias || !!depthBiasSlopeScale || !!depthBiasClamp;
+    const shouldSucceed = !hasDepthBias || isTriangleTopology;
 
     const descriptor = t.getDescriptor({
       primitive: { topology },
@@ -237,7 +241,7 @@ g.test('depth_bias')
         depthBiasClamp,
       },
     });
-    t.doCreateRenderPipelineTest(isAsync, !hasDepthBias || isTriangleTopology, descriptor);
+    t.doCreateRenderPipelineTest(isAsync, shouldSucceed, descriptor);
   });
 
 g.test('stencil_test')


### PR DESCRIPTION
Adds tests for the new depthBias validation added in https://github.com/gpuweb/gpuweb/pull/4743. Does not succeed on any browsers yet, but will succeed on Chrome once the deprecation period has passed.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [ ] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
