### PR TITLE
Choose smaller texture sizes

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/texture_utils.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/texture_utils.ts
@@ -2197,7 +2197,9 @@ export function chooseTextureSize({
   const width = align(Math.max(minSize, blockWidth * minBlocks), blockWidth);
   const height = align(Math.max(minSize, blockHeight * minBlocks), blockHeight);
   if (viewDimension === 'cube' || viewDimension === 'cube-array') {
-    const size = lcm(width, height);
+    const blockLCM = lcm(blockWidth, blockHeight);
+    const largest = Math.max(width, height);
+    const size = align(largest, blockLCM);
     return [size, size, viewDimension === 'cube-array' ? 24 : 6];
   }
   const depthOrArrayLayers = getDepthOrArrayLayersForViewDimension(viewDimension);


### PR DESCRIPTION
The old code did an lcm of width vs height where for for cubemaps because cubemaps must be square and
textures must be a multiple of block sizes.

With a format with a blockSize of 5x8 and a minSize of 32 that would end up doing lcm of 35x32 which is 1120. Then for a cube array it would end up allocating
1120x1120x24 and if the format is rgba32float that's 418meg.

The new code just gets the lcm of the blockWidth vs blockHeight and then aligning to that which will be much much smaller.



