### PR TITLE
textureStore: fix compat texture view restriction

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/textureStore.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureStore.spec.ts
@@ -743,6 +743,18 @@ g.test('out_of_bounds_array')
         return true;
       })
   )
+  .beforeAllSubcases(t => {
+    if (t.isCompatibility) {
+      t.skipIf(
+        t.params.baseLevel !== 0,
+        'view base array layer must equal 0 in compatibility mode'
+      );
+      t.skipIf(
+        t.params.arrayLevels !== kArrayLevels,
+        'view array layers must equal texture array layers in compatibility mode'
+      );
+    }
+  })
   .fn(t => {
     const dim = '2d';
     const view_dim = '2d-array';


### PR DESCRIPTION


Issue: https://crbug.com/367440985

Chrome fix coming

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.) 
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
