### PR TITLE
Avoid subnormals in expression validation for quantizing types (in normalize and refract)

### DIFF
--- a/src/webgpu/shader/validation/expression/call/builtin/normalize.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/normalize.spec.ts
@@ -12,7 +12,13 @@ import {
   scalarTypeOf,
   ScalarType,
 } from '../../../../../util/conversion.js';
-import { QuantizeFunc, quantizeToF16, quantizeToF32, isSubnormalNumberF16, isSubnormalNumberF32 } from '../../../../../util/math.js';
+import {
+  QuantizeFunc,
+  quantizeToF16,
+  quantizeToF32,
+  isSubnormalNumberF16,
+  isSubnormalNumberF32,
+} from '../../../../../util/math.js';
 import { ShaderValidationTest } from '../../../shader_validation_test.js';
 
 import {
@@ -37,7 +43,7 @@ function quantizeFunctionForScalarType(type: ScalarType): QuantizeFunc<number> {
   }
 }
 
-function isSubnormalFunctionForScalarType(type: ScalarType): (v:number) => boolean {
+function isSubnormalFunctionForScalarType(type: ScalarType): (v: number) => boolean {
   switch (type) {
     case Type.f32:
       return isSubnormalNumberF32;
@@ -84,7 +90,7 @@ Validates that constant evaluation and override evaluation of ${builtin}() rejec
       expectedResult = false;
     }
 
-    // We skip tests with values that would involve subnormal computations in 
+    // We skip tests with values that would involve subnormal computations in
     // order to avoid defining a specific behavior (flush to zero).
     const isSubnormalFn = isSubnormalFunctionForScalarType(scalarType);
     t.skipIf(isSubnormalFn(vv) || isSubnormalFn(dp) || isSubnormalFn(len));

--- a/src/webgpu/shader/validation/expression/call/builtin/normalize.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/normalize.spec.ts
@@ -12,7 +12,7 @@ import {
   scalarTypeOf,
   ScalarType,
 } from '../../../../../util/conversion.js';
-import { QuantizeFunc, quantizeToF16, quantizeToF32 } from '../../../../../util/math.js';
+import { QuantizeFunc, quantizeToF16, quantizeToF32, isSubnormalNumberF16, isSubnormalNumberF32 } from '../../../../../util/math.js';
 import { ShaderValidationTest } from '../../../shader_validation_test.js';
 
 import {
@@ -34,6 +34,17 @@ function quantizeFunctionForScalarType(type: ScalarType): QuantizeFunc<number> {
       return quantizeToF16;
     default:
       return (v: number) => v;
+  }
+}
+
+function isSubnormalFunctionForScalarType(type: ScalarType): (v:number) => boolean {
+  switch (type) {
+    case Type.f32:
+      return isSubnormalNumberF32;
+    case Type.f16:
+      return isSubnormalNumberF16;
+    default:
+      return (v: number) => false;
   }
 }
 
@@ -72,6 +83,11 @@ Validates that constant evaluation and override evaluation of ${builtin}() rejec
     if (vv === Infinity || dp === Infinity || len === 0) {
       expectedResult = false;
     }
+
+    // We skip tests with values that would involve subnormal computations in 
+    // order to avoid defining a specific behavior.
+    const isSubnormalFn = isSubnormalFunctionForScalarType(scalarType);
+    t.skipIf(isSubnormalFn(vv) || isSubnormalFn(dp) || isSubnormalFn(len));
 
     validateConstOrOverrideBuiltinEval(
       t,

--- a/src/webgpu/shader/validation/expression/call/builtin/normalize.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/normalize.spec.ts
@@ -85,7 +85,7 @@ Validates that constant evaluation and override evaluation of ${builtin}() rejec
     }
 
     // We skip tests with values that would involve subnormal computations in 
-    // order to avoid defining a specific behavior.
+    // order to avoid defining a specific behavior (flush to zero).
     const isSubnormalFn = isSubnormalFunctionForScalarType(scalarType);
     t.skipIf(isSubnormalFn(vv) || isSubnormalFn(dp) || isSubnormalFn(len));
 

--- a/src/webgpu/shader/validation/expression/call/builtin/refract.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/refract.spec.ts
@@ -2,10 +2,21 @@ const builtin = 'refract';
 export const description = `
 Validation tests for the ${builtin}() builtin.
 `;
-import { QuantizeFunc, quantizeToF16, quantizeToF32, isSubnormalNumberF16, isSubnormalNumberF32 } from '../../../../../util/math.js';
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { keysOf, objectsToRecord } from '../../../../../../common/util/data_tables.js';
-import { Type, kConvertableToFloatVectors, scalarTypeOf, ScalarType } from '../../../../../util/conversion.js';
+import {
+  Type,
+  kConvertableToFloatVectors,
+  scalarTypeOf,
+  ScalarType,
+} from '../../../../../util/conversion.js';
+import {
+  QuantizeFunc,
+  quantizeToF16,
+  quantizeToF32,
+  isSubnormalNumberF16,
+  isSubnormalNumberF32,
+} from '../../../../../util/math.js';
 import { ShaderValidationTest } from '../../../shader_validation_test.js';
 
 import {
@@ -41,7 +52,6 @@ function isSubnormalFunctionForScalarType(type: ScalarType): (v: number) => bool
       return (v: number) => false;
   }
 }
-
 
 g.test('values')
   .desc(
@@ -89,12 +99,14 @@ where a the calculations result in a non-representable value for the given type.
 
     const quantizeFn = quantizeFunctionForScalarType(scalarType);
     const isSubnormalFn = isSubnormalFunctionForScalarType(scalarType);
-    // We skip tests with values that would involve subnormal computations in 
+    // We skip tests with values that would involve subnormal computations in
     // order to avoid defining a specific behavior (flush to zero).
-    t.skipIf(isSubnormalFn(quantizeFn(b_dot_a)) ||
-      isSubnormalFn(quantizeFn(b_dot_a_2)) ||
-      isSubnormalFn(quantizeFn(c2)) ||
-      isSubnormalFn(quantizeFn(k)));
+    t.skipIf(
+      isSubnormalFn(quantizeFn(b_dot_a)) ||
+        isSubnormalFn(quantizeFn(b_dot_a_2)) ||
+        isSubnormalFn(quantizeFn(c2)) ||
+        isSubnormalFn(quantizeFn(k))
+    );
 
     if (k >= 0) {
       // If the k is near zero it may fail on some implementations which implement sqrt as

--- a/src/webgpu/shader/validation/expression/call/builtin/refract.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/refract.spec.ts
@@ -2,10 +2,10 @@ const builtin = 'refract';
 export const description = `
 Validation tests for the ${builtin}() builtin.
 `;
-
+import { QuantizeFunc, quantizeToF16, quantizeToF32, isSubnormalNumberF16, isSubnormalNumberF32 } from '../../../../../util/math.js';
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { keysOf, objectsToRecord } from '../../../../../../common/util/data_tables.js';
-import { Type, kConvertableToFloatVectors, scalarTypeOf } from '../../../../../util/conversion.js';
+import { Type, kConvertableToFloatVectors, scalarTypeOf, ScalarType } from '../../../../../util/conversion.js';
 import { ShaderValidationTest } from '../../../shader_validation_test.js';
 
 import {
@@ -19,6 +19,29 @@ import {
 export const g = makeTestGroup(ShaderValidationTest);
 
 const kValidArgumentTypes = objectsToRecord(kConvertableToFloatVectors);
+
+function quantizeFunctionForScalarType(type: ScalarType): QuantizeFunc<number> {
+  switch (type) {
+    case Type.f32:
+      return quantizeToF32;
+    case Type.f16:
+      return quantizeToF16;
+    default:
+      return (v: number) => v;
+  }
+}
+
+function isSubnormalFunctionForScalarType(type: ScalarType): (v: number) => boolean {
+  switch (type) {
+    case Type.f32:
+      return isSubnormalNumberF32;
+    case Type.f16:
+      return isSubnormalNumberF16;
+    default:
+      return (v: number) => false;
+  }
+}
+
 
 g.test('values')
   .desc(
@@ -63,6 +86,15 @@ where a the calculations result in a non-representable value for the given type.
     const c2 = vCheck.checkedResult(c * c);
     const c2_one_minus_b_dot_a_2 = vCheck.checkedResult(c2 * one_minus_b_dot_a_2);
     const k = vCheck.checkedResult(1.0 - c2_one_minus_b_dot_a_2);
+
+    const quantizeFn = quantizeFunctionForScalarType(scalarType);
+    const isSubnormalFn = isSubnormalFunctionForScalarType(scalarType);
+    // We skip tests with values that would involve subnormal computations in 
+    // order to avoid defining a specific behavior (flush to zero).
+    t.skipIf(isSubnormalFn(quantizeFn(b_dot_a)) ||
+      isSubnormalFn(quantizeFn(b_dot_a_2)) ||
+      isSubnormalFn(quantizeFn(c2)) ||
+      isSubnormalFn(quantizeFn(k)));
 
     if (k >= 0) {
       // If the k is near zero it may fail on some implementations which implement sqrt as


### PR DESCRIPTION
We want to avoid specifying behavior for subnormal values of quantized floating types (f32/f16)
We can not specify a validation outcome because that would depend on the exact expression evaluation computations and their interaction with subnormal values.

The flush to zero behavior is under-specified.
https://github.com/gpuweb/cts/blob/main/docs/fp_primer.md#subnormal-numbers

crbug.com/341282612