### PR TITLE
Use batching for shader,validation,expression,call,builtin,*:values:

### DIFF
--- a/src/webgpu/shader/validation/expression/call/builtin/abs.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/abs.spec.ts
@@ -24,6 +24,7 @@ export const g = makeTestGroup(ShaderValidationTest);
 const kValuesTypes = objectsToRecord(kAllNumericScalarsAndVectors);
 
 g.test('values')
+  .batch(125)
   .desc(
     `
 Validates that constant evaluation and override evaluation of ${builtin}() never errors

--- a/src/webgpu/shader/validation/expression/call/builtin/acos.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/acos.spec.ts
@@ -28,6 +28,7 @@ export const g = makeTestGroup(ShaderValidationTest);
 const kValuesTypes = objectsToRecord(kConvertableToFloatScalarsAndVectors);
 
 g.test('values')
+  .batch(125)
   .desc(
     `
 Validates that constant evaluation and override evaluation of ${builtin}() rejects invalid values

--- a/src/webgpu/shader/validation/expression/call/builtin/acosh.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/acosh.spec.ts
@@ -28,6 +28,7 @@ export const g = makeTestGroup(ShaderValidationTest);
 const kValuesTypes = objectsToRecord(kConvertableToFloatScalarsAndVectors);
 
 g.test('values')
+  .batch(125)
   .desc(
     `
 Validates that constant evaluation and override evaluation of ${builtin}() rejects invalid values

--- a/src/webgpu/shader/validation/expression/call/builtin/asin.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/asin.spec.ts
@@ -28,6 +28,7 @@ export const g = makeTestGroup(ShaderValidationTest);
 const kValuesTypes = objectsToRecord(kConvertableToFloatScalarsAndVectors);
 
 g.test('values')
+  .batch(125)
   .desc(
     `
 Validates that constant evaluation and override evaluation of ${builtin}() rejects invalid values

--- a/src/webgpu/shader/validation/expression/call/builtin/asinh.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/asinh.spec.ts
@@ -34,6 +34,7 @@ const additionalRangeForType = rangeForType(
 );
 
 g.test('values')
+  .batch(125)
   .desc(
     `
 Validates that constant evaluation and override evaluation of ${builtin}() rejects invalid values

--- a/src/webgpu/shader/validation/expression/call/builtin/atan.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/atan.spec.ts
@@ -27,6 +27,7 @@ export const g = makeTestGroup(ShaderValidationTest);
 const kValuesTypes = objectsToRecord(kConvertableToFloatScalarsAndVectors);
 
 g.test('values')
+  .batch(125)
   .desc(
     `
 Validates that constant evaluation and override evaluation of ${builtin}() rejects invalid values

--- a/src/webgpu/shader/validation/expression/call/builtin/atan2.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/atan2.spec.ts
@@ -31,6 +31,7 @@ export const g = makeTestGroup(ShaderValidationTest);
 const kValuesTypes = objectsToRecord(kFloatScalarsAndVectors);
 
 g.test('values')
+  .batch(125)
   .desc(
     `
 Validates that constant evaluation and override evaluation of ${builtin}() rejects invalid values

--- a/src/webgpu/shader/validation/expression/call/builtin/atanh.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/atanh.spec.ts
@@ -28,6 +28,7 @@ export const g = makeTestGroup(ShaderValidationTest);
 const kValuesTypes = objectsToRecord(kConvertableToFloatScalarsAndVectors);
 
 g.test('values')
+  .batch(125)
   .desc(
     `
 Validates that constant evaluation and override evaluation of ${builtin}() rejects invalid values

--- a/src/webgpu/shader/validation/expression/call/builtin/ceil.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/ceil.spec.ts
@@ -25,6 +25,7 @@ export const g = makeTestGroup(ShaderValidationTest);
 const kValuesTypes = objectsToRecord(kConvertableToFloatScalarsAndVectors);
 
 g.test('values')
+  .batch(125)
   .desc(
     `
 Validates that constant evaluation and override evaluation of ${builtin}() never errors

--- a/src/webgpu/shader/validation/expression/call/builtin/clamp.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/clamp.spec.ts
@@ -29,6 +29,7 @@ const kValuesTypes = objectsToRecord([
 ]);
 
 g.test('values')
+  .batch(125)
   .desc(
     `
 Validates that constant evaluation and override evaluation of ${builtin}() rejects invalid values

--- a/src/webgpu/shader/validation/expression/call/builtin/cos.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/cos.spec.ts
@@ -27,6 +27,7 @@ export const g = makeTestGroup(ShaderValidationTest);
 const kValuesTypes = objectsToRecord(kConvertableToFloatScalarsAndVectors);
 
 g.test('values')
+  .batch(125)
   .desc(
     `
 Validates that constant evaluation and override evaluation of ${builtin}() rejects invalid values

--- a/src/webgpu/shader/validation/expression/call/builtin/cosh.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/cosh.spec.ts
@@ -25,6 +25,7 @@ export const g = makeTestGroup(ShaderValidationTest);
 const kValuesTypes = objectsToRecord(kConvertableToFloatScalarsAndVectors);
 
 g.test('values')
+  .batch(125)
   .desc(
     `
 Validates that constant evaluation and override evaluation of ${builtin}() rejects invalid values

--- a/src/webgpu/shader/validation/expression/call/builtin/countLeadingZeros.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/countLeadingZeros.spec.ts
@@ -24,6 +24,7 @@ export const g = makeTestGroup(ShaderValidationTest);
 const kValuesTypes = objectsToRecord(kConcreteIntegerScalarsAndVectors);
 
 g.test('values')
+  .batch(125)
   .desc(
     `
 Validates that constant evaluation and override evaluation of ${builtin}() never errors

--- a/src/webgpu/shader/validation/expression/call/builtin/countOneBits.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/countOneBits.spec.ts
@@ -24,6 +24,7 @@ export const g = makeTestGroup(ShaderValidationTest);
 const kValuesTypes = objectsToRecord(kConcreteIntegerScalarsAndVectors);
 
 g.test('values')
+  .batch(125)
   .desc(
     `
 Validates that constant evaluation and override evaluation of ${builtin}() never errors

--- a/src/webgpu/shader/validation/expression/call/builtin/countTrailingZeros.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/countTrailingZeros.spec.ts
@@ -24,6 +24,7 @@ export const g = makeTestGroup(ShaderValidationTest);
 const kValuesTypes = objectsToRecord(kConcreteIntegerScalarsAndVectors);
 
 g.test('values')
+  .batch(125)
   .desc(
     `
 Validates that constant evaluation and override evaluation of ${builtin}() never errors

--- a/src/webgpu/shader/validation/expression/call/builtin/cross.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/cross.spec.ts
@@ -37,6 +37,7 @@ function quantizeFunctionForScalarType(type: ScalarType): QuantizeFunc<number> {
 }
 
 g.test('values')
+  .batch(125)
   .desc(
     `
 Validates that constant evaluation and override evaluation of ${builtin}() never errors

--- a/src/webgpu/shader/validation/expression/call/builtin/degrees.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/degrees.spec.ts
@@ -26,6 +26,7 @@ export const g = makeTestGroup(ShaderValidationTest);
 const kValuesTypes = objectsToRecord(kConvertableToFloatScalarsAndVectors);
 
 g.test('values')
+  .batch(125)
   .desc(
     `
 Validates that constant evaluation and override evaluation of ${builtin}() inputs rejects invalid values

--- a/src/webgpu/shader/validation/expression/call/builtin/distance.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/distance.spec.ts
@@ -25,6 +25,7 @@ export const g = makeTestGroup(ShaderValidationTest);
 const kValidArgumentTypes = objectsToRecord(kConvertableToFloatScalarsAndVectors);
 
 g.test('values')
+  .batch(125)
   .desc(
     `
 Validates that constant evaluation and override evaluation of ${builtin}() never errors

--- a/src/webgpu/shader/validation/expression/call/builtin/dot.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/dot.spec.ts
@@ -21,6 +21,7 @@ export const g = makeTestGroup(ShaderValidationTest);
 const kValidArgumentTypes = objectsToRecord(kConvertableToFloatVectors);
 
 g.test('values')
+  .batch(125)
   .desc(
     `
 Validates that constant evaluation and override evaluation of ${builtin}() never errors

--- a/src/webgpu/shader/validation/expression/call/builtin/exp.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/exp.spec.ts
@@ -55,6 +55,7 @@ const valueForType = rangeForType(
 );
 
 g.test('values')
+  .batch(125)
   .desc(
     `
 Validates that constant evaluation and override evaluation of ${builtin}() rejects invalid values

--- a/src/webgpu/shader/validation/expression/call/builtin/exp2.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/exp2.spec.ts
@@ -55,6 +55,7 @@ const valueForType = rangeForType(
 );
 
 g.test('values')
+  .batch(125)
   .desc(
     `
 Validates that constant evaluation and override evaluation of ${builtin}() rejects invalid values

--- a/src/webgpu/shader/validation/expression/call/builtin/extractBits.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/extractBits.spec.ts
@@ -25,6 +25,7 @@ export const g = makeTestGroup(ShaderValidationTest);
 const kValuesTypes = objectsToRecord(kConcreteIntegerScalarsAndVectors);
 
 g.test('values')
+  .batch(125)
   .desc(
     `
 Validates that constant evaluation and override evaluation of ${builtin}() never errors on valid inputs

--- a/src/webgpu/shader/validation/expression/call/builtin/faceForward.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/faceForward.spec.ts
@@ -37,6 +37,7 @@ function quantizeFunctionForScalarType(type: ScalarType): QuantizeFunc<number> {
 }
 
 g.test('values')
+  .batch(125)
   .desc(
     `
 Validates that constant evaluation and override evaluation of ${builtin}() never errors

--- a/src/webgpu/shader/validation/expression/call/builtin/firstLeadingBit.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/firstLeadingBit.spec.ts
@@ -24,6 +24,7 @@ export const g = makeTestGroup(ShaderValidationTest);
 const kValuesTypes = objectsToRecord(kConcreteIntegerScalarsAndVectors);
 
 g.test('values')
+  .batch(125)
   .desc(
     `
 Validates that constant evaluation and override evaluation of ${builtin}() never errors

--- a/src/webgpu/shader/validation/expression/call/builtin/firstTrailingBit.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/firstTrailingBit.spec.ts
@@ -24,6 +24,7 @@ export const g = makeTestGroup(ShaderValidationTest);
 const kValuesTypes = objectsToRecord(kConcreteIntegerScalarsAndVectors);
 
 g.test('values')
+  .batch(125)
   .desc(
     `
 Validates that constant evaluation and override evaluation of ${builtin}() never errors

--- a/src/webgpu/shader/validation/expression/call/builtin/floor.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/floor.spec.ts
@@ -25,6 +25,7 @@ export const g = makeTestGroup(ShaderValidationTest);
 const kValuesTypes = objectsToRecord(kConvertableToFloatScalarsAndVectors);
 
 g.test('values')
+  .batch(125)
   .desc(
     `
 Validates that constant evaluation and override evaluation of ${builtin}() never errors

--- a/src/webgpu/shader/validation/expression/call/builtin/fma.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/fma.spec.ts
@@ -21,6 +21,7 @@ export const g = makeTestGroup(ShaderValidationTest);
 const kValidArgumentTypes = objectsToRecord(kConvertableToFloatVectors);
 
 g.test('values')
+  .batch(125)
   .desc(
     `
 Validates that constant evaluation and override evaluation of ${builtin}() only errors in cases

--- a/src/webgpu/shader/validation/expression/call/builtin/fract.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/fract.spec.ts
@@ -24,6 +24,7 @@ export const g = makeTestGroup(ShaderValidationTest);
 const kValidArgumentTypes = objectsToRecord(kConvertableToFloatScalarsAndVectors);
 
 g.test('values')
+  .batch(125)
   .desc(
     `
 Validates that constant evaluation and override evaluation of ${builtin}() error on invalid inputs.

--- a/src/webgpu/shader/validation/expression/call/builtin/frexp.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/frexp.spec.ts
@@ -24,6 +24,7 @@ export const g = makeTestGroup(ShaderValidationTest);
 const kValidArgumentTypes = objectsToRecord(kConvertableToFloatScalarsAndVectors);
 
 g.test('values')
+  .batch(125)
   .desc(
     `
 Validates that constant evaluation and override evaluation of ${builtin}() error on invalid inputs.

--- a/src/webgpu/shader/validation/expression/call/builtin/insertBits.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/insertBits.spec.ts
@@ -25,6 +25,7 @@ export const g = makeTestGroup(ShaderValidationTest);
 const kValuesTypes = objectsToRecord(kConcreteIntegerScalarsAndVectors);
 
 g.test('values')
+  .batch(125)
   .desc(
     `
 Validates that constant evaluation and override evaluation of ${builtin}() never errors on valid inputs

--- a/src/webgpu/shader/validation/expression/call/builtin/inverseSqrt.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/inverseSqrt.spec.ts
@@ -27,6 +27,7 @@ export const g = makeTestGroup(ShaderValidationTest);
 const kValuesTypes = objectsToRecord(kConvertableToFloatScalarsAndVectors);
 
 g.test('values')
+  .batch(125)
   .desc(
     `
 Validates that constant evaluation and override evaluation of ${builtin}() inputs rejects invalid values

--- a/src/webgpu/shader/validation/expression/call/builtin/ldexp.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/ldexp.spec.ts
@@ -68,6 +68,7 @@ function biasRange(type: VectorType | ScalarType) {
 }
 
 g.test('values')
+  .batch(125)
   .desc(
     `
 Validates that constant evaluation and override evaluation of ${builtin}() never errors

--- a/src/webgpu/shader/validation/expression/call/builtin/log.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/log.spec.ts
@@ -25,6 +25,7 @@ export const g = makeTestGroup(ShaderValidationTest);
 const kValuesTypes = objectsToRecord(kConvertableToFloatScalarsAndVectors);
 
 g.test('values')
+  .batch(125)
   .desc(
     `
 Validates that constant evaluation and override evaluation of ${builtin}() inputs rejects invalid values

--- a/src/webgpu/shader/validation/expression/call/builtin/log2.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/log2.spec.ts
@@ -25,6 +25,7 @@ export const g = makeTestGroup(ShaderValidationTest);
 const kValuesTypes = objectsToRecord(kConvertableToFloatScalarsAndVectors);
 
 g.test('values')
+  .batch(125)
   .desc(
     `
 Validates that constant evaluation and override evaluation of ${builtin}() inputs rejects invalid values

--- a/src/webgpu/shader/validation/expression/call/builtin/max.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/max.spec.ts
@@ -24,6 +24,7 @@ export const g = makeTestGroup(ShaderValidationTest);
 const kValuesTypes = objectsToRecord(kAllNumericScalarsAndVectors);
 
 g.test('values')
+  .batch(125)
   .desc(
     `
 Validates that constant evaluation and override evaluation of ${builtin}() never errors

--- a/src/webgpu/shader/validation/expression/call/builtin/min.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/min.spec.ts
@@ -24,6 +24,7 @@ export const g = makeTestGroup(ShaderValidationTest);
 const kValuesTypes = objectsToRecord(kAllNumericScalarsAndVectors);
 
 g.test('values')
+  .batch(125)
   .desc(
     `
 Validates that constant evaluation and override evaluation of ${builtin}() never errors

--- a/src/webgpu/shader/validation/expression/call/builtin/mix.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/mix.spec.ts
@@ -21,6 +21,7 @@ export const g = makeTestGroup(ShaderValidationTest);
 const kValidArgumentTypes = objectsToRecord(kConvertableToFloatVectors);
 
 g.test('values')
+  .batch(125)
   .desc(
     `
 Validates that constant evaluation and override evaluation of ${builtin}() never errors

--- a/src/webgpu/shader/validation/expression/call/builtin/modf.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/modf.spec.ts
@@ -25,6 +25,7 @@ export const g = makeTestGroup(ShaderValidationTest);
 const kValuesTypes = objectsToRecord(kConvertableToFloatScalarsAndVectors);
 
 g.test('values')
+  .batch(125)
   .desc(
     `
 Validates that constant evaluation and override evaluation of ${builtin}() rejects invalid values

--- a/src/webgpu/shader/validation/expression/call/builtin/normalize.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/normalize.spec.ts
@@ -55,6 +55,7 @@ function isSubnormalFunctionForScalarType(type: ScalarType): (v: number) => bool
 }
 
 g.test('values')
+  .batch(125)
   .desc(
     `
 Validates that constant evaluation and override evaluation of ${builtin}() rejects invalid values

--- a/src/webgpu/shader/validation/expression/call/builtin/pow.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/pow.spec.ts
@@ -38,6 +38,7 @@ function quantizeFunctionForScalarType(type: ScalarType): QuantizeFunc<number> {
 }
 
 g.test('values')
+  .batch(125)
   .desc(
     `
 Validates that constant evaluation and override evaluation of ${builtin}() rejects invalid values

--- a/src/webgpu/shader/validation/expression/call/builtin/quantizeToF16.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/quantizeToF16.spec.ts
@@ -27,6 +27,7 @@ const kValidArgumentTypes = objectsToRecord([
 ]);
 
 g.test('values')
+  .batch(125)
   .desc(
     `
 Validates that constant evaluation and override evaluation of ${builtin}() error on invalid inputs.

--- a/src/webgpu/shader/validation/expression/call/builtin/radians.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/radians.spec.ts
@@ -25,6 +25,7 @@ export const g = makeTestGroup(ShaderValidationTest);
 const kValuesTypes = objectsToRecord(kConvertableToFloatScalarsAndVectors);
 
 g.test('values')
+  .batch(125)
   .desc(
     `
 Validates that constant evaluation and override evaluation of ${builtin}() inputs rejects invalid values

--- a/src/webgpu/shader/validation/expression/call/builtin/reflect.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/reflect.spec.ts
@@ -37,6 +37,7 @@ function quantizeFunctionForScalarType(type: ScalarType): QuantizeFunc<number> {
 }
 
 g.test('values')
+  .batch(125)
   .desc(
     `
 Validates that constant evaluation and override evaluation of ${builtin}() never errors

--- a/src/webgpu/shader/validation/expression/call/builtin/refract.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/refract.spec.ts
@@ -54,6 +54,7 @@ function isSubnormalFunctionForScalarType(type: ScalarType): (v: number) => bool
 }
 
 g.test('values')
+  .batch(125)
   .desc(
     `
 Validates that constant evaluation and override evaluation of ${builtin}() only errors in cases

--- a/src/webgpu/shader/validation/expression/call/builtin/reverseBits.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/reverseBits.spec.ts
@@ -24,6 +24,7 @@ export const g = makeTestGroup(ShaderValidationTest);
 const kValuesTypes = objectsToRecord(kConcreteIntegerScalarsAndVectors);
 
 g.test('values')
+  .batch(125)
   .desc(
     `
 Validates that constant evaluation and override evaluation of ${builtin}() never errors

--- a/src/webgpu/shader/validation/expression/call/builtin/round.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/round.spec.ts
@@ -27,6 +27,7 @@ export const g = makeTestGroup(ShaderValidationTest);
 const kValuesTypes = objectsToRecord(kConvertableToFloatScalarsAndVectors);
 
 g.test('values')
+  .batch(125)
   .desc(
     `
 Validates that constant evaluation and override evaluation of ${builtin}() inputs rejects invalid values

--- a/src/webgpu/shader/validation/expression/call/builtin/saturate.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/saturate.spec.ts
@@ -25,6 +25,7 @@ export const g = makeTestGroup(ShaderValidationTest);
 const kValuesTypes = objectsToRecord(kConvertableToFloatScalarsAndVectors);
 
 g.test('values')
+  .batch(125)
   .desc(
     `
 Validates that constant evaluation and override evaluation of ${builtin}() inputs rejects invalid values

--- a/src/webgpu/shader/validation/expression/call/builtin/sign.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/sign.spec.ts
@@ -28,6 +28,7 @@ const kValuesTypes = objectsToRecord([
 ]);
 
 g.test('values')
+  .batch(125)
   .desc(
     `
 Validates that constant evaluation and override evaluation of ${builtin}() inputs rejects invalid values

--- a/src/webgpu/shader/validation/expression/call/builtin/sin.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/sin.spec.ts
@@ -27,6 +27,7 @@ export const g = makeTestGroup(ShaderValidationTest);
 const kValuesTypes = objectsToRecord(kConvertableToFloatScalarsAndVectors);
 
 g.test('values')
+  .batch(125)
   .desc(
     `
 Validates that constant evaluation and override evaluation of ${builtin}() rejects invalid values

--- a/src/webgpu/shader/validation/expression/call/builtin/sinh.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/sinh.spec.ts
@@ -25,6 +25,7 @@ export const g = makeTestGroup(ShaderValidationTest);
 const kValuesTypes = objectsToRecord(kConvertableToFloatScalarsAndVectors);
 
 g.test('values')
+  .batch(125)
   .desc(
     `
 Validates that constant evaluation and override evaluation of ${builtin}() rejects invalid values

--- a/src/webgpu/shader/validation/expression/call/builtin/smoothstep.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/smoothstep.spec.ts
@@ -29,6 +29,7 @@ const kValuesTypes = objectsToRecord(kConvertableToFloatScalarsAndVectors);
 const kArgumentTypes = objectsToRecord(kAllScalarsAndVectors);
 
 g.test('values')
+  .batch(125)
   .desc(
     `
 Validates that constant evaluation and override evaluation of ${builtin}() rejects invalid values

--- a/src/webgpu/shader/validation/expression/call/builtin/sqrt.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/sqrt.spec.ts
@@ -28,6 +28,7 @@ export const g = makeTestGroup(ShaderValidationTest);
 const kValuesTypes = objectsToRecord(kConvertableToFloatScalarsAndVectors);
 
 g.test('values')
+  .batch(125)
   .desc(
     `
 Validates that constant evaluation and override evaluation of ${builtin}() inputs rejects invalid values

--- a/src/webgpu/shader/validation/expression/call/builtin/step.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/step.spec.ts
@@ -24,6 +24,7 @@ export const g = makeTestGroup(ShaderValidationTest);
 const kValidArgumentTypes = objectsToRecord(kConvertableToFloatScalarsAndVectors);
 
 g.test('values')
+  .batch(125)
   .desc(
     `
 Validates that constant evaluation and override evaluation of ${builtin}() error on invalid inputs.

--- a/src/webgpu/shader/validation/expression/call/builtin/tan.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/tan.spec.ts
@@ -27,6 +27,7 @@ export const g = makeTestGroup(ShaderValidationTest);
 const kValuesTypes = objectsToRecord(kConvertableToFloatScalarsAndVectors);
 
 g.test('values')
+  .batch(125)
   .desc(
     `
 Validates that constant evaluation and override evaluation of ${builtin}() rejects invalid values

--- a/src/webgpu/shader/validation/expression/call/builtin/tanh.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/tanh.spec.ts
@@ -25,6 +25,7 @@ export const g = makeTestGroup(ShaderValidationTest);
 const kValuesTypes = objectsToRecord(kConvertableToFloatScalarsAndVectors);
 
 g.test('values')
+  .batch(125)
   .desc(
     `
 Validates that constant evaluation and override evaluation of ${builtin}() rejects invalid values

--- a/src/webgpu/shader/validation/expression/call/builtin/transpose.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/transpose.spec.ts
@@ -26,6 +26,7 @@ export const g = makeTestGroup(ShaderValidationTest);
 const kValidArgumentTypes = objectsToRecord(kAllMatrices);
 
 g.test('values')
+  .batch(125)
   .desc(
     `
 Validates that constant evaluation and override evaluation of ${builtin}() accept valid inputs.

--- a/src/webgpu/shader/validation/expression/call/builtin/trunc.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/trunc.spec.ts
@@ -24,6 +24,7 @@ export const g = makeTestGroup(ShaderValidationTest);
 const kValidArgumentTypes = objectsToRecord(kConvertableToFloatScalarsAndVectors);
 
 g.test('values')
+  .batch(125)
   .desc(
     `
 Validates that constant evaluation and override evaluation of ${builtin}() error on invalid inputs.

--- a/src/webgpu/shader/validation/expression/call/builtin/unpack2x16float.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/unpack2x16float.spec.ts
@@ -66,6 +66,7 @@ const isValidPacked2xF16 = (packed2xF16AsU32: number) => {
 export const g = makeTestGroup(ShaderValidationTest);
 
 g.test('values')
+  .batch(125)
   .desc(
     `
 Validates that constant evaluation and override evaluation of ${builtin} rejects invalid values.

--- a/src/webgpu/shader/validation/expression/call/builtin/unpack2x16snorm.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/unpack2x16snorm.spec.ts
@@ -47,6 +47,7 @@ const kArgCases = {
 export const g = makeTestGroup(ShaderValidationTest);
 
 g.test('values')
+  .batch(125)
   .desc(
     `
 Validates that constant evaluation and override evaluation of ${builtin} rejects invalid values.

--- a/src/webgpu/shader/validation/expression/call/builtin/unpack2x16unorm.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/unpack2x16unorm.spec.ts
@@ -47,6 +47,7 @@ const kArgCases = {
 export const g = makeTestGroup(ShaderValidationTest);
 
 g.test('values')
+  .batch(125)
   .desc(
     `
 Validates that constant evaluation and override evaluation of ${builtin} rejects invalid values.

--- a/src/webgpu/shader/validation/expression/call/builtin/unpack4x8snorm.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/unpack4x8snorm.spec.ts
@@ -47,6 +47,7 @@ const kArgCases = {
 export const g = makeTestGroup(ShaderValidationTest);
 
 g.test('values')
+  .batch(125)
   .desc(
     `
 Validates that constant evaluation and override evaluation of ${builtin} rejects invalid values.

--- a/src/webgpu/shader/validation/expression/call/builtin/unpack4x8unorm.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/unpack4x8unorm.spec.ts
@@ -47,6 +47,7 @@ const kArgCases = {
 export const g = makeTestGroup(ShaderValidationTest);
 
 g.test('values')
+  .batch(125)
   .desc(
     `
 Validates that constant evaluation and override evaluation of ${builtin} rejects invalid values.

--- a/src/webgpu/shader/validation/expression/call/builtin/unpack4xI8.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/unpack4xI8.spec.ts
@@ -68,6 +68,7 @@ g.test('supported')
   });
 
 g.test('values')
+  .batch(125)
   .desc(
     `
 Validates that constant evaluation and override evaluation of ${builtin} rejects invalid values.

--- a/src/webgpu/shader/validation/expression/call/builtin/unpack4xU8.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/unpack4xU8.spec.ts
@@ -68,6 +68,7 @@ g.test('supported')
   });
 
 g.test('values')
+  .batch(125)
   .desc(
     `
 Validates that constant evaluation and override evaluation of ${builtin} rejects invalid values.


### PR DESCRIPTION
Many of these tests have too many subcases, which run in parallel and can run out of resources. We can use batching to break tests into more cases (without having to break them up arbitrarily by the numeric values passed to builtins).

Not all of the `values` tests actually have more than 125 subcases; if they don't, then `batch` has no effect. I added `batch` to all of them anyway so that when tests are added in the future, they'll serve as an example and get copied over.

Hopefully helps with https://crbug.com/373478528
and https://crbug.com/373485785

Issue: None

<hr>

**Requirements for PR author:**

- [n/a] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [n/a] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [skipped] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
