### PR TITLE
Fixes for no attachments being an error.

### DIFF
--- a/src/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.ts
@@ -20,6 +20,7 @@ function getPipelineDescriptor(device: GPUDevice, testValue: number): GPURenderP
       module,
       entryPoint: 'vs',
     },
+    depthStencil: { format: 'depth32float', depthWriteEnabled: true, depthCompare: 'always' },
   };
 }
 

--- a/src/webgpu/api/validation/capability_checks/limits/maxVertexAttributes.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxVertexAttributes.spec.ts
@@ -19,6 +19,7 @@ function getPipelineDescriptor(device: GPUDevice, lastIndex: number): GPURenderP
         },
       ],
     },
+    depthStencil: { format: 'depth32float', depthWriteEnabled: true, depthCompare: 'always' },
   };
 }
 

--- a/src/webgpu/api/validation/capability_checks/limits/maxVertexBufferArrayStride.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxVertexBufferArrayStride.spec.ts
@@ -32,6 +32,7 @@ function getPipelineDescriptor(device: GPUDevice, testValue: number): GPURenderP
         },
       ],
     },
+    depthStencil: { format: 'depth32float', depthWriteEnabled: true, depthCompare: 'always' },
   };
 }
 

--- a/src/webgpu/api/validation/capability_checks/limits/maxVertexBuffers.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxVertexBuffers.spec.ts
@@ -19,6 +19,7 @@ function getPipelineDescriptor(device: GPUDevice, testValue: number): GPURenderP
       module,
       buffers,
     },
+    depthStencil: { format: 'depth32float', depthWriteEnabled: true, depthCompare: 'always' },
   };
 }
 

--- a/src/webgpu/api/validation/layout_shader_compat.spec.ts
+++ b/src/webgpu/api/validation/layout_shader_compat.spec.ts
@@ -253,6 +253,7 @@ g.test('pipeline_layout_shader_exact_match')
               code: vertexShader,
             }),
           },
+          depthStencil: { format: 'depth32float', depthWriteEnabled: true, depthCompare: 'always' },
         });
         break;
       }

--- a/src/webgpu/api/validation/render_pipeline/misc.spec.ts
+++ b/src/webgpu/api/validation/render_pipeline/misc.spec.ts
@@ -36,7 +36,7 @@ g.test('no_attachment')
 g.test('vertex_state_only')
   .desc(
     `Tests creating vertex-state-only render pipeline. A vertex-only render pipeline has no fragment
-state (and thus has no color state), and can be created with or without depth stencil state.`
+state (and thus has no color state), and must have a depth-stencil state as an attachment is required.`
   )
   .params(u =>
     u
@@ -76,7 +76,7 @@ state (and thus has no color state), and can be created with or without depth st
       targets: hasColor ? [{ format: 'rgba8unorm' }] : [],
     });
 
-    t.doCreateRenderPipelineTest(isAsync, true, descriptor);
+    t.doCreateRenderPipelineTest(isAsync, depthStencilState !== undefined, descriptor);
   });
 
 g.test('pipeline_layout,device_mismatch')

--- a/src/webgpu/api/validation/shader_module/entry_point.spec.ts
+++ b/src/webgpu/api/validation/shader_module/entry_point.spec.ts
@@ -128,6 +128,7 @@ and check that the APIs only accept matching entryPoint.
         module: t.device.createShaderModule({ code }),
         entryPoint,
       },
+      depthStencil: { format: 'depth32float', depthWriteEnabled: true, depthCompare: 'always' },
     };
     let _success = true;
     if (shaderModuleStage !== 'vertex') {
@@ -258,6 +259,7 @@ an undefined entryPoint is valid if there's an extra shader stage.
         }),
         entryPoint: undefined,
       },
+      depthStencil: { format: 'depth32float', depthWriteEnabled: true, depthCompare: 'always' },
     };
 
     const success = extraShaderModuleStage !== 'vertex';


### PR DESCRIPTION
Previously Dawn didn't correctly validate that render pipelines with no attachments are errors. After fixing Dawn some CTS tests hit the new validation. Fix them up to follow the WebGPU spec.

See #3754




Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [X] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
