### PR TITLE
Clean output directories when building less than `all`

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -24,7 +24,10 @@ module.exports = function (grunt) {
     pkg: grunt.file.readJSON('package.json'),
 
     clean: {
-      out: ['gen/', 'out/', 'out-wpt/', 'out-node/'],
+      gen: ['gen/'],
+      out: ['out/'],
+      'out-wpt': ['out-wpt/'],
+      'out-node': ['out-node/'],
     },
 
     run: {
@@ -246,17 +249,20 @@ module.exports = function (grunt) {
   });
 
   grunt.registerTask('generate-common', 'Generate files into gen/ and src/', [
+    'clean:gen',
     'run:generate-version',
     'run:generate-listings-and-webworkers',
     'run:generate-cache',
   ]);
   grunt.registerTask('build-standalone', 'Build out/ (no checks; run after generate-common)', [
+    'clean:out',
     'run:build-out',
     'run:copy-assets',
     'copy:gen-to-out',
     'copy:htmlfiles-to-out',
   ]);
   grunt.registerTask('build-wpt', 'Build out-wpt/ (no checks; run after generate-common)', [
+    'clean:out-wpt',
     'run:build-out-wpt',
     'run:copy-assets-wpt',
     'copy:gen-to-out-wpt',
@@ -265,6 +271,7 @@ module.exports = function (grunt) {
     'run:autoformat-out-wpt',
   ]);
   grunt.registerTask('build-node', 'Build out-node/ (no checks; run after generate-common)', [
+    'clean:out-node',
     'run:build-out-node',
     'run:copy-assets-node',
   ]);
@@ -282,7 +289,6 @@ module.exports = function (grunt) {
   grunt.registerTask('pre', ['all']);
 
   registerTaskAndAddToHelp('all', 'Run all builds and checks', [
-    'clean',
     'generate-common',
     'concurrent:all-builds-and-checks',
   ]);


### PR DESCRIPTION
Previously only the `all` target (`npx grunt all`) would clean the output directories, potentially leaving old files behind when using the `standalone`, `wpt`, or `node` targets.

This splits up the `clean` command and invokes each one exactly when necessary so that old files aren't left behind.

Tested with:
```
mkdir -p {gen,out,out-node,out-wpt}/BAD
npx grunt generate-common # leaves only {out,out-node,out-wpt}/BAD

mkdir -p {gen,out,out-node,out-wpt}/BAD
npx grunt standalone # leaves only {out-node,out-wpt}/BAD

mkdir -p {gen,out,out-node,out-wpt}/BAD
npx grunt wpt # leaves only {out,out-node}/BAD

mkdir -p {gen,out,out-node,out-wpt}/BAD
npx grunt node # leaves only {out,out-wpt}/BAD

mkdir -p {gen,out,out-node,out-wpt}/BAD
npx grunt clean # cleans all 4, leaves no BADs
```

Issue: Fixes #3834

<hr>

**Requirements for PR author:** N/A

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):** N/A