### PR TITLE
Fix textureNumLayers view_type subcase

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/textureNumLayers.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureNumLayers.spec.ts
@@ -51,13 +51,13 @@ Parameters
   .params(u =>
     u
       .combine('texture_type', ['texture_2d_array', 'texture_cube_array'] as const)
+      .combine('view_type', ['full', 'partial'] as const)
       .beginSubcases()
       .combine('sampled_type', ['f32', 'i32', 'u32'] as const)
-      .combine('view_type', ['full', 'partial'] as const)
   )
   .beforeAllSubcases(t => {
     t.skipIf(
-      t.isCompatibility && t.params.view === 'partial',
+      t.isCompatibility && t.params.view_type === 'partial',
       'compatibility mode does not support partial layer views'
     );
     t.skipIf(
@@ -110,12 +110,11 @@ Parameters
   .params(u =>
     u
       .combine('texture_type', ['texture_depth_2d_array', 'texture_depth_cube_array'] as const)
-      .beginSubcases()
       .combine('view_type', ['full', 'partial'] as const)
   )
   .beforeAllSubcases(t => {
     t.skipIf(
-      t.isCompatibility && t.params.view === 'partial',
+      t.isCompatibility && t.params.view_type === 'partial',
       'compatibility mode does not support partial layer views'
     );
     t.skipIf(
@@ -184,14 +183,20 @@ Parameters
   .params(u =>
     u
       .combineWithParams(TexelFormats)
+      .combine('view_type', ['full', 'partial'] as const)
       .beginSubcases()
       .combine('access_mode', ['read', 'write', 'read_write'] as const)
       .filter(
         t => t.access_mode !== 'read_write' || kTextureFormatInfo[t.format].color?.readWriteStorage
       )
-      .combine('view_type', ['full', 'partial'] as const)
   )
-  .beforeAllSubcases(t => t.skipIfTextureFormatNotUsableAsStorageTexture(t.params.format))
+  .beforeAllSubcases(t => {
+    t.skipIf(
+      t.isCompatibility && t.params.view_type === 'partial',
+      'compatibility mode does not support partial layer views'
+    );
+    t.skipIfTextureFormatNotUsableAsStorageTexture(t.params.format);
+  })
   .fn(t => {
     const { format, access_mode, view_type } = t.params;
 


### PR DESCRIPTION
* It seems that inside `beforeAllSubcases` subcases parameters are not present in `t.params`.
* Somehow my default vscode typescript setup intellisense didn't report `t.params.view` is undefined (Because `t.params.aaa` inside `beforeAllSubcases` is JSONWithUndefined, [Bug filed](https://github.com/gpuweb/cts/issues/3965)). ~~`npm run fix` runs eslint. Shall we use typescript-eslint?~~ 

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
