### PR TITLE
Add shader validation tests about `clip_distances` and the extension

### DIFF
--- a/src/webgpu/shader/validation/extension/clip_distances.spec.ts
+++ b/src/webgpu/shader/validation/extension/clip_distances.spec.ts
@@ -1,0 +1,43 @@
+export const description = `
+Validation tests for the clip_distances extension
+`;
+
+import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { ShaderValidationTest } from '../shader_validation_test.js';
+
+export const g = makeTestGroup(ShaderValidationTest);
+
+g.test('use_clip_distances_requires_extension_enabled')
+  .desc(
+    `Checks that the clip_distances built-in variable is only allowed with the WGSL extension
+     clip_distances enabled in shader and the WebGPU extension clip-distances supported on the
+     device.`
+  )
+  .params(u =>
+    u.combine('requireExtension', [true, false]).combine('enableExtension', [true, false])
+  )
+  .beforeAllSubcases(t => {
+    if (t.params.requireExtension) {
+      t.selectDeviceOrSkipTestCase({ requiredFeatures: ['clip-distances'] });
+    }
+  })
+  .fn(t => {
+    const { requireExtension, enableExtension } = t.params;
+
+    t.expectCompileResult(
+      requireExtension && enableExtension,
+      `
+        ${enableExtension ? 'enable clip_distances;' : ''}
+        struct VertexOut {
+          @builtin(clip_distances) my_clip_distances : array<f32, 1>,
+          @builtin(position) my_position : vec4f,
+        }
+        @vertex fn main() -> VertexOut {
+          var output : VertexOut;
+          output.my_clip_distances[0] = 1.0;
+          output.my_position = vec4f(0.0, 0.0, 0.0, 1.0);
+          return output;
+        }
+    `
+    );
+  });


### PR DESCRIPTION
This patch adds shader validation tests to verify that using `clip_distances` the extension `clip_distances` must be enabled in the shader.




Issue: #3773

<hr>

**Requirements for PR author:**

- [*] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [*] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [*] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [*] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
