### PR TITLE
Update tests for validating canvas texture formats in `configure()`

### DIFF
--- a/src/webgpu/web_platform/canvas/configure.spec.ts
+++ b/src/webgpu/web_platform/canvas/configure.spec.ts
@@ -173,21 +173,21 @@ g.test('format')
       }
     }
 
-    t.expectValidationError(() => {
+    if (validFormat) {
       ctx.configure({
         device: t.device,
         format,
       });
-    }, !validFormat);
-
-    const configuration = ctx.getConfiguration();
-    t.expect(configuration!.format === format);
-
-    t.expectValidationError(() => {
-      // Should always return a texture, whether the configured format was valid or not.
-      const currentTexture = ctx.getCurrentTexture();
-      t.expect(currentTexture instanceof GPUTexture);
-    }, !validFormat);
+      const configuration = ctx.getConfiguration();
+      t.expect(configuration!.format === format);
+    } else {
+      t.shouldThrow('TypeError', () => {
+        ctx.configure({
+          device: t.device,
+          format,
+        });
+      });
+    }
   });
 
 g.test('usage')


### PR DESCRIPTION
The updated test now checks for supported context formats in `configure()` on content timeline (TypeError) instead of GPU validation error.

Spec PR: https://github.com/gpuweb/gpuweb/pull/4911

<img width="1433" alt="image" src="https://github.com/user-attachments/assets/b7eee82e-c2ea-44fe-aa77-6fbe3c0797ee">

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.) It runs in Chromium patched with https://chromium-review.googlesource.com/c/chromium/src/+/5921467
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
