### PR TITLE
WGSL textureSample tests

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/textureSample.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureSample.spec.ts
@@ -1,14 +1,22 @@
 export const description = `
 Samples a texture.
 
+- TODO: test cube maps with derivatives. These are currently filtered out via kCoord3DViewsForDerivativeTests
+        or by t.skip below.
+
 note: uniformity validation is covered in src/webgpu/shader/validation/uniformity/uniformity.spec.ts
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import {
   isCompressedTextureFormat,
+  isDepthTextureFormat,
+  isEncodableTextureFormat,
   kCompressedTextureFormats,
+  kDepthStencilFormats,
   kEncodableTextureFormats,
+  kTextureFormatInfo,
+  textureDimensionAndFormatCompatible,
 } from '../../../../../format_info.js';
 import { TextureTestMixin } from '../../../../../gpu_test.js';
 
@@ -29,11 +37,13 @@ import {
   chooseTextureSize,
   isPotentiallyFilterableAndFillable,
   skipIfTextureFormatNotSupportedNotAvailableOrNotFilterable,
-  getDepthOrArrayLayersForViewDimension,
   getTextureTypeForTextureViewDimension,
   WGSLTextureSampleTest,
+  kCoord3DViewsForDerivativeTests,
+  isSupportedViewFormatCombo,
+  vec1,
+  generateTextureBuiltinInputs1D,
 } from './texture_utils.js';
-import { generateCoordBoundaries, generateOffsets } from './utils.js';
 
 const kTestableColorFormats = [...kEncodableTextureFormats, ...kCompressedTextureFormats] as const;
 
@@ -51,12 +61,63 @@ Parameters:
  * coords The texture coordinates used for sampling.
 `
   )
-  .paramsSubcasesOnly(u =>
+  .params(u =>
     u
-      .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'] as const)
-      .combine('coords', generateCoordBoundaries(1))
+      .combine('format', kTestableColorFormats)
+      .filter(t => textureDimensionAndFormatCompatible('1d', t.format))
+      .filter(t => isPotentiallyFilterableAndFillable(t.format))
+      .combine('samplePoints', kSamplePointMethods)
+      .beginSubcases()
+      .combine('addressModeU', ['clamp-to-edge', 'repeat', 'mirror-repeat'] as const)
+      .combine('minFilter', ['nearest', 'linear'] as const)
   )
-  .unimplemented();
+  .beforeAllSubcases(t =>
+    skipIfTextureFormatNotSupportedNotAvailableOrNotFilterable(t, t.params.format)
+  )
+  .fn(async t => {
+    const { format, samplePoints, addressModeU, minFilter } = t.params;
+
+    // We want at least 4 blocks or something wide enough for 3 mip levels.
+    const size = chooseTextureSize({ minSize: 8, minBlocks: 4, format, viewDimension: '1d' });
+
+    const descriptor: GPUTextureDescriptor = {
+      format,
+      dimension: '1d',
+      size,
+      usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+    };
+    const { texels, texture } = await createTextureWithRandomDataAndGetTexels(t, descriptor);
+    const sampler: GPUSamplerDescriptor = {
+      addressModeU,
+      minFilter,
+      magFilter: minFilter,
+    };
+
+    const calls: TextureCall<vec1>[] = generateTextureBuiltinInputs1D(50, {
+      sampler,
+      method: samplePoints,
+      descriptor,
+      hashInputs: [format, samplePoints, addressModeU, minFilter],
+    }).map(({ coords, offset }) => {
+      return {
+        builtin: 'textureSample',
+        coordType: 'f',
+        coords,
+      };
+    });
+    const viewDescriptor = {};
+    const textureType = 'texture_1d<f32>';
+    const results = await doTextureCalls(t, texture, viewDescriptor, textureType, sampler, calls);
+    const res = await checkCallResults(
+      t,
+      { texels, descriptor, viewDescriptor },
+      textureType,
+      sampler,
+      calls,
+      results
+    );
+    t.expectOK(res);
+  });
 
 g.test('sampled_2d_coords')
   .specURL('https://www.w3.org/TR/WGSL/#texturesample')
@@ -125,18 +186,12 @@ Parameters:
       };
     });
     const viewDescriptor = {};
-    const results = await doTextureCalls(
-      t,
-      texture,
-      viewDescriptor,
-      'texture_2d<f32>',
-      sampler,
-      calls
-    );
+    const textureType = 'texture_2d<f32>';
+    const results = await doTextureCalls(t, texture, viewDescriptor, textureType, sampler, calls);
     const res = await checkCallResults(
       t,
       { texels, descriptor, viewDescriptor },
-      'texture_2d<f32>',
+      textureType,
       sampler,
       calls,
       results
@@ -236,7 +291,7 @@ Parameters:
       .combine('format', kTestableColorFormats)
       .filter(t => isPotentiallyFilterableAndFillable(t.format))
       .combine('viewDimension', ['3d', 'cube'] as const)
-      .filter(t => !isCompressedTextureFormat(t.format) || t.viewDimension === 'cube')
+      .filter(t => isSupportedViewFormatCombo(t.format, t.viewDimension))
       .combine('samplePoints', kCubeSamplePointMethods)
       .filter(t => t.samplePoints !== 'cube-edges' || t.viewDimension !== '3d')
       .beginSubcases()
@@ -262,14 +317,12 @@ Parameters:
       offset,
     } = t.params;
 
-    const [width, height] = chooseTextureSize({ minSize: 8, minBlocks: 2, format, viewDimension });
-    const depthOrArrayLayers = getDepthOrArrayLayersForViewDimension(viewDimension);
-
+    const size = chooseTextureSize({ minSize: 8, minBlocks: 2, format, viewDimension });
     const descriptor: GPUTextureDescriptor = {
       format,
       dimension: viewDimension === '3d' ? '3d' : '2d',
       ...(t.isCompatibility && { textureBindingViewDimension: viewDimension }),
-      size: { width, height, depthOrArrayLayers },
+      size,
       usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
     };
     const { texels, texture } = await createTextureWithRandomDataAndGetTexels(t, descriptor);
@@ -323,7 +376,7 @@ Parameters:
     const viewDescriptor = {
       dimension: viewDimension,
     };
-    const textureType = getTextureTypeForTextureViewDimension(viewDimension);
+    const textureType = getTextureTypeForTextureViewDimension(viewDimension)!;
     const results = await doTextureCalls(t, texture, viewDescriptor, textureType, sampler, calls);
     const res = await checkCallResults(
       t,
@@ -334,6 +387,101 @@ Parameters:
       results
     );
     t.expectOK(res);
+  });
+
+g.test('sampled_3d_coords,derivatives')
+  .specURL('https://www.w3.org/TR/WGSL/#texturesample')
+  .desc(
+    `
+fn textureSample(t: texture_3d<f32>, s: sampler, coords: vec3<f32>) -> vec4<f32>
+fn textureSample(t: texture_3d<f32>, s: sampler, coords: vec3<f32>, offset: vec3<i32>) -> vec4<f32>
+fn textureSample(t: texture_cube<f32>, s: sampler, coords: vec3<f32>) -> vec4<f32>
+
+test mip level selection based on derivatives
+
+* TODO: test 3d compressed textures formats. Just remove the filter below 'viewDimension'
+`
+  )
+  .params(u =>
+    u
+      .combine('format', kTestableColorFormats)
+      .filter(t => {
+        const type = kTextureFormatInfo[t.format].color?.type;
+        const canPotentialFilter = type === 'float' || type === 'unfilterable-float';
+        // We can't easily put random bytes into compressed textures if they are float formats
+        // since we want the range to be +/- 1000 and not +/- infinity or NaN.
+        const isFillable = !isCompressedTextureFormat(t.format) || !t.format.endsWith('float');
+        return canPotentialFilter && isFillable;
+      })
+      .combine('viewDimension', kCoord3DViewsForDerivativeTests)
+      .filter(t => isSupportedViewFormatCombo(t.format, t.viewDimension))
+      .combine('mipmapFilter', ['nearest', 'linear'] as const)
+      .beginSubcases()
+      // note: this is the derivative we want at sample time. It is not the value
+      // passed directly to the shader. This way if we change the texture size
+      // or render target size we can compute the correct values to achieve the
+      // same results.
+      .combineWithParams([
+        { ddx: 0.5, ddy: 0.5 }, // test mag filter
+        { ddx: 1, ddy: 1 }, // test level 0
+        { ddx: 2, ddy: 1 }, // test level 1 via ddx
+        { ddx: 1, ddy: 4 }, // test level 2 via ddy
+        { ddx: 1.5, ddy: 1.5 }, // test mix between 1 and 2
+        { ddx: 6, ddy: 6 }, // test mix between 2 and 3 (there is no 3 so we should get just 2)
+        { ddx: 1.5, ddy: 1.5, offset: [4, 7, -8] as const }, // test mix between 1 and 2 with offset
+        { ddx: 1.5, ddy: 1.5, offset: [3, -3, 2] as const }, // test mix between 1 and 2 with offset
+        { ddx: 1.5, ddy: 1.5, uvwStart: [-3.5, -4, -5] as const }, // test mix between 1 and 2 with negative coords
+      ])
+      .filter(t => !(t.viewDimension === 'cube' && t.offset !== undefined))
+  )
+  .beforeAllSubcases(t => {
+    const { format } = t.params;
+    t.skipIfTextureFormatNotSupported(format);
+    const info = kTextureFormatInfo[format];
+    if (info.color?.type === 'unfilterable-float') {
+      t.selectDeviceOrSkipTestCase('float32-filterable');
+    } else {
+      t.selectDeviceForTextureFormatOrSkipTestCase(t.params.format);
+    }
+  })
+  .fn(async t => {
+    const { format, mipmapFilter, ddx, ddy, uvwStart, offset, viewDimension } = t.params;
+
+    // We want at least 4 blocks or something wide enough for 3 mip levels.
+    const size = chooseTextureSize({
+      minSize: 8,
+      minBlocks: 4,
+      format,
+      viewDimension,
+    });
+
+    const descriptor: GPUTextureDescriptor = {
+      format,
+      dimension: viewDimension === '3d' ? '3d' : '2d',
+      ...(t.isCompatibility && { textureBindingViewDimension: viewDimension }),
+      mipLevelCount: 3,
+      size,
+      usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+    };
+
+    const sampler: GPUSamplerDescriptor = {
+      addressModeU: 'repeat',
+      addressModeV: 'repeat',
+      addressModeW: 'repeat',
+      minFilter: 'linear',
+      magFilter: 'linear',
+      mipmapFilter,
+    };
+    const viewDescriptor = {
+      dimension: viewDimension,
+    };
+    await putDataInTextureThenDrawAndCheckResultsComparedToSoftwareRasterizer(
+      t,
+      descriptor,
+      viewDescriptor,
+      sampler,
+      { ddx, ddy, uvwStart, offset }
+    );
   });
 
 g.test('depth_2d_coords')
@@ -355,22 +503,139 @@ Parameters:
       Values outside of this range will result in a shader-creation error.
 `
   )
-  .paramsSubcasesOnly(u =>
+  .params(u =>
     u
-      .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'] as const)
-      .combine('coords', generateCoordBoundaries(2))
-      .combine('offset', generateOffsets(2))
+      .combine('format', kDepthStencilFormats)
+      // filter out stencil only formats
+      .filter(t => isDepthTextureFormat(t.format))
+      // MAINTENANCE_TODO: Remove when support for depth24plus, depth24plus-stencil8, and depth32float-stencil8 is added.
+      .filter(t => isEncodableTextureFormat(t.format))
+      .beginSubcases()
+      .combine('samplePoints', kSamplePointMethods)
+      .combine('addressModeU', ['clamp-to-edge', 'repeat', 'mirror-repeat'] as const)
+      .combine('addressModeV', ['clamp-to-edge', 'repeat', 'mirror-repeat'] as const)
+      .combine('minFilter', ['nearest', 'linear'] as const)
+      .combine('offset', [false, true] as const)
   )
-  .unimplemented();
+  .fn(async t => {
+    const { format, samplePoints, addressModeU, addressModeV, minFilter, offset } = t.params;
+
+    // We want at least 4 blocks or something wide enough for 3 mip levels.
+    const [width, height] = chooseTextureSize({ minSize: 8, minBlocks: 4, format });
+    const descriptor: GPUTextureDescriptor = {
+      format,
+      size: { width, height },
+      usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+    };
+    const { texels, texture } = await createTextureWithRandomDataAndGetTexels(t, descriptor);
+    const sampler: GPUSamplerDescriptor = {
+      addressModeU,
+      addressModeV,
+      minFilter,
+      magFilter: minFilter,
+      mipmapFilter: minFilter,
+    };
+
+    const calls: TextureCall<vec2>[] = generateTextureBuiltinInputs2D(50, {
+      sampler,
+      method: samplePoints,
+      descriptor,
+      offset,
+      hashInputs: [format, samplePoints, addressModeU, addressModeV, minFilter, offset],
+    }).map(({ coords, offset }) => {
+      return {
+        builtin: 'textureSample',
+        coordType: 'f',
+        coords,
+        offset,
+      };
+    });
+
+    const viewDescriptor = {};
+    const textureType = 'texture_depth_2d';
+    const results = await doTextureCalls(t, texture, viewDescriptor, textureType, sampler, calls);
+    const res = await checkCallResults(
+      t,
+      { texels, descriptor, viewDescriptor },
+      textureType,
+      sampler,
+      calls,
+      results
+    );
+    t.expectOK(res);
+  });
+
+g.test('depth_2d_coords,derivatives')
+  .specURL('https://www.w3.org/TR/WGSL/#texturesample')
+  .desc(
+    `
+fn textureSample(t: texture_depth_2d, s: sampler, coords: vec2<f32>) -> f32
+fn textureSample(t: texture_depth_2d, s: sampler, coords: vec2<f32>, offset: vec2<i32>) -> f32
+
+test mip level selection based on derivatives
+`
+  )
+  .params(u =>
+    u
+      .combine('format', kDepthStencilFormats)
+      // filter out stencil only formats
+      .filter(t => isDepthTextureFormat(t.format))
+      // MAINTENANCE_TODO: Remove when support for depth24plus, depth24plus-stencil8, and depth32float-stencil8 is added.
+      .filter(t => isEncodableTextureFormat(t.format))
+      .beginSubcases()
+      .combine('mipmapFilter', ['nearest', 'linear'] as const)
+      // note: this is the derivative we want at sample time. It is not the value
+      // passed directly to the shader. This way if we change the texture size
+      // or render target size we can compute the correct values to achieve the
+      // same results.
+      .combineWithParams([
+        { ddx: 0.5, ddy: 0.5 }, // test mag filter
+        { ddx: 1, ddy: 1 }, // test level 0
+        { ddx: 2, ddy: 1 }, // test level 1 via ddx
+        { ddx: 1, ddy: 4 }, // test level 2 via ddy
+        { ddx: 1.5, ddy: 1.5 }, // test mix between 1 and 2
+        { ddx: 6, ddy: 6 }, // test mix between 2 and 3 (there is no 3 so we should get just 2)
+        { ddx: 1.5, ddy: 1.5, offset: [7, -8] as const }, // test mix between 1 and 2 with offset
+        { ddx: 1.5, ddy: 1.5, offset: [3, -3] as const }, // test mix between 1 and 2 with offset
+        { ddx: 1.5, ddy: 1.5, uvwStart: [-3.5, -4] as const }, // test mix between 1 and 2 with negative coords
+      ])
+  )
+  .fn(async t => {
+    const { format, mipmapFilter, ddx, ddy, uvwStart, offset } = t.params;
+
+    // We want at least 4 blocks or something wide enough for 3 mip levels.
+    const [width, height] = chooseTextureSize({ minSize: 8, minBlocks: 4, format });
+    const descriptor: GPUTextureDescriptor = {
+      format,
+      size: { width, height },
+      usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+      mipLevelCount: 3,
+    };
+    const sampler: GPUSamplerDescriptor = {
+      addressModeU: 'repeat',
+      addressModeV: 'repeat',
+      minFilter: 'linear',
+      magFilter: 'linear',
+      mipmapFilter,
+    };
+    const viewDescriptor = {};
+    await putDataInTextureThenDrawAndCheckResultsComparedToSoftwareRasterizer(
+      t,
+      descriptor,
+      viewDescriptor,
+      sampler,
+      { ddx, ddy, uvwStart, offset, depthTexture: true }
+    );
+  });
 
 g.test('sampled_array_2d_coords')
   .specURL('https://www.w3.org/TR/WGSL/#texturesample')
   .desc(
     `
-C is i32 or u32
+A is i32 or u32
 
-fn textureSample(t: texture_2d_array<f32>, s: sampler, coords: vec2<f32>, array_index: C) -> vec4<f32>
-fn textureSample(t: texture_2d_array<f32>, s: sampler, coords: vec2<f32>, array_index: C, offset: vec2<i32>) -> vec4<f32>
+fn textureSample(t: texture_2d_array<f32>, s: sampler, coords: vec2<f32>, array_index: A) -> vec4<f32>
+fn textureSample(t: texture_2d_array<f32>, s: sampler, coords: vec2<f32>, array_index: A, offset: vec2<i32>) -> vec4<f32>
 
 Parameters:
  * t  The sampled, depth, or external texture to sample.
@@ -385,24 +650,157 @@ Parameters:
       Values outside of this range will result in a shader-creation error.
 `
   )
-  .paramsSubcasesOnly(u =>
+  .params(u =>
     u
-      .combine('C', ['i32', 'u32'] as const)
-      .combine('C_value', [-1, 0, 1, 2, 3, 4] as const)
-      .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'] as const)
-      .combine('coords', generateCoordBoundaries(2))
-      /* array_index not param'd as out-of-bounds is implementation specific */
-      .combine('offset', generateOffsets(2))
+      .combine('format', kTestableColorFormats)
+      .filter(t => isPotentiallyFilterableAndFillable(t.format))
+      .beginSubcases()
+      .combine('samplePoints', kSamplePointMethods)
+      .combine('A', ['i32', 'u32'] as const)
+      .combine('addressModeU', ['clamp-to-edge', 'repeat', 'mirror-repeat'] as const)
+      .combine('addressModeV', ['clamp-to-edge', 'repeat', 'mirror-repeat'] as const)
+      .combine('minFilter', ['nearest', 'linear'] as const)
+      .combine('offset', [false, true] as const)
   )
-  .unimplemented();
+  .beforeAllSubcases(t =>
+    skipIfTextureFormatNotSupportedNotAvailableOrNotFilterable(t, t.params.format)
+  )
+  .fn(async t => {
+    const { format, samplePoints, A, addressModeU, addressModeV, minFilter, offset } = t.params;
+
+    // We want at least 4 blocks or something wide enough for 3 mip levels.
+    const [width, height] = chooseTextureSize({ minSize: 8, minBlocks: 4, format });
+    const depthOrArrayLayers = 4;
+
+    const descriptor: GPUTextureDescriptor = {
+      format,
+      size: { width, height, depthOrArrayLayers },
+      usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+    };
+    const { texels, texture } = await createTextureWithRandomDataAndGetTexels(t, descriptor);
+    const sampler: GPUSamplerDescriptor = {
+      addressModeU,
+      addressModeV,
+      minFilter,
+      magFilter: minFilter,
+      mipmapFilter: minFilter,
+    };
+
+    const calls: TextureCall<vec2>[] = generateTextureBuiltinInputs2D(50, {
+      method: samplePoints,
+      sampler,
+      descriptor,
+      arrayIndex: { num: texture.depthOrArrayLayers, type: A },
+      offset,
+      hashInputs: [format, samplePoints, A, addressModeU, addressModeV, minFilter, offset],
+    }).map(({ coords, arrayIndex, offset }) => {
+      return {
+        builtin: 'textureSample',
+        coordType: 'f',
+        coords,
+        arrayIndex,
+        arrayIndexType: A === 'i32' ? 'i' : 'u',
+        offset,
+      };
+    });
+    const textureType = 'texture_2d_array<f32>';
+    const viewDescriptor = {};
+    const results = await doTextureCalls(t, texture, viewDescriptor, textureType, sampler, calls);
+    const res = await checkCallResults(
+      t,
+      { texels, descriptor, viewDescriptor },
+      textureType,
+      sampler,
+      calls,
+      results
+    );
+    t.expectOK(res);
+  });
+
+g.test('sampled_array_2d_coords,derivatives')
+  .specURL('https://www.w3.org/TR/WGSL/#texturesample')
+  .desc(
+    `
+A is i32 or u32
+
+fn textureSample(t: texture_2d_array<f32>, s: sampler, coords: vec2<f32>, array_index: A) -> vec4<f32>
+fn textureSample(t: texture_2d_array<f32>, s: sampler, coords: vec2<f32>, array_index: A, offset: vec2<i32>) -> vec4<f32>
+
+test mip level selection based on derivatives
+`
+  )
+  .params(u =>
+    u
+      .combine('format', kTestableColorFormats)
+      .filter(t => isPotentiallyFilterableAndFillable(t.format))
+      .combine('mipmapFilter', ['nearest', 'linear'] as const)
+      .beginSubcases()
+      .combine('A', ['i32', 'u32'] as const)
+      // note: this is the derivative we want at sample time. It is not the value
+      // passed directly to the shader. This way if we change the texture size
+      // or render target size we can compute the correct values to achieve the
+      // same results.
+      .combineWithParams([
+        { ddx: 0.5, ddy: 0.5 }, // test mag filter
+        { ddx: 1, ddy: 1 }, // test level 0
+        { ddx: 2, ddy: 1 }, // test level 1 via ddx
+        { ddx: 1, ddy: 4 }, // test level 2 via ddy
+        { ddx: 1.5, ddy: 1.5 }, // test mix between 1 and 2
+        { ddx: 6, ddy: 6 }, // test mix between 2 and 3 (there is no 3 so we should get just 2)
+        { ddx: 1.5, ddy: 1.5, offset: [7, -8] as const }, // test mix between 1 and 2 with offset
+        { ddx: 1.5, ddy: 1.5, offset: [3, -3] as const }, // test mix between 1 and 2 with offset
+        { ddx: 1.5, ddy: 1.5, uvwStart: [-3.5, -4] as const }, // test mix between 1 and 2 with negative coords
+      ])
+  )
+  .beforeAllSubcases(t =>
+    skipIfTextureFormatNotSupportedNotAvailableOrNotFilterable(t, t.params.format)
+  )
+  .fn(async t => {
+    const { format, A, mipmapFilter, ddx, ddy, uvwStart, offset } = t.params;
+
+    // We want at least 4 blocks or something wide enough for 3 mip levels.
+    const viewDimension: GPUTextureViewDimension = '2d-array';
+    const size = chooseTextureSize({ minSize: 8, minBlocks: 4, format, viewDimension });
+
+    const descriptor: GPUTextureDescriptor = {
+      format,
+      mipLevelCount: 3,
+      size,
+      usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+    };
+
+    const sampler: GPUSamplerDescriptor = {
+      addressModeU: 'repeat',
+      addressModeV: 'repeat',
+      minFilter: 'linear',
+      magFilter: 'linear',
+      mipmapFilter,
+    };
+    const viewDescriptor = {
+      dimension: viewDimension,
+    };
+    await putDataInTextureThenDrawAndCheckResultsComparedToSoftwareRasterizer(
+      t,
+      descriptor,
+      viewDescriptor,
+      sampler,
+      {
+        ddx,
+        ddy,
+        uvwStart,
+        offset,
+        arrayIndexType: A === 'i32' ? 'i' : 'u',
+      }
+    );
+  });
 
 g.test('sampled_array_3d_coords')
   .specURL('https://www.w3.org/TR/WGSL/#texturesample')
   .desc(
     `
-C is i32 or u32
+A is i32 or u32
 
-fn textureSample(t: texture_cube_array<f32>, s: sampler, coords: vec3<f32>, array_index: C) -> vec4<f32>
+fn textureSample(t: texture_cube_array<f32>, s: sampler, coords: vec3<f32>, array_index: A) -> vec4<f32>
 
 Parameters:
  * t  The sampled, depth, or external texture to sample.
@@ -411,16 +809,165 @@ Parameters:
  * array_index The 0-based texture array index to sample.
 `
   )
-  .paramsSubcasesOnly(
-    u =>
-      u
-        .combine('C', ['i32', 'u32'] as const)
-        .combine('C_value', [-1, 0, 1, 2, 3, 4] as const)
-        .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'] as const)
-        .combine('coords', generateCoordBoundaries(3))
-    /* array_index not param'd as out-of-bounds is implementation specific */
+  .params(u =>
+    u
+      .combine('format', kTestableColorFormats)
+      .filter(t => isPotentiallyFilterableAndFillable(t.format))
+      .beginSubcases()
+      .combine('samplePoints', kCubeSamplePointMethods)
+      .combine('A', ['i32', 'u32'] as const)
+      .combine('addressMode', ['clamp-to-edge', 'repeat', 'mirror-repeat'] as const)
+      .combine('minFilter', ['nearest', 'linear'] as const)
   )
-  .unimplemented();
+  .beforeAllSubcases(t => {
+    skipIfTextureFormatNotSupportedNotAvailableOrNotFilterable(t, t.params.format);
+    t.skipIfTextureViewDimensionNotSupported('cube-array');
+  })
+  .fn(async t => {
+    const { format, samplePoints, A, addressMode, minFilter } = t.params;
+
+    const viewDimension: GPUTextureViewDimension = 'cube-array';
+    const size = chooseTextureSize({
+      minSize: 32,
+      minBlocks: 4,
+      format,
+      viewDimension,
+    });
+    const descriptor: GPUTextureDescriptor = {
+      format,
+      size,
+      usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+    };
+    const { texels, texture } = await createTextureWithRandomDataAndGetTexels(t, descriptor);
+    const sampler: GPUSamplerDescriptor = {
+      addressModeU: addressMode,
+      addressModeV: addressMode,
+      addressModeW: addressMode,
+      minFilter,
+      magFilter: minFilter,
+      mipmapFilter: minFilter,
+    };
+
+    const calls: TextureCall<vec3>[] = generateSamplePointsCube(50, {
+      method: samplePoints,
+      sampler,
+      descriptor,
+      arrayIndex: { num: texture.depthOrArrayLayers / 6, type: A },
+      hashInputs: [format, viewDimension, A, samplePoints, addressMode, minFilter],
+    }).map(({ coords, arrayIndex }) => {
+      return {
+        builtin: 'textureSample',
+        coordType: 'f',
+        coords,
+        arrayIndex,
+        arrayIndexType: A === 'i32' ? 'i' : 'u',
+      };
+    });
+    const viewDescriptor = {
+      dimension: viewDimension,
+    };
+    const textureType = getTextureTypeForTextureViewDimension(viewDimension);
+    const results = await doTextureCalls(t, texture, viewDescriptor, textureType, sampler, calls);
+    const res = await checkCallResults(
+      t,
+      { texels, descriptor, viewDescriptor },
+      textureType,
+      sampler,
+      calls,
+      results
+    );
+    t.expectOK(res);
+  });
+
+g.test('sampled_array_3d_coords,derivatives')
+  .specURL('https://www.w3.org/TR/WGSL/#texturesample')
+  .desc(
+    `
+A is i32 or u32
+
+fn textureSample(t: texture_cube_array<f32>, s: sampler, coords: vec3<f32>, array_index: A) -> vec4<f32>
+
+test mip level selection based on derivatives
+
+Parameters:
+ * t  The sampled, depth, or external texture to sample.
+ * s  The sampler type.
+ * coords The texture coordinates used for sampling.
+ * array_index The 0-based texture array index to sample.
+`
+  )
+  .params(u =>
+    u
+      .combine('format', kTestableColorFormats)
+      .filter(t => {
+        const type = kTextureFormatInfo[t.format].color?.type;
+        const canPotentialFilter = type === 'float' || type === 'unfilterable-float';
+        // We can't easily put random bytes into compressed textures if they are float formats
+        // since we want the range to be +/- 1000 and not +/- infinity or NaN.
+        const isFillable = !isCompressedTextureFormat(t.format) || !t.format.endsWith('float');
+        return canPotentialFilter && isFillable;
+      })
+      .combine('mipmapFilter', ['nearest', 'linear'] as const)
+      .beginSubcases()
+      .combine('A', ['i32', 'u32'] as const)
+      // note: this is the derivative we want at sample time. It is not the value
+      // passed directly to the shader. This way if we change the texture size
+      // or render target size we can compute the correct values to achieve the
+      // same results.
+      .combineWithParams([
+        { ddx: 0.5, ddy: 0.5 }, // test mag filter
+        { ddx: 1, ddy: 1 }, // test level 0
+        { ddx: 2, ddy: 1 }, // test level 1 via ddx
+        { ddx: 1, ddy: 4 }, // test level 2 via ddy
+        { ddx: 1.5, ddy: 1.5 }, // test mix between 1 and 2
+        { ddx: 6, ddy: 6 }, // test mix between 2 and 3 (there is no 3 so we should get just 2)
+        { ddx: 1.5, ddy: 1.5, uvwStart: [-3.5, -4, -5] as const }, // test mix between 1 and 2 with negative coords
+      ])
+  )
+  .beforeAllSubcases(t => {
+    skipIfTextureFormatNotSupportedNotAvailableOrNotFilterable(t, t.params.format);
+    t.skipIfTextureViewDimensionNotSupported('cube-array');
+    t.skip('testing cube maps with derivatives is not yet supported');
+  })
+  .fn(async t => {
+    const { format, mipmapFilter, ddx, ddy, uvwStart, A } = t.params;
+
+    const viewDimension: GPUTextureViewDimension = 'cube-array';
+    // We want at least 4 blocks or something wide enough for 3 mip levels.
+    const size = chooseTextureSize({
+      minSize: 32,
+      minBlocks: 4,
+      format,
+      viewDimension,
+    });
+
+    const descriptor: GPUTextureDescriptor = {
+      format,
+      ...(t.isCompatibility && { textureBindingViewDimension: viewDimension }),
+      mipLevelCount: 3,
+      size,
+      usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+    };
+
+    const sampler: GPUSamplerDescriptor = {
+      addressModeU: 'repeat',
+      addressModeV: 'repeat',
+      addressModeW: 'repeat',
+      minFilter: 'linear',
+      magFilter: 'linear',
+      mipmapFilter,
+    };
+    const viewDescriptor = {
+      dimension: viewDimension,
+    };
+    await putDataInTextureThenDrawAndCheckResultsComparedToSoftwareRasterizer(
+      t,
+      descriptor,
+      viewDescriptor,
+      sampler,
+      { ddx, ddy, uvwStart, arrayIndexType: A === 'i32' ? 'i' : 'u' }
+    );
+  });
 
 g.test('depth_3d_coords')
   .specURL('https://www.w3.org/TR/WGSL/#texturesample')
@@ -434,21 +981,171 @@ Parameters:
  * coords The texture coordinates used for sampling.
 `
   )
-  .paramsSubcasesOnly(u =>
+  .params(u =>
     u
-      .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'] as const)
-      .combine('coords', generateCoordBoundaries(3))
+      .combine('format', kDepthStencilFormats)
+      // filter out stencil only formats
+      .filter(t => isDepthTextureFormat(t.format))
+      // MAINTENANCE_TODO: Remove when support for depth24plus, depth24plus-stencil8, and depth32float-stencil8 is added.
+      .filter(t => isEncodableTextureFormat(t.format))
+      .combineWithParams([
+        { viewDimension: 'cube' },
+        { viewDimension: 'cube-array', A: 'i32' },
+        { viewDimension: 'cube-array', A: 'u32' },
+      ] as const)
+      .beginSubcases()
+      .combine('samplePoints', kCubeSamplePointMethods)
+      .combine('addressMode', ['clamp-to-edge', 'repeat', 'mirror-repeat'] as const)
+      .combine('minFilter', ['nearest', 'linear'] as const)
   )
-  .unimplemented();
+  .beforeAllSubcases(t => {
+    t.skipIfTextureViewDimensionNotSupported(t.params.viewDimension);
+  })
+  .fn(async t => {
+    const { format, viewDimension, samplePoints, A, addressMode, minFilter } = t.params;
+
+    const size = chooseTextureSize({
+      minSize: 32,
+      minBlocks: 4,
+      format,
+      viewDimension,
+    });
+    const descriptor: GPUTextureDescriptor = {
+      format,
+      size,
+      usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+      ...(t.isCompatibility && { textureBindingViewDimension: viewDimension }),
+    };
+    const { texels, texture } = await createTextureWithRandomDataAndGetTexels(t, descriptor);
+    const sampler: GPUSamplerDescriptor = {
+      addressModeU: addressMode,
+      addressModeV: addressMode,
+      addressModeW: addressMode,
+      minFilter,
+      magFilter: minFilter,
+      mipmapFilter: minFilter,
+    };
+
+    const calls: TextureCall<vec3>[] = generateSamplePointsCube(50, {
+      method: samplePoints,
+      sampler,
+      descriptor,
+      arrayIndex: A ? { num: texture.depthOrArrayLayers / 6, type: A } : undefined,
+      hashInputs: [format, viewDimension, samplePoints, addressMode, minFilter],
+    }).map(({ coords, arrayIndex }) => {
+      return {
+        builtin: 'textureSample',
+        coordType: 'f',
+        coords,
+        arrayIndex,
+        arrayIndexType: A ? (A === 'i32' ? 'i' : 'u') : undefined,
+      };
+    });
+    const viewDescriptor = {
+      dimension: viewDimension,
+    };
+    const textureType =
+      viewDimension === 'cube' ? 'texture_depth_cube' : 'texture_depth_cube_array';
+    const results = await doTextureCalls(t, texture, viewDescriptor, textureType, sampler, calls);
+
+    const res = await checkCallResults(
+      t,
+      { texels, descriptor, viewDescriptor },
+      textureType,
+      sampler,
+      calls,
+      results
+    );
+    t.expectOK(res);
+  });
+
+g.test('depth_3d_coords,derivatives')
+  .specURL('https://www.w3.org/TR/WGSL/#texturesample')
+  .desc(
+    `
+fn textureSample(t: texture_depth_cube, s: sampler, coords: vec3<f32>) -> f32
+
+test mip level selection based on derivatives
+
+Parameters:
+ * t  The sampled, depth, or external texture to sample.
+ * s  The sampler type.
+ * coords The texture coordinates used for sampling.
+`
+  )
+  .params(u =>
+    u
+      .combine('format', kDepthStencilFormats)
+      // filter out stencil only formats
+      .filter(t => isDepthTextureFormat(t.format))
+      // MAINTENANCE_TODO: Remove when support for depth24plus, depth24plus-stencil8, and depth32float-stencil8 is added.
+      .filter(t => isEncodableTextureFormat(t.format))
+      .combine('mipmapFilter', ['nearest', 'linear'] as const)
+      .beginSubcases()
+      // note: this is the derivative we want at sample time. It is not the value
+      // passed directly to the shader. This way if we change the texture size
+      // or render target size we can compute the correct values to achieve the
+      // same results.
+      .combineWithParams([
+        { ddx: 0.5, ddy: 0.5 }, // test mag filter
+        { ddx: 1, ddy: 1 }, // test level 0
+        { ddx: 2, ddy: 1 }, // test level 1 via ddx
+        { ddx: 1, ddy: 4 }, // test level 2 via ddy
+        { ddx: 1.5, ddy: 1.5 }, // test mix between 1 and 2
+        { ddx: 6, ddy: 6 }, // test mix between 2 and 3 (there is no 3 so we should get just 2)
+      ])
+  )
+  .beforeAllSubcases(t => {
+    t.skip('testing cube maps with derivatives is not yet supported');
+  })
+  .fn(async t => {
+    const { format, mipmapFilter, ddx, ddy } = t.params;
+    const viewDimension: GPUTextureViewDimension = 'cube';
+
+    // We want at least 4 blocks or something wide enough for 3 mip levels.
+    const size = chooseTextureSize({
+      minSize: 32,
+      minBlocks: 4,
+      format,
+      viewDimension,
+    });
+
+    const descriptor: GPUTextureDescriptor = {
+      format,
+      ...(t.isCompatibility && { textureBindingViewDimension: viewDimension }),
+      mipLevelCount: 3,
+      size,
+      usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+    };
+
+    const sampler: GPUSamplerDescriptor = {
+      addressModeU: 'repeat',
+      addressModeV: 'repeat',
+      addressModeW: 'repeat',
+      minFilter: 'linear',
+      magFilter: 'linear',
+      mipmapFilter,
+    };
+    const viewDescriptor = {
+      dimension: viewDimension,
+    };
+    await putDataInTextureThenDrawAndCheckResultsComparedToSoftwareRasterizer(
+      t,
+      descriptor,
+      viewDescriptor,
+      sampler,
+      { ddx, ddy, depthTexture: true }
+    );
+  });
 
 g.test('depth_array_2d_coords')
   .specURL('https://www.w3.org/TR/WGSL/#texturesample')
   .desc(
     `
-C is i32 or u32
+A is i32 or u32
 
-fn textureSample(t: texture_depth_2d_array, s: sampler, coords: vec2<f32>, array_index: C) -> f32
-fn textureSample(t: texture_depth_2d_array, s: sampler, coords: vec2<f32>, array_index: C, offset: vec2<i32>) -> f32
+fn textureSample(t: texture_depth_2d_array, s: sampler, coords: vec2<f32>, array_index: A) -> f32
+fn textureSample(t: texture_depth_2d_array, s: sampler, coords: vec2<f32>, array_index: A, offset: vec2<i32>) -> f32
 
 Parameters:
  * t  The sampled, depth, or external texture to sample.
@@ -463,24 +1160,157 @@ Parameters:
       Values outside of this range will result in a shader-creation error.
 `
   )
-  .paramsSubcasesOnly(u =>
+  .params(u =>
     u
-      .combine('C', ['i32', 'u32'] as const)
-      .combine('C_value', [-1, 0, 1, 2, 3, 4] as const)
-      .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'] as const)
-      .combine('coords', generateCoordBoundaries(2))
-      /* array_index not param'd as out-of-bounds is implementation specific */
-      .combine('offset', generateOffsets(2))
+      .combine('format', kDepthStencilFormats)
+      // filter out stencil only formats
+      .filter(t => isDepthTextureFormat(t.format))
+      // MAINTENANCE_TODO: Remove when support for depth24plus, depth24plus-stencil8, and depth32float-stencil8 is added.
+      .filter(t => isEncodableTextureFormat(t.format))
+      .beginSubcases()
+      .combine('samplePoints', kSamplePointMethods)
+      .combine('addressMode', ['clamp-to-edge', 'repeat', 'mirror-repeat'] as const)
+      .combine('minFilter', ['nearest', 'linear'] as const)
+      .combine('A', ['i32', 'u32'] as const)
+      .combine('L', ['i32', 'u32'] as const)
+      .combine('offset', [false, true] as const)
   )
-  .unimplemented();
+  .fn(async t => {
+    const { format, samplePoints, addressMode, minFilter, A, L, offset } = t.params;
+
+    // We want at least 4 blocks or something wide enough for 3 mip levels.
+    const [width, height] = chooseTextureSize({ minSize: 8, minBlocks: 4, format });
+    const descriptor: GPUTextureDescriptor = {
+      format,
+      size: { width, height },
+      usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+      ...(t.isCompatibility && { textureBindingViewDimension: '2d-array' }),
+    };
+    const { texels, texture } = await createTextureWithRandomDataAndGetTexels(t, descriptor);
+    const sampler: GPUSamplerDescriptor = {
+      addressModeU: addressMode,
+      addressModeV: addressMode,
+      minFilter,
+      magFilter: minFilter,
+      mipmapFilter: minFilter,
+    };
+
+    const calls: TextureCall<vec2>[] = generateTextureBuiltinInputs2D(50, {
+      method: samplePoints,
+      sampler,
+      descriptor,
+      arrayIndex: { num: texture.depthOrArrayLayers, type: A },
+      offset,
+      hashInputs: [format, samplePoints, addressMode, minFilter, L, A, offset],
+    }).map(({ coords, arrayIndex, offset }) => {
+      return {
+        builtin: 'textureSample',
+        coordType: 'f',
+        coords,
+        arrayIndex,
+        arrayIndexType: A === 'i32' ? 'i' : 'u',
+        offset,
+      };
+    });
+    const textureType = 'texture_depth_2d_array';
+    const viewDescriptor: GPUTextureViewDescriptor = { dimension: '2d-array' };
+    const results = await doTextureCalls(t, texture, viewDescriptor, textureType, sampler, calls);
+    const res = await checkCallResults(
+      t,
+      { texels, descriptor, viewDescriptor },
+      textureType,
+      sampler,
+      calls,
+      results
+    );
+    t.expectOK(res);
+  });
+
+g.test('depth_array_2d_coords,derivatives')
+  .specURL('https://www.w3.org/TR/WGSL/#texturesample')
+  .desc(
+    `
+A is i32 or u32
+
+fn textureSample(t: texture_depth_2d_array, s: sampler, coords: vec2<f32>, array_index: A) -> f32
+fn textureSample(t: texture_depth_2d_array, s: sampler, coords: vec2<f32>, array_index: A, offset: vec2<i32>) -> f32
+
+test mip level selection based on derivatives
+`
+  )
+  .params(u =>
+    u
+      .combine('format', kDepthStencilFormats)
+      // filter out stencil only formats
+      .filter(t => isDepthTextureFormat(t.format))
+      // MAINTENANCE_TODO: Remove when support for depth24plus, depth24plus-stencil8, and depth32float-stencil8 is added.
+      .filter(t => isEncodableTextureFormat(t.format))
+      .combine('mipmapFilter', ['nearest', 'linear'] as const)
+      .beginSubcases()
+      .combine('A', ['i32', 'u32'] as const)
+      // note: this is the derivative we want at sample time. It is not the value
+      // passed directly to the shader. This way if we change the texture size
+      // or render target size we can compute the correct values to achieve the
+      // same results.
+      .combineWithParams([
+        { ddx: 0.5, ddy: 0.5 }, // test mag filter
+        { ddx: 1, ddy: 1 }, // test level 0
+        { ddx: 2, ddy: 1 }, // test level 1 via ddx
+        { ddx: 1, ddy: 4 }, // test level 2 via ddy
+        { ddx: 1.5, ddy: 1.5 }, // test mix between 1 and 2
+        { ddx: 6, ddy: 6 }, // test mix between 2 and 3 (there is no 3 so we should get just 2)
+        { ddx: 1.5, ddy: 1.5, offset: [7, -8] as const }, // test mix between 1 and 2 with offset
+        { ddx: 1.5, ddy: 1.5, offset: [3, -3] as const }, // test mix between 1 and 2 with offset
+        { ddx: 1.5, ddy: 1.5, uvwStart: [-3.5, -4] as const }, // test mix between 1 and 2 with negative coords
+      ])
+  )
+  .fn(async t => {
+    const { format, A, mipmapFilter, ddx, ddy, uvwStart, offset } = t.params;
+
+    // We want at least 4 blocks or something wide enough for 3 mip levels.
+    const viewDimension: GPUTextureViewDimension = '2d-array';
+    const size = chooseTextureSize({ minSize: 8, minBlocks: 4, format, viewDimension });
+
+    const descriptor: GPUTextureDescriptor = {
+      format,
+      mipLevelCount: 3,
+      size,
+      usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+    };
+
+    const sampler: GPUSamplerDescriptor = {
+      addressModeU: 'repeat',
+      addressModeV: 'repeat',
+      minFilter: 'linear',
+      magFilter: 'linear',
+      mipmapFilter,
+    };
+    const viewDescriptor = {
+      dimension: viewDimension,
+    };
+    await putDataInTextureThenDrawAndCheckResultsComparedToSoftwareRasterizer(
+      t,
+      descriptor,
+      viewDescriptor,
+      sampler,
+      {
+        ddx,
+        ddy,
+        uvwStart,
+        offset,
+        arrayIndexType: A === 'i32' ? 'i' : 'u',
+        depthTexture: true,
+      }
+    );
+  });
 
 g.test('depth_array_3d_coords')
   .specURL('https://www.w3.org/TR/WGSL/#texturesample')
   .desc(
     `
-C is i32 or u32
+A is i32 or u32
 
-fn textureSample(t: texture_depth_cube_array, s: sampler, coords: vec3<f32>, array_index: C) -> f32
+fn textureSample(t: texture_depth_cube_array, s: sampler, coords: vec3<f32>, array_index: A) -> f32
 
 Parameters:
  * t  The sampled, depth, or external texture to sample.
@@ -489,13 +1319,161 @@ Parameters:
  * array_index The 0-based texture array index to sample.
 `
   )
-  .paramsSubcasesOnly(
-    u =>
-      u
-        .combine('C', ['i32', 'u32'] as const)
-        .combine('C_value', [-1, 0, 1, 2, 3, 4] as const)
-        .combine('S', ['clamp-to-edge', 'repeat', 'mirror-repeat'] as const)
-        .combine('coords', generateCoordBoundaries(3))
-    /* array_index not param'd as out-of-bounds is implementation specific */
+  .params(u =>
+    u
+      .combine('format', kDepthStencilFormats)
+      // filter out stencil only formats
+      .filter(t => isDepthTextureFormat(t.format))
+      // MAINTENANCE_TODO: Remove when support for depth24plus, depth24plus-stencil8, and depth32float-stencil8 is added.
+      .filter(t => isEncodableTextureFormat(t.format))
+      .beginSubcases()
+      .combine('samplePoints', kCubeSamplePointMethods)
+      .combine('addressMode', ['clamp-to-edge', 'repeat', 'mirror-repeat'] as const)
+      .combine('minFilter', ['nearest', 'linear'] as const)
+      .combine('A', ['i32', 'u32'] as const)
   )
-  .unimplemented();
+  .beforeAllSubcases(t => {
+    t.skipIfTextureViewDimensionNotSupported('cube-array');
+  })
+  .fn(async t => {
+    const { format, samplePoints, A, addressMode, minFilter } = t.params;
+
+    const viewDimension: GPUTextureViewDimension = 'cube-array';
+    const size = chooseTextureSize({
+      minSize: 32,
+      minBlocks: 4,
+      format,
+      viewDimension,
+    });
+    const descriptor: GPUTextureDescriptor = {
+      format,
+      size,
+      usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+      ...(t.isCompatibility && { textureBindingViewDimension: viewDimension }),
+    };
+    const { texels, texture } = await createTextureWithRandomDataAndGetTexels(t, descriptor);
+    const sampler: GPUSamplerDescriptor = {
+      addressModeU: addressMode,
+      addressModeV: addressMode,
+      addressModeW: addressMode,
+      minFilter,
+      magFilter: minFilter,
+      mipmapFilter: minFilter,
+    };
+
+    const calls: TextureCall<vec3>[] = generateSamplePointsCube(50, {
+      method: samplePoints,
+      sampler,
+      descriptor,
+      arrayIndex: A ? { num: texture.depthOrArrayLayers / 6, type: A } : undefined,
+      hashInputs: [format, viewDimension, samplePoints, addressMode, minFilter],
+    }).map(({ coords, arrayIndex }) => {
+      return {
+        builtin: 'textureSample',
+        coordType: 'f',
+        coords,
+        arrayIndex,
+        arrayIndexType: A ? (A === 'i32' ? 'i' : 'u') : undefined,
+      };
+    });
+    const viewDescriptor = {
+      dimension: viewDimension,
+    };
+    const textureType = 'texture_depth_cube_array';
+    const results = await doTextureCalls(t, texture, viewDescriptor, textureType, sampler, calls);
+
+    const res = await checkCallResults(
+      t,
+      { texels, descriptor, viewDescriptor },
+      textureType,
+      sampler,
+      calls,
+      results
+    );
+    t.expectOK(res);
+  });
+
+g.test('depth_array_3d_coords,derivatives')
+  .specURL('https://www.w3.org/TR/WGSL/#texturesample')
+  .desc(
+    `
+A is i32 or u32
+
+fn textureSample(t: texture_depth_cube_array, s: sampler, coords: vec3<f32>, array_index: A) -> f32
+
+Parameters:
+ * t  The sampled, depth, or external texture to sample.
+ * s  The sampler type.
+ * coords The texture coordinates used for sampling.
+ * array_index The 0-based texture array index to sample.
+
+test mip level selection based on derivatives
+`
+  )
+  .params(u =>
+    u
+      .combine('format', kDepthStencilFormats)
+      // filter out stencil only formats
+      .filter(t => isDepthTextureFormat(t.format))
+      // MAINTENANCE_TODO: Remove when support for depth24plus, depth24plus-stencil8, and depth32float-stencil8 is added.
+      .filter(t => isEncodableTextureFormat(t.format))
+      .combine('mipmapFilter', ['nearest', 'linear'] as const)
+      .beginSubcases()
+      .combine('A', ['i32', 'u32'] as const)
+      // note: this is the derivative we want at sample time. It is not the value
+      // passed directly to the shader. This way if we change the texture size
+      // or render target size we can compute the correct values to achieve the
+      // same results.
+      .combineWithParams([
+        { ddx: 0.5, ddy: 0.5 }, // test mag filter
+        { ddx: 1, ddy: 1 }, // test level 0
+        { ddx: 2, ddy: 1 }, // test level 1 via ddx
+        { ddx: 1, ddy: 4 }, // test level 2 via ddy
+        { ddx: 1.5, ddy: 1.5 }, // test mix between 1 and 2
+        { ddx: 6, ddy: 6 }, // test mix between 2 and 3 (there is no 3 so we should get just 2)
+        { ddx: 1.5, ddy: 1.5, uvwStart: [-3.5, -4, -5] as const }, // test mix between 1 and 2 with negative coords
+      ])
+  )
+  .beforeAllSubcases(t => {
+    t.skipIfTextureViewDimensionNotSupported('cube-array');
+    t.skip('testing cube maps with derivatives is not yet supported');
+  })
+  .fn(async t => {
+    const { format, mipmapFilter, ddx, ddy, uvwStart, A } = t.params;
+
+    const viewDimension: GPUTextureViewDimension = 'cube-array';
+    // We want at least 4 blocks or something wide enough for 3 mip levels.
+    const size = chooseTextureSize({
+      minSize: 32,
+      minBlocks: 4,
+      format,
+      viewDimension,
+    });
+
+    const descriptor: GPUTextureDescriptor = {
+      format,
+      ...(t.isCompatibility && { textureBindingViewDimension: viewDimension }),
+      mipLevelCount: 3,
+      size,
+      usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
+    };
+
+    const sampler: GPUSamplerDescriptor = {
+      addressModeU: 'repeat',
+      addressModeV: 'repeat',
+      addressModeW: 'repeat',
+      minFilter: 'linear',
+      magFilter: 'linear',
+      mipmapFilter,
+    };
+    const viewDescriptor = {
+      dimension: viewDimension,
+    };
+    await putDataInTextureThenDrawAndCheckResultsComparedToSoftwareRasterizer(
+      t,
+      descriptor,
+      viewDescriptor,
+      sampler,
+      { ddx, ddy, uvwStart, depthTexture: true, arrayIndexType: A === 'i32' ? 'i' : 'u' }
+    );
+  });

--- a/src/webgpu/shader/execution/expression/call/builtin/texture_utils.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/texture_utils.ts
@@ -158,7 +158,7 @@ export function skipIfTextureFormatNotSupportedNotAvailableOrNotFilterable(
 }
 
 /**
- * Splits in array into multiple arrays were every Nth value goes to a different array
+ * Splits in array into multiple arrays where every Nth value goes to a different array
  */
 function unzip<T>(array: T[], num: number) {
   const arrays: T[][] = range(num, () => []);
@@ -193,31 +193,6 @@ function validateWeights(weights: number[]) {
     `expected more unique weights\n${showWeights()}`
   );
 
-  // Note: for 16 steps, these are the AMD weights
-  //
-  //                 standard
-  // step  mipLevel    gpu        AMD
-  // ----  --------  --------  ----------
-  //  0:   0         0           0
-  //  1:   0.0625    0.0625      0
-  //  2:   0.125     0.125       0.03125
-  //  3:   0.1875    0.1875      0.109375
-  //  4:   0.25      0.25        0.1875
-  //  5:   0.3125    0.3125      0.265625
-  //  6:   0.375     0.375       0.34375
-  //  7:   0.4375    0.4375      0.421875
-  //  8:   0.5       0.5         0.5
-  //  9:   0.5625    0.5625      0.578125
-  // 10:   0.625     0.625       0.65625
-  // 11:   0.6875    0.6875      0.734375
-  // 12:   0.75      0.75        0.8125
-  // 13:   0.8125    0.8125      0.890625
-  // 14:   0.875     0.875       0.96875
-  // 15:   0.9375    0.9375      1
-  // 16:   1         1           1
-  //
-  // notice step 1 is 0 and step 15 is 1.
-  // so we only check the 1 through 14.
   for (let i = 0; i < kMipGradientSteps; ++i) {
     assert(
       weights[i] <= weights[i + 1],
@@ -407,7 +382,6 @@ async function queryMipGradientValuesForDevice(t: GPUTest) {
       @fragment fn fs(v: VSOutput) -> @location(0) vec4f {
         let mipLevel = f32(v.ndx) / ${kMipGradientSteps};
         let size = textureDimensions(tex);
-        let d = mix(0.125, 0.25, mipLevel) * 4.;
         let u = f32(v.pos.x) * pow(2.0, mipLevel) / f32(size.x);
         let g = mix(0.5, 1.0, mipLevel);
 


### PR DESCRIPTION
Add all the textureSample tests. cube and cube-array tests with derivatives are currently skipped or filtered out as the software rasterizer can't handle this case correctly or at least doesn't match too many GPUs. Rather than increase the tolerances I'm hoping to find something I can measure, like the mapping between derivative and mix-weight, that will give us some way to test per GPU.

There's a big change to the soft rasterizer to compute derivatives by setting up 2x2 pixels and computing the derivatives by the differences between the directions.

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [X] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
