### PR TITLE
Fix interpolate test for compat

### DIFF
--- a/src/webgpu/shader/validation/shader_io/interpolate.spec.ts
+++ b/src/webgpu/shader/validation/shader_io/interpolate.spec.ts
@@ -9,15 +9,11 @@ import { generateShader } from './util.js';
 export const g = makeTestGroup(ShaderValidationTest);
 
 // List of valid interpolation attributes.
-const kValidCompatInterpolationAttributes = new Set([
+const kValidInterpolationAttributes = new Set([
   '',
-  '@interpolate(flat, either)',
   '@interpolate(perspective)',
   '@interpolate(perspective, center)',
   '@interpolate(perspective, centroid)',
-]);
-const kValidInterpolationAttributes = new Set([
-  ...kValidCompatInterpolationAttributes,
   '@interpolate(flat)',
   '@interpolate(flat, first)',
   '@interpolate(flat, either)',
@@ -83,10 +79,7 @@ g.test('type_and_sampling')
       io: t.params.io,
       use_struct: t.params.use_struct,
     });
-    const validInterpolationAttributes = t.isCompatibility
-      ? kValidCompatInterpolationAttributes
-      : kValidInterpolationAttributes;
-    t.expectCompileResult(validInterpolationAttributes.has(interpolate), code);
+    t.expectCompileResult(kValidInterpolationAttributes.has(interpolate), code);
   });
 
 g.test('require_location')


### PR DESCRIPTION
These are no longer compile time errors in compat. They are pipeline errors. As pipeline errors they
are tested in

src/webgpu/api/validation/render_pipeline/inter_stage.spec.ts


