### PR TITLE
generateTypes: Avoid generating test case with invalid alignment

### DIFF
--- a/src/webgpu/shader/execution/robust_access.spec.ts
+++ b/src/webgpu/shader/execution/robust_access.spec.ts
@@ -199,13 +199,6 @@ g.test('linear_memory')
     assert(_kTypeInfo !== undefined, 'not an indexable type');
     assert('arrayLength' in _kTypeInfo);
 
-    if (baseType === 'f16' && addressSpace === 'uniform' && containerType === 'array') {
-      // Array elements must be aligned to 16 bytes, but the logic in generateTypes
-      // creates an array of vec4 of the baseType. But for f16 that's only 8 bytes.
-      // We would need to write more complex logic for that.
-      t.skip('Test logic does not handle array of f16 in the uniform address space');
-    }
-
     let usesCanary = false;
     let globalSource = '';
     let testFunctionSource = '';

--- a/src/webgpu/shader/types.ts
+++ b/src/webgpu/shader/types.ts
@@ -314,6 +314,7 @@ export function* generateTypes({
     let supportsAtomics = scalarInfo.supportsAtomics;
     let layout: undefined | AlignmentAndSize = undefined;
     let accessSuffixes: undefined | string[] = undefined;
+    let validLayoutForAddressSpace = true;
     if (scalarInfo.layout) {
       // Compute the layout of the array type.
       // Adjust the array element count or element type as needed.
@@ -326,7 +327,9 @@ export function* generateTypes({
         supportsAtomics = false;
         accessSuffixes = ['.x', '.y', '.z', '.w'];
         const arrayElemLayout = vectorLayout('vec4', baseType) as AlignmentAndSize;
-        // assert(arrayElemLayout.alignment % 16 === 0); // Callers responsibility to avoid
+        // Arrays in uniform address space have to be 16 byte-aligned.
+        // An array of vec4<f16> is only 8byte aligned.
+        validLayoutForAddressSpace = arrayElemLayout.alignment % 16 === 0;
         arrayElementCount = align(arrayElementCount, 4) / 4;
         const arrayByteSize = arrayElementCount * arrayElemLayout.size;
         layout = { alignment: arrayElemLayout.alignment, size: arrayByteSize };
@@ -354,11 +357,13 @@ export function* generateTypes({
       accessSuffixes,
     };
 
-    // Sized
-    yield { type: `array<${arrayElemType},${arrayElementCount}>`, _kTypeInfo: arrayTypeInfo };
-    // Unsized
-    if (addressSpace === 'storage') {
-      yield { type: `array<${arrayElemType}>`, _kTypeInfo: arrayTypeInfo };
+    if (validLayoutForAddressSpace) {
+      // Sized
+      yield { type: `array<${arrayElemType},${arrayElementCount}>`, _kTypeInfo: arrayTypeInfo };
+      // Unsized
+      if (addressSpace === 'storage') {
+        yield { type: `array<${arrayElemType}>`, _kTypeInfo: arrayTypeInfo };
+      }
     }
   }
 


### PR DESCRIPTION
This is the last step in the code cleanup for adding f16 to generateTypes

Fixed: #3405




Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
