### PR TITLE
Add validation tests on blend factors with Src1 and @blend_src

### DIFF
--- a/src/webgpu/api/validation/render_pipeline/fragment_state.spec.ts
+++ b/src/webgpu/api/validation/render_pipeline/fragment_state.spec.ts
@@ -597,7 +597,7 @@ g.test('dual_source_blending,use_blend_src')
 
           struct FragOutput {
             @location(0) ${useBlendSrc1 ? '@blend_src(0)' : ''} color : vec4f,
-            ${useBlendSrc1 ? ' @location(0) @blend_src(1) blend : vec4f,' : ''}
+            ${useBlendSrc1 ? '@location(0) @blend_src(1) blend : vec4f,' : ''}
           }
 
           @fragment fn main() -> FragOutput {


### PR DESCRIPTION
This patch adds the validation tests on the use of blend factors with `Src1` and `@blend_src` in the fragment shader. When the blend factor uses `Src1`, `@blend_src` must be used in the fragment shader whether the corresponding colorWriteMask is 0 or not, as is required by Metal.

The changes against WebGPU SPEC is https://github.com/gpuweb/gpuweb/pull/4791.


Issue: #3810

<hr>

**Requirements for PR author:**

- [*] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [*] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [*] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [*] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
