### PR TITLE
Fix textureSampleBias test

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/texture_utils.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/texture_utils.ts
@@ -2085,10 +2085,6 @@ const sumOfCharCodesOfString = (s: unknown) =>
     .split('')
     .reduce((sum, c) => sum + c.charCodeAt(0), 0);
 
-function roundDownToMultipleOf(v: number, multiple: number) {
-  return Math.floor(v / multiple) * multiple;
-}
-
 /**
  * Makes a function that fills a block portion of a Uint8Array with random valid data
  * for an astc block.
@@ -3061,8 +3057,7 @@ function generateTextureBuiltinInputsImpl<T extends Dimensionality>(
       // choose one axis to set
       const ndx = makeRangeValue({ num: coords.length - 1, type: 'u32' }, i, 8);
       assert(ndx < coords.length);
-      // Align to 3rds to avoid edge cases.
-      mult[ndx] = Math.pow(2, roundDownToMultipleOf(mipLevel, 1 / 3));
+      mult[ndx] = Math.pow(2, mipLevel);
       return mult as T;
     };
 
@@ -3595,8 +3590,7 @@ export function generateSamplePointsCube(
       // choose one axis to set
       const ndx = makeRangeValue({ num: coords.length - 1, type: 'u32' }, i, 8);
       assert(ndx < coords.length);
-      // Align to 3rds to avoid edge cases.
-      mult[ndx] = Math.pow(2, roundDownToMultipleOf(mipLevel, 1 / 3));
+      mult[ndx] = Math.pow(2, mipLevel);
       return mult as vec3;
     };
 


### PR DESCRIPTION
The derivative portion of mip level selection
was being incorrectly quantized. That quanization
is left over from a previous implementation but
now, quantization happens when the mip level is
chosen.



