### PR TITLE
clear reftest-wait if reftest throws

### DIFF
--- a/src/webgpu/web_platform/reftests/gpu_ref_test.ts
+++ b/src/webgpu/web_platform/reftests/gpu_ref_test.ts
@@ -1,5 +1,5 @@
 import { assert } from '../../../common/util/util.js';
-import { takeScreenshotDelayed } from '../../../common/util/wpt_reftest_wait.js';
+import { takeScreenshot, takeScreenshotDelayed } from '../../../common/util/wpt_reftest_wait.js';
 
 interface GPURefTest {
   readonly device: GPUDevice;
@@ -22,5 +22,8 @@ export function runRefTest(fn: (t: GPURefTest) => Promise<void> | void): void {
     await fn({ device, queue });
 
     takeScreenshotDelayed(50);
-  })();
+  })().catch(() => {
+    // remove reftest-wait to mark end of test
+    takeScreenshot();
+  });
 }


### PR DESCRIPTION
Issue: #3993

<hr>

**Requirements for PR author:**

- [ ] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [ ] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [ ] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
