### PR TITLE
Remove GPUShaderModuleDescriptor.sourceMap

### DIFF
--- a/src/webgpu/api/operation/shader_module/compilation_info.spec.ts
+++ b/src/webgpu/api/operation/shader_module/compilation_info.spec.ts
@@ -3,7 +3,6 @@ ShaderModule CompilationInfo tests.
 `;
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
-import { keysOf } from '../../../../common/util/data_tables.js';
 import { assert } from '../../../../common/util/util.js';
 import { GPUTest } from '../../../gpu_test.js';
 
@@ -79,66 +78,24 @@ const kInvalidShaderSources = [
 
 const kAllShaderSources = [...kValidShaderSources, ...kInvalidShaderSources];
 
-// This is the source the sourcemap refers to.
-const kOriginalSource = new Array(20)
-  .fill(0)
-  .map((_, i) => `original line ${i}`)
-  .join('\n');
-
-const kSourceMaps: { [name: string]: undefined | object } = {
-  none: undefined,
-  empty: {},
-  // A valid source map. It maps `unknown` on lines 4 and line 5 to
-  // `wasUnknown` from lines 20, 21 respectively
-  valid: {
-    version: 3,
-    sources: ['myCode'],
-    sourcesContent: [kOriginalSource],
-    names: ['myMain', 'wasUnknown'],
-    mappings: ';kBAYkCA,OACd;SAElB;gBAKOC;gBACAA',
-  },
-  // not a valid sourcemap
-  invalid: {
-    version: -123,
-    notAnything: {},
-  },
-  // The correct format but this data is for lines 11,12 even
-  // though the source only has 5 or 6 lines
-  nonMatching: {
-    version: 3,
-    sources: ['myCode'],
-    sourcesContent: [kOriginalSource],
-    names: ['myMain'],
-    mappings: ';;;;;;;;;;kBAYkCA,OACd;SAElB',
-  },
-};
-const kSourceMapsKeys = keysOf(kSourceMaps);
-
 g.test('getCompilationInfo_returns')
   .desc(
     `
     Test that getCompilationInfo() can be called on any ShaderModule.
-
-    Note: sourcemaps are not used in the WebGPU API. We are only testing that
-    browser that happen to use them don't fail or crash if the sourcemap is
-    bad or invalid.
 
     - Test for both valid and invalid shader modules.
     - Test for shader modules containing only ASCII and those containing unicode characters.
     - Test that the compilation info for valid shader modules contains no errors.
     - Test that the compilation info for invalid shader modules contains at least one error.`
   )
-  .params(u =>
-    u.combineWithParams(kAllShaderSources).beginSubcases().combine('sourceMapName', kSourceMapsKeys)
-  )
+  .params(u => u.combineWithParams(kAllShaderSources))
   .fn(async t => {
-    const { _code, valid, sourceMapName } = t.params;
+    const { _code, valid } = t.params;
 
     const shaderModule = t.expectGPUError(
       'validation',
       () => {
-        const sourceMap = kSourceMaps[sourceMapName];
-        return t.device.createShaderModule({ code: _code, ...(sourceMap && { sourceMap }) });
+        return t.device.createShaderModule({ code: _code });
       },
       !valid
     );
@@ -171,25 +128,15 @@ g.test('line_number_and_position')
     Test that line numbers reported by compilationInfo either point at an appropriate line and
     position or at 0:0, indicating an unknown position.
 
-    Note: sourcemaps are not used in the WebGPU API. We are only testing that
-    browser that happen to use them don't fail or crash if the sourcemap is
-    bad or invalid.
-
     - Test for invalid shader modules containing containing at least one error.
     - Test for shader modules containing only ASCII and those containing unicode characters.`
   )
-  .params(u =>
-    u
-      .combineWithParams(kInvalidShaderSources)
-      .beginSubcases()
-      .combine('sourceMapName', kSourceMapsKeys)
-  )
+  .params(u => u.combineWithParams(kInvalidShaderSources))
   .fn(async t => {
-    const { _code, _errorLine, _errorLinePos, sourceMapName } = t.params;
+    const { _code, _errorLine, _errorLinePos } = t.params;
 
     const shaderModule = t.expectGPUError('validation', () => {
-      const sourceMap = kSourceMaps[sourceMapName];
-      return t.device.createShaderModule({ code: _code, ...(sourceMap && { sourceMap }) });
+      return t.device.createShaderModule({ code: _code });
     });
 
     const info = await shaderModule.getCompilationInfo();
@@ -232,24 +179,17 @@ g.test('offset_and_length')
   .desc(
     `Test that message offsets and lengths are valid and align with any reported lineNum and linePos.
 
-     Note: sourcemaps are not used in the WebGPU API. We are only testing that
-     browser that happen to use them don't fail or crash if the sourcemap is
-     bad or invalid.
-
     - Test for valid and invalid shader modules.
     - Test for shader modules containing only ASCII and those containing unicode characters.`
   )
-  .params(u =>
-    u.combineWithParams(kAllShaderSources).beginSubcases().combine('sourceMapName', kSourceMapsKeys)
-  )
+  .params(u => u.combineWithParams(kAllShaderSources))
   .fn(async t => {
-    const { _code, valid, sourceMapName } = t.params;
+    const { _code, valid } = t.params;
 
     const shaderModule = t.expectGPUError(
       'validation',
       () => {
-        const sourceMap = kSourceMaps[sourceMapName];
-        return t.device.createShaderModule({ code: _code, ...(sourceMap && { sourceMap }) });
+        return t.device.createShaderModule({ code: _code });
       },
       !valid
     );


### PR DESCRIPTION
This PR removes testing of the unused GPUShaderModuleDescriptor.sourceMap that was removed from the WebGPU spec at https://github.com/gpuweb/gpuweb/pull/4840


![image](https://github.com/user-attachments/assets/a4a6a90c-99e4-4d9c-9a68-be5ee393464e)

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.) http://127.0.0.1:8080/standalone/?q=webgpu:api,operation,shader_module,compilation_info:*
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
