### PR TITLE
Make identifySamplePoints handle compare

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/textureGather.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureGather.spec.ts
@@ -156,7 +156,8 @@ Parameters:
       sampler,
       calls,
       results,
-      stage
+      stage,
+      texture
     );
     t.expectOK(res);
   });
@@ -254,7 +255,8 @@ Parameters:
       sampler,
       calls,
       results,
-      stage
+      stage,
+      texture
     );
     t.expectOK(res);
   });
@@ -376,7 +378,8 @@ Parameters:
       sampler,
       calls,
       results,
-      stage
+      stage,
+      texture
     );
     t.expectOK(res);
   });
@@ -481,7 +484,8 @@ Parameters:
       sampler,
       calls,
       results,
-      stage
+      stage,
+      texture
     );
     t.expectOK(res);
   });
@@ -573,7 +577,8 @@ Parameters:
       sampler,
       calls,
       results,
-      stage
+      stage,
+      texture
     );
     t.expectOK(res);
   });
@@ -660,7 +665,8 @@ Parameters:
       sampler,
       calls,
       results,
-      stage
+      stage,
+      texture
     );
     t.expectOK(res);
   });
@@ -766,7 +772,8 @@ Parameters:
       sampler,
       calls,
       results,
-      stage
+      stage,
+      texture
     );
     t.expectOK(res);
   });
@@ -862,7 +869,8 @@ Parameters:
       sampler,
       calls,
       results,
-      stage
+      stage,
+      texture
     );
     t.expectOK(res);
   });

--- a/src/webgpu/shader/execution/expression/call/builtin/textureGatherCompare.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureGatherCompare.spec.ts
@@ -157,7 +157,8 @@ Parameters:
       sampler,
       calls,
       results,
-      stage
+      stage,
+      texture
     );
     t.expectOK(res);
   });
@@ -259,7 +260,8 @@ Parameters:
       sampler,
       calls,
       results,
-      stage
+      stage,
+      texture
     );
     t.expectOK(res);
   });
@@ -356,7 +358,8 @@ Parameters:
       sampler,
       calls,
       results,
-      stage
+      stage,
+      texture
     );
     t.expectOK(res);
   });
@@ -448,7 +451,8 @@ Parameters:
       sampler,
       calls,
       results,
-      stage
+      stage,
+      texture
     );
     t.expectOK(res);
   });

--- a/src/webgpu/shader/execution/expression/call/builtin/textureLoad.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureLoad.spec.ts
@@ -155,7 +155,8 @@ Parameters:
       sampler,
       calls,
       results,
-      stage
+      stage,
+      texture
     );
     t.expectOK(res);
   });
@@ -237,7 +238,8 @@ Parameters:
       sampler,
       calls,
       results,
-      stage
+      stage,
+      texture
     );
     t.expectOK(res);
   });
@@ -320,7 +322,8 @@ Parameters:
       sampler,
       calls,
       results,
-      stage
+      stage,
+      texture
     );
     t.expectOK(res);
   });
@@ -416,7 +419,8 @@ Parameters:
       sampler,
       calls,
       results,
-      stage
+      stage,
+      texture
     );
     t.expectOK(res);
   });
@@ -498,7 +502,8 @@ Parameters:
       sampler,
       calls,
       results,
-      stage
+      stage,
+      texture
     );
     t.expectOK(res);
   });
@@ -674,7 +679,8 @@ Parameters:
       sampler,
       calls,
       results,
-      stage
+      stage,
+      texture
     );
     t.expectOK(res);
   });
@@ -752,7 +758,8 @@ Parameters:
       sampler,
       calls,
       results,
-      stage
+      stage,
+      texture
     );
     t.expectOK(res);
   });
@@ -828,7 +835,8 @@ Parameters:
       sampler,
       calls,
       results,
-      stage
+      stage,
+      texture
     );
     t.expectOK(res);
   });
@@ -912,7 +920,8 @@ Parameters:
       sampler,
       calls,
       results,
-      stage
+      stage,
+      texture
     );
     t.expectOK(res);
   });
@@ -989,7 +998,8 @@ Parameters:
       sampler,
       calls,
       results,
-      stage
+      stage,
+      texture
     );
     t.expectOK(res);
   });

--- a/src/webgpu/shader/execution/expression/call/builtin/textureSample.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureSample.spec.ts
@@ -113,7 +113,9 @@ Parameters:
       textureType,
       sampler,
       calls,
-      results
+      results,
+      'fragment',
+      texture
     );
     t.expectOK(res);
   });
@@ -198,7 +200,9 @@ Parameters:
       textureType,
       sampler,
       calls,
-      results
+      results,
+      'fragment',
+      texture
     );
     t.expectOK(res);
   });
@@ -323,7 +327,9 @@ Parameters:
       textureType,
       sampler,
       calls,
-      results
+      results,
+      'fragment',
+      texture
     );
     t.expectOK(res);
   });
@@ -407,7 +413,9 @@ Parameters:
       textureType,
       sampler,
       calls,
-      results
+      results,
+      'fragment',
+      texture
     );
     t.expectOK(res);
   });
@@ -500,7 +508,9 @@ Parameters:
       textureType,
       sampler,
       calls,
-      results
+      results,
+      'fragment',
+      texture
     );
     t.expectOK(res);
   });
@@ -590,7 +600,9 @@ Parameters:
       textureType,
       sampler,
       calls,
-      results
+      results,
+      'fragment',
+      texture
     );
     t.expectOK(res);
   });
@@ -684,7 +696,9 @@ Parameters:
       textureType,
       sampler,
       calls,
-      results
+      results,
+      'fragment',
+      texture
     );
     t.expectOK(res);
   });
@@ -775,7 +789,9 @@ Parameters:
       textureType,
       sampler,
       calls,
-      results
+      results,
+      'fragment',
+      texture
     );
     t.expectOK(res);
   });
@@ -868,7 +884,9 @@ Parameters:
       textureType,
       sampler,
       calls,
-      results
+      results,
+      'fragment',
+      texture
     );
     t.expectOK(res);
   });

--- a/src/webgpu/shader/execution/expression/call/builtin/textureSampleBias.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureSampleBias.spec.ts
@@ -119,7 +119,9 @@ Parameters:
       textureType,
       sampler,
       calls,
-      results
+      results,
+      'fragment',
+      texture
     );
     t.expectOK(res);
   });
@@ -244,7 +246,9 @@ Parameters:
       textureType,
       sampler,
       calls,
-      results
+      results,
+      'fragment',
+      texture
     );
     t.expectOK(res);
   });
@@ -339,7 +343,9 @@ Parameters:
       textureType,
       sampler,
       calls,
-      results
+      results,
+      'fragment',
+      texture
     );
     t.expectOK(res);
   });
@@ -437,7 +443,9 @@ Parameters:
       textureType,
       sampler,
       calls,
-      results
+      results,
+      'fragment',
+      texture
     );
     t.expectOK(res);
   });

--- a/src/webgpu/shader/execution/expression/call/builtin/textureSampleCompare.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureSampleCompare.spec.ts
@@ -118,7 +118,9 @@ Parameters:
       textureType,
       sampler,
       calls,
-      results
+      results,
+      'fragment',
+      texture
     );
     t.expectOK(res);
   });
@@ -204,7 +206,9 @@ Parameters:
       textureType,
       sampler,
       calls,
-      results
+      results,
+      'fragment',
+      texture
     );
     t.expectOK(res);
   });
@@ -307,7 +311,9 @@ Parameters:
       textureType,
       sampler,
       calls,
-      results
+      results,
+      'fragment',
+      texture
     );
     t.expectOK(res);
   });
@@ -403,7 +409,9 @@ Parameters:
       textureType,
       sampler,
       calls,
-      results
+      results,
+      'fragment',
+      texture
     );
     t.expectOK(res);
   });

--- a/src/webgpu/shader/execution/expression/call/builtin/textureSampleCompareLevel.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureSampleCompareLevel.spec.ts
@@ -135,7 +135,8 @@ Parameters:
       sampler,
       calls,
       results,
-      stage
+      stage,
+      texture
     );
     t.expectOK(res);
   });
@@ -231,7 +232,8 @@ Parameters:
       sampler,
       calls,
       results,
-      stage
+      stage,
+      texture
     );
     t.expectOK(res);
   });
@@ -353,7 +355,8 @@ Parameters:
       sampler,
       calls,
       results,
-      stage
+      stage,
+      texture
     );
     t.expectOK(res);
   });
@@ -457,7 +460,8 @@ Parameters:
       sampler,
       calls,
       results,
-      stage
+      stage,
+      texture
     );
     t.expectOK(res);
   });

--- a/src/webgpu/shader/execution/expression/call/builtin/textureSampleGrad.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureSampleGrad.spec.ts
@@ -128,7 +128,8 @@ Parameters:
       sampler,
       calls,
       results,
-      stage
+      stage,
+      texture
     );
     t.expectOK(res);
   });
@@ -265,7 +266,8 @@ Parameters:
       sampler,
       calls,
       results,
-      stage
+      stage,
+      texture
     );
     t.expectOK(res);
   });
@@ -372,7 +374,8 @@ Parameters:
       sampler,
       calls,
       results,
-      stage
+      stage,
+      texture
     );
     t.expectOK(res);
   });
@@ -481,7 +484,8 @@ Parameters:
       sampler,
       calls,
       results,
-      stage
+      stage,
+      texture
     );
     t.expectOK(res);
   });

--- a/src/webgpu/shader/execution/expression/call/builtin/textureSampleLevel.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureSampleLevel.spec.ts
@@ -137,7 +137,8 @@ Parameters:
       sampler,
       calls,
       results,
-      stage
+      stage,
+      texture
     );
     t.expectOK(res);
   });
@@ -247,7 +248,8 @@ Parameters:
       sampler,
       calls,
       results,
-      stage
+      stage,
+      texture
     );
     t.expectOK(res);
   });
@@ -368,7 +370,8 @@ Parameters:
       sampler,
       calls,
       results,
-      stage
+      stage,
+      texture
     );
     t.expectOK(res);
   });
@@ -481,7 +484,8 @@ Parameters:
       sampler,
       calls,
       results,
-      stage
+      stage,
+      texture
     );
     t.expectOK(res);
   });
@@ -585,7 +589,8 @@ Parameters:
       sampler,
       calls,
       results,
-      stage
+      stage,
+      texture
     );
     t.expectOK(res);
   });
@@ -696,7 +701,8 @@ Parameters:
       sampler,
       calls,
       results,
-      stage
+      stage,
+      texture
     );
     t.expectOK(res);
   });
@@ -817,7 +823,8 @@ Parameters:
       sampler,
       calls,
       results,
-      stage
+      stage,
+      texture
     );
     t.expectOK(res);
   });


### PR DESCRIPTION
identifySamplePoints works by doing a binary search filling a texture with black (0,0,0,0) and white (1,1,1,1) texels and then sampling it. Any non-zero results means those white pixels were sampled.

This doesn't work for comparisons like textureSampleCompare, textureSampleCompareLevel, and textureGatherCompare because the result of those are 0 or 1 so for example, of the comparison is 'always' then all texels will show up as sampled.

So, instead, if the builtin being tested is a comparison we convert the call to the corresponding non-comparsion builtin.

* textureSampleCompare -> textureSample
* textureSampleCompareLevel -> textureSampleLevel
* textureGatherCompare -> textureGather

This lets us find the sample points as best we can (it assumes those functions sample the same texels).

Once we have the sample point we then want to look up the actual values of the texels and print them out. To do this requires reading the texture back from the GPU. We made the texture ourselves so we could maybe theoretically pass the data we sent to the GPU down to identifySamplePoints but it seems good to get the values from the GPU itself so at least they made a round trip through the GPU

When, if it's a comparison, we print out the result of each comparison with that texel. Hopefully this will help us identify why these tests don't pass on some devices.

