### PR TITLE
Add validation tests about dual source blending and color targets

### DIFF
--- a/src/webgpu/api/validation/render_pipeline/common.ts
+++ b/src/webgpu/api/validation/render_pipeline/common.ts
@@ -6,7 +6,7 @@ import {
 } from '../../../util/shader.js';
 import { ValidationTest } from '../validation_test.js';
 
-type ColorTargetState = GPUColorTargetState & { format: ColorTextureFormat };
+export type ColorTargetState = GPUColorTargetState & { format: ColorTextureFormat };
 
 const values = [0, 1, 0, 1];
 export class CreateRenderPipelineValidationTest extends ValidationTest {

--- a/src/webgpu/api/validation/render_pipeline/fragment_state.spec.ts
+++ b/src/webgpu/api/validation/render_pipeline/fragment_state.spec.ts
@@ -9,6 +9,7 @@ import {
   kBlendOperations,
   kMaxColorAttachmentsToTest,
 } from '../../../capability_info.js';
+import { GPUConst } from '../../../constants.js';
 import {
   kAllTextureFormats,
   kRenderableColorTextureFormats,
@@ -504,30 +505,25 @@ g.test('dual_source_blending,color_target_count')
       operation: 'add',
     };
 
-    const colorTargetState: ColorTargetState = {
-      format: 'rgba8unorm',
-    };
-    const defaultTargetState: ColorTargetState = {
-      format: 'rgba8unorm',
-      blend: {
-        color: defaultBlendComponent,
-        alpha: defaultBlendComponent,
-      },
-    };
-    colorTargetState.blend = {
-      color: component === 'color' ? testBlendComponent : defaultBlendComponent,
-      alpha: component === 'alpha' ? testBlendComponent : defaultBlendComponent,
-    };
-
     assert(colorTargetsCount >= 1);
     const colorTargetStates = new Array<ColorTargetState>(colorTargetsCount);
-    colorTargetStates[0] = colorTargetState;
+    colorTargetStates[0] = {
+      format: 'rgba8unorm',
+      blend: {
+        color: component === 'color' ? testBlendComponent : defaultBlendComponent,
+        alpha: component === 'alpha' ? testBlendComponent : defaultBlendComponent,
+      },
+    };
 
     for (let i = 1; i < colorTargetsCount; ++i) {
-      colorTargetStates[i] = defaultTargetState;
-      if (maskOutNonZeroIndexColorTargets) {
-        colorTargetStates[i].writeMask = 0;
-      }
+      colorTargetStates[i] = {
+        format: 'rgba8unorm',
+        blend: {
+          color: defaultBlendComponent,
+          alpha: defaultBlendComponent,
+        },
+        writeMask: maskOutNonZeroIndexColorTargets ? 0 : GPUConst.ColorWrite.ALL,
+      };
     }
 
     const descriptor = t.getDescriptor({

--- a/src/webgpu/api/validation/render_pipeline/fragment_state.spec.ts
+++ b/src/webgpu/api/validation/render_pipeline/fragment_state.spec.ts
@@ -24,7 +24,7 @@ import {
 } from '../../../util/shader.js';
 import { kTexelRepresentationInfo } from '../../../util/texture/texel_data.js';
 
-import { CreateRenderPipelineValidationTest } from './common.js';
+import { ColorTargetState, CreateRenderPipelineValidationTest } from './common.js';
 
 export const g = makeTestGroup(CreateRenderPipelineValidationTest);
 
@@ -465,5 +465,91 @@ g.test('pipeline_output_targets,blend')
       info.color.type === sampleType &&
       componentCount >= kTexelRepresentationInfo[format].componentOrder.length &&
       meetsExtraBlendingRequirement;
+    t.doCreateRenderPipelineTest(isAsync, _success, descriptor);
+  });
+
+const kDualSourceBlendingFactors: GPUBlendFactor[] = [
+  'src1',
+  'one-minus-src1',
+  'src1-alpha',
+  'one-minus-src1-alpha',
+];
+
+g.test('dual_source_blending,color_target_count')
+  .desc(
+    `Test that when the blend factor of color attachment 0 uses src1 (the second input of the
+   corresponding blending unit), there must be exactly one color target.
+`
+  )
+  .beforeAllSubcases(t => t.selectDeviceOrSkipTestCase('dual-source-blending'))
+  .params(u =>
+    u
+      .combine('blendFactor', kDualSourceBlendingFactors)
+      .combine('colorTargetsCount', [1, 2] as const)
+      .combine('maskOutNonZeroIndexColorTargets', [true, false] as const)
+      .beginSubcases()
+      .combine('component', ['color', 'alpha'] as const)
+  )
+  .fn(t => {
+    const { blendFactor, colorTargetsCount, maskOutNonZeroIndexColorTargets, component } = t.params;
+
+    const defaultBlendComponent: GPUBlendComponent = {
+      srcFactor: 'src-alpha',
+      dstFactor: 'dst-alpha',
+      operation: 'add',
+    };
+    const testBlendComponent: GPUBlendComponent = {
+      srcFactor: blendFactor,
+      dstFactor: blendFactor,
+      operation: 'add',
+    };
+
+    const colorTargetState: ColorTargetState = {
+      format: 'rgba8unorm',
+    };
+    const defaultTargetState: ColorTargetState = {
+      format: 'rgba8unorm',
+      blend: {
+        color: defaultBlendComponent,
+        alpha: defaultBlendComponent,
+      },
+    };
+    colorTargetState.blend = {
+      color: component === 'color' ? testBlendComponent : defaultBlendComponent,
+      alpha: component === 'alpha' ? testBlendComponent : defaultBlendComponent,
+    };
+
+    assert(colorTargetsCount >= 1);
+    const colorTargetStates = new Array<ColorTargetState>(colorTargetsCount);
+    colorTargetStates[0] = colorTargetState;
+
+    for (let i = 1; i < colorTargetsCount; ++i) {
+      colorTargetStates[i] = defaultTargetState;
+      if (maskOutNonZeroIndexColorTargets) {
+        colorTargetStates[i].writeMask = 0;
+      }
+    }
+
+    const descriptor = t.getDescriptor({
+      targets: colorTargetStates,
+      fragmentShaderCode: `
+          enable dual_source_blending;
+
+          struct FragOutput {
+            @location(0) @blend_src(0) color : vec4f,
+            @location(0) @blend_src(1) blend : vec4f,
+          }
+
+          @fragment fn main() -> FragOutput {
+            var fragmentOutput : FragOutput;
+            fragmentOutput.color = vec4f(0.0, 1.0, 0.0, 1.0);
+            fragmentOutput.blend = fragmentOutput.color;
+            return fragmentOutput;
+          }
+          `,
+    });
+
+    const isAsync = false;
+    const _success = colorTargetsCount === 1;
     t.doCreateRenderPipelineTest(isAsync, _success, descriptor);
   });


### PR DESCRIPTION
This patch adds validation tests about using dual source blending and color attachments. When dual source blending is used, there can only be exactly one color target, whether its write mask is 0 or not, which is required by D3D12.


Issue: #3810

<hr>

**Requirements for PR author:**

- [*] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [*] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [*] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [*] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
