### PR TITLE
Reduce the number of shader modules used in texture tests

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/texture_utils.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/texture_utils.ts
@@ -2266,9 +2266,10 @@ function generateTextureBuiltinInputsImpl<T extends Dimensionality>(
       (hashU32(..._hashInputs, ...hashInputs) / 0x1_0000_0000) * range - (type === 'u32' ? 0 : 1);
     return type === 'f32' ? number : Math.floor(number);
   };
-  const makeIntHashValue = (min: number, max: number, ...hashInputs: number[]) => {
+  // Generates the same values per coord instead of using all the extra `_hashInputs`.
+  const makeIntHashValueRepeatable = (min: number, max: number, ...hashInputs: number[]) => {
     const range = max - min;
-    return min + Math.floor((hashU32(..._hashInputs, ...hashInputs) / 0x1_0000_0000) * range);
+    return min + Math.floor((hashU32(...hashInputs) / 0x1_0000_0000) * range);
   };
 
   // Samplers across devices use different methods to interpolate.
@@ -2305,7 +2306,7 @@ function generateTextureBuiltinInputsImpl<T extends Dimensionality>(
       sampleIndex: args.sampleIndex ? makeRangeValue(args.sampleIndex, i, 1) : undefined,
       arrayIndex: args.arrayIndex ? makeRangeValue(args.arrayIndex, i, 2) : undefined,
       offset: args.offset
-        ? (coords.map((_, j) => makeIntHashValue(-8, 8, i, 3 + j)) as T)
+        ? (coords.map((_, j) => makeIntHashValueRepeatable(-8, 8, i, 3 + j)) as T)
         : undefined,
     };
   });


### PR DESCRIPTION
This change reduces the number of shader modules created by 2 orders of magnitude. The issue is offsets must be constants so randomly generating them makes a new shader. This makes them less random so they are the same per test.

So for example: webgpu:shader,execution,expression,call,builtin,textureSampleLevel:sampled_2d_coords:* goes from 1197 shader modules to 4



