### PR TITLE
fix texture_formats:canvas_configuration test for supported context format

### DIFF
--- a/src/webgpu/api/validation/capability_checks/features/texture_formats.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/features/texture_formats.spec.ts
@@ -5,6 +5,7 @@ Tests for capability checking for features enabling optional texture formats.
 import { makeTestGroup } from '../../../../../common/framework/test_group.js';
 import { getGPU } from '../../../../../common/util/navigator_gpu.js';
 import { assert } from '../../../../../common/util/util.js';
+import { kCanvasTextureFormats } from '../../../../capability_info.js';
 import { kAllTextureFormats, kTextureFormatInfo } from '../../../../format_info.js';
 import { kAllCanvasTypes, createCanvas } from '../../../../util/create_elements.js';
 import { ValidationTest } from '../../validation_test.js';
@@ -161,15 +162,15 @@ g.test('canvas_configuration')
       usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.COPY_DST,
     };
 
-    if (enable_required_feature) {
-      t.expectValidationError(() => {
-        ctx.configure(canvasConf);
-      });
-    } else {
-      t.shouldThrow('TypeError', () => {
-        ctx.configure(canvasConf);
-      });
-    }
+    const expectedError =
+      enable_required_feature &&
+      (kCanvasTextureFormats as unknown as Array<GPUTextureFormat>).includes(format)
+        ? false
+        : 'TypeError';
+
+    t.shouldThrow(expectedError, () => {
+      ctx.configure(canvasConf);
+    });
   });
 
 g.test('canvas_configuration_view_formats')


### PR DESCRIPTION
Spec PR: https://github.com/gpuweb/gpuweb/pull/4911 now checks for supported context formats in configure() on content timeline (TypeError) instead of GPU validation error, so we cannot really differentiate between missing required features and unsupported context format. Currently this test is useless, but if we ever add supported context format that requires features this will be important.

Works in servo, currently deployed at [https://sagudev.github.io/cts/standalone/?q=webgpu:api,validation,capability_checks,features,texture_formats:canvas_configuration:*](https://sagudev.github.io/cts/standalone/?q=webgpu:api,validation,capability_checks,features,texture_formats:canvas_configuration:*)

<hr>

**Requirements for PR author:**

- [ ] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [ ] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [ ] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
