### PR TITLE
Fix reifyTextureViewDescriptor

### DIFF
--- a/src/webgpu/util/texture/base.ts
+++ b/src/webgpu/util/texture/base.ts
@@ -239,7 +239,7 @@ export function reifyTextureViewDescriptor(
   const format = view.format ?? texture.format;
   const mipLevelCount = view.mipLevelCount ?? texture.mipLevelCount - baseMipLevel;
   const dimension = view.dimension ?? defaultViewDimensionsForTexture(texture);
-  const usage = (view.usage ?? 0) === 0 ? texture.usage : view.usage;
+  const usage = (view.usage ?? 0) === 0 ? texture.usage : view.usage!;
 
   let arrayLayerCount = view.arrayLayerCount;
   if (arrayLayerCount === undefined) {

--- a/src/webgpu/util/texture/base.ts
+++ b/src/webgpu/util/texture/base.ts
@@ -239,7 +239,7 @@ export function reifyTextureViewDescriptor(
   const format = view.format ?? texture.format;
   const mipLevelCount = view.mipLevelCount ?? texture.mipLevelCount - baseMipLevel;
   const dimension = view.dimension ?? defaultViewDimensionsForTexture(texture);
-  const usage = (view.usage === 0 || view.usage === undefined) ? texture.usage : view.usage;
+  const usage = (view.usage ?? 0) === 0 ? texture.usage : view.usage;
 
   let arrayLayerCount = view.arrayLayerCount;
   if (arrayLayerCount === undefined) {

--- a/src/webgpu/util/texture/base.ts
+++ b/src/webgpu/util/texture/base.ts
@@ -239,6 +239,7 @@ export function reifyTextureViewDescriptor(
   const format = view.format ?? texture.format;
   const mipLevelCount = view.mipLevelCount ?? texture.mipLevelCount - baseMipLevel;
   const dimension = view.dimension ?? defaultViewDimensionsForTexture(texture);
+  const usage = (view.usage === 0 || view.usage === undefined) ? texture.usage : view.usage;
 
   let arrayLayerCount = view.arrayLayerCount;
   if (arrayLayerCount === undefined) {
@@ -255,7 +256,7 @@ export function reifyTextureViewDescriptor(
     format,
     dimension,
     aspect,
-    usage: texture.usage,
+    usage,
     baseMipLevel,
     mipLevelCount,
     baseArrayLayer,


### PR DESCRIPTION
I updated it incorrectly in the types roll. Not sure why, I just didn't think about it. (Nothing actually triggers this right now because none of the tests are setting `usage` on the view descriptor, so it doesn't affect any existing tests.)




Issue: #3953

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
