### PR TITLE
feat(standalone): add `title` to test node

### DIFF
--- a/src/common/runtime/standalone.ts
+++ b/src/common/runtime/standalone.ts
@@ -491,6 +491,7 @@ function makeTreeNodeHeaderHTML(
   {
     $('<input>')
       .attr('type', 'text')
+      .attr('title', n.query.toString())
       .prop('readonly', true)
       .addClass('nodequery')
       .on('click', event => {


### PR DESCRIPTION
This is only a standalone front-end change, so I'm uncertain how much of the PR template even applies. 😅

This (opinionated) change is nice for when a path starts to get so long that it runs off the screen[^1], and one wants to see the whole thing. Copying and pasting from the `input` field of the node into my URL bar in Firefox is my current workaround, but also strictly less convenient than hovering the mouse over the test node.

[^1]: i.e., <http://127.0.0.1:8080/standalone/?q=webgpu:web_platform,copyToTexture,ImageBitmap:from_ImageData:alpha=%22none%22;orientation=%22none%22;colorSpaceConversion=%22none%22;srcFlipYInCopy=true;dstFormat=%22r16float%22;dstPremultiplied=true>