### PR TITLE
clamp validation: conditionally include test function

### DIFF
--- a/src/webgpu/shader/validation/expression/call/builtin/clamp.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/clamp.spec.ts
@@ -127,6 +127,8 @@ Validates that low <= high.
         const scalar = scalarTypeOf(ty);
         return scalar !== Type.abstractInt && scalar !== Type.abstractFloat;
       })
+      // in_shader: Is the function call statically accessed by the entry point?
+      .combine('in_shader', [false, true] as const)
   )
   .beforeAllSubcases(t => {
     const ty = kValuesTypes[t.params.type];
@@ -176,7 +178,10 @@ fn foo() {
     const shader_error =
       error && t.params.lowStage === 'constant' && t.params.highStage === 'constant';
     const pipeline_error =
-      error && t.params.lowStage !== 'runtime' && t.params.highStage !== 'runtime';
+      t.params.in_shader &&
+      error &&
+      t.params.lowStage !== 'runtime' &&
+      t.params.highStage !== 'runtime';
     t.expectCompileResult(!shader_error, wgsl);
     if (!shader_error) {
       const constants: Record<string, number> = {};
@@ -187,7 +192,7 @@ fn foo() {
         code: wgsl,
         constants,
         reference: ['o_low', 'o_high'],
-        statements: ['foo();'],
+        statements: t.params.in_shader ? ['foo();'] : [],
       });
     }
   });


### PR DESCRIPTION
Add variants where the function containing the function call being tested is both in and not-in the tested shader, i.e. statically accessed or not.

This matters for override validation.




Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [ ] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [ ] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [ ] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
