### PR TITLE
Use device subgroup limits in subgroup_size tests

### DIFF
--- a/src/webgpu/shader/execution/shader_io/compute_builtins.spec.ts
+++ b/src/webgpu/shader/execution/shader_io/compute_builtins.spec.ts
@@ -398,9 +398,11 @@ g.test('subgroup_size')
     t.selectDeviceOrSkipTestCase('subgroups' as GPUFeatureName);
   })
   .fn(async t => {
-    // Replace these with the limits when they are wired up.
-    const minSize = 4;
-    const maxSize = 128;
+    interface SubgroupLimits extends GPUSupportedLimits {
+      minSubgroupSize: number;
+      maxSubgroupSize: number;
+    }
+    const { minSubgroupSize, maxSubgroupSize } = t.device.limits as SubgroupLimits;
 
     const wgx = t.params.sizes[0];
     const wgy = t.params.sizes[1];
@@ -512,7 +514,15 @@ fn main(@builtin(subgroup_size) size : u32,
     });
     const compareData: Uint32Array = compareReadback.data;
 
-    t.expectOK(checkSubgroupSizeConsistency(sizesData, compareData, minSize, maxSize, wgThreads));
+    t.expectOK(
+      checkSubgroupSizeConsistency(
+        sizesData,
+        compareData,
+        minSubgroupSize,
+        maxSubgroupSize,
+        wgThreads
+      )
+    );
   });
 
 /**


### PR DESCRIPTION
https://dawn-review.googlesource.com/c/dawn/+/200574 adds node bindings for subgroup limits so now they can be wired up.

Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [ ] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [ ] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [ ] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
