### PR TITLE
Improve cube-array error logging

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/texture_utils.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/texture_utils.ts
@@ -2346,7 +2346,12 @@ async function identifySamplePoints<T extends Dimensionality>(
       const orderedTexelIndices: number[] = [];
       lines.push('');
       const unSampled = layerEntries ? '' : 'un-sampled';
-      lines.push(`layer: ${layer}${isCube ? ` (${kFaceNames[layer]})` : ''} ${unSampled}`);
+      if (isCube) {
+        const face = kFaceNames[layer % 6];
+        lines.push(`layer: ${layer}, cube-layer: ${(layer / 6) | 0} (${face}) ${unSampled}`);
+      } else {
+        lines.push(`layer: ${unSampled}`);
+      }
 
       if (!layerEntries) {
         continue;


### PR DESCRIPTION
Before:

     layer: 6 (undefined)

After:

     layer: 6, cube-layer: 1 (+x)

The issue was the layer is in 2d layers not cube layers. Cube layers = six 2d layers. So, now it prints both, and it prints the correct face name (+x, -x, +y, ...) for the face when layer >= 6


