### PR TITLE
fix smoothstep validation

### DIFF
--- a/src/webgpu/shader/validation/expression/call/builtin/smoothstep.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/smoothstep.spec.ts
@@ -51,16 +51,15 @@ Validates that constant evaluation and override evaluation of ${builtin}() rejec
   .fn(t => {
     const type = kValuesTypes[t.params.type];
 
-    // We expect to fail if low >= high as it results in a DBZ
-    const expectedResult = t.params.value1 >= t.params.value2;
+    // We expect to fail if low >= high.
+    const expectedResult = t.params.value1 < t.params.value2;
 
     validateConstOrOverrideBuiltinEval(
       t,
       builtin,
       expectedResult,
       [type.create(t.params.value1), type.create(t.params.value2), type.create(0)],
-      t.params.stage,
-      /* returnType */ concreteTypeOf(type, [Type.f32])
+      t.params.stage
     );
   });
 
@@ -141,6 +140,7 @@ fn foo() {
         code: wgsl,
         constants,
         reference: ['o_low', 'o_high'],
+        statements: ['foo();'],
       });
     }
   });
@@ -159,10 +159,11 @@ Validates that scalar and vector arguments are rejected by ${builtin}() if not f
   })
   .fn(t => {
     const type = kArgumentTypes[t.params.type];
+    const expectedResult = isConvertibleToFloatType(elementTypeOf(type));
     validateConstOrOverrideBuiltinEval(
       t,
       builtin,
-      /* expectedResult */ isConvertibleToFloatType(elementTypeOf(type)),
+      expectedResult,
       [type.create(0), type.create(1), type.create(2)],
       'constant',
       /* returnType */ concreteTypeOf(type, [Type.f32])
@@ -344,7 +345,7 @@ g.test('early_eval_errors')
       t,
       builtin,
       /* expectedResult */ t.params.low < t.params.high,
-      [f32(0), f32(t.params.low), f32(t.params.high)],
+      [f32(t.params.low), f32(t.params.high), f32(0)],
       t.params.stage
     );
   });


### PR DESCRIPTION
'values' test:
* Infer result type instead of explicitly specifying it.   If specified,
  it's used as the explicit type of the result variable.  Infer it
  instead.  This fixes cases where the type is abstract.
* low == high is an error
  https://github.com/gpuweb/gpuweb/pull/4616

'partial_eval_errs' test:
* Test function foo() must be called from the entry point so that overrides are validated.

'early_eval_errs' test:
* Fix argument order: low and high args are first and second.

Bug: crbug.com/351378281




Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [ ] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
