### PR TITLE
ldexp validation: conditionally include tested code in the shader

### DIFF
--- a/src/webgpu/shader/validation/expression/call/builtin/ldexp.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/ldexp.spec.ts
@@ -143,6 +143,8 @@ g.test('partial_values')
         cases.push({ value: bias + 2 });
         return cases;
       })
+      // in_shader: Is the functino call statically accessed by the entry point?
+      .combine('in_shader', [false, true] as const)
   )
   .beforeAllSubcases(t => {
     const ty = kValidArgumentTypesA[t.params.typeA];
@@ -179,7 +181,7 @@ fn foo() {
     const bias = biasForType(scalarTypeOf(tyA));
     const error = t.params.value > bias + 1;
     const shader_error = error && t.params.stage === 'constant';
-    const pipeline_error = error && t.params.stage === 'override';
+    const pipeline_error = t.params.in_shader && error && t.params.stage === 'override';
     t.expectCompileResult(!shader_error, wgsl);
     if (!shader_error) {
       const constants: Record<string, number> = {};
@@ -189,6 +191,7 @@ fn foo() {
         code: wgsl,
         constants,
         reference: ['o_b'],
+        statements: t.params.in_shader ? ['foo();'] : [],
       });
     }
   });


### PR DESCRIPTION
This affects 'override' cases in the 'partial_values' subtest.




Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
