### PR TITLE
Fixes for no attachments being an error in webgpu/compat

### DIFF
--- a/src/webgpu/compat/api/validation/render_pipeline/unsupported_wgsl.spec.ts
+++ b/src/webgpu/compat/api/validation/render_pipeline/unsupported_wgsl.spec.ts
@@ -232,6 +232,7 @@ g.test('unsupportedStorageTextureFormats,renderPipeline')
     t.doCreateRenderPipelineTest(async, isValid, {
       layout: 'auto',
       vertex: { module, entryPoint },
+      depthStencil: { format: 'depth32float', depthWriteEnabled: true, depthCompare: 'always' },
     });
   });
 
@@ -305,5 +306,6 @@ g.test('textureLoad_with_depth_textures,renderPipeline')
     t.doCreateRenderPipelineTest(async, isValid, {
       layout: 'auto',
       vertex: { module, entryPoint },
+      depthStencil: { format: 'depth32float', depthWriteEnabled: true, depthCompare: 'always' },
     });
   });


### PR DESCRIPTION


Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
