### PR TITLE
Add float32-blendable feature validation tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@types/w3c-image-capture": "^1.0.10",
         "@typescript-eslint/eslint-plugin": "^6.9.1",
         "@typescript-eslint/parser": "^6.9.1",
-        "@webgpu/types": "^0.1.48",
+        "@webgpu/types": "^0.1.49",
         "ansi-colors": "4.1.3",
         "babel-plugin-add-header-comment": "^1.0.3",
         "babel-plugin-const-enum": "^1.2.0",
@@ -1539,11 +1539,10 @@
       "dev": true
     },
     "node_modules/@webgpu/types": {
-      "version": "0.1.48",
-      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.48.tgz",
-      "integrity": "sha512-e3zmDEPih4Rle+JrP5cT8nCCtDizoUpEaN72OuD1clbhXGERtn0wwuMdxOrBymu3kMLWKDd8hd+ERhSheLuLTg==",
-      "dev": true,
-      "license": "BSD-3-Clause"
+      "version": "0.1.49",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.49.tgz",
+      "integrity": "sha512-NMmS8/DofhH/IFeW+876XrHVWel+J/vdcFCHLDqeJgkH9x0DeiwjVd8LcBdaxdG/T7Rf8VUAYsA8X1efMzLjRQ==",
+      "dev": true
     },
     "node_modules/abbrev": {
       "version": "1.1.1",
@@ -10077,9 +10076,9 @@
       "dev": true
     },
     "@webgpu/types": {
-      "version": "0.1.48",
-      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.48.tgz",
-      "integrity": "sha512-e3zmDEPih4Rle+JrP5cT8nCCtDizoUpEaN72OuD1clbhXGERtn0wwuMdxOrBymu3kMLWKDd8hd+ERhSheLuLTg==",
+      "version": "0.1.49",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.49.tgz",
+      "integrity": "sha512-NMmS8/DofhH/IFeW+876XrHVWel+J/vdcFCHLDqeJgkH9x0DeiwjVd8LcBdaxdG/T7Rf8VUAYsA8X1efMzLjRQ==",
       "dev": true
     },
     "abbrev": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@types/w3c-image-capture": "^1.0.10",
     "@typescript-eslint/eslint-plugin": "^6.9.1",
     "@typescript-eslint/parser": "^6.9.1",
-    "@webgpu/types": "^0.1.48",
+    "@webgpu/types": "^0.1.49",
     "ansi-colors": "4.1.3",
     "babel-plugin-add-header-comment": "^1.0.3",
     "babel-plugin-const-enum": "^1.2.0",

--- a/src/webgpu/api/validation/render_pipeline/float32_blendable.spec.ts
+++ b/src/webgpu/api/validation/render_pipeline/float32_blendable.spec.ts
@@ -1,0 +1,46 @@
+export const description = `
+Tests for capabilities added by float32-blendable flag.
+`;
+
+import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { ColorTextureFormat } from '../../../format_info.js';
+
+import { CreateRenderPipelineValidationTest } from './common.js';
+
+export const g = makeTestGroup(CreateRenderPipelineValidationTest);
+
+const kFloat32Formats: ColorTextureFormat[] = ['r32float', 'rg32float', 'rgba32float'];
+
+g.test('create_render_pipeline')
+  .desc(
+    `
+Tests that the float32-blendable feature is required if blend is not undefined.
+`
+  )
+  .params(u =>
+    u
+      .combine('isAsync', [false, true])
+      .combine('enabled', [true, false] as const)
+      .beginSubcases()
+      .combine('hasBlend', [true, false] as const)
+      .combine('format', kFloat32Formats)
+  )
+  .beforeAllSubcases(t => {
+    if (t.params.enabled) {
+      t.selectDeviceOrSkipTestCase('float32-blendable');
+    }
+  })
+  .fn(t => {
+    const { isAsync, enabled, hasBlend, format } = t.params;
+
+    const descriptor = t.getDescriptor({
+      targets: [
+        {
+          format,
+          blend: hasBlend ? { color: {}, alpha: {} } : undefined,
+        },
+      ],
+    });
+
+    t.doCreateRenderPipelineTest(isAsync, enabled || !hasBlend, descriptor);
+  });

--- a/src/webgpu/api/validation/render_pipeline/float32_blendable.spec.ts
+++ b/src/webgpu/api/validation/render_pipeline/float32_blendable.spec.ts
@@ -14,7 +14,8 @@ const kFloat32Formats: ColorTextureFormat[] = ['r32float', 'rg32float', 'rgba32f
 g.test('create_render_pipeline')
   .desc(
     `
-Tests that the float32-blendable feature is required if blend is not undefined.
+Tests that the float32-blendable feature is required to create a render
+pipeline that uses blending with any float32-format attachment.
 `
   )
   .params(u =>

--- a/src/webgpu/capability_info.ts
+++ b/src/webgpu/capability_info.ts
@@ -830,6 +830,7 @@ export const kFeatureNameInfo: {
   'shader-f16':                         {},
   'rg11b10ufloat-renderable':           {},
   'float32-filterable':                 {},
+  'float32-blendable':                  {},
   'clip-distances':                     {},
   'dual-source-blending':               {},
 };


### PR DESCRIPTION
This PR adds `"float32-blendable"` feature validation tests to the CTS after it was added to the spec in https://github.com/gpuweb/gpuweb/pull/4896.

It currently requires Chromium patched with https://dawn-review.googlesource.com/c/dawn/+/210754 and https://chromium-review.googlesource.com/c/chromium/src/+/5929023

<img width="1149" alt="image" src="https://github.com/user-attachments/assets/02f01da0-3ae6-485e-ac6d-09c099ba4083">

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
