### PR TITLE
Add some tests for GPUCanvasContext getConfiguration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@types/w3c-image-capture": "^1.0.10",
         "@typescript-eslint/eslint-plugin": "^6.9.1",
         "@typescript-eslint/parser": "^6.9.1",
-        "@webgpu/types": "^0.1.46",
+        "@webgpu/types": "^0.1.47",
         "ansi-colors": "4.1.3",
         "babel-plugin-add-header-comment": "^1.0.3",
         "babel-plugin-const-enum": "^1.2.0",
@@ -1539,10 +1539,11 @@
       "dev": true
     },
     "node_modules/@webgpu/types": {
-      "version": "0.1.46",
-      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.46.tgz",
-      "integrity": "sha512-2iogO6Zh0pTbKLGZuuGWEmJpF/fTABGs7G9wXxpn7s24XSJchSUIiMqIJHURi5zsMZRRTuXrV/3GLOkmOFjq5w==",
-      "dev": true
+      "version": "0.1.47",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.47.tgz",
+      "integrity": "sha512-vOUHDxj0azl7BSj4YAy6cc6q5s7F1KfF5GI1er/w6togN0MqzS/d8U+H0LH1XpLbFup+UaA7aMtia/aSx3DE0w==",
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/abbrev": {
       "version": "1.1.1",
@@ -10076,9 +10077,9 @@
       "dev": true
     },
     "@webgpu/types": {
-      "version": "0.1.46",
-      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.46.tgz",
-      "integrity": "sha512-2iogO6Zh0pTbKLGZuuGWEmJpF/fTABGs7G9wXxpn7s24XSJchSUIiMqIJHURi5zsMZRRTuXrV/3GLOkmOFjq5w==",
+      "version": "0.1.47",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.47.tgz",
+      "integrity": "sha512-vOUHDxj0azl7BSj4YAy6cc6q5s7F1KfF5GI1er/w6togN0MqzS/d8U+H0LH1XpLbFup+UaA7aMtia/aSx3DE0w==",
       "dev": true
     },
     "abbrev": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@types/w3c-image-capture": "^1.0.10",
     "@typescript-eslint/eslint-plugin": "^6.9.1",
     "@typescript-eslint/parser": "^6.9.1",
-    "@webgpu/types": "^0.1.46",
+    "@webgpu/types": "^0.1.47",
     "ansi-colors": "4.1.3",
     "babel-plugin-add-header-comment": "^1.0.3",
     "babel-plugin-const-enum": "^1.2.0",

--- a/src/webgpu/web_platform/canvas/configure.spec.ts
+++ b/src/webgpu/web_platform/canvas/configure.spec.ts
@@ -43,14 +43,14 @@ g.test('defaults')
     });
 
     const configuration = ctx.getConfiguration();
-    t.expect(configuration !== null);
-    t.expect(configuration!.device === t.device);
-    t.expect(configuration!.format === 'rgba8unorm');
-    t.expect(configuration!.usage === GPUTextureUsage.RENDER_ATTACHMENT);
-    t.expect(Array.from(configuration!.viewFormats!).length === 0);
-    t.expect(configuration!.colorSpace === 'srgb');
-    t.expect(configuration!.toneMapping!.mode === 'standard');
-    t.expect(configuration!.alphaMode === 'opaque');
+    assert(configuration !== null);
+    t.expect(configuration.device === t.device);
+    t.expect(configuration.format === 'rgba8unorm');
+    t.expect(configuration.usage === GPUTextureUsage.RENDER_ATTACHMENT);
+    t.expect((configuration.viewFormats as GPUTextureFormat[]).length === 0);
+    t.expect(configuration.colorSpace === 'srgb');
+    t.expect(configuration.toneMapping!.mode === 'standard');
+    t.expect(configuration.alphaMode === 'opaque');
 
     const currentTexture = ctx.getCurrentTexture();
     t.expect(currentTexture.format === 'rgba8unorm');
@@ -103,14 +103,14 @@ g.test('device')
 
     // getConfiguration will succeed after configure.
     const configuration = ctx.getConfiguration();
-    t.expect(configuration !== null);
-    t.expect(configuration!.device === t.device);
-    t.expect(configuration!.format === 'rgba8unorm');
-    t.expect(configuration!.usage === GPUTextureUsage.RENDER_ATTACHMENT);
-    t.expect(Array.from(configuration!.viewFormats!).length === 0);
-    t.expect(configuration!.colorSpace === 'srgb');
-    t.expect(configuration!.toneMapping!.mode === 'standard');
-    t.expect(configuration!.alphaMode === 'opaque');
+    assert(configuration !== null);
+    t.expect(configuration.device === t.device);
+    t.expect(configuration.format === 'rgba8unorm');
+    t.expect(configuration.usage === GPUTextureUsage.RENDER_ATTACHMENT);
+    t.expect((configuration.viewFormats as GPUTextureFormat[]).length === 0);
+    t.expect(configuration.colorSpace === 'srgb');
+    t.expect(configuration.toneMapping!.mode === 'standard');
+    t.expect(configuration.alphaMode === 'opaque');
 
     // getCurrentTexture will succeed with a valid device.
     ctx.getCurrentTexture();
@@ -134,14 +134,14 @@ g.test('device')
 
     // getConfiguration will succeed after configure.
     const newConfiguration = ctx.getConfiguration();
-    t.expect(newConfiguration !== null);
-    t.expect(newConfiguration!.device === t.device);
-    t.expect(newConfiguration!.format === 'rgba8unorm');
-    t.expect(newConfiguration!.usage === GPUTextureUsage.RENDER_ATTACHMENT);
-    t.expect(Array.from(newConfiguration!.viewFormats!).length === 0);
-    t.expect(newConfiguration!.colorSpace === 'srgb');
-    t.expect(newConfiguration!.toneMapping!.mode === 'standard');
-    t.expect(newConfiguration!.alphaMode === 'premultiplied');
+    assert(newConfiguration !== null);
+    t.expect(newConfiguration.device === t.device);
+    t.expect(newConfiguration.format === 'rgba8unorm');
+    t.expect(newConfiguration.usage === GPUTextureUsage.RENDER_ATTACHMENT);
+    t.expect((newConfiguration.viewFormats as GPUTextureFormat[]).length === 0);
+    t.expect(newConfiguration.colorSpace === 'srgb');
+    t.expect(newConfiguration.toneMapping!.mode === 'standard');
+    t.expect(newConfiguration.alphaMode === 'premultiplied');
   });
 
 g.test('format')
@@ -461,9 +461,8 @@ g.test('viewFormats')
       });
     }, !compatible);
 
-    const configuration = ctx.getConfiguration();
-    const viewFormats = Array.from(configuration!.viewFormats!);
-    t.expect(viewFormats.length === 1);
+    const viewFormats = ctx.getConfiguration()!.viewFormats!;
+    assert(Array.isArray(viewFormats));
     t.expect(viewFormats[0] === viewFormat);
 
     // Likewise for getCurrentTexture().

--- a/src/webgpu/web_platform/canvas/configure.spec.ts
+++ b/src/webgpu/web_platform/canvas/configure.spec.ts
@@ -43,13 +43,14 @@ g.test('defaults')
     });
 
     const configuration = ctx.getConfiguration();
-    t.expect(configuration.device === t.device);
-    t.expect(configuration.format === 'rgba8unorm');
-    t.expect(configuration.usage === GPUTextureUsage.RENDER_ATTACHMENT);
-    t.expect(configuration.viewFormats?.length === 0);
-    t.expect(configuration.colorSpace === 'srgb');
-    t.expect(configuration.toneMapping.mode === 'standard');
-    t.expect(configuration.alphaMode === 'opaque');
+    t.expect(configuration !== null);
+    t.expect(configuration!.device === t.device);
+    t.expect(configuration!.format === 'rgba8unorm');
+    t.expect(configuration!.usage === GPUTextureUsage.RENDER_ATTACHMENT);
+    t.expect(Array.from(configuration!.viewFormats!).length === 0);
+    t.expect(configuration!.colorSpace === 'srgb');
+    t.expect(configuration!.toneMapping!.mode === 'standard');
+    t.expect(configuration!.alphaMode === 'opaque');
 
     const currentTexture = ctx.getCurrentTexture();
     t.expect(currentTexture.format === 'rgba8unorm');
@@ -102,13 +103,14 @@ g.test('device')
 
     // getConfiguration will succeed after configure.
     const configuration = ctx.getConfiguration();
-    t.expect(configuration.device === t.device);
-    t.expect(configuration.format === 'rgba8unorm');
-    t.expect(configuration.usage === GPUTextureUsage.RENDER_ATTACHMENT);
-    t.expect(configuration.viewFormats?.length === 0);
-    t.expect(configuration.colorSpace === 'srgb');
-    t.expect(configuration.toneMapping.mode === 'standard');
-    t.expect(configuration.alphaMode === 'opaque');
+    t.expect(configuration !== null);
+    t.expect(configuration!.device === t.device);
+    t.expect(configuration!.format === 'rgba8unorm');
+    t.expect(configuration!.usage === GPUTextureUsage.RENDER_ATTACHMENT);
+    t.expect(Array.from(configuration!.viewFormats!).length === 0);
+    t.expect(configuration!.colorSpace === 'srgb');
+    t.expect(configuration!.toneMapping!.mode === 'standard');
+    t.expect(configuration!.alphaMode === 'opaque');
 
     // getCurrentTexture will succeed with a valid device.
     ctx.getCurrentTexture();
@@ -132,13 +134,14 @@ g.test('device')
 
     // getConfiguration will succeed after configure.
     const newConfiguration = ctx.getConfiguration();
-    t.expect(newConfiguration.device === t.device);
-    t.expect(newConfiguration.format === 'rgba8unorm');
-    t.expect(newConfiguration.usage === GPUTextureUsage.RENDER_ATTACHMENT);
-    t.expect(newConfiguration.viewFormats?.length === 0);
-    t.expect(newConfiguration.colorSpace === 'srgb');
-    t.expect(newConfiguration.toneMapping.mode === 'standard');
-    t.expect(newConfiguration.alphaMode === 'premultiplied');
+    t.expect(newConfiguration !== null);
+    t.expect(newConfiguration!.device === t.device);
+    t.expect(newConfiguration!.format === 'rgba8unorm');
+    t.expect(newConfiguration!.usage === GPUTextureUsage.RENDER_ATTACHMENT);
+    t.expect(Array.from(newConfiguration!.viewFormats!).length === 0);
+    t.expect(newConfiguration!.colorSpace === 'srgb');
+    t.expect(newConfiguration!.toneMapping!.mode === 'standard');
+    t.expect(newConfiguration!.alphaMode === 'premultiplied');
   });
 
 g.test('format')
@@ -178,7 +181,7 @@ g.test('format')
     }, !validFormat);
 
     const configuration = ctx.getConfiguration();
-    t.expect(configuration.format === format);
+    t.expect(configuration!.format === format);
 
     t.expectValidationError(() => {
       // Should always return a texture, whether the configured format was valid or not.
@@ -220,7 +223,7 @@ g.test('usage')
     });
 
     const configuration = ctx.getConfiguration();
-    t.expect(configuration.usage === usage);
+    t.expect(configuration!.usage === usage);
 
     const currentTexture = ctx.getCurrentTexture();
     t.expect(currentTexture instanceof GPUTexture);
@@ -333,7 +336,7 @@ g.test('alpha_mode')
     });
 
     const configuration = ctx.getConfiguration();
-    t.expect(configuration.alphaMode === alphaMode);
+    t.expect(configuration!.alphaMode === alphaMode);
 
     const currentTexture = ctx.getCurrentTexture();
     t.expect(currentTexture instanceof GPUTexture);
@@ -459,8 +462,9 @@ g.test('viewFormats')
     }, !compatible);
 
     const configuration = ctx.getConfiguration();
-    t.expect(configuration.viewFormats?.length === 1);
-    t.expect(configuration.viewFormats[0] === viewFormat);
+    const viewFormats = Array.from(configuration!.viewFormats!);
+    t.expect(viewFormats.length === 1);
+    t.expect(viewFormats[0] === viewFormat);
 
     // Likewise for getCurrentTexture().
     let currentTexture: GPUTexture;

--- a/src/webgpu/web_platform/canvas/configure.spec.ts
+++ b/src/webgpu/web_platform/canvas/configure.spec.ts
@@ -3,7 +3,7 @@ Tests for GPUCanvasContext.configure.
 
 TODO:
 - Test colorSpace
-- Test viewFormats
+- Test toneMapping
 `;
 
 import { makeTestGroup } from '../../../common/framework/test_group.js';
@@ -42,6 +42,15 @@ g.test('defaults')
       format: 'rgba8unorm',
     });
 
+    const configuration = ctx.getConfiguration();
+    t.expect(configuration.device === t.device);
+    t.expect(configuration.format === 'rgba8unorm');
+    t.expect(configuration.usage === GPUTextureUsage.RENDER_ATTACHMENT);
+    t.expect(configuration.viewFormats?.length === 0);
+    t.expect(configuration.colorSpace === 'srgb');
+    t.expect(configuration.toneMapping.mode === 'standard');
+    t.expect(configuration.alphaMode === 'opaque');
+
     const currentTexture = ctx.getCurrentTexture();
     t.expect(currentTexture.format === 'rgba8unorm');
     t.expect(currentTexture.usage === GPUTextureUsage.RENDER_ATTACHMENT);
@@ -69,6 +78,9 @@ g.test('device')
     const ctx = canvas.getContext('webgpu');
     assert(ctx instanceof GPUCanvasContext, 'Failed to get WebGPU context from canvas');
 
+    // getConfiguration returns null before configure.
+    t.expect(ctx.getConfiguration() === null);
+
     // Calling configure without a device should throw a TypeError.
     t.shouldThrow('TypeError', () => {
       ctx.configure({
@@ -85,7 +97,18 @@ g.test('device')
     ctx.configure({
       device: t.device,
       format: 'rgba8unorm',
+      alphaMode: 'opaque',
     });
+
+    // getConfiguration will succeed after configure.
+    const configuration = ctx.getConfiguration();
+    t.expect(configuration.device === t.device);
+    t.expect(configuration.format === 'rgba8unorm');
+    t.expect(configuration.usage === GPUTextureUsage.RENDER_ATTACHMENT);
+    t.expect(configuration.viewFormats?.length === 0);
+    t.expect(configuration.colorSpace === 'srgb');
+    t.expect(configuration.toneMapping.mode === 'standard');
+    t.expect(configuration.alphaMode === 'opaque');
 
     // getCurrentTexture will succeed with a valid device.
     ctx.getCurrentTexture();
@@ -96,12 +119,26 @@ g.test('device')
       ctx.getCurrentTexture();
     });
 
+    // getConfiguration returns null after unconfigure.
+    t.expect(ctx.getConfiguration() === null);
+
     // Should be able to successfully configure again after unconfiguring.
     ctx.configure({
       device: t.device,
       format: 'rgba8unorm',
+      alphaMode: 'premultiplied',
     });
     ctx.getCurrentTexture();
+
+    // getConfiguration will succeed after configure.
+    const newConfiguration = ctx.getConfiguration();
+    t.expect(newConfiguration.device === t.device);
+    t.expect(newConfiguration.format === 'rgba8unorm');
+    t.expect(newConfiguration.usage === GPUTextureUsage.RENDER_ATTACHMENT);
+    t.expect(newConfiguration.viewFormats?.length === 0);
+    t.expect(newConfiguration.colorSpace === 'srgb');
+    t.expect(newConfiguration.toneMapping.mode === 'standard');
+    t.expect(newConfiguration.alphaMode === 'premultiplied');
   });
 
 g.test('format')
@@ -139,6 +176,9 @@ g.test('format')
         format,
       });
     }, !validFormat);
+
+    const configuration = ctx.getConfiguration();
+    t.expect(configuration.format === format);
 
     t.expectValidationError(() => {
       // Should always return a texture, whether the configured format was valid or not.
@@ -178,6 +218,9 @@ g.test('usage')
       format: 'rgba8unorm',
       usage,
     });
+
+    const configuration = ctx.getConfiguration();
+    t.expect(configuration.usage === usage);
 
     const currentTexture = ctx.getCurrentTexture();
     t.expect(currentTexture instanceof GPUTexture);
@@ -288,6 +331,9 @@ g.test('alpha_mode')
       format: 'rgba8unorm',
       alphaMode,
     });
+
+    const configuration = ctx.getConfiguration();
+    t.expect(configuration.alphaMode === alphaMode);
 
     const currentTexture = ctx.getCurrentTexture();
     t.expect(currentTexture instanceof GPUTexture);
@@ -411,6 +457,10 @@ g.test('viewFormats')
         viewFormats: [viewFormat],
       });
     }, !compatible);
+
+    const configuration = ctx.getConfiguration();
+    t.expect(configuration.viewFormats?.length === 1);
+    t.expect(configuration.viewFormats[0] === viewFormat);
 
     // Likewise for getCurrentTexture().
     let currentTexture: GPUTexture;


### PR DESCRIPTION
This PR adds tests for the GPUCanvasContext `getConfiguration()` method that can be tested in Chromium patched with https://chromium-review.googlesource.com/c/chromium/src/+/5890176. It currently requires to run chromium with the experimental WebGPUExperimentalFeatures blink runtime feature (`--enable-blink-features=WebGPUExperimentalFeatures`). This is implied if you enable the "Unsafe WebGPU support" flag at `chrome://flag#enable-unsafe-webgpu`.

Spec PR: https://github.com/gpuweb/gpuweb/pull/4899

<img width="1433" alt="image" src="https://github.com/user-attachments/assets/bcb2f0fc-1b71-4030-81eb-fdd3968d9895">

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
