### PR TITLE
Fix div-by-0 partial eval tests

### DIFF
--- a/src/webgpu/shader/validation/expression/binary/div_rem.spec.ts
+++ b/src/webgpu/shader/validation/expression/binary/div_rem.spec.ts
@@ -142,10 +142,14 @@ g.test('scalar_vector_out_of_range')
         return p.nonOneIndex === 0;
       })
       .expandWithParams(p => {
+        // When lhs is a non-const expression, division by zero is only an error for integral types.
+        const partialDivByZeroIsError = [Type.i32, Type.u32].includes(
+          scalarTypeOf(kScalarAndVectorTypes[p.rhs])
+        );
         const cases = [
           { leftValue: 42, rightValue: 0, error: true, leftRuntime: false },
-          { leftValue: 42, rightValue: 0, error: true, leftRuntime: true },
-          { leftValue: 0, rightValue: 0, error: true, leftRuntime: true },
+          { leftValue: 42, rightValue: 0, error: partialDivByZeroIsError, leftRuntime: true },
+          { leftValue: 0, rightValue: 0, error: partialDivByZeroIsError, leftRuntime: true },
           { leftValue: 0, rightValue: 42, error: false, leftRuntime: false },
         ];
         if (p.lhs === 'i32') {


### PR DESCRIPTION
According to the spec, division by zero is invalid even if only the rhs can be constant evaluated for integral types. However, for FP types, it is only an error if the whole expression can be const-evaled.

These tests are not yet passing in Dawn, but will be following: https://dawn-review.googlesource.com/c/dawn/+/199776

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
