### PR TITLE
Add shader validation tests about built-in variable `clip_distances`

### DIFF
--- a/src/webgpu/shader/validation/shader_io/builtins.spec.ts
+++ b/src/webgpu/shader/validation/shader_io/builtins.spec.ts
@@ -10,7 +10,7 @@ export const g = makeTestGroup(ShaderValidationTest);
 
 // List of all built-in variables and their stage, in|out usage, and type.
 // Taken from table in Section 15:
-// https://www.w3.org/TR/2021/WD-WGSL-20211013/#builtin-variables
+// https://www.w3.org/TR/WGSL/#builtin-inputs-outputs
 export const kBuiltins = [
   { name: 'vertex_index', stage: 'vertex', io: 'in', type: 'u32' },
   { name: 'instance_index', stage: 'vertex', io: 'in', type: 'u32' },
@@ -30,6 +30,14 @@ export const kBuiltins = [
   { name: 'subgroup_size', stage: 'compute', io: 'in', type: 'u32' },
   { name: 'subgroup_invocation_id', stage: 'fragment', io: 'in', type: 'u32' },
   { name: 'subgroup_size', stage: 'fragment', io: 'in', type: 'u32' },
+  { name: 'clip_distances', stage: 'vertex', io: 'out', type: 'array<f32,1>' },
+  { name: 'clip_distances', stage: 'vertex', io: 'out', type: 'array<f32,2>' },
+  { name: 'clip_distances', stage: 'vertex', io: 'out', type: 'array<f32,3>' },
+  { name: 'clip_distances', stage: 'vertex', io: 'out', type: 'array<f32,4>' },
+  { name: 'clip_distances', stage: 'vertex', io: 'out', type: 'array<f32,5>' },
+  { name: 'clip_distances', stage: 'vertex', io: 'out', type: 'array<f32,6>' },
+  { name: 'clip_distances', stage: 'vertex', io: 'out', type: 'array<f32,7>' },
+  { name: 'clip_distances', stage: 'vertex', io: 'out', type: 'array<f32,8>' },
 ] as const;
 
 // List of types to test against.
@@ -64,7 +72,15 @@ const kTestTypes = [
   'array<bool,4>',
   'array<u32,4>',
   'array<i32,4>',
+  'array<f32,1>',
+  'array<f32,2>',
+  'array<f32,3>',
   'array<f32,4>',
+  'array<f32,5>',
+  'array<f32,6>',
+  'array<f32,7>',
+  'array<f32,8>',
+  'array<f32,9>',
   'MyStruct',
 ] as const;
 
@@ -87,7 +103,16 @@ g.test('stage_inout')
     );
     if (t.params.name.includes('subgroup')) {
       t.selectDeviceOrSkipTestCase('subgroups' as GPUFeatureName);
+    } else if (t.params.name === 'clip_distances') {
+      t.selectDeviceOrSkipTestCase('clip-distances' as GPUFeatureName);
     }
+    t.skipIf(
+      t.params.name !== 'position' &&
+        t.params.target_stage === 'vertex' &&
+        t.params.target_io === 'out' &&
+        !t.params.use_struct,
+      'missing @builtin(position) in the vertex output when the vertex output is not a struct'
+    );
   })
   .fn(t => {
     const code = generateShader({
@@ -117,9 +142,9 @@ g.test('type')
   .params(u =>
     u
       .combineWithParams(kBuiltins)
+      .combine('use_struct', [true, false] as const)
       .beginSubcases()
       .combine('target_type', kTestTypes)
-      .combine('use_struct', [true, false] as const)
   )
   .beforeAllSubcases(t => {
     t.skipIf(
@@ -128,7 +153,16 @@ g.test('type')
     );
     if (t.params.name.includes('subgroup')) {
       t.selectDeviceOrSkipTestCase('subgroups' as GPUFeatureName);
+    } else if (t.params.name === 'clip_distances') {
+      t.selectDeviceOrSkipTestCase('clip-distances' as GPUFeatureName);
     }
+    t.skipIf(
+      t.params.name !== 'position' &&
+        t.params.stage === 'vertex' &&
+        t.params.io === 'out' &&
+        !t.params.use_struct,
+      'missing @builtin(position) in the vertex output'
+    );
   })
   .fn(t => {
     let code = '';
@@ -301,6 +335,8 @@ g.test('reuse_builtin_name')
   .beforeAllSubcases(t => {
     if (t.params.name.includes('subgroup')) {
       t.selectDeviceOrSkipTestCase('subgroups' as GPUFeatureName);
+    } else if (t.params.name === 'clip_distances') {
+      t.selectDeviceOrSkipTestCase('clip-distances' as GPUFeatureName);
     }
   })
   .fn(t => {

--- a/src/webgpu/shader/validation/shader_io/builtins.spec.ts
+++ b/src/webgpu/shader/validation/shader_io/builtins.spec.ts
@@ -331,9 +331,30 @@ g.test('reuse_builtin_name')
     u
       .combineWithParams(kBuiltins)
       .combine('use', ['alias', 'struct', 'function', 'module-var', 'function-var'])
+      .combine('enable_extension', [true, false])
+      .unless(
+        t => t.enable_extension && !(t.name.includes('subgroup') || t.name === 'clip_distances')
+      )
   )
+  .beforeAllSubcases(t => {
+    if (!t.params.enable_extension) {
+      return;
+    }
+    if (t.params.name.includes('subgroup')) {
+      t.selectDeviceOrSkipTestCase('subgroups' as GPUFeatureName);
+    } else if (t.params.name === 'clip_distances') {
+      t.selectDeviceOrSkipTestCase('clip-distances' as GPUFeatureName);
+    }
+  })
   .fn(t => {
     let code = '';
+    if (t.params.enable_extension) {
+      if (t.params.name.includes('subgroups')) {
+        code += 'enable subgroup;\n';
+      } else if (t.params.name === 'clip_distances') {
+        code += 'enable clip_distances;\n';
+      }
+    }
     if (t.params.use === 'alias') {
       code += `alias ${t.params.name} = i32;`;
     } else if (t.params.use === `struct`) {

--- a/src/webgpu/shader/validation/shader_io/builtins.spec.ts
+++ b/src/webgpu/shader/validation/shader_io/builtins.spec.ts
@@ -332,13 +332,6 @@ g.test('reuse_builtin_name')
       .combineWithParams(kBuiltins)
       .combine('use', ['alias', 'struct', 'function', 'module-var', 'function-var'])
   )
-  .beforeAllSubcases(t => {
-    if (t.params.name.includes('subgroup')) {
-      t.selectDeviceOrSkipTestCase('subgroups' as GPUFeatureName);
-    } else if (t.params.name === 'clip_distances') {
-      t.selectDeviceOrSkipTestCase('clip-distances' as GPUFeatureName);
-    }
-  })
   .fn(t => {
     let code = '';
     if (t.params.use === 'alias') {

--- a/src/webgpu/shader/validation/shader_io/util.ts
+++ b/src/webgpu/shader/validation/shader_io/util.ts
@@ -27,6 +27,9 @@ export function generateShader({
   if (attribute.includes('subgroup')) {
     code += 'enable subgroups;\n';
   }
+  if (attribute.includes('clip_distances')) {
+    code += 'enable clip_distances;\n';
+  }
 
   if (use_struct) {
     // Generate a struct that wraps the entry point IO variable.


### PR DESCRIPTION


Issue: #3773

<hr>

**Requirements for PR author:**

- [*] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [*] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [*] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [*] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
