### PR TITLE
Add dual source blending blend factors to `kBlendFactors`

### DIFF
--- a/src/webgpu/api/operation/rendering/color_target_state.spec.ts
+++ b/src/webgpu/api/operation/rendering/color_target_state.spec.ts
@@ -9,7 +9,11 @@ TODO:
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { assert, TypedArrayBufferView, unreachable } from '../../../../common/util/util.js';
-import { kBlendFactors, kBlendOperations } from '../../../capability_info.js';
+import {
+  kBlendFactors,
+  kDualSourceBlendingFactorsSet,
+  kBlendOperations,
+} from '../../../capability_info.js';
 import { GPUConst } from '../../../constants.js';
 import { kRegularTextureFormats, kTextureFormatInfo } from '../../../format_info.js';
 import { GPUTest, TextureTestMixin } from '../../../gpu_test.js';
@@ -155,16 +159,6 @@ function computeBlendOperation(
   }
 }
 
-const kDualSourceBlendingFactors: GPUBlendFactor[] = [
-  'src1',
-  'one-minus-src1',
-  'src1-alpha',
-  'one-minus-src1-alpha',
-];
-const kDualSourceBlendingFactorsSet = new Set(kDualSourceBlendingFactors);
-
-const kAllBlendFactors = [...kBlendFactors, ...kDualSourceBlendingFactors];
-
 g.test('blending,GPUBlendComponent')
   .desc(
     `Test all combinations of parameters for GPUBlendComponent.
@@ -182,8 +176,8 @@ g.test('blending,GPUBlendComponent')
   .params(u =>
     u //
       .combine('component', ['color', 'alpha'] as const)
-      .combine('srcFactor', kAllBlendFactors)
-      .combine('dstFactor', kAllBlendFactors)
+      .combine('srcFactor', kBlendFactors)
+      .combine('dstFactor', kBlendFactors)
       .beginSubcases()
       .combine('operation', kBlendOperations)
       .filter(t => {

--- a/src/webgpu/api/validation/render_pipeline/fragment_state.spec.ts
+++ b/src/webgpu/api/validation/render_pipeline/fragment_state.spec.ts
@@ -434,9 +434,12 @@ g.test('pipeline_output_targets')
 
 g.test('pipeline_output_targets,blend')
   .desc(
-    `On top of requirements from pipeline_output_targets, when blending is enabled and alpha channel is read indicated by any blend factor, an extra requirement is added:
-  - fragment output must be vec4.
-  TODO: Test Dual Source Blending
+    `On top of requirements from pipeline_output_targets, when blending is enabled and alpha channel
+    is read indicated by any color blend factor, an extra requirement is added:
+      - fragment output must be vec4.
+
+    TODO: Implement all the skipped tests about the blend factors added in the extension
+          "dual-source-blending"
   `
   )
   .params(u =>

--- a/src/webgpu/capability_info.ts
+++ b/src/webgpu/capability_info.ts
@@ -659,7 +659,19 @@ export const kBlendFactors: readonly GPUBlendFactor[] = [
   'src-alpha-saturated',
   'constant',
   'one-minus-constant',
+  'src1',
+  'one-minus-src1',
+  'src1-alpha',
+  'one-minus-src1-alpha',
 ];
+
+/** Set of all GPUBlendFactor values added in the extension "dual-source-blending". */
+export const kDualSourceBlendingFactorsSet = new Set([
+  'src1',
+  'one-minus-src1',
+  'src1-alpha',
+  'one-minus-src1-alpha',
+]);
 
 /** List of all GPUBlendOperation values. */
 export const kBlendOperations: readonly GPUBlendOperation[] = [


### PR DESCRIPTION
This patch adds all the blend factors defined in the extension "dual-source-blending" to `kBlendFactors` in capability_info.ts so that all the tests about blend factors can test these newly added blend factors.

This patch also removes the validation tests about using the alpha channel of `Src1` because it doesn't follow the latest SPEC: only when the color blend factor uses the alpha channel of `Src` must the fragment output be `vec4`. When the color target doesn't have the alpha channel, the alpha blend factor is ignored so it is OK to set it as if it "uses" the alpha channel of `Src`.

Note that the new validation test against `Src1-alpha` will be added into 'pipeline_output_targets,blend' after the fix is landed in the browser.




Issue: #3810 
<hr>

**Requirements for PR author:**

- [*] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [*] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [*] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [*] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
