### PR TITLE
Correct expectation for shift equal to bit width

### DIFF
--- a/src/webgpu/shader/validation/expression/binary/bitwise_shift.spec.ts
+++ b/src/webgpu/shader/validation/expression/binary/bitwise_shift.spec.ts
@@ -298,14 +298,14 @@ g.test('shift_right_abstract')
   });
 
 g.test('partial_eval_errors')
-  .desc('Tests partial evaluation errors for left shift')
+  .desc('Tests partial evaluation errors for left and right shift')
   .params(u =>
     u
       .combine('op', ['<<', '>>'] as const)
       .combine('type', ['i32', 'u32'] as const)
       .beginSubcases()
       .combine('stage', ['shader', 'pipeline'] as const)
-      .combine('value', [32, 33, 64] as const)
+      .combine('value', [31, 32, 33, 64] as const)
   )
   .fn(t => {
     const u32 = Type.u32;
@@ -320,7 +320,7 @@ fn foo() {
   let tmp = v ${t.params.op} ${rhs};
 }`;
 
-    const expect = t.params.value <= 32;
+    const expect = t.params.value < 32;
     if (t.params.stage === 'shader') {
       t.expectCompileResult(expect, wgsl);
     } else {

--- a/src/webgpu/shader/validation/expression/binary/bitwise_shift.spec.ts
+++ b/src/webgpu/shader/validation/expression/binary/bitwise_shift.spec.ts
@@ -315,9 +315,9 @@ g.test('partial_eval_errors')
     }
     const wgsl = `
 override o = 0u;
-fn foo() {
+fn foo() -> ${t.params.type} {
   var v : ${t.params.type} = 0;
-  let tmp = v ${t.params.op} ${rhs};
+  return v ${t.params.op} ${rhs};
 }`;
 
     const expect = t.params.value < 32;
@@ -330,7 +330,7 @@ fn foo() {
         expectedResult: expect,
         code: wgsl,
         constants,
-        reference: ['o'],
+        reference: ['o', 'foo()'],
       });
     }
   });


### PR DESCRIPTION
It is a shader/pipeline-creation error if the number of bits to shift is greater than *or equal to* the bit width of the value to shift. This change corrects the expectations for the equals case, and adds a function reference to the pipeline subcase so it isn't stripped out.

These tests will pass in Dawn following: https://dawn-review.googlesource.com/c/dawn/+/199075

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
