### PR TITLE
WGSL textureLoad tests for multisampled and depth textures

### DIFF
--- a/src/webgpu/format_info.ts
+++ b/src/webgpu/format_info.ts
@@ -1785,6 +1785,14 @@ export function isDepthOrStencilTextureFormat(format: GPUTextureFormat) {
   return isDepthTextureFormat(format) || isStencilTextureFormat(format);
 }
 
+export function isEncodableTextureFormat(format: GPUTextureFormat) {
+  return kEncodableTextureFormats.includes(format as EncodableTextureFormat);
+}
+
+export function canUseAsRenderTarget(format: GPUTextureFormat) {
+  return kTextureFormatInfo[format].colorRender || isDepthOrStencilTextureFormat(format);
+}
+
 export const kCompatModeUnsupportedStorageTextureFormats: readonly GPUTextureFormat[] = [
   'rg32float',
   'rg32sint',
@@ -1813,6 +1821,13 @@ export function isRegularTextureFormat(format: GPUTextureFormat) {
  */
 export function isCompressedFloatTextureFormat(format: GPUTextureFormat) {
   return isCompressedTextureFormat(format) && format.includes('float');
+}
+
+/**
+ * Returns true of format can be multisampled.
+ */
+export function isMultisampledTextureFormat(format: GPUTextureFormat): boolean {
+  return kAllTextureFormatInfo[format].multisample;
 }
 
 export const kFeaturesForFormats = getFeaturesForFormats(kAllTextureFormats);

--- a/src/webgpu/shader/execution/expression/call/builtin/textureLoad.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureLoad.spec.ts
@@ -16,14 +16,22 @@ If an out of bounds access occurs, the built-in function returns one of:
  * 0.0 for depth textures
 
 TODO: Test textureLoad with depth textures as texture_2d, etc...
+TODO: Test textureLoad with multisampled stencil8 format
+TODO: Test un-encodable formats.
+TODO: Test stencil8 format.
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { unreachable, iterRange } from '../../../../../../common/util/util.js';
 import {
+  canUseAsRenderTarget,
   isCompressedFloatTextureFormat,
   isDepthTextureFormat,
+  isEncodableTextureFormat,
+  isMultisampledTextureFormat,
+  isStencilTextureFormat,
   kCompressedTextureFormats,
+  kDepthStencilFormats,
   kEncodableTextureFormats,
   kTextureFormatInfo,
   textureDimensionAndFormatCompatible,
@@ -58,16 +66,13 @@ import {
   getCoordinateForBoundaries,
   getLayerFromLayerSpec,
   getMipLevelFromLevelSpec,
+  getSampleIndexFromSampleIndexSpec,
   isBoundaryNegative,
   isLayerSpecNegative,
   isLevelSpecNegative,
 } from './utils.js';
 
 const kTestableColorFormats = [...kEncodableTextureFormats, ...kCompressedTextureFormats] as const;
-
-function filterOutDepthAndCompressedFloatTextureFormats({ format }: { format: GPUTextureFormat }) {
-  return !isDepthTextureFormat(format) && !isCompressedFloatTextureFormat(format);
-}
 
 function filterOutU32WithNegativeValues(t: {
   C: 'i32' | 'u32';
@@ -178,7 +183,8 @@ Parameters:
   .params(u =>
     u
       .combine('format', kTestableColorFormats)
-      .filter(filterOutDepthAndCompressedFloatTextureFormats)
+      // MAINTENANCE_TODO: Update createTextureFromTexelViews to support stencil8 and remove this filter.
+      .filter(t => t.format !== 'stencil8' && !isCompressedFloatTextureFormat(t.format))
       .beginSubcases()
       .combine('C', ['i32', 'u32'] as const)
       .combine('L', ['i32', 'u32'] as const)
@@ -202,7 +208,10 @@ Parameters:
     const descriptor: GPUTextureDescriptor = {
       format,
       size,
-      usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+      usage:
+        GPUTextureUsage.COPY_DST |
+        GPUTextureUsage.TEXTURE_BINDING |
+        (canUseAsRenderTarget(format) ? GPUTextureUsage.RENDER_ATTACHMENT : 0),
       mipLevelCount: maxMipLevelCount({ size }),
     };
     const { texels, texture } = await createTextureWithRandomDataAndGetTexels(t, descriptor);
@@ -311,9 +320,10 @@ g.test('multisampled')
   .desc(
     `
 C is i32 or u32
+S is i32 or u32
 
-fn textureLoad(t: texture_multisampled_2d<T>, coords: vec2<C>, sample_index: C)-> vec4<T>
-fn textureLoad(t: texture_depth_multisampled_2d, coords: vec2<C>, sample_index: C)-> f32
+fn textureLoad(t: texture_multisampled_2d<T>, coords: vec2<C>, sample_index: S)-> vec4<T>
+fn textureLoad(t: texture_depth_multisampled_2d, coords: vec2<C>, sample_index: S)-> f32
 
 Parameters:
  * t: The sampled texture to read from
@@ -327,12 +337,68 @@ Parameters:
         'texture_multisampled_2d',
         'texture_depth_multisampled_2d',
       ] as const)
+      .combine('format', kTestableColorFormats)
+      .filter(t => isMultisampledTextureFormat(t.format))
+      .filter(t => !isStencilTextureFormat(t.format))
+      // Filter out texture_depth_multisampled_2d with non-depth formats
+      .filter(
+        t =>
+          !(t.texture_type === 'texture_depth_multisampled_2d' && !isDepthTextureFormat(t.format))
+      )
       .beginSubcases()
       .combine('C', ['i32', 'u32'] as const)
-      .combine('coords', generateCoordBoundaries(2))
+      .combine('S', ['i32', 'u32'] as const)
+      .combine('coordsBoundary', generateCoordBoundaries(2))
       .combine('sample_index', [-1, 0, `sampleCount-1`, `sampleCount`] as const)
+      // Only test sample_index out of bounds if coordBoundary is in-bounds
+      .filter(t => !(t.sample_index !== 0 && t.coordsBoundary !== 'in-bounds'))
   )
-  .unimplemented();
+  .beforeAllSubcases(t => {
+    const { format } = t.params;
+    t.skipIfTextureFormatNotSupported(format);
+    t.skipIfTextureLoadNotSupportedForTextureType(t.params.texture_type);
+    t.selectDeviceForTextureFormatOrSkipTestCase(t.params.format);
+  })
+  .fn(async t => {
+    const { texture_type, format, C, S, coordsBoundary, sample_index } = t.params;
+
+    const sampleCount = 4;
+    const descriptor: GPUTextureDescriptor = {
+      format,
+      size: [8, 8],
+      usage:
+        GPUTextureUsage.COPY_DST |
+        GPUTextureUsage.TEXTURE_BINDING |
+        GPUTextureUsage.RENDER_ATTACHMENT,
+      sampleCount,
+    };
+    const { texels, texture } = await createTextureWithRandomDataAndGetTexels(t, descriptor);
+    const sampleIndex = getSampleIndexFromSampleIndexSpec(texture.sampleCount, sample_index);
+    const coords = getCoordinateForBoundaries<vec2>(texture, 0, coordsBoundary);
+
+    const calls: TextureCall<vec2>[] = [
+      {
+        builtin: 'textureLoad',
+        coordType: C === 'i32' ? 'i' : 'u',
+        sampleIndexType: S === 'i32' ? 'i' : 'u',
+        sampleIndex,
+        coords,
+      },
+    ];
+    const textureType = appendComponentTypeForFormatToTextureType(texture_type, texture.format);
+    const viewDescriptor = {};
+    const sampler = undefined;
+    const results = await doTextureCalls(t, texture, viewDescriptor, textureType, sampler, calls);
+    const res = await checkCallResults(
+      t,
+      { texels, descriptor, viewDescriptor },
+      textureType,
+      sampler,
+      calls,
+      results
+    );
+    t.expectOK(res);
+  });
 
 g.test('depth')
   .specURL('https://www.w3.org/TR/WGSL/#textureload')
@@ -340,7 +406,7 @@ g.test('depth')
     `
 C is i32 or u32
 
-fn textureLoad(t: texture_depth_2d, coords: vec2<C>, level: C) -> f32
+fn textureLoad(t: texture_depth_2d, coords: vec2<C>, level: L) -> f32
 
 Parameters:
  * t: The sampled texture to read from
@@ -348,13 +414,67 @@ Parameters:
  * level: The mip level, with level 0 containing a full size version of the texture
 `
   )
-  .paramsSubcasesOnly(u =>
+  .params(u =>
     u
+      .combine('format', kDepthStencilFormats)
+      // filter out stencil only formats
+      .filter(t => isDepthTextureFormat(t.format))
+      // MAINTENANCE_TODO: Remove when support for depth24plus, depth24plus-stencil8, and depth32float-stencil8 is added.
+      .filter(t => isEncodableTextureFormat(t.format))
+      .beginSubcases()
       .combine('C', ['i32', 'u32'] as const)
-      .combine('coords', generateCoordBoundaries(2))
+      .combine('L', ['i32', 'u32'] as const)
+      .combine('coordsBoundary', generateCoordBoundaries(2))
       .combine('level', [-1, 0, `numLevels-1`, `numLevels`] as const)
+      // Only test level out of bounds if coordBoundary is in-bounds
+      .filter(t => !(t.level !== 0 && t.coordsBoundary !== 'in-bounds'))
+      .filter(filterOutU32WithNegativeValues)
   )
-  .unimplemented();
+  .beforeAllSubcases(t => {
+    t.skipIfTextureLoadNotSupportedForTextureType('texture_depth_2d');
+  })
+  .fn(async t => {
+    const { format, C, L, coordsBoundary, level } = t.params;
+
+    // We want at least 4 blocks or something wide enough for 3 mip levels.
+    const size = chooseTextureSize({ minSize: 8, minBlocks: 4, format });
+
+    const descriptor: GPUTextureDescriptor = {
+      format,
+      size,
+      usage:
+        GPUTextureUsage.COPY_DST |
+        GPUTextureUsage.TEXTURE_BINDING |
+        GPUTextureUsage.RENDER_ATTACHMENT,
+      mipLevelCount: maxMipLevelCount({ size }),
+    };
+    const { texels, texture } = await createTextureWithRandomDataAndGetTexels(t, descriptor);
+    const mipLevel = getMipLevelFromLevelSpec(texture.mipLevelCount, level);
+    const coords = getCoordinateForBoundaries<vec2>(texture, mipLevel, coordsBoundary);
+
+    const calls: TextureCall<vec2>[] = [
+      {
+        builtin: 'textureLoad',
+        coordType: C === 'i32' ? 'i' : 'u',
+        levelType: L === 'i32' ? 'i' : 'u',
+        mipLevel,
+        coords,
+      },
+    ];
+    const textureType = 'texture_depth_2d';
+    const viewDescriptor = {};
+    const sampler = undefined;
+    const results = await doTextureCalls(t, texture, viewDescriptor, textureType, sampler, calls);
+    const res = await checkCallResults(
+      t,
+      { texels, descriptor, viewDescriptor },
+      textureType,
+      sampler,
+      calls,
+      results
+    );
+    t.expectOK(res);
+  });
 
 g.test('external')
   .specURL('https://www.w3.org/TR/WGSL/#textureload')
@@ -393,8 +513,8 @@ Parameters:
   .params(u =>
     u
       .combine('format', kTestableColorFormats)
-      // MAINTENANCE_TODO: Update createTextureFromTexelViews to support depth32float and remove this filter.
-      .filter(t => t.format !== 'depth32float' && !isCompressedFloatTextureFormat(t.format))
+      // MAINTENANCE_TODO: Update createTextureFromTexelViews to support stencil8 and remove this filter.
+      .filter(t => t.format !== 'stencil8' && !isCompressedFloatTextureFormat(t.format))
       .combine('texture_type', ['texture_2d_array', 'texture_depth_2d_array'] as const)
       .filter(
         t => !(t.texture_type === 'texture_depth_2d_array' && !isDepthTextureFormat(t.format))
@@ -426,7 +546,10 @@ Parameters:
     const descriptor: GPUTextureDescriptor = {
       format,
       size,
-      usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+      usage:
+        GPUTextureUsage.COPY_DST |
+        GPUTextureUsage.TEXTURE_BINDING |
+        (canUseAsRenderTarget(format) ? GPUTextureUsage.RENDER_ATTACHMENT : 0),
       mipLevelCount: maxMipLevelCount({ size }),
     };
     const { texels, texture } = await createTextureWithRandomDataAndGetTexels(t, descriptor);

--- a/src/webgpu/shader/execution/expression/call/builtin/textureLoad.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureLoad.spec.ts
@@ -535,6 +535,7 @@ Parameters:
   .beforeAllSubcases(t => {
     const { format } = t.params;
     t.skipIfTextureFormatNotSupported(format);
+    t.skipIfTextureLoadNotSupportedForTextureType(t.params.texture_type);
     t.selectDeviceForTextureFormatOrSkipTestCase(t.params.format);
   })
   .fn(async t => {

--- a/src/webgpu/shader/execution/expression/call/builtin/utils.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/utils.ts
@@ -88,6 +88,30 @@ export function isLayerSpecNegative(layerSpec: LayerSpec) {
   return layerSpec === -1;
 }
 
+export type SampleIndexSpec = -1 | 0 | 'sampleCount-1' | 'sampleCount';
+
+export function getSampleIndexFromSampleIndexSpec(
+  sampleCount: number,
+  sampleIndexSpec: SampleIndexSpec
+): number {
+  switch (sampleIndexSpec) {
+    case -1:
+      return -1;
+    case 0:
+      return 0;
+    case 'sampleCount':
+      return sampleCount;
+    case 'sampleCount-1':
+      return sampleCount - 1;
+    default:
+      unreachable();
+  }
+}
+
+export function isSampleIndexSpecNegative(layerSpec: SampleIndexSpec) {
+  return layerSpec === -1;
+}
+
 function getCoordForSize(size: [number, number, number], boundary: Boundary) {
   const coord = size.map(v => Math.floor(v / 2));
   switch (boundary) {

--- a/src/webgpu/util/texture.ts
+++ b/src/webgpu/util/texture.ts
@@ -1,9 +1,406 @@
 import { assert } from '../../common/util/util.js';
+import { isDepthOrStencilTextureFormat, kTextureFormatInfo } from '../format_info.js';
 import { GPUTest } from '../gpu_test.js';
 
 import { getTextureCopyLayout } from './texture/layout.js';
 import { TexelView } from './texture/texel_view.js';
-import { reifyExtent3D } from './unions.js';
+import { reifyExtent3D, reifyOrigin3D } from './unions.js';
+
+const kLoadValueFromStorageInfo: Partial<{
+  [k in GPUTextureFormat]: {
+    storageType: string;
+    texelType: string;
+    unpackWGSL: string;
+    useFragDepth?: boolean;
+  };
+}> = {
+  r8unorm: {
+    storageType: 'u32',
+    texelType: 'vec4f',
+    unpackWGSL: `
+    return vec4f(unpack4x8unorm(src[byteOffset / 4])[byteOffset % 4])
+  `,
+  },
+  r8uint: {
+    storageType: 'u32',
+    texelType: 'vec4u',
+    unpackWGSL: `
+    return vec4u(unpack4xU8(src[byteOffset / 4])[byteOffset % 4])
+  `,
+  },
+  r8sint: {
+    storageType: 'u32',
+    texelType: 'vec4i',
+    unpackWGSL: `
+    return vec4i(unpack4xI8(src[byteOffset / 4])[byteOffset % 4])
+  `,
+  },
+  rg8unorm: {
+    storageType: 'u32',
+    texelType: 'vec4f',
+    unpackWGSL: `
+    let v = unpack4x8unorm(src[byteOffset / 4]);
+    return vec4f(select(v.rg, v.ba, byteOffset % 4 >= 2), 0, 1)
+  `,
+  },
+  rg8uint: {
+    storageType: 'u32',
+    texelType: 'vec4u',
+    unpackWGSL: `
+    let v = unpack4xU8(src[byteOffset / 4]);
+    return vec4u(select(v.rg, v.ba, byteOffset % 4 >= 2), 0, 1)
+  `,
+  },
+  rg8sint: {
+    storageType: 'u32',
+    texelType: 'vec4i',
+    unpackWGSL: `
+    let v = unpack4xI8(src[byteOffset / 4]);
+    return vec4i(select(v.rg, v.ba, byteOffset % 4 >= 2), 0, 1)
+  `,
+  },
+  rgba8unorm: {
+    storageType: 'u32',
+    texelType: 'vec4f',
+    unpackWGSL: 'return unpack4x8unorm(src[byteOffset / 4])',
+  },
+  'rgba8unorm-srgb': {
+    storageType: 'u32',
+    texelType: 'vec4f',
+    unpackWGSL: `
+      let v = unpack4x8unorm(src[byteOffset / 4]);
+      let srgb = select(
+        v / 12.92,
+        pow((v + 0.055) / 1.055, vec4f(2.4)),
+        v >= vec4f(0.04045)
+      );
+      return vec4f(srgb.rgb, v.a);
+    `,
+  },
+  bgra8unorm: {
+    storageType: 'u32',
+    texelType: 'vec4f',
+    unpackWGSL: 'return unpack4x8unorm(src[byteOffset / 4]).bgra',
+  },
+  'bgra8unorm-srgb': {
+    storageType: 'u32',
+    texelType: 'vec4f',
+    unpackWGSL: `
+      let v = unpack4x8unorm(src[byteOffset / 4]);
+      let srgb = select(
+        v / 12.92,
+        pow((v + 0.055) / 1.055, vec4f(2.4)),
+        v >= vec4f(0.04045)
+      );
+      return vec4f(srgb.bgr, v.a);
+    `,
+  },
+  rgba8uint: {
+    storageType: 'u32',
+    texelType: 'vec4u',
+    unpackWGSL: 'return unpack4xU8(src[byteOffset / 4])',
+  },
+  rgba8sint: {
+    storageType: 'u32',
+    texelType: 'vec4i',
+    unpackWGSL: 'return unpack4xI8(src[byteOffset / 4])',
+  },
+  r16float: {
+    storageType: 'u32',
+    texelType: 'vec4f',
+    unpackWGSL: 'return vec4f(unpack2x16float(src[byteOffset / 4])[byteOffset % 4 / 2], 0, 0, 1)',
+  },
+  r16uint: {
+    storageType: 'u32',
+    texelType: 'vec4u',
+    unpackWGSL:
+      'return vec4u(extractBits(src[byteOffset / 4], (byteOffset % 4 / 2 * 16), 16), 0, 0, 0)',
+  },
+  r16sint: {
+    storageType: 'i32',
+    texelType: 'vec4i',
+    unpackWGSL:
+      'return vec4i(extractBits(src[byteOffset / 4], byteOffset % 4 / 2 * 16, 16), 0, 0, 0)',
+  },
+  rg16float: {
+    storageType: 'u32',
+    texelType: 'vec4f',
+    unpackWGSL: 'return vec4f(unpack2x16float(src[byteOffset / 4]), 0, 1)',
+  },
+  rg16uint: {
+    storageType: 'u32',
+    texelType: 'vec4u',
+    unpackWGSL: `
+      let v = src[byteOffset / 4];
+      return vec4u(v & 0xFFFF, v >> 16, 0, 0)
+    `,
+  },
+  rg16sint: {
+    storageType: 'i32',
+    texelType: 'vec4i',
+    unpackWGSL: `
+      let v = src[byteOffset / 4];
+      return vec4i(
+        extractBits(v, 0, 16),
+        extractBits(v, 16, 16),
+        0, 0)
+    `,
+  },
+  rgba16float: {
+    storageType: 'u32',
+    texelType: 'vec4f',
+    unpackWGSL: `
+      return vec4f(
+        unpack2x16float(src[byteOffset / 4]),
+        unpack2x16float(src[byteOffset / 4 + 1]))
+    `,
+  },
+  rgba16uint: {
+    storageType: 'u32',
+    texelType: 'vec4u',
+    unpackWGSL: `
+      let v0 = src[byteOffset / 4];
+      let v1 = src[byteOffset / 4 + 1];
+      return vec4u(v0 & 0xFFFF, v0 >> 16, v1 & 0xFFFF, v1 >> 16)
+    `,
+  },
+  rgba16sint: {
+    storageType: 'i32',
+    texelType: 'vec4i',
+    unpackWGSL: `
+      let v0 = src[byteOffset / 4];
+      let v1 = src[byteOffset / 4 + 1];
+      return vec4i(
+        extractBits(v0, 0, 16),
+        extractBits(v0, 16, 16),
+        extractBits(v1, 0, 16),
+        extractBits(v1, 16, 16),
+      )
+    `,
+  },
+  r32float: {
+    storageType: 'f32',
+    texelType: 'vec4f',
+    unpackWGSL: 'return vec4f(src[byteOffset / 4], 0, 0, 1)',
+  },
+  rgb10a2uint: {
+    storageType: 'u32',
+    texelType: 'vec4u',
+    unpackWGSL: `
+      let v = src[byteOffset / 4];
+      return vec4u(
+        extractBits(v, 0, 10),
+        extractBits(v, 10, 10),
+        extractBits(v, 20, 10),
+        extractBits(v, 30, 2),
+      )
+    `,
+  },
+  rgb10a2unorm: {
+    storageType: 'u32',
+    texelType: 'vec4f',
+    unpackWGSL: `
+      let v = src[byteOffset / 4];
+      return vec4f(
+        f32(extractBits(v, 0, 10)) / f32(0x3FF),
+        f32(extractBits(v, 10, 10)) / f32(0x3FF),
+        f32(extractBits(v, 20, 10)) / f32(0x3FF),
+        f32(extractBits(v, 30, 2)) / f32(0x3),
+      )
+    `,
+  },
+  depth16unorm: {
+    storageType: 'u32',
+    texelType: 'vec4f',
+    unpackWGSL: `
+      let v = unpack2x16unorm(src[byteOffset / 4])[byteOffset % 4 / 2];
+      return vec4f(v, v, v, 1)
+    `,
+    useFragDepth: true,
+  },
+  depth32float: {
+    storageType: 'f32',
+    texelType: 'vec4f',
+    unpackWGSL: `
+      let v = src[byteOffset / 4];
+      return vec4f(v, v, v, 1)
+    `,
+    useFragDepth: true,
+  },
+};
+
+function getCopyBufferToTextureViaRenderCode(format: GPUTextureFormat) {
+  const info = kLoadValueFromStorageInfo[format];
+  assert(!!info);
+  const { storageType, texelType, unpackWGSL, useFragDepth } = info;
+
+  const [depthDecl, depthCode] = useFragDepth
+    ? ['@builtin(frag_depth) d: f32,', 'fs.d = fs.v[0];']
+    : ['', ''];
+
+  return `
+    struct Uniforms {
+      numTexelRows: u32,
+      bytesPerRow: u32,
+      bytesPerSample: u32,
+      sampleCount: u32,
+    };
+
+    struct VSOutput {
+      @builtin(position) pos: vec4f,
+      @location(0) @interpolate(flat, either) sampleIndex: u32,
+    };
+
+    @vertex fn vs(@builtin(vertex_index) vNdx: u32) -> VSOutput {
+      let points = array(
+        vec2f(0, 0), vec2f(1, 0), vec2f(0, 1), vec2f(1, 1),
+      );
+      let sampleRow = vNdx / 4;
+      let numSampleRows = f32(uni.numTexelRows * uni.sampleCount);
+      let rowOffset = f32(sampleRow) / numSampleRows;
+      let rowMult = 1.0 / numSampleRows;
+      let p = (points[vNdx % 4] * vec2f(1, rowMult) + vec2f(0, rowOffset)) * 2.0 - 1.0;
+      return VSOutput(vec4f(p, 0, 1), uni.sampleCount - sampleRow % uni.sampleCount - 1);
+    }
+
+    @group(0) @binding(0) var<uniform> uni: Uniforms;
+    @group(0) @binding(1) var<storage> src: array<${storageType}>;
+
+    fn unpack(byteOffset: u32) -> ${texelType} {
+      ${unpackWGSL};
+    }
+
+    struct FSOutput {
+      @location(0) v: ${texelType},
+      ${depthDecl}
+    };
+
+    @fragment fn fs(vin: VSOutput) -> FSOutput {
+      let coord = vec2u(vin.pos.xy);
+      let byteOffset =
+        coord.y * uni.bytesPerRow +
+        (coord.x * uni.sampleCount + vin.sampleIndex) * uni.bytesPerSample;
+      var fs: FSOutput;
+      fs.v = unpack(byteOffset);
+      ${depthCode}
+      return fs;
+    }
+    `;
+}
+
+function copyBufferToTextureViaRender(
+  t: GPUTest,
+  encoder: GPUCommandEncoder,
+  source: GPUImageCopyBuffer,
+  dest: GPUImageCopyTexture,
+  size: GPUExtent3D
+) {
+  const { format, sampleCount } = dest.texture;
+  const origin = reifyOrigin3D(dest.origin ?? [0]);
+  const copySize = reifyExtent3D(size);
+
+  const msInfo = kLoadValueFromStorageInfo[format];
+  assert(!!msInfo);
+  const { useFragDepth } = msInfo;
+
+  const { device } = t;
+  const code = getCopyBufferToTextureViaRenderCode(format);
+  const module = device.createShaderModule({ code });
+  const pipeline = device.createRenderPipeline({
+    layout: 'auto',
+    vertex: { module },
+    ...(useFragDepth
+      ? {
+          fragment: {
+            module,
+            targets: [],
+          },
+          depthStencil: {
+            depthWriteEnabled: true,
+            depthCompare: 'always',
+            format,
+          },
+        }
+      : {
+          fragment: {
+            module,
+            targets: [{ format }],
+          },
+        }),
+    primitive: {
+      topology: 'triangle-strip',
+    },
+    ...(sampleCount > 1 && { multisample: { count: sampleCount } }),
+  });
+
+  const info = kTextureFormatInfo[format];
+  const uniforms = new Uint32Array([
+    copySize.height, //  numTexelRows: u32,
+    source.bytesPerRow!, //  bytesPerRow: u32,
+    info.bytesPerBlock!, //  bytesPerSample: u32,
+    dest.texture.sampleCount, //  sampleCount: u32,
+  ]);
+  const uniformBuffer = t.makeBufferWithContents(
+    uniforms,
+    GPUBufferUsage.COPY_DST | GPUBufferUsage.UNIFORM
+  );
+  const storageBuffer = t.createBufferTracked({
+    size: source.buffer.size,
+    usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE,
+  });
+  encoder.copyBufferToBuffer(source.buffer, 0, storageBuffer, 0, storageBuffer.size);
+  const baseMipLevel = dest.mipLevel;
+  for (let l = 0; l < copySize.depthOrArrayLayers; ++l) {
+    const baseArrayLayer = origin.z + l;
+    const pass = encoder.beginRenderPass(
+      useFragDepth
+        ? {
+            colorAttachments: [],
+            depthStencilAttachment: {
+              view: dest.texture.createView({
+                baseMipLevel,
+                baseArrayLayer,
+                mipLevelCount: 1,
+                arrayLayerCount: 1,
+              }),
+              depthClearValue: 0.5,
+              depthLoadOp: 'clear',
+              depthStoreOp: 'store',
+            },
+          }
+        : {
+            colorAttachments: [
+              {
+                view: dest.texture.createView({
+                  baseMipLevel,
+                  baseArrayLayer,
+                  mipLevelCount: 1,
+                  arrayLayerCount: 1,
+                }),
+                loadOp: 'clear',
+                storeOp: 'store',
+              },
+            ],
+          }
+    );
+    pass.setViewport(origin.x, origin.y, copySize.width, copySize.height, 0, 1);
+    pass.setPipeline(pipeline);
+
+    const offset =
+      (source.offset ?? 0) + (source.bytesPerRow ?? 0) * (source.rowsPerImage ?? 0) * l;
+    const bindGroup = device.createBindGroup({
+      layout: pipeline.getBindGroupLayout(0),
+      entries: [
+        { binding: 0, resource: { buffer: uniformBuffer } },
+        { binding: 1, resource: { buffer: storageBuffer, offset } },
+      ],
+    });
+
+    pass.setBindGroup(0, bindGroup);
+    pass.draw(4 * copySize.height * dest.texture.sampleCount);
+    pass.end();
+  }
+}
 
 /**
  * Creates a mipmapped texture where each mipmap level's (`i`) content is
@@ -22,7 +419,7 @@ export function createTextureFromTexelViews(
   // Create the texture and then initialize each mipmap level separately.
   const texture = t.createTextureTracked({
     ...desc,
-    format: texelViews[0].format,
+    format,
     usage: desc.usage | GPUTextureUsage.COPY_DST,
     mipLevelCount: texelViews.length,
   });
@@ -53,15 +450,26 @@ export function createTextureFromTexelViews(
       rowsPerImage: mipHeight,
       subrectOrigin: [0, 0, 0],
       subrectSize: [mipWidth, mipHeight, mipDepthOrArray],
+      sampleCount: texture.sampleCount,
     });
     stagingBuffer.unmap();
 
-    // Copy from the staging buffer into the texture.
-    commandEncoder.copyBufferToTexture(
-      { buffer: stagingBuffer, bytesPerRow, rowsPerImage },
-      { texture, mipLevel },
-      [mipWidth, mipHeight, mipDepthOrArray]
-    );
+    if (texture.sampleCount > 1 || isDepthOrStencilTextureFormat(format)) {
+      copyBufferToTextureViaRender(
+        t,
+        commandEncoder,
+        { buffer: stagingBuffer, bytesPerRow, rowsPerImage },
+        { texture, mipLevel },
+        [mipWidth, mipHeight, mipDepthOrArray]
+      );
+    } else {
+      // Copy from the staging buffer into the texture.
+      commandEncoder.copyBufferToTexture(
+        { buffer: stagingBuffer, bytesPerRow, rowsPerImage },
+        { texture, mipLevel },
+        [mipWidth, mipHeight, mipDepthOrArray]
+      );
+    }
   }
   t.device.queue.submit([commandEncoder.finish()]);
 

--- a/src/webgpu/util/texture/base.ts
+++ b/src/webgpu/util/texture/base.ts
@@ -3,6 +3,8 @@ import { kTextureFormatInfo } from '../../format_info.js';
 import { align } from '../../util/math.js';
 import { reifyExtent3D } from '../../util/unions.js';
 
+export type SampleCoord = Required<GPUOrigin3DDict> & { sampleIndex?: number };
+
 /**
  * Compute the maximum mip level count allowed for a given texture size and texture dimension.
  */
@@ -266,13 +268,16 @@ export function reifyTextureViewDescriptor(
  * @param subrectSize - Subrect size
  */
 export function* fullSubrectCoordinates(
-  subrectOrigin: Required<GPUOrigin3DDict>,
-  subrectSize: Required<GPUExtent3DDict>
-): Generator<Required<GPUOrigin3DDict>> {
+  subrectOrigin: SampleCoord,
+  subrectSize: Required<GPUExtent3DDict>,
+  sampleCount = 1
+): Generator<Required<SampleCoord>> {
   for (let z = subrectOrigin.z; z < subrectOrigin.z + subrectSize.depthOrArrayLayers; ++z) {
     for (let y = subrectOrigin.y; y < subrectOrigin.y + subrectSize.height; ++y) {
       for (let x = subrectOrigin.x; x < subrectOrigin.x + subrectSize.width; ++x) {
-        yield { x, y, z };
+        for (let sampleIndex = 0; sampleIndex < sampleCount; ++sampleIndex) {
+          yield { x, y, z, sampleIndex };
+        }
       }
     }
   }


### PR DESCRIPTION
I wasn't sure what to do here. I ended up adding `sampleIndex` into `TexelView`.

[Here's a roll test](https://dawn-review.googlesource.com/c/dawn/+/199538)

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [X] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
