### PR TITLE
Fix for textureGather

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/textureGather.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureGather.spec.ts
@@ -119,6 +119,7 @@ Parameters:
 
     const calls: TextureCall<vec2>[] = generateTextureBuiltinInputs2D(50, {
       method: samplePoints,
+      textureBuiltin: 'textureGather',
       sampler,
       descriptor,
       offset,
@@ -304,6 +305,7 @@ Parameters:
 
     const calls: TextureCall<vec2>[] = generateTextureBuiltinInputs2D(50, {
       method: samplePoints,
+      textureBuiltin: 'textureGather',
       sampler,
       descriptor,
       arrayIndex: { num: texture.depthOrArrayLayers, type: A },
@@ -486,6 +488,7 @@ Parameters:
 
     const calls: TextureCall<vec2>[] = generateTextureBuiltinInputs2D(50, {
       method: samplePoints,
+      textureBuiltin: 'textureGather',
       sampler,
       descriptor,
       offset,
@@ -654,6 +657,7 @@ Parameters:
 
     const calls: TextureCall<vec2>[] = generateTextureBuiltinInputs2D(50, {
       method: samplePoints,
+      textureBuiltin: 'textureGather',
       sampler,
       descriptor,
       arrayIndex: { num: texture.depthOrArrayLayers, type: A },

--- a/src/webgpu/shader/execution/expression/call/builtin/textureGatherCompare.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureGatherCompare.spec.ts
@@ -107,6 +107,7 @@ Parameters:
 
     const calls: TextureCall<vec2>[] = generateTextureBuiltinInputs2D(50, {
       method: samplePoints,
+      textureBuiltin: 'textureGatherCompare',
       sampler,
       descriptor,
       arrayIndex: { num: texture.depthOrArrayLayers, type: A },
@@ -284,6 +285,7 @@ Parameters:
 
     const calls: TextureCall<vec2>[] = generateTextureBuiltinInputs2D(50, {
       method: samplePoints,
+      textureBuiltin: 'textureGatherCompare',
       sampler,
       descriptor,
       offset,

--- a/src/webgpu/shader/execution/expression/call/builtin/texture_utils.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/texture_utils.ts
@@ -569,7 +569,7 @@ export interface TextureCall<T extends Dimensionality> extends TextureCallArgs<T
 }
 
 const isBuiltinComparison = (builtin: TextureBuiltin) => builtin === 'textureGatherCompare';
-const isBuiltinGather = (builtin: TextureBuiltin) =>
+const isBuiltinGather = (builtin: TextureBuiltin | undefined) =>
   builtin === 'textureGather' || builtin === 'textureGatherCompare';
 
 const s_u32 = new Uint32Array(1);
@@ -2515,8 +2515,8 @@ function generateTextureBuiltinInputsImpl<T extends Dimensionality>(
   // MacOS, M1 Mac: 256
   const kSubdivisionsPerTexel = 4;
   const avoidEdgeCase =
-    !args.sampler || args.sampler.minFilter === 'nearest' || isBuiltinGather(args.textureBuiltin!);
-  const edgeRemainder = args.textureBuiltin === 'textureGather' ? kSubdivisionsPerTexel / 2 : 0;
+    !args.sampler || args.sampler.minFilter === 'nearest' || isBuiltinGather(args.textureBuiltin);
+  const edgeRemainder = isBuiltinGather(args.textureBuiltin) ? kSubdivisionsPerTexel / 2 : 0;
   const numComponents = isDepthOrStencilTextureFormat(descriptor.format) ? 1 : 4;
   return coords.map((c, i) => {
     const mipLevel = args.mipLevel
@@ -2948,8 +2948,8 @@ export function generateSamplePointsCube(
   //
   const kSubdivisionsPerTexel = 4;
   const avoidEdgeCase =
-    !args.sampler || args.sampler.minFilter === 'nearest' || isBuiltinGather(args.textureBuiltin!);
-  const edgeRemainder = isBuiltinGather(args.textureBuiltin!) ? kSubdivisionsPerTexel / 2 : 0;
+    !args.sampler || args.sampler.minFilter === 'nearest' || isBuiltinGather(args.textureBuiltin);
+  const edgeRemainder = isBuiltinGather(args.textureBuiltin) ? kSubdivisionsPerTexel / 2 : 0;
 
   return coords.map((c, i) => {
     const mipLevel = args.mipLevel


### PR DESCRIPTION
textureGather needs to not choose centers of texels because depending on the backend it could choose the texels to the left or right (up or down) from the texture coordinate.

There was code to do this but it needed to know it was being used for textureGather.


