### PR TITLE
Include depth textures in more tests

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/textureSample.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureSample.spec.ts
@@ -39,6 +39,7 @@ import {
   isSupportedViewFormatCombo,
   vec1,
   generateTextureBuiltinInputs1D,
+  skipIfNeedsFilteringAndIsUnfilterable,
 } from './texture_utils.js';
 
 const kTestableColorFormats = [...kEncodableTextureFormats, ...kCompressedTextureFormats] as const;
@@ -147,11 +148,12 @@ Parameters:
       .combine('addressModeV', ['clamp-to-edge', 'repeat', 'mirror-repeat'] as const)
       .combine('minFilter', ['nearest', 'linear'] as const)
   )
-  .beforeAllSubcases(t =>
-    skipIfTextureFormatNotSupportedNotAvailableOrNotFilterable(t, t.params.format)
-  )
+  .beforeAllSubcases(t => {
+    skipIfTextureFormatNotSupportedNotAvailableOrNotFilterable(t, t.params.format);
+  })
   .fn(async t => {
     const { format, samplePoints, addressModeU, addressModeV, minFilter, offset } = t.params;
+    skipIfNeedsFilteringAndIsUnfilterable(t, minFilter, format);
 
     // We want at least 4 blocks or something wide enough for 3 mip levels.
     const [width, height] = chooseTextureSize({ minSize: 8, minBlocks: 4, format });
@@ -253,6 +255,7 @@ Parameters:
       minFilter,
       offset,
     } = t.params;
+    skipIfNeedsFilteringAndIsUnfilterable(t, minFilter, format);
 
     const size = chooseTextureSize({ minSize: 8, minBlocks: 2, format, viewDimension });
     const descriptor: GPUTextureDescriptor = {
@@ -448,6 +451,7 @@ Parameters:
   )
   .fn(async t => {
     const { format, samplePoints, A, addressModeU, addressModeV, minFilter, offset } = t.params;
+    skipIfNeedsFilteringAndIsUnfilterable(t, minFilter, format);
 
     // We want at least 4 blocks or something wide enough for 3 mip levels.
     const [width, height] = chooseTextureSize({ minSize: 8, minBlocks: 4, format });
@@ -532,6 +536,7 @@ Parameters:
   })
   .fn(async t => {
     const { format, samplePoints, A, addressMode, minFilter } = t.params;
+    skipIfNeedsFilteringAndIsUnfilterable(t, minFilter, format);
 
     const viewDimension: GPUTextureViewDimension = 'cube-array';
     const size = chooseTextureSize({

--- a/src/webgpu/shader/execution/expression/call/builtin/textureSampleBias.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureSampleBias.spec.ts
@@ -30,6 +30,7 @@ import {
   getTextureTypeForTextureViewDimension,
   WGSLTextureSampleTest,
   isSupportedViewFormatCombo,
+  skipIfNeedsFilteringAndIsUnfilterable,
 } from './texture_utils.js';
 
 const kTestableColorFormats = [...kEncodableTextureFormats, ...kCompressedTextureFormats] as const;
@@ -72,6 +73,7 @@ Parameters:
   )
   .fn(async t => {
     const { format, samplePoints, addressModeU, addressModeV, minFilter, offset } = t.params;
+    skipIfNeedsFilteringAndIsUnfilterable(t, minFilter, format);
 
     // We want at least 4 blocks or something wide enough for 3 mip levels.
     const [width, height] = chooseTextureSize({ minSize: 8, minBlocks: 4, format });
@@ -173,6 +175,7 @@ Parameters:
       minFilter,
       offset,
     } = t.params;
+    skipIfNeedsFilteringAndIsUnfilterable(t, minFilter, format);
 
     const size = chooseTextureSize({ minSize: 8, minBlocks: 2, format, viewDimension });
     const descriptor: GPUTextureDescriptor = {
@@ -286,6 +289,7 @@ Parameters:
   )
   .fn(async t => {
     const { format, samplePoints, A, addressModeU, addressModeV, minFilter, offset } = t.params;
+    skipIfNeedsFilteringAndIsUnfilterable(t, minFilter, format);
 
     // We want at least 4 blocks or something wide enough for 3 mip levels.
     const [width, height] = chooseTextureSize({ minSize: 8, minBlocks: 4, format });
@@ -378,6 +382,7 @@ Parameters:
   })
   .fn(async t => {
     const { format, samplePoints, A, addressMode, minFilter } = t.params;
+    skipIfNeedsFilteringAndIsUnfilterable(t, minFilter, format);
 
     const viewDimension: GPUTextureViewDimension = 'cube-array';
     const size = chooseTextureSize({

--- a/src/webgpu/shader/execution/expression/call/builtin/textureSampleGrad.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureSampleGrad.spec.ts
@@ -24,6 +24,7 @@ import {
   kCubeSamplePointMethods,
   kSamplePointMethods,
   SamplePointMethods,
+  skipIfNeedsFilteringAndIsUnfilterable,
   skipIfTextureFormatNotSupportedNotAvailableOrNotFilterable,
   TextureCall,
   vec2,
@@ -73,6 +74,7 @@ Parameters:
   )
   .fn(async t => {
     const { format, stage, samplePoints, addressModeU, addressModeV, minFilter, offset } = t.params;
+    skipIfNeedsFilteringAndIsUnfilterable(t, minFilter, format);
 
     // We want at least 4 blocks or something wide enough for 3 mip levels.
     const [width, height] = chooseTextureSize({ minSize: 8, minBlocks: 4, format });
@@ -185,6 +187,7 @@ Parameters:
       minFilter,
       offset,
     } = t.params;
+    skipIfNeedsFilteringAndIsUnfilterable(t, minFilter, format);
 
     const size = chooseTextureSize({ minSize: 8, minBlocks: 2, format, viewDimension });
     const descriptor: GPUTextureDescriptor = {
@@ -310,6 +313,7 @@ Parameters:
   .fn(async t => {
     const { format, stage, samplePoints, A, addressModeU, addressModeV, minFilter, offset } =
       t.params;
+    skipIfNeedsFilteringAndIsUnfilterable(t, minFilter, format);
 
     // We want at least 4 blocks or something wide enough for 3 mip levels.
     const [width, height] = chooseTextureSize({ minSize: 8, minBlocks: 4, format });
@@ -413,6 +417,7 @@ Parameters:
   })
   .fn(async t => {
     const { format, stage, samplePoints, A, addressMode, minFilter } = t.params;
+    skipIfNeedsFilteringAndIsUnfilterable(t, minFilter, format);
 
     const viewDimension: GPUTextureViewDimension = 'cube-array';
     const size = chooseTextureSize({

--- a/src/webgpu/shader/execution/expression/call/builtin/textureSampleLevel.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureSampleLevel.spec.ts
@@ -6,7 +6,6 @@ Samples a texture.
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import {
-  isCompressedTextureFormat,
   isDepthTextureFormat,
   isEncodableTextureFormat,
   kCompressedTextureFormats,
@@ -27,9 +26,11 @@ import {
   getDepthOrArrayLayersForViewDimension,
   getTextureTypeForTextureViewDimension,
   isPotentiallyFilterableAndFillable,
+  isSupportedViewFormatCombo,
   kCubeSamplePointMethods,
   kSamplePointMethods,
   SamplePointMethods,
+  skipIfNeedsFilteringAndIsUnfilterable,
   skipIfTextureFormatNotSupportedNotAvailableOrNotFilterable,
   TextureCall,
   vec2,
@@ -82,6 +83,7 @@ Parameters:
   )
   .fn(async t => {
     const { format, stage, samplePoints, addressModeU, addressModeV, minFilter, offset } = t.params;
+    skipIfNeedsFilteringAndIsUnfilterable(t, minFilter, format);
 
     // We want at least 4 blocks or something wide enough for 3 mip levels.
     const [width, height] = chooseTextureSize({ minSize: 8, minBlocks: 4, format });
@@ -186,6 +188,7 @@ Parameters:
   .fn(async t => {
     const { format, stage, samplePoints, A, addressModeU, addressModeV, minFilter, offset } =
       t.params;
+    skipIfNeedsFilteringAndIsUnfilterable(t, minFilter, format);
 
     // We want at least 4 blocks or something wide enough for 3 mip levels.
     const [width, height] = chooseTextureSize({ minSize: 8, minBlocks: 4, format });
@@ -280,7 +283,7 @@ Parameters:
       .combine('format', kTestableColorFormats)
       .filter(t => isPotentiallyFilterableAndFillable(t.format))
       .combine('viewDimension', ['3d', 'cube'] as const)
-      .filter(t => !isCompressedTextureFormat(t.format) || t.viewDimension === 'cube')
+      .filter(t => isSupportedViewFormatCombo(t.format, t.viewDimension))
       .combine('offset', [false, true] as const)
       .filter(t => t.viewDimension !== 'cube' || t.offset !== true)
       .beginSubcases()
@@ -294,6 +297,7 @@ Parameters:
   )
   .fn(async t => {
     const { format, viewDimension, stage, samplePoints, addressMode, minFilter, offset } = t.params;
+    skipIfNeedsFilteringAndIsUnfilterable(t, minFilter, format);
 
     const [width, height] = chooseTextureSize({ minSize: 32, minBlocks: 2, format, viewDimension });
     const depthOrArrayLayers = getDepthOrArrayLayersForViewDimension(viewDimension);
@@ -414,6 +418,7 @@ Parameters:
   })
   .fn(async t => {
     const { format, stage, samplePoints, A, addressMode, minFilter } = t.params;
+    skipIfNeedsFilteringAndIsUnfilterable(t, minFilter, format);
 
     const viewDimension: GPUTextureViewDimension = 'cube-array';
     const size = chooseTextureSize({


### PR DESCRIPTION
Depth textures were excluded originally because there was no way to fill one via copyBufferToTexture. We added a way to fill them later which was used for the textureLoad tests. Now going back and enabling them for other tests.

Note that might be better to move minFilter to a case instead of a subcase but that would break all expectations in CQs so it seemed best to filter these in the test itself.


