### PR TITLE
Fix textureSampleLevel tests.

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/texture_utils.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/texture_utils.ts
@@ -203,9 +203,12 @@ async function initMipGradientValuesForDevice(t: GPUTest) {
     resultBuffer.destroy();
 
     // Validate the weights
-    assert(weights[0] === 0);
-    assert(weights[kMipGradientSteps] === 1);
-    assert(weights[kMipGradientSteps / 2] === 0.5);
+    assert(weights[0] === 0, 'weight 0 is 0');
+    assert(weights[kMipGradientSteps] === 1, 'top weight is 1');
+    assert(
+      Math.abs(weights[kMipGradientSteps / 2] - 0.5) < 0.0001,
+      'middle weight is approximately 0.5'
+    );
 
     // Note: for 16 steps, these are the AMD weights
     //


### PR DESCRIPTION
The tests query the GPUs mip to mip interpolation. The test that the query was successful was too strict so this PR relaxes that check.

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [X] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
