### PR TITLE
insertBits validation: conditionally include tested code in the shader

### DIFF
--- a/src/webgpu/shader/validation/expression/call/builtin/insertBits.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/insertBits.spec.ts
@@ -119,6 +119,8 @@ Validates that count and offset must be smaller than the size of the primitive.
         { offset: 0, count: 33 },
         { offset: 1, count: 33 },
       ] as const)
+      // in_shader: Is the function call statically accessed by the entry point?
+      .combine('in_shader', [false, true] as const)
   )
   .fn(t => {
     let offsetArg = '';
@@ -160,7 +162,10 @@ fn foo() {
     const shader_error =
       error && t.params.offsetStage === 'constant' && t.params.countStage === 'constant';
     const pipeline_error =
-      error && t.params.offsetStage !== 'runtime' && t.params.countStage !== 'runtime';
+      t.params.in_shader &&
+      error &&
+      t.params.offsetStage !== 'runtime' &&
+      t.params.countStage !== 'runtime';
     t.expectCompileResult(!shader_error, wgsl);
     if (!shader_error) {
       const constants: Record<string, number> = {};
@@ -171,6 +176,7 @@ fn foo() {
         code: wgsl,
         constants,
         reference: ['o_offset', 'o_count'],
+        statements: t.params.in_shader ? ['foo();'] : [],
       });
     }
   });


### PR DESCRIPTION
This matters when exercising the 'override' cases.




Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
