### PR TITLE
fix smoothstep execution: only compute valid cases when const

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/smoothstep.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/smoothstep.spec.ts
@@ -7,17 +7,29 @@ T is S or vecN<S>
 Returns the smooth Hermite interpolation between 0 and 1.
 Component-wise when T is a vector.
 For scalar T, the result is t * t * (3.0 - 2.0 * t), where t = clamp((x - low) / (high - low), 0.0, 1.0).
+
+If low >= high:
+* It is a shader-creation error if low and high are const-expressions.
+* It is a pipeline-creation error if low and high are override-expressions.
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUTest } from '../../../../../gpu_test.js';
-import { Type } from '../../../../../util/conversion.js';
+import { ScalarValue, Type, Value } from '../../../../../util/conversion.js';
+import { Case } from '../../case.js';
 import { allInputSources, onlyConstInputSource, run } from '../../expression.js';
 
 import { abstractFloatBuiltin, builtin } from './builtin.js';
 import { d } from './smoothstep.cache.js';
 
 export const g = makeTestGroup(GPUTest);
+
+// Returns true if `c` is valid for a const evaluation of smoothstep.
+function validForConst(c: Case): boolean {
+  const low = (c.input as Value[])[0] as ScalarValue;
+  const high = (c.input as Value[])[1] as ScalarValue;
+  return low.value < high.value;
+}
 
 g.test('abstract_float')
   .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
@@ -28,7 +40,7 @@ g.test('abstract_float')
       .combine('vectorize', [undefined, 2, 3, 4] as const)
   )
   .fn(async t => {
-    const cases = await d.get('abstract_const');
+    const cases = (await d.get('abstract_const')).filter(c => validForConst(c));
     await run(
       t,
       abstractFloatBuiltin('smoothstep'),
@@ -47,7 +59,15 @@ g.test('f32')
   )
   .fn(async t => {
     const cases = await d.get(t.params.inputSource === 'const' ? 'f32_const' : 'f32_non_const');
-    await run(t, builtin('smoothstep'), [Type.f32, Type.f32, Type.f32], Type.f32, t.params, cases);
+    const validCases = cases.filter(c => t.params.inputSource !== 'const' || validForConst(c));
+    await run(
+      t,
+      builtin('smoothstep'),
+      [Type.f32, Type.f32, Type.f32],
+      Type.f32,
+      t.params,
+      validCases
+    );
   });
 
 g.test('f16')
@@ -61,5 +81,13 @@ g.test('f16')
   })
   .fn(async t => {
     const cases = await d.get(t.params.inputSource === 'const' ? 'f16_const' : 'f16_non_const');
-    await run(t, builtin('smoothstep'), [Type.f16, Type.f16, Type.f16], Type.f16, t.params, cases);
+    const validCases = cases.filter(c => t.params.inputSource !== 'const' || validForConst(c));
+    await run(
+      t,
+      builtin('smoothstep'),
+      [Type.f16, Type.f16, Type.f16],
+      Type.f16,
+      t.params,
+      validCases
+    );
   });


### PR DESCRIPTION
For const cases, low < high is required
See https://github.com/gpuweb/gpuweb/pull/4616

Bug: crbug.com/351378281




Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
