### PR TITLE
Fix TestCaseRecord proxy

### DIFF
--- a/src/common/internal/test_group.ts
+++ b/src/common/internal/test_group.ts
@@ -620,7 +620,7 @@ class RunCaseSpecific implements RunCase {
             const subcasePrefix = 'subcase: ' + stringifyPublicParams(subParams);
             const subRec = new Proxy(rec, {
               get: (target, k: keyof TestCaseRecorder) => {
-                const prop = TestCaseRecorder.prototype[k];
+                const prop = rec[k] ?? TestCaseRecorder.prototype[k];
                 if (typeof prop === 'function') {
                   testHeartbeatCallback();
                   return function (...args: Parameters<typeof prop>) {


### PR DESCRIPTION
This needs to check local properties otherwise they don't get forwarded.

In particular `t.rec.debugging` was undefined in a test since it wasn't being forwarded by the proxy.

