### PR TITLE
in_render_common: fix compat texture view restriction

### DIFF
--- a/src/webgpu/api/validation/resource_usages/texture/in_render_common.spec.ts
+++ b/src/webgpu/api/validation/resource_usages/texture/in_render_common.spec.ts
@@ -188,10 +188,7 @@ g.test('subresources,color_attachment_and_bind_group')
   )
   .beforeAllSubcases(t => {
     if (t.isCompatibility) {
-      t.skipIf(
-        t.params.bgLayer !== 0,
-        'view base array layer must equal 0 in compatibility mode'
-      );
+      t.skipIf(t.params.bgLayer !== 0, 'view base array layer must equal 0 in compatibility mode');
       t.skipIf(
         t.params.bgLayerCount !== kTextureLayers,
         'view array layers must equal texture array layers in compatibility mode'
@@ -311,10 +308,7 @@ g.test('subresources,depth_stencil_attachment_and_bind_group')
   )
   .beforeAllSubcases(t => {
     if (t.isCompatibility) {
-      t.skipIf(
-        t.params.bgLayer !== 0,
-        'view base array layer must equal 0 in compatibility mode'
-      );
+      t.skipIf(t.params.bgLayer !== 0, 'view base array layer must equal 0 in compatibility mode');
       t.skipIf(
         t.params.bgLayerCount !== kTextureLayers,
         'view array layers must equal texture array layers in compatibility mode'
@@ -588,7 +582,8 @@ g.test('subresources,depth_stencil_texture_in_bind_groups')
         'view base array layer must equal 0 in compatibility mode'
       );
       t.skipIf(
-        t.params.view0Layers.count !== kTextureLayers || t.params.view1Layers.count !== kTextureLayers,
+        t.params.view0Layers.count !== kTextureLayers ||
+          t.params.view1Layers.count !== kTextureLayers,
         'view array layers must equal texture array layers in compatibility mode'
       );
     }

--- a/src/webgpu/api/validation/resource_usages/texture/in_render_common.spec.ts
+++ b/src/webgpu/api/validation/resource_usages/texture/in_render_common.spec.ts
@@ -180,11 +180,24 @@ g.test('subresources,color_attachment_and_bind_group')
         { bgLayer: 0, bgLayerCount: 1 },
         { bgLayer: 1, bgLayerCount: 1 },
         { bgLayer: 1, bgLayerCount: 2 },
+        { bgLayer: 0, bgLayerCount: kTextureLayers },
       ])
       .combine('bgUsage', kTextureBindingTypes)
       .unless(t => t.bgUsage !== 'sampled-texture' && t.bgLevelCount > 1)
       .combine('inSamePass', [true, false])
   )
+  .beforeAllSubcases(t => {
+    if (t.isCompatibility) {
+      t.skipIf(
+        t.params.bgLayer !== 0,
+        'view base array layer must equal 0 in compatibility mode'
+      );
+      t.skipIf(
+        t.params.bgLayerCount !== kTextureLayers,
+        'view array layers must equal texture array layers in compatibility mode'
+      );
+    }
+  })
   .fn(t => {
     const {
       colorAttachmentLevel,
@@ -288,6 +301,7 @@ g.test('subresources,depth_stencil_attachment_and_bind_group')
         { bgLayer: 0, bgLayerCount: 1 },
         { bgLayer: 1, bgLayerCount: 1 },
         { bgLayer: 1, bgLayerCount: 2 },
+        { bgLayer: 0, bgLayerCount: kTextureLayers },
       ])
       .beginSubcases()
       .combine('depthReadOnly', [true, false])
@@ -295,6 +309,18 @@ g.test('subresources,depth_stencil_attachment_and_bind_group')
       .combine('bgAspect', ['depth-only', 'stencil-only'] as const)
       .combine('inSamePass', [true, false])
   )
+  .beforeAllSubcases(t => {
+    if (t.isCompatibility) {
+      t.skipIf(
+        t.params.bgLayer !== 0,
+        'view base array layer must equal 0 in compatibility mode'
+      );
+      t.skipIf(
+        t.params.bgLayerCount !== kTextureLayers,
+        'view array layers must equal texture array layers in compatibility mode'
+      );
+    }
+  })
   .fn(t => {
     const {
       dsLevel,
@@ -411,6 +437,7 @@ g.test('subresources,multiple_bind_groups')
         { base: 0, count: 1 },
         { base: 1, count: 1 },
         { base: 1, count: 2 },
+        { base: 0, count: kTextureLayers },
       ])
       .combine('bg1Levels', [
         { base: 0, count: 1 },
@@ -421,6 +448,7 @@ g.test('subresources,multiple_bind_groups')
         { base: 0, count: 1 },
         { base: 1, count: 1 },
         { base: 1, count: 2 },
+        { base: 0, count: kTextureLayers },
       ])
       .combine('bgUsage0', kTextureBindingTypes)
       .combine('bgUsage1', kTextureBindingTypes)
@@ -432,6 +460,18 @@ g.test('subresources,multiple_bind_groups')
       .beginSubcases()
       .combine('inSamePass', [true, false])
   )
+  .beforeAllSubcases(t => {
+    if (t.isCompatibility) {
+      t.skipIf(
+        t.params.bg0Layers.base !== 0 || t.params.bg1Layers.base !== 0,
+        'view base array layer must equal 0 in compatibility mode'
+      );
+      t.skipIf(
+        t.params.bg0Layers.count !== kTextureLayers || t.params.bg1Layers.count !== kTextureLayers,
+        'view array layers must equal texture array layers in compatibility mode'
+      );
+    }
+  })
   .fn(t => {
     const { bg0Levels, bg0Layers, bg1Levels, bg1Layers, bgUsage0, bgUsage1, inSamePass } = t.params;
 
@@ -524,6 +564,7 @@ g.test('subresources,depth_stencil_texture_in_bind_groups')
         { base: 0, count: 1 },
         { base: 1, count: 1 },
         { base: 1, count: 2 },
+        { base: 0, count: kTextureLayers },
       ])
       .combine('view1Levels', [
         { base: 0, count: 1 },
@@ -534,11 +575,24 @@ g.test('subresources,depth_stencil_texture_in_bind_groups')
         { base: 0, count: 1 },
         { base: 1, count: 1 },
         { base: 1, count: 2 },
+        { base: 0, count: kTextureLayers },
       ])
       .combine('aspect0', ['depth-only', 'stencil-only'] as const)
       .combine('aspect1', ['depth-only', 'stencil-only'] as const)
       .combine('inSamePass', [true, false])
   )
+  .beforeAllSubcases(t => {
+    if (t.isCompatibility) {
+      t.skipIf(
+        t.params.view0Layers.base !== 0 || t.params.view1Layers.base !== 0,
+        'view base array layer must equal 0 in compatibility mode'
+      );
+      t.skipIf(
+        t.params.view0Layers.count !== kTextureLayers || t.params.view1Layers.count !== kTextureLayers,
+        'view array layers must equal texture array layers in compatibility mode'
+      );
+    }
+  })
   .fn(t => {
     const { view0Levels, view0Layers, view1Levels, view1Layers, aspect0, aspect1, inSamePass } =
       t.params;


### PR DESCRIPTION
Issue: https://crbug.com/367440985

Chrome fix coming
<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
