### PR TITLE
Add validation tests on the limit of max vertex output location with …

### DIFF
--- a/src/webgpu/api/validation/capability_checks/features/clip_distances.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/features/clip_distances.spec.ts
@@ -6,7 +6,8 @@ function getPipelineDescriptorWithClipDistances(
   device: GPUDevice,
   interStageShaderVariables: number,
   pointList: boolean,
-  clipDistances: number
+  clipDistances: number,
+  startLocation: number = 0
 ): GPURenderPipelineDescriptor {
   const vertexOutputVariables =
     interStageShaderVariables - (pointList ? 1 : 0) - align(clipDistances, 4) / 4;
@@ -14,7 +15,10 @@ function getPipelineDescriptorWithClipDistances(
     device.limits.maxInterStageShaderVariables - (pointList ? 1 : 0) - align(clipDistances, 4) / 4;
 
   const varyings = `
-      ${range(vertexOutputVariables, i => `@location(${i}) v4_${i}: vec4f,`).join('\n')}
+      ${range(
+        vertexOutputVariables,
+        i => `@location(${i + startLocation}) v4_${i + startLocation}: vec4f,`
+      ).join('\n')}
   `;
 
   const code = `
@@ -29,6 +33,7 @@ function getPipelineDescriptorWithClipDistances(
     }
     // maxInterStageVariables:           : ${maxVertexOutputVariables}
     // num used inter stage variables    : ${vertexOutputVariables}
+    // vertex output start location      : ${startLocation}
 
     enable clip_distances;
 
@@ -111,4 +116,46 @@ g.test('createRenderPipeline,at_over')
       undefined,
       ['clip-distances']
     );
+  });
+
+g.test('createRenderPipeline,max_vertex_output_location')
+  .desc(`Test using clip_distances will limit the maximum value of vertex output location`)
+  .params(u =>
+    u
+      .combine('pointList', [false, true])
+      .combine('clipDistances', [1, 2, 3, 4, 5, 6, 7, 8])
+      .combine('startLocation', [0, 1, 2])
+  )
+  .beforeAllSubcases(t => {
+    t.selectDeviceOrSkipTestCase('clip-distances');
+  })
+  .fn(async t => {
+    const { pointList, clipDistances, startLocation } = t.params;
+
+    const maxInterStageShaderVariables = t.adapter.limits.maxInterStageShaderVariables;
+    const deviceInTest = await t.requestDeviceTracked(t.adapter, {
+      requiredFeatures: ['clip-distances'],
+      requiredLimits: {
+        maxInterStageShaderVariables: t.adapter.limits.maxInterStageShaderVariables,
+      },
+    });
+    const pipelineDescriptor = getPipelineDescriptorWithClipDistances(
+      deviceInTest,
+      maxInterStageShaderVariables,
+      pointList,
+      clipDistances,
+      startLocation
+    );
+    const vertexOutputVariables =
+      maxInterStageShaderVariables - (pointList ? 1 : 0) - align(clipDistances, 4) / 4;
+    const maxLocationInTest = startLocation + vertexOutputVariables - 1;
+    const maxAllowedLocation = maxInterStageShaderVariables - 1 - align(clipDistances, 4) / 4;
+    const shouldError = maxLocationInTest > maxAllowedLocation;
+
+    deviceInTest.pushErrorScope('validation');
+    deviceInTest.createRenderPipeline(pipelineDescriptor);
+    const error = await deviceInTest.popErrorScope();
+    t.expect(!!error === shouldError, `${error?.message || 'no error when one was expected'}`);
+
+    deviceInTest.destroy();
   });


### PR DESCRIPTION
…clip_distances

This patch adds the validation tests on the limit of max vertex output location with clip_distances. According to the WebGPU SPEC, the maximum vertex output location will be decreased by (align(clipDistancesArraySize, 4) / 4) when clip_distances is used.




Fixed: #3773 

<hr>

**Requirements for PR author:**

- [*] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [*] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [*] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [*] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
