### PR TITLE
Revert "robust_access_vertex shader add float tolerance (#3968)"

### DIFF
--- a/src/webgpu/shader/execution/robust_access_vertex.spec.ts
+++ b/src/webgpu/shader/execution/robust_access_vertex.spec.ts
@@ -63,10 +63,6 @@ import { makeTestGroup } from '../../../common/framework/test_group.js';
 import { assert } from '../../../common/util/util.js';
 import { GPUTest, TextureTestMixin } from '../../gpu_test.js';
 
-// This is a tolerance that should be less strict than oneULP(X) of a f32 where X is any arbitraryValues or 0.
-// Given that in GLSL compat highp float can < 32 bit.
-const kFloatTolerance = 0.000001;
-
 // Encapsulates a draw call (either indexed or non-indexed)
 class DrawCall {
   private test: GPUTest;
@@ -269,15 +265,11 @@ const typeInfoMap: { [k: string]: VertexInfo } = {
     sizeInBytes: 12,
     validationFunc: 'return valid(v.x) && valid(v.y) && valid(v.z);',
   },
-  // It is valid to return (0, 0, 0, X) for an OOB access. (X can be anything)
-  // https://gpuweb.github.io/gpuweb/#security-shader
   float32x4: {
     wgslType: 'vec4<f32>',
     sizeInBytes: 16,
     validationFunc: `return (valid(v.x) && valid(v.y) && valid(v.z) && valid(v.w)) ||
-                            (abs(v.x - 0.0) <= ${kFloatTolerance} &&
-                             abs(v.y - 0.0) <= ${kFloatTolerance} &&
-                             abs(v.z - 0.0) <= ${kFloatTolerance});`,
+                            (v.x == 0.0 && v.y == 0.0 && v.z == 0.0 && (v.w == 0.0 || v.w == 1.0));`,
   },
 };
 
@@ -371,7 +363,7 @@ class F extends TextureTestMixin(GPUTest) {
       ${layoutStr}
 
       fn valid(f : f32) -> bool {
-        return ${validValues.map(v => `abs(f - ${v}.0) <= ${kFloatTolerance}`).join(' || ')};
+        return ${validValues.map(v => `f == ${v}.0`).join(' || ')};
       }
 
       fn validationFunc(v : ${typeInfo.wgslType}) -> bool {


### PR DESCRIPTION
This reverts commit 11ac59b4615daf73d2e90de913d1d7de9ea6050a.

dawn switching gl angle backend correctly and it seems it's now passing without tolerance.


Issue: https://crbug.com/365974434

<hr>

**Requirements for PR author:**

- [ ] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [ ] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [ ] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
