### PR TITLE
Texture builtins: move addressMode? to case

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/textureGather.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureGather.spec.ts
@@ -32,7 +32,6 @@ import {
   kDepthStencilFormats,
   kEncodableTextureFormats,
 } from '../../../../../format_info.js';
-import { kShaderStages } from '../../../../validation/decl/util.js';
 
 import {
   appendComponentTypeForFormatToTextureType,
@@ -45,6 +44,9 @@ import {
   isFillable,
   kCubeSamplePointMethods,
   kSamplePointMethods,
+  kShortAddressModes,
+  kShortAddressModeToAddressMode,
+  kShortShaderStages,
   skipIfNeedsFilteringAndIsUnfilterableOrSelectDevice,
   TextureCall,
   vec2,
@@ -84,24 +86,23 @@ Parameters:
   )
   .params(u =>
     u
-      .combine('stage', kShaderStages)
+      .combine('stage', kShortShaderStages)
       .combine('format', kTestableColorFormats)
       .filter(t => isFillable(t.format))
-      .combine('minFilter', ['nearest', 'linear'] as const)
+      .combine('filt', ['nearest', 'linear'] as const)
+      .combine('modeU', kShortAddressModes)
+      .combine('modeV', kShortAddressModes)
       .combine('offset', [false, true] as const)
       .beginSubcases()
       .combine('C', ['i32', 'u32'] as const)
       .combine('samplePoints', kSamplePointMethods)
-      .combine('addressModeU', ['clamp-to-edge', 'repeat', 'mirror-repeat'] as const)
-      .combine('addressModeV', ['clamp-to-edge', 'repeat', 'mirror-repeat'] as const)
   )
   .beforeAllSubcases(t => {
     t.skipIfTextureFormatNotSupported(t.params.format);
-    skipIfNeedsFilteringAndIsUnfilterableOrSelectDevice(t, t.params.minFilter, t.params.format);
+    skipIfNeedsFilteringAndIsUnfilterableOrSelectDevice(t, t.params.filt, t.params.format);
   })
   .fn(async t => {
-    const { format, C, samplePoints, stage, addressModeU, addressModeV, minFilter, offset } =
-      t.params;
+    const { format, C, samplePoints, stage, modeU, modeV, filt: minFilter, offset } = t.params;
 
     // We want at least 4 blocks or something wide enough for 3 mip levels.
     const [width, height] = chooseTextureSize({ minSize: 8, minBlocks: 4, format });
@@ -113,8 +114,8 @@ Parameters:
     };
     const { texels, texture } = await createTextureWithRandomDataAndGetTexels(t, descriptor);
     const sampler: GPUSamplerDescriptor = {
-      addressModeU,
-      addressModeV,
+      addressModeU: kShortAddressModeToAddressMode[modeU],
+      addressModeV: kShortAddressModeToAddressMode[modeV],
       minFilter,
       magFilter: minFilter,
       mipmapFilter: minFilter,
@@ -127,7 +128,7 @@ Parameters:
       descriptor,
       offset,
       component: true,
-      hashInputs: [stage, format, C, samplePoints, addressModeU, addressModeV, minFilter, offset],
+      hashInputs: [stage, format, C, samplePoints, modeU, modeV, minFilter, offset],
     }).map(({ coords, component, offset }) => {
       return {
         builtin: 'textureGather',
@@ -182,21 +183,21 @@ Parameters:
   )
   .params(u =>
     u
-      .combine('stage', kShaderStages)
+      .combine('stage', kShortShaderStages)
       .combine('format', kTestableColorFormats)
       .filter(t => isFillable(t.format))
-      .combine('minFilter', ['nearest', 'linear'] as const)
+      .combine('filt', ['nearest', 'linear'] as const)
+      .combine('mode', kShortAddressModes)
       .beginSubcases()
       .combine('C', ['i32', 'u32'] as const)
       .combine('samplePoints', kCubeSamplePointMethods)
-      .combine('addressMode', ['clamp-to-edge', 'repeat', 'mirror-repeat'] as const)
   )
   .beforeAllSubcases(t => {
     t.skipIfTextureFormatNotSupported(t.params.format);
-    skipIfNeedsFilteringAndIsUnfilterableOrSelectDevice(t, t.params.minFilter, t.params.format);
+    skipIfNeedsFilteringAndIsUnfilterableOrSelectDevice(t, t.params.filt, t.params.format);
   })
   .fn(async t => {
-    const { format, C, stage, samplePoints, addressMode, minFilter } = t.params;
+    const { format, C, stage, samplePoints, mode, filt: minFilter } = t.params;
 
     const viewDimension: GPUTextureViewDimension = 'cube';
     const [width, height] = chooseTextureSize({ minSize: 8, minBlocks: 2, format, viewDimension });
@@ -211,9 +212,9 @@ Parameters:
     };
     const { texels, texture } = await createTextureWithRandomDataAndGetTexels(t, descriptor);
     const sampler: GPUSamplerDescriptor = {
-      addressModeU: addressMode,
-      addressModeV: addressMode,
-      addressModeW: addressMode,
+      addressModeU: kShortAddressModeToAddressMode[mode],
+      addressModeV: kShortAddressModeToAddressMode[mode],
+      addressModeW: kShortAddressModeToAddressMode[mode],
       minFilter,
       magFilter: minFilter,
       mipmapFilter: minFilter,
@@ -225,7 +226,7 @@ Parameters:
       descriptor,
       component: true,
       textureBuiltin: 'textureGather',
-      hashInputs: [stage, format, C, samplePoints, addressMode, minFilter],
+      hashInputs: [stage, format, C, samplePoints, mode, minFilter],
     }).map(({ coords, component }) => {
       return {
         builtin: 'textureGather',
@@ -290,25 +291,24 @@ Parameters:
   )
   .params(u =>
     u
-      .combine('stage', kShaderStages)
+      .combine('stage', kShortShaderStages)
       .combine('format', kTestableColorFormats)
       .filter(t => isFillable(t.format))
-      .combine('minFilter', ['nearest', 'linear'] as const)
+      .combine('filt', ['nearest', 'linear'] as const)
+      .combine('modeU', kShortAddressModes)
+      .combine('modeV', kShortAddressModes)
       .combine('offset', [false, true] as const)
       .beginSubcases()
       .combine('samplePoints', kSamplePointMethods)
       .combine('C', ['i32', 'u32'] as const)
       .combine('A', ['i32', 'u32'] as const)
-      .combine('addressModeU', ['clamp-to-edge', 'repeat', 'mirror-repeat'] as const)
-      .combine('addressModeV', ['clamp-to-edge', 'repeat', 'mirror-repeat'] as const)
   )
   .beforeAllSubcases(t => {
     t.skipIfTextureFormatNotSupported(t.params.format);
-    skipIfNeedsFilteringAndIsUnfilterableOrSelectDevice(t, t.params.minFilter, t.params.format);
+    skipIfNeedsFilteringAndIsUnfilterableOrSelectDevice(t, t.params.filt, t.params.format);
   })
   .fn(async t => {
-    const { format, stage, samplePoints, C, A, addressModeU, addressModeV, minFilter, offset } =
-      t.params;
+    const { format, stage, samplePoints, C, A, modeU, modeV, filt: minFilter, offset } = t.params;
 
     // We want at least 4 blocks or something wide enough for 3 mip levels.
     const [width, height] = chooseTextureSize({ minSize: 8, minBlocks: 4, format });
@@ -322,8 +322,8 @@ Parameters:
     };
     const { texels, texture } = await createTextureWithRandomDataAndGetTexels(t, descriptor);
     const sampler: GPUSamplerDescriptor = {
-      addressModeU,
-      addressModeV,
+      addressModeU: kShortAddressModeToAddressMode[modeU],
+      addressModeV: kShortAddressModeToAddressMode[modeV],
       minFilter,
       magFilter: minFilter,
       mipmapFilter: minFilter,
@@ -337,17 +337,7 @@ Parameters:
       arrayIndex: { num: texture.depthOrArrayLayers, type: A },
       offset,
       component: true,
-      hashInputs: [
-        stage,
-        format,
-        samplePoints,
-        C,
-        A,
-        addressModeU,
-        addressModeV,
-        minFilter,
-        offset,
-      ],
+      hashInputs: [stage, format, samplePoints, C, A, modeU, modeV, minFilter, offset],
     }).map(({ coords, component, arrayIndex, offset }) => {
       return {
         builtin: 'textureGather',
@@ -407,23 +397,23 @@ Parameters:
   )
   .params(u =>
     u
-      .combine('stage', kShaderStages)
+      .combine('stage', kShortShaderStages)
       .combine('format', kTestableColorFormats)
       .filter(t => isFillable(t.format))
-      .combine('minFilter', ['nearest', 'linear'] as const)
+      .combine('filt', ['nearest', 'linear'] as const)
+      .combine('mode', kShortAddressModes)
       .beginSubcases()
       .combine('samplePoints', kCubeSamplePointMethods)
       .combine('C', ['i32', 'u32'] as const)
       .combine('A', ['i32', 'u32'] as const)
-      .combine('addressMode', ['clamp-to-edge', 'repeat', 'mirror-repeat'] as const)
   )
   .beforeAllSubcases(t => {
     t.skipIfTextureFormatNotSupported(t.params.format);
     t.skipIfTextureViewDimensionNotSupported('cube-array');
-    skipIfNeedsFilteringAndIsUnfilterableOrSelectDevice(t, t.params.minFilter, t.params.format);
+    skipIfNeedsFilteringAndIsUnfilterableOrSelectDevice(t, t.params.filt, t.params.format);
   })
   .fn(async t => {
-    const { format, C, A, stage, samplePoints, addressMode, minFilter } = t.params;
+    const { format, C, A, stage, samplePoints, mode, filt: minFilter } = t.params;
 
     const viewDimension: GPUTextureViewDimension = 'cube-array';
     const size = chooseTextureSize({ minSize: 8, minBlocks: 2, format, viewDimension });
@@ -437,9 +427,9 @@ Parameters:
     };
     const { texels, texture } = await createTextureWithRandomDataAndGetTexels(t, descriptor);
     const sampler: GPUSamplerDescriptor = {
-      addressModeU: addressMode,
-      addressModeV: addressMode,
-      addressModeW: addressMode,
+      addressModeU: kShortAddressModeToAddressMode[mode],
+      addressModeV: kShortAddressModeToAddressMode[mode],
+      addressModeW: kShortAddressModeToAddressMode[mode],
       minFilter,
       magFilter: minFilter,
       mipmapFilter: minFilter,
@@ -452,7 +442,7 @@ Parameters:
       component: true,
       textureBuiltin: 'textureGather',
       arrayIndex: { num: texture.depthOrArrayLayers / 6, type: A },
-      hashInputs: [stage, format, C, samplePoints, addressMode, minFilter],
+      hashInputs: [stage, format, C, samplePoints, mode, minFilter],
     }).map(({ coords, component, arrayIndex }) => {
       return {
         builtin: 'textureGather',
@@ -511,21 +501,21 @@ Parameters:
   )
   .params(u =>
     u
-      .combine('stage', kShaderStages)
+      .combine('stage', kShortShaderStages)
       .combine('format', kDepthStencilFormats)
       // filter out stencil only formats
       .filter(t => isDepthTextureFormat(t.format))
       // MAINTENANCE_TODO: Remove when support for depth24plus, depth24plus-stencil8, and depth32float-stencil8 is added.
       .filter(t => isEncodableTextureFormat(t.format))
-      .combine('minFilter', ['nearest', 'linear'] as const)
+      .combine('filt', ['nearest', 'linear'] as const)
+      .combine('modeU', kShortAddressModes)
+      .combine('modeV', kShortAddressModes)
       .combine('offset', [false, true] as const)
       .beginSubcases()
       .combine('samplePoints', kSamplePointMethods)
-      .combine('addressModeU', ['clamp-to-edge', 'repeat', 'mirror-repeat'] as const)
-      .combine('addressModeV', ['clamp-to-edge', 'repeat', 'mirror-repeat'] as const)
   )
   .fn(async t => {
-    const { format, stage, samplePoints, addressModeU, addressModeV, minFilter, offset } = t.params;
+    const { format, stage, samplePoints, modeU, modeV, filt: minFilter, offset } = t.params;
 
     // We want at least 4 blocks or something wide enough for 3 mip levels.
     const [width, height] = chooseTextureSize({ minSize: 8, minBlocks: 4, format });
@@ -537,8 +527,8 @@ Parameters:
     };
     const { texels, texture } = await createTextureWithRandomDataAndGetTexels(t, descriptor);
     const sampler: GPUSamplerDescriptor = {
-      addressModeU,
-      addressModeV,
+      addressModeU: kShortAddressModeToAddressMode[modeU],
+      addressModeV: kShortAddressModeToAddressMode[modeV],
       minFilter,
       magFilter: minFilter,
       mipmapFilter: minFilter,
@@ -550,7 +540,7 @@ Parameters:
       sampler,
       descriptor,
       offset,
-      hashInputs: [stage, format, samplePoints, addressModeU, addressModeV, minFilter, offset],
+      hashInputs: [stage, format, samplePoints, modeU, modeV, minFilter, offset],
     }).map(({ coords, offset }) => {
       return {
         builtin: 'textureGather',
@@ -597,19 +587,19 @@ Parameters:
   )
   .params(u =>
     u
-      .combine('stage', kShaderStages)
+      .combine('stage', kShortShaderStages)
       .combine('format', kDepthStencilFormats)
       // filter out stencil only formats
       .filter(t => isDepthTextureFormat(t.format))
       // MAINTENANCE_TODO: Remove when support for depth24plus, depth24plus-stencil8, and depth32float-stencil8 is added.
       .filter(t => isEncodableTextureFormat(t.format))
-      .combine('minFilter', ['nearest', 'linear'] as const)
+      .combine('filt', ['nearest', 'linear'] as const)
+      .combine('mode', kShortAddressModes)
       .beginSubcases()
       .combine('samplePoints', kCubeSamplePointMethods)
-      .combine('addressMode', ['clamp-to-edge', 'repeat', 'mirror-repeat'] as const)
   )
   .fn(async t => {
-    const { format, stage, samplePoints, addressMode, minFilter } = t.params;
+    const { format, stage, samplePoints, mode, filt: minFilter } = t.params;
 
     const viewDimension: GPUTextureViewDimension = 'cube';
     const [width, height] = chooseTextureSize({ minSize: 8, minBlocks: 2, format, viewDimension });
@@ -624,9 +614,9 @@ Parameters:
     };
     const { texels, texture } = await createTextureWithRandomDataAndGetTexels(t, descriptor);
     const sampler: GPUSamplerDescriptor = {
-      addressModeU: addressMode,
-      addressModeV: addressMode,
-      addressModeW: addressMode,
+      addressModeU: kShortAddressModeToAddressMode[mode],
+      addressModeV: kShortAddressModeToAddressMode[mode],
+      addressModeW: kShortAddressModeToAddressMode[mode],
       minFilter,
       magFilter: minFilter,
       mipmapFilter: minFilter,
@@ -637,7 +627,7 @@ Parameters:
       sampler,
       descriptor,
       textureBuiltin: 'textureGather',
-      hashInputs: [stage, format, samplePoints, addressMode, minFilter],
+      hashInputs: [stage, format, samplePoints, mode, minFilter],
     }).map(({ coords, component }) => {
       return {
         builtin: 'textureGather',
@@ -695,27 +685,26 @@ Parameters:
   )
   .params(u =>
     u
-      .combine('stage', kShaderStages)
+      .combine('stage', kShortShaderStages)
       .combine('format', kDepthStencilFormats)
       // filter out stencil only formats
       .filter(t => isDepthTextureFormat(t.format))
       // MAINTENANCE_TODO: Remove when support for depth24plus, depth24plus-stencil8, and depth32float-stencil8 is added.
       .filter(t => isEncodableTextureFormat(t.format))
-      .combine('minFilter', ['nearest', 'linear'] as const)
+      .combine('filt', ['nearest', 'linear'] as const)
+      .combine('modeU', kShortAddressModes)
+      .combine('modeV', kShortAddressModes)
       .combine('offset', [false, true] as const)
       .beginSubcases()
       .combine('samplePoints', kSamplePointMethods)
       .combine('A', ['i32', 'u32'] as const)
-      .combine('addressModeU', ['clamp-to-edge', 'repeat', 'mirror-repeat'] as const)
-      .combine('addressModeV', ['clamp-to-edge', 'repeat', 'mirror-repeat'] as const)
   )
   .beforeAllSubcases(t => {
     t.skipIfTextureFormatNotSupported(t.params.format);
-    skipIfNeedsFilteringAndIsUnfilterableOrSelectDevice(t, t.params.minFilter, t.params.format);
+    skipIfNeedsFilteringAndIsUnfilterableOrSelectDevice(t, t.params.filt, t.params.format);
   })
   .fn(async t => {
-    const { format, stage, samplePoints, A, addressModeU, addressModeV, minFilter, offset } =
-      t.params;
+    const { format, stage, samplePoints, A, modeU, modeV, filt: minFilter, offset } = t.params;
 
     // We want at least 4 blocks or something wide enough for 3 mip levels.
     const [width, height] = chooseTextureSize({ minSize: 8, minBlocks: 4, format });
@@ -729,8 +718,8 @@ Parameters:
     };
     const { texels, texture } = await createTextureWithRandomDataAndGetTexels(t, descriptor);
     const sampler: GPUSamplerDescriptor = {
-      addressModeU,
-      addressModeV,
+      addressModeU: kShortAddressModeToAddressMode[modeU],
+      addressModeV: kShortAddressModeToAddressMode[modeV],
       minFilter,
       magFilter: minFilter,
       mipmapFilter: minFilter,
@@ -743,7 +732,7 @@ Parameters:
       descriptor,
       arrayIndex: { num: texture.depthOrArrayLayers, type: A },
       offset,
-      hashInputs: [stage, format, samplePoints, A, addressModeU, addressModeV, minFilter, offset],
+      hashInputs: [stage, format, samplePoints, A, modeU, modeV, minFilter, offset],
     }).map(({ coords, arrayIndex, offset }) => {
       return {
         builtin: 'textureGather',
@@ -795,23 +784,23 @@ Parameters:
   )
   .params(u =>
     u
-      .combine('stage', kShaderStages)
+      .combine('stage', kShortShaderStages)
       .combine('format', kDepthStencilFormats)
       // filter out stencil only formats
       .filter(t => isDepthTextureFormat(t.format))
       // MAINTENANCE_TODO: Remove when support for depth24plus, depth24plus-stencil8, and depth32float-stencil8 is added.
       .filter(t => isEncodableTextureFormat(t.format))
-      .combine('minFilter', ['nearest', 'linear'] as const)
+      .combine('filt', ['nearest', 'linear'] as const)
+      .combine('mode', kShortAddressModes)
       .beginSubcases()
       .combine('samplePoints', kCubeSamplePointMethods)
       .combine('A', ['i32', 'u32'] as const)
-      .combine('addressMode', ['clamp-to-edge', 'repeat', 'mirror-repeat'] as const)
   )
   .beforeAllSubcases(t => {
     t.skipIfTextureViewDimensionNotSupported('cube-array');
   })
   .fn(async t => {
-    const { format, A, stage, samplePoints, addressMode, minFilter } = t.params;
+    const { format, A, stage, samplePoints, mode, filt: minFilter } = t.params;
 
     const viewDimension: GPUTextureViewDimension = 'cube-array';
     const size = chooseTextureSize({ minSize: 8, minBlocks: 2, format, viewDimension });
@@ -825,9 +814,9 @@ Parameters:
     };
     const { texels, texture } = await createTextureWithRandomDataAndGetTexels(t, descriptor);
     const sampler: GPUSamplerDescriptor = {
-      addressModeU: addressMode,
-      addressModeV: addressMode,
-      addressModeW: addressMode,
+      addressModeU: kShortAddressModeToAddressMode[mode],
+      addressModeV: kShortAddressModeToAddressMode[mode],
+      addressModeW: kShortAddressModeToAddressMode[mode],
       minFilter,
       magFilter: minFilter,
       mipmapFilter: minFilter,
@@ -839,7 +828,7 @@ Parameters:
       descriptor,
       textureBuiltin: 'textureGather',
       arrayIndex: { num: texture.depthOrArrayLayers / 6, type: A },
-      hashInputs: [stage, format, samplePoints, addressMode, minFilter],
+      hashInputs: [stage, format, samplePoints, mode, minFilter],
     }).map(({ coords, arrayIndex }) => {
       return {
         builtin: 'textureGather',

--- a/src/webgpu/shader/execution/expression/call/builtin/textureGatherCompare.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureGatherCompare.spec.ts
@@ -23,7 +23,6 @@ import {
   isEncodableTextureFormat,
   kDepthStencilFormats,
 } from '../../../../../format_info.js';
-import { kShaderStages } from '../../../../validation/decl/util.js';
 
 import {
   checkCallResults,
@@ -34,6 +33,9 @@ import {
   generateTextureBuiltinInputs2D,
   kCubeSamplePointMethods,
   kSamplePointMethods,
+  kShortAddressModes,
+  kShortAddressModeToAddressMode,
+  kShortShaderStages,
   makeRandomDepthComparisonTexelGenerator,
   TextureCall,
   vec2,
@@ -68,19 +70,19 @@ Parameters:
   )
   .params(u =>
     u
-      .combine('stage', kShaderStages)
+      .combine('stage', kShortShaderStages)
       .combine('format', kDepthStencilFormats)
       // filter out stencil only formats
       .filter(t => isDepthTextureFormat(t.format))
       // MAINTENANCE_TODO: Remove when support for depth24plus, depth24plus-stencil8, and depth32float-stencil8 is added.
       .filter(t => isEncodableTextureFormat(t.format))
-      .combine('minFilter', ['nearest', 'linear'] as const)
+      .combine('filt', ['nearest', 'linear'] as const)
+      .combine('modeU', kShortAddressModes)
+      .combine('modeV', kShortAddressModes)
       .combine('offset', [false, true] as const)
       .beginSubcases()
       .combine('samplePoints', kSamplePointMethods)
       .combine('A', ['i32', 'u32'] as const)
-      .combine('addressModeU', ['clamp-to-edge', 'repeat', 'mirror-repeat'] as const)
-      .combine('addressModeV', ['clamp-to-edge', 'repeat', 'mirror-repeat'] as const)
       .combine('compare', kCompareFunctions)
   )
   .beforeAllSubcases(t => {
@@ -92,9 +94,9 @@ Parameters:
       stage,
       samplePoints,
       A,
-      addressModeU,
-      addressModeV,
-      minFilter,
+      modeU,
+      modeV,
+      filt: minFilter,
       compare,
       offset,
     } = t.params;
@@ -111,8 +113,8 @@ Parameters:
       generator: makeRandomDepthComparisonTexelGenerator(descriptor, compare),
     });
     const sampler: GPUSamplerDescriptor = {
-      addressModeU,
-      addressModeV,
+      addressModeU: kShortAddressModeToAddressMode[modeU],
+      addressModeV: kShortAddressModeToAddressMode[modeV],
       compare,
       minFilter,
       magFilter: minFilter,
@@ -127,7 +129,7 @@ Parameters:
       arrayIndex: { num: texture.depthOrArrayLayers, type: A },
       depthRef: true,
       offset,
-      hashInputs: [stage, format, samplePoints, A, addressModeU, addressModeV, minFilter, offset],
+      hashInputs: [stage, format, samplePoints, A, modeU, modeV, minFilter, offset],
     }).map(({ coords, arrayIndex, depthRef, offset }) => {
       return {
         builtin: 'textureGatherCompare',
@@ -181,24 +183,24 @@ Parameters:
   )
   .params(u =>
     u
-      .combine('stage', kShaderStages)
+      .combine('stage', kShortShaderStages)
       .combine('format', kDepthStencilFormats)
       // filter out stencil only formats
       .filter(t => isDepthTextureFormat(t.format))
       // MAINTENANCE_TODO: Remove when support for depth24plus, depth24plus-stencil8, and depth32float-stencil8 is added.
       .filter(t => isEncodableTextureFormat(t.format))
-      .combine('minFilter', ['nearest', 'linear'] as const)
+      .combine('filt', ['nearest', 'linear'] as const)
+      .combine('mode', kShortAddressModes)
       .beginSubcases()
       .combine('samplePoints', kCubeSamplePointMethods)
       .combine('A', ['i32', 'u32'] as const)
-      .combine('addressMode', ['clamp-to-edge', 'repeat', 'mirror-repeat'] as const)
       .combine('compare', kCompareFunctions)
   )
   .beforeAllSubcases(t => {
     t.skipIfTextureViewDimensionNotSupported('cube-array');
   })
   .fn(async t => {
-    const { format, A, stage, samplePoints, addressMode, minFilter, compare } = t.params;
+    const { format, A, stage, samplePoints, mode, filt: minFilter, compare } = t.params;
 
     const viewDimension: GPUTextureViewDimension = 'cube-array';
     const size = chooseTextureSize({ minSize: 8, minBlocks: 2, format, viewDimension });
@@ -213,9 +215,9 @@ Parameters:
       generator: makeRandomDepthComparisonTexelGenerator(descriptor, compare),
     });
     const sampler: GPUSamplerDescriptor = {
-      addressModeU: addressMode,
-      addressModeV: addressMode,
-      addressModeW: addressMode,
+      addressModeU: kShortAddressModeToAddressMode[mode],
+      addressModeV: kShortAddressModeToAddressMode[mode],
+      addressModeW: kShortAddressModeToAddressMode[mode],
       compare,
       minFilter,
       magFilter: minFilter,
@@ -229,7 +231,7 @@ Parameters:
       textureBuiltin: 'textureGatherCompare',
       arrayIndex: { num: texture.depthOrArrayLayers / 6, type: A },
       depthRef: true,
-      hashInputs: [stage, format, samplePoints, addressMode, minFilter],
+      hashInputs: [stage, format, samplePoints, mode, minFilter],
     }).map(({ coords, depthRef, arrayIndex }) => {
       return {
         builtin: 'textureGatherCompare',
@@ -288,22 +290,22 @@ Parameters:
   )
   .params(u =>
     u
-      .combine('stage', kShaderStages)
+      .combine('stage', kShortShaderStages)
       .combine('format', kDepthStencilFormats)
       // filter out stencil only formats
       .filter(t => isDepthTextureFormat(t.format))
       // MAINTENANCE_TODO: Remove when support for depth24plus, depth24plus-stencil8, and depth32float-stencil8 is added.
       .filter(t => isEncodableTextureFormat(t.format))
-      .combine('minFilter', ['nearest', 'linear'] as const)
+      .combine('filt', ['nearest', 'linear'] as const)
+      .combine('mode', kShortAddressModes)
       .combine('offset', [false, true] as const)
       .beginSubcases()
       .combine('C', ['i32', 'u32'] as const)
       .combine('samplePoints', kSamplePointMethods)
-      .combine('addressMode', ['clamp-to-edge', 'repeat', 'mirror-repeat'] as const)
       .combine('compare', kCompareFunctions)
   )
   .fn(async t => {
-    const { format, C, stage, samplePoints, addressMode, compare, minFilter, offset } = t.params;
+    const { format, C, stage, samplePoints, mode, compare, filt: minFilter, offset } = t.params;
 
     const size = chooseTextureSize({ minSize: 8, minBlocks: 4, format });
     const descriptor: GPUTextureDescriptor = {
@@ -315,8 +317,8 @@ Parameters:
       generator: makeRandomDepthComparisonTexelGenerator(descriptor, compare),
     });
     const sampler: GPUSamplerDescriptor = {
-      addressModeU: addressMode,
-      addressModeV: addressMode,
+      addressModeU: kShortAddressModeToAddressMode[mode],
+      addressModeV: kShortAddressModeToAddressMode[mode],
       compare,
       minFilter,
       magFilter: minFilter,
@@ -330,7 +332,7 @@ Parameters:
       descriptor,
       offset,
       depthRef: true,
-      hashInputs: [stage, format, C, samplePoints, addressMode, minFilter, compare, offset],
+      hashInputs: [stage, format, C, samplePoints, mode, minFilter, compare, offset],
     }).map(({ coords, depthRef, offset }) => {
       return {
         builtin: 'textureGatherCompare',
@@ -379,20 +381,20 @@ Parameters:
   )
   .params(u =>
     u
-      .combine('stage', kShaderStages)
+      .combine('stage', kShortShaderStages)
       .combine('format', kDepthStencilFormats)
       // filter out stencil only formats
       .filter(t => isDepthTextureFormat(t.format))
       // MAINTENANCE_TODO: Remove when support for depth24plus, depth24plus-stencil8, and depth32float-stencil8 is added.
       .filter(t => isEncodableTextureFormat(t.format))
-      .combine('minFilter', ['nearest', 'linear'] as const)
+      .combine('filt', ['nearest', 'linear'] as const)
+      .combine('mode', kShortAddressModes)
       .beginSubcases()
       .combine('samplePoints', kCubeSamplePointMethods)
-      .combine('addressMode', ['clamp-to-edge', 'repeat', 'mirror-repeat'] as const)
       .combine('compare', kCompareFunctions)
   )
   .fn(async t => {
-    const { format, stage, samplePoints, addressMode, minFilter, compare } = t.params;
+    const { format, stage, samplePoints, mode, filt: minFilter, compare } = t.params;
 
     const viewDimension: GPUTextureViewDimension = 'cube';
     const size = chooseTextureSize({ minSize: 8, minBlocks: 2, format, viewDimension });
@@ -407,9 +409,9 @@ Parameters:
       generator: makeRandomDepthComparisonTexelGenerator(descriptor, compare),
     });
     const sampler: GPUSamplerDescriptor = {
-      addressModeU: addressMode,
-      addressModeV: addressMode,
-      addressModeW: addressMode,
+      addressModeU: kShortAddressModeToAddressMode[mode],
+      addressModeV: kShortAddressModeToAddressMode[mode],
+      addressModeW: kShortAddressModeToAddressMode[mode],
       compare,
       minFilter,
       magFilter: minFilter,
@@ -422,7 +424,7 @@ Parameters:
       descriptor,
       depthRef: true,
       textureBuiltin: 'textureGatherCompare',
-      hashInputs: [stage, format, samplePoints, addressMode, minFilter, compare],
+      hashInputs: [stage, format, samplePoints, mode, minFilter, compare],
     }).map(({ coords, depthRef }) => {
       return {
         builtin: 'textureGatherCompare',

--- a/src/webgpu/shader/execution/expression/call/builtin/textureLoad.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureLoad.spec.ts
@@ -38,7 +38,6 @@ import {
 import { GPUTest } from '../../../../../gpu_test.js';
 import { maxMipLevelCount, virtualMipSize } from '../../../../../util/texture/base.js';
 import { TexelFormats } from '../../../../types.js';
-import { kShaderStages } from '../../../../validation/decl/util.js';
 
 import {
   TextureCall,
@@ -51,6 +50,7 @@ import {
   vec2,
   vec3,
   kSamplePointMethods,
+  kShortShaderStages,
   generateTextureBuiltinInputs1D,
   generateTextureBuiltinInputs2D,
   generateTextureBuiltinInputs3D,
@@ -91,7 +91,7 @@ Parameters:
   )
   .params(u =>
     u
-      .combine('stage', kShaderStages)
+      .combine('stage', kShortShaderStages)
       .combine('format', kTestableColorFormats)
       .filter(t => textureDimensionAndFormatCompatible('1d', t.format))
       // 1d textures can't have a height !== 1
@@ -178,7 +178,7 @@ Parameters:
   )
   .params(u =>
     u
-      .combine('stage', kShaderStages)
+      .combine('stage', kShortShaderStages)
       .combine('format', kTestableColorFormats)
       .filter(t => !isCompressedFloatTextureFormat(t.format))
       .beginSubcases()
@@ -260,7 +260,7 @@ Parameters:
   )
   .params(u =>
     u
-      .combine('stage', kShaderStages)
+      .combine('stage', kShortShaderStages)
       .combine('format', kTestableColorFormats)
       .filter(t => textureDimensionAndFormatCompatible('3d', t.format))
       .beginSubcases()
@@ -346,7 +346,7 @@ Parameters:
   )
   .params(u =>
     u
-      .combine('stage', kShaderStages)
+      .combine('stage', kShortShaderStages)
       .combine('texture_type', [
         'texture_multisampled_2d',
         'texture_depth_multisampled_2d',
@@ -441,7 +441,7 @@ Parameters:
   )
   .params(u =>
     u
-      .combine('stage', kShaderStages)
+      .combine('stage', kShortShaderStages)
       .combine('format', kDepthStencilFormats)
       // filter out stencil only formats
       .filter(t => isDepthTextureFormat(t.format))
@@ -523,7 +523,7 @@ Parameters:
   )
   .params(u =>
     u
-      .combine('stage', kShaderStages)
+      .combine('stage', kShortShaderStages)
       .beginSubcases()
       .combine('samplePoints', kSamplePointMethods)
       .combine('C', ['i32', 'u32'] as const)
@@ -603,7 +603,7 @@ Parameters:
   )
   .params(u =>
     u
-      .combine('stage', kShaderStages)
+      .combine('stage', kShortShaderStages)
       .combine('format', kTestableColorFormats)
       // MAINTENANCE_TODO: Update createTextureFromTexelViews to support stencil8 and remove this filter.
       .filter(t => t.format !== 'stencil8' && !isCompressedFloatTextureFormat(t.format))
@@ -700,7 +700,7 @@ Parameters:
   )
   .params(u =>
     u
-      .combine('stage', kShaderStages)
+      .combine('stage', kShortShaderStages)
       .combineWithParams([...TexelFormats, { format: 'bgra8unorm' }] as const)
       .beginSubcases()
       .combine('samplePoints', kSamplePointMethods)
@@ -779,7 +779,7 @@ Parameters:
   )
   .params(u =>
     u
-      .combine('stage', kShaderStages)
+      .combine('stage', kShortShaderStages)
       .combineWithParams([...TexelFormats, { format: 'bgra8unorm' }] as const)
       .beginSubcases()
       .combine('samplePoints', kSamplePointMethods)
@@ -858,7 +858,7 @@ Parameters:
   )
   .params(u =>
     u
-      .combine('stage', kShaderStages)
+      .combine('stage', kShortShaderStages)
       .combineWithParams([...TexelFormats, { format: 'bgra8unorm' }] as const)
       .beginSubcases()
       .combine('samplePoints', kSamplePointMethods)
@@ -941,7 +941,7 @@ Parameters:
   )
   .params(u =>
     u
-      .combine('stage', kShaderStages)
+      .combine('stage', kShortShaderStages)
       .combineWithParams([...TexelFormats, { format: 'bgra8unorm' }] as const)
       .beginSubcases()
       .combine('samplePoints', kSamplePointMethods)

--- a/src/webgpu/shader/execution/expression/call/builtin/textureSampleBias.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureSampleBias.spec.ts
@@ -18,6 +18,8 @@ import {
   generateTextureBuiltinInputs2D,
   generateTextureBuiltinInputs3D,
   kSamplePointMethods,
+  kShortAddressModes,
+  kShortAddressModeToAddressMode,
   doTextureCalls,
   checkCallResults,
   createTextureWithRandomDataAndGetTexels,
@@ -61,18 +63,18 @@ Parameters:
     u
       .combine('format', kTestableColorFormats)
       .filter(t => isPotentiallyFilterableAndFillable(t.format))
+      .combine('filt', ['nearest', 'linear'] as const)
+      .combine('modeU', kShortAddressModes)
+      .combine('modeV', kShortAddressModes)
       .combine('offset', [false, true] as const)
       .beginSubcases()
       .combine('samplePoints', kSamplePointMethods)
-      .combine('addressModeU', ['clamp-to-edge', 'repeat', 'mirror-repeat'] as const)
-      .combine('addressModeV', ['clamp-to-edge', 'repeat', 'mirror-repeat'] as const)
-      .combine('minFilter', ['nearest', 'linear'] as const)
   )
   .beforeAllSubcases(t =>
     skipIfTextureFormatNotSupportedNotAvailableOrNotFilterable(t, t.params.format)
   )
   .fn(async t => {
-    const { format, samplePoints, addressModeU, addressModeV, minFilter, offset } = t.params;
+    const { format, samplePoints, modeU, modeV, filt: minFilter, offset } = t.params;
     skipIfNeedsFilteringAndIsUnfilterable(t, minFilter, format);
 
     // We want at least 4 blocks or something wide enough for 3 mip levels.
@@ -86,8 +88,8 @@ Parameters:
     };
     const { texels, texture } = await createTextureWithRandomDataAndGetTexels(t, descriptor);
     const sampler: GPUSamplerDescriptor = {
-      addressModeU,
-      addressModeV,
+      addressModeU: kShortAddressModeToAddressMode[modeU],
+      addressModeV: kShortAddressModeToAddressMode[modeV],
       minFilter,
       magFilter: minFilter,
       mipmapFilter: minFilter,
@@ -99,7 +101,7 @@ Parameters:
       descriptor,
       bias: true,
       offset,
-      hashInputs: [format, samplePoints, addressModeU, addressModeV, minFilter, offset],
+      hashInputs: [format, samplePoints, modeU, modeV, minFilter, offset],
     }).map(({ coords, derivativeMult, offset, bias }) => {
       return {
         builtin: 'textureSampleBias',
@@ -112,7 +114,15 @@ Parameters:
     });
     const viewDescriptor = {};
     const textureType = 'texture_2d<f32>';
-    const results = await doTextureCalls(t, texture, viewDescriptor, textureType, sampler, calls);
+    const results = await doTextureCalls(
+      t,
+      texture,
+      viewDescriptor,
+      textureType,
+      sampler,
+      calls,
+      'f'
+    );
     const res = await checkCallResults(
       t,
       { texels, descriptor, viewDescriptor },
@@ -120,7 +130,7 @@ Parameters:
       sampler,
       calls,
       results,
-      'fragment',
+      'f',
       texture
     );
     t.expectOK(res);
@@ -151,17 +161,17 @@ Parameters:
     u
       .combine('format', kTestableColorFormats)
       .filter(t => isPotentiallyFilterableAndFillable(t.format))
-      .combine('viewDimension', ['3d', 'cube'] as const)
-      .filter(t => isSupportedViewFormatCombo(t.format, t.viewDimension))
+      .combine('dim', ['3d', 'cube'] as const)
+      .filter(t => isSupportedViewFormatCombo(t.format, t.dim))
+      .combine('filt', ['nearest', 'linear'] as const)
+      .combine('modeU', kShortAddressModes)
+      .combine('modeV', kShortAddressModes)
+      .combine('modeW', kShortAddressModes)
       .combine('offset', [false, true] as const)
-      .filter(t => t.viewDimension !== 'cube' || t.offset !== true)
+      .filter(t => t.dim !== 'cube' || t.offset !== true)
       .beginSubcases()
       .combine('samplePoints', kCubeSamplePointMethods)
-      .filter(t => t.samplePoints !== 'cube-edges' || t.viewDimension !== '3d')
-      .combine('addressModeU', ['clamp-to-edge', 'repeat', 'mirror-repeat'] as const)
-      .combine('addressModeV', ['clamp-to-edge', 'repeat', 'mirror-repeat'] as const)
-      .combine('addressModeW', ['clamp-to-edge', 'repeat', 'mirror-repeat'] as const)
-      .combine('minFilter', ['nearest', 'linear'] as const)
+      .filter(t => t.samplePoints !== 'cube-edges' || t.dim !== '3d')
   )
   .beforeAllSubcases(t =>
     skipIfTextureFormatNotSupportedNotAvailableOrNotFilterable(t, t.params.format)
@@ -169,12 +179,12 @@ Parameters:
   .fn(async t => {
     const {
       format,
-      viewDimension,
+      dim: viewDimension,
       samplePoints,
-      addressModeU,
-      addressModeV,
-      addressModeW,
-      minFilter,
+      modeU,
+      modeV,
+      modeW,
+      filt: minFilter,
       offset,
     } = t.params;
     skipIfNeedsFilteringAndIsUnfilterable(t, minFilter, format);
@@ -191,9 +201,9 @@ Parameters:
     };
     const { texels, texture } = await createTextureWithRandomDataAndGetTexels(t, descriptor);
     const sampler: GPUSamplerDescriptor = {
-      addressModeU,
-      addressModeV,
-      addressModeW,
+      addressModeU: kShortAddressModeToAddressMode[modeU],
+      addressModeV: kShortAddressModeToAddressMode[modeV],
+      addressModeW: kShortAddressModeToAddressMode[modeW],
       minFilter,
       magFilter: minFilter,
     };
@@ -202,9 +212,9 @@ Parameters:
       format,
       viewDimension,
       samplePoints,
-      addressModeU,
-      addressModeV,
-      addressModeW,
+      modeU,
+      modeV,
+      modeW,
       minFilter,
       offset,
     ];
@@ -239,7 +249,15 @@ Parameters:
       dimension: viewDimension,
     };
     const textureType = getTextureTypeForTextureViewDimension(viewDimension)!;
-    const results = await doTextureCalls(t, texture, viewDescriptor, textureType, sampler, calls);
+    const results = await doTextureCalls(
+      t,
+      texture,
+      viewDescriptor,
+      textureType,
+      sampler,
+      calls,
+      'f'
+    );
     const res = await checkCallResults(
       t,
       { texels, descriptor, viewDescriptor },
@@ -247,7 +265,7 @@ Parameters:
       sampler,
       calls,
       results,
-      'fragment',
+      'f',
       texture
     );
     t.expectOK(res);
@@ -280,19 +298,19 @@ Parameters:
     u
       .combine('format', kTestableColorFormats)
       .filter(t => isPotentiallyFilterableAndFillable(t.format))
+      .combine('filt', ['nearest', 'linear'] as const)
+      .combine('modeU', kShortAddressModes)
+      .combine('modeV', kShortAddressModes)
       .combine('offset', [false, true] as const)
       .beginSubcases()
       .combine('samplePoints', kSamplePointMethods)
       .combine('A', ['i32', 'u32'] as const)
-      .combine('addressModeU', ['clamp-to-edge', 'repeat', 'mirror-repeat'] as const)
-      .combine('addressModeV', ['clamp-to-edge', 'repeat', 'mirror-repeat'] as const)
-      .combine('minFilter', ['nearest', 'linear'] as const)
   )
   .beforeAllSubcases(t =>
     skipIfTextureFormatNotSupportedNotAvailableOrNotFilterable(t, t.params.format)
   )
   .fn(async t => {
-    const { format, samplePoints, A, addressModeU, addressModeV, minFilter, offset } = t.params;
+    const { format, samplePoints, A, modeU, modeV, filt: minFilter, offset } = t.params;
     skipIfNeedsFilteringAndIsUnfilterable(t, minFilter, format);
 
     // We want at least 4 blocks or something wide enough for 3 mip levels.
@@ -307,8 +325,8 @@ Parameters:
     };
     const { texels, texture } = await createTextureWithRandomDataAndGetTexels(t, descriptor);
     const sampler: GPUSamplerDescriptor = {
-      addressModeU,
-      addressModeV,
+      addressModeU: kShortAddressModeToAddressMode[modeU],
+      addressModeV: kShortAddressModeToAddressMode[modeV],
       minFilter,
       magFilter: minFilter,
       mipmapFilter: minFilter,
@@ -321,7 +339,7 @@ Parameters:
       arrayIndex: { num: texture.depthOrArrayLayers, type: A },
       bias: true,
       offset,
-      hashInputs: [format, samplePoints, A, addressModeU, addressModeV, minFilter, offset],
+      hashInputs: [format, samplePoints, A, modeU, modeV, minFilter, offset],
     }).map(({ coords, derivativeMult, arrayIndex, bias, offset }) => {
       return {
         builtin: 'textureSampleBias',
@@ -336,7 +354,15 @@ Parameters:
     });
     const textureType = 'texture_2d_array<f32>';
     const viewDescriptor = {};
-    const results = await doTextureCalls(t, texture, viewDescriptor, textureType, sampler, calls);
+    const results = await doTextureCalls(
+      t,
+      texture,
+      viewDescriptor,
+      textureType,
+      sampler,
+      calls,
+      'f'
+    );
     const res = await checkCallResults(
       t,
       { texels, descriptor, viewDescriptor },
@@ -344,7 +370,7 @@ Parameters:
       sampler,
       calls,
       results,
-      'fragment',
+      'f',
       texture
     );
     t.expectOK(res);
@@ -376,18 +402,18 @@ Parameters:
     u
       .combine('format', kTestableColorFormats)
       .filter(t => isPotentiallyFilterableAndFillable(t.format))
+      .combine('filt', ['nearest', 'linear'] as const)
+      .combine('mode', kShortAddressModes)
       .beginSubcases()
       .combine('samplePoints', kCubeSamplePointMethods)
       .combine('A', ['i32', 'u32'] as const)
-      .combine('addressMode', ['clamp-to-edge', 'repeat', 'mirror-repeat'] as const)
-      .combine('minFilter', ['nearest', 'linear'] as const)
   )
   .beforeAllSubcases(t => {
     skipIfTextureFormatNotSupportedNotAvailableOrNotFilterable(t, t.params.format);
     t.skipIfTextureViewDimensionNotSupported('cube-array');
   })
   .fn(async t => {
-    const { format, samplePoints, A, addressMode, minFilter } = t.params;
+    const { format, samplePoints, A, mode, filt: minFilter } = t.params;
     skipIfNeedsFilteringAndIsUnfilterable(t, minFilter, format);
 
     const viewDimension: GPUTextureViewDimension = 'cube-array';
@@ -406,9 +432,9 @@ Parameters:
     };
     const { texels, texture } = await createTextureWithRandomDataAndGetTexels(t, descriptor);
     const sampler: GPUSamplerDescriptor = {
-      addressModeU: addressMode,
-      addressModeV: addressMode,
-      addressModeW: addressMode,
+      addressModeU: kShortAddressModeToAddressMode[mode],
+      addressModeV: kShortAddressModeToAddressMode[mode],
+      addressModeW: kShortAddressModeToAddressMode[mode],
       minFilter,
       magFilter: minFilter,
       mipmapFilter: minFilter,
@@ -420,7 +446,7 @@ Parameters:
       descriptor,
       bias: true,
       arrayIndex: { num: texture.depthOrArrayLayers / 6, type: A },
-      hashInputs: [format, viewDimension, A, samplePoints, addressMode, minFilter],
+      hashInputs: [format, viewDimension, A, samplePoints, mode, minFilter],
     }).map(({ coords, derivativeMult, arrayIndex, bias }) => {
       return {
         builtin: 'textureSampleBias',
@@ -436,7 +462,15 @@ Parameters:
       dimension: viewDimension,
     };
     const textureType = getTextureTypeForTextureViewDimension(viewDimension);
-    const results = await doTextureCalls(t, texture, viewDescriptor, textureType, sampler, calls);
+    const results = await doTextureCalls(
+      t,
+      texture,
+      viewDescriptor,
+      textureType,
+      sampler,
+      calls,
+      'f'
+    );
     const res = await checkCallResults(
       t,
       { texels, descriptor, viewDescriptor },
@@ -444,7 +478,7 @@ Parameters:
       sampler,
       calls,
       results,
-      'fragment',
+      'f',
       texture
     );
     t.expectOK(res);

--- a/src/webgpu/shader/execution/expression/call/builtin/textureSampleCompare.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureSampleCompare.spec.ts
@@ -22,6 +22,8 @@ import {
   generateTextureBuiltinInputs2D,
   kCubeSamplePointMethods,
   kSamplePointMethods,
+  kShortAddressModes,
+  kShortAddressModeToAddressMode,
   makeRandomDepthComparisonTexelGenerator,
   TextureCall,
   vec2,
@@ -58,17 +60,16 @@ Parameters:
       .filter(t => isDepthTextureFormat(t.format))
       // MAINTENANCE_TODO: Remove when support for depth24plus, depth24plus-stencil8, and depth32float-stencil8 is added.
       .filter(t => isEncodableTextureFormat(t.format))
-      .combine('minFilter', ['nearest', 'linear'] as const)
+      .combine('filt', ['nearest', 'linear'] as const)
+      .combine('modeU', kShortAddressModes)
+      .combine('modeV', kShortAddressModes)
       .combine('offset', [false, true] as const)
       .beginSubcases()
       .combine('samplePoints', kSamplePointMethods)
-      .combine('addressModeU', ['clamp-to-edge', 'repeat', 'mirror-repeat'] as const)
-      .combine('addressModeV', ['clamp-to-edge', 'repeat', 'mirror-repeat'] as const)
       .combine('compare', kCompareFunctions)
   )
   .fn(async t => {
-    const { format, samplePoints, addressModeU, addressModeV, minFilter, compare, offset } =
-      t.params;
+    const { format, samplePoints, modeU, modeV, filt: minFilter, compare, offset } = t.params;
 
     const size = chooseTextureSize({ minSize: 16, minBlocks: 4, format });
 
@@ -82,8 +83,8 @@ Parameters:
       generator: makeRandomDepthComparisonTexelGenerator(descriptor, compare),
     });
     const sampler: GPUSamplerDescriptor = {
-      addressModeU,
-      addressModeV,
+      addressModeU: kShortAddressModeToAddressMode[modeU],
+      addressModeV: kShortAddressModeToAddressMode[modeV],
       compare,
       minFilter,
       magFilter: minFilter,
@@ -98,7 +99,7 @@ Parameters:
       derivatives: true,
       depthRef: true,
       offset,
-      hashInputs: [format, samplePoints, addressModeU, addressModeV, minFilter, offset],
+      hashInputs: [format, samplePoints, modeU, modeV, minFilter, offset],
     }).map(({ coords, derivativeMult, arrayIndex, depthRef, offset }) => {
       return {
         builtin: 'textureSampleCompare',
@@ -111,7 +112,15 @@ Parameters:
     });
     const textureType = 'texture_depth_2d';
     const viewDescriptor = {};
-    const results = await doTextureCalls(t, texture, viewDescriptor, textureType, sampler, calls);
+    const results = await doTextureCalls(
+      t,
+      texture,
+      viewDescriptor,
+      textureType,
+      sampler,
+      calls,
+      'f'
+    );
     const res = await checkCallResults(
       t,
       { texels, descriptor, viewDescriptor },
@@ -119,7 +128,7 @@ Parameters:
       sampler,
       calls,
       results,
-      'fragment',
+      'f',
       texture
     );
     t.expectOK(res);
@@ -145,14 +154,14 @@ Parameters:
       .filter(t => isDepthTextureFormat(t.format))
       // MAINTENANCE_TODO: Remove when support for depth24plus, depth24plus-stencil8, and depth32float-stencil8 is added.
       .filter(t => isEncodableTextureFormat(t.format))
-      .combine('minFilter', ['nearest', 'linear'] as const)
+      .combine('filt', ['nearest', 'linear'] as const)
+      .combine('mode', kShortAddressModes)
       .beginSubcases()
       .combine('samplePoints', kCubeSamplePointMethods)
-      .combine('addressMode', ['clamp-to-edge', 'repeat', 'mirror-repeat'] as const)
       .combine('compare', kCompareFunctions)
   )
   .fn(async t => {
-    const { format, samplePoints, addressMode, minFilter, compare } = t.params;
+    const { format, samplePoints, mode, filt: minFilter, compare } = t.params;
 
     const viewDimension: GPUTextureViewDimension = 'cube';
     const size = chooseTextureSize({ minSize: 16, minBlocks: 2, format, viewDimension });
@@ -169,9 +178,9 @@ Parameters:
       generator: makeRandomDepthComparisonTexelGenerator(descriptor, compare),
     });
     const sampler: GPUSamplerDescriptor = {
-      addressModeU: addressMode,
-      addressModeV: addressMode,
-      addressModeW: addressMode,
+      addressModeU: kShortAddressModeToAddressMode[mode],
+      addressModeV: kShortAddressModeToAddressMode[mode],
+      addressModeW: kShortAddressModeToAddressMode[mode],
       compare,
       minFilter,
       magFilter: minFilter,
@@ -185,7 +194,7 @@ Parameters:
       derivatives: true,
       depthRef: true,
       textureBuiltin: 'textureSampleCompare',
-      hashInputs: [format, samplePoints, addressMode, minFilter, compare],
+      hashInputs: [format, samplePoints, mode, minFilter, compare],
     }).map(({ coords, derivativeMult, depthRef }) => {
       return {
         builtin: 'textureSampleCompare',
@@ -199,7 +208,15 @@ Parameters:
       dimension: viewDimension,
     };
     const textureType = 'texture_depth_cube';
-    const results = await doTextureCalls(t, texture, viewDescriptor, textureType, sampler, calls);
+    const results = await doTextureCalls(
+      t,
+      texture,
+      viewDescriptor,
+      textureType,
+      sampler,
+      calls,
+      'f'
+    );
     const res = await checkCallResults(
       t,
       { texels, descriptor, viewDescriptor },
@@ -207,7 +224,7 @@ Parameters:
       sampler,
       calls,
       results,
-      'fragment',
+      'f',
       texture
     );
     t.expectOK(res);
@@ -243,21 +260,20 @@ Parameters:
       .filter(t => isDepthTextureFormat(t.format))
       // MAINTENANCE_TODO: Remove when support for depth24plus, depth24plus-stencil8, and depth32float-stencil8 is added.
       .filter(t => isEncodableTextureFormat(t.format))
-      .combine('minFilter', ['nearest', 'linear'] as const)
+      .combine('filt', ['nearest', 'linear'] as const)
+      .combine('modeU', kShortAddressModes)
+      .combine('modeV', kShortAddressModes)
       .combine('offset', [false, true] as const)
       .beginSubcases()
       .combine('samplePoints', kSamplePointMethods)
       .combine('A', ['i32', 'u32'] as const)
-      .combine('addressModeU', ['clamp-to-edge', 'repeat', 'mirror-repeat'] as const)
-      .combine('addressModeV', ['clamp-to-edge', 'repeat', 'mirror-repeat'] as const)
       .combine('compare', kCompareFunctions)
   )
   .beforeAllSubcases(t => {
     t.skipIfTextureFormatNotSupported(t.params.format);
   })
   .fn(async t => {
-    const { format, samplePoints, A, addressModeU, addressModeV, minFilter, compare, offset } =
-      t.params;
+    const { format, samplePoints, A, modeU, modeV, filt: minFilter, compare, offset } = t.params;
 
     const viewDimension = '2d-array';
     const size = chooseTextureSize({ minSize: 16, minBlocks: 4, format, viewDimension });
@@ -272,8 +288,8 @@ Parameters:
       generator: makeRandomDepthComparisonTexelGenerator(descriptor, compare),
     });
     const sampler: GPUSamplerDescriptor = {
-      addressModeU,
-      addressModeV,
+      addressModeU: kShortAddressModeToAddressMode[modeU],
+      addressModeV: kShortAddressModeToAddressMode[modeV],
       compare,
       minFilter,
       magFilter: minFilter,
@@ -289,7 +305,7 @@ Parameters:
       arrayIndex: { num: texture.depthOrArrayLayers, type: A },
       depthRef: true,
       offset,
-      hashInputs: [format, samplePoints, A, addressModeU, addressModeV, minFilter, offset],
+      hashInputs: [format, samplePoints, A, modeU, modeV, minFilter, offset],
     }).map(({ coords, derivativeMult, arrayIndex, depthRef, offset }) => {
       return {
         builtin: 'textureSampleCompare',
@@ -304,7 +320,15 @@ Parameters:
     });
     const textureType = 'texture_depth_2d_array';
     const viewDescriptor = {};
-    const results = await doTextureCalls(t, texture, viewDescriptor, textureType, sampler, calls);
+    const results = await doTextureCalls(
+      t,
+      texture,
+      viewDescriptor,
+      textureType,
+      sampler,
+      calls,
+      'f'
+    );
     const res = await checkCallResults(
       t,
       { texels, descriptor, viewDescriptor },
@@ -312,7 +336,7 @@ Parameters:
       sampler,
       calls,
       results,
-      'fragment',
+      'f',
       texture
     );
     t.expectOK(res);
@@ -341,18 +365,18 @@ Parameters:
       .filter(t => isDepthTextureFormat(t.format))
       // MAINTENANCE_TODO: Remove when support for depth24plus, depth24plus-stencil8, and depth32float-stencil8 is added.
       .filter(t => isEncodableTextureFormat(t.format))
-      .combine('minFilter', ['nearest', 'linear'] as const)
+      .combine('filt', ['nearest', 'linear'] as const)
+      .combine('mode', kShortAddressModes)
       .beginSubcases()
       .combine('samplePoints', kCubeSamplePointMethods)
       .combine('A', ['i32', 'u32'] as const)
-      .combine('addressMode', ['clamp-to-edge', 'repeat', 'mirror-repeat'] as const)
       .combine('compare', kCompareFunctions)
   )
   .beforeAllSubcases(t => {
     t.skipIfTextureViewDimensionNotSupported('cube-array');
   })
   .fn(async t => {
-    const { format, A, samplePoints, addressMode, minFilter, compare } = t.params;
+    const { format, A, samplePoints, mode, filt: minFilter, compare } = t.params;
 
     const viewDimension: GPUTextureViewDimension = 'cube-array';
     const size = chooseTextureSize({ minSize: 8, minBlocks: 2, format, viewDimension });
@@ -369,9 +393,9 @@ Parameters:
       generator: makeRandomDepthComparisonTexelGenerator(descriptor, compare),
     });
     const sampler: GPUSamplerDescriptor = {
-      addressModeU: addressMode,
-      addressModeV: addressMode,
-      addressModeW: addressMode,
+      addressModeU: kShortAddressModeToAddressMode[mode],
+      addressModeV: kShortAddressModeToAddressMode[mode],
+      addressModeW: kShortAddressModeToAddressMode[mode],
       compare,
       minFilter,
       magFilter: minFilter,
@@ -386,7 +410,7 @@ Parameters:
       textureBuiltin: 'textureSampleCompare',
       arrayIndex: { num: texture.depthOrArrayLayers / 6, type: A },
       depthRef: true,
-      hashInputs: [format, samplePoints, addressMode, minFilter],
+      hashInputs: [format, samplePoints, mode, minFilter],
     }).map(({ coords, derivativeMult, depthRef, arrayIndex }) => {
       return {
         builtin: 'textureSampleCompare',
@@ -402,7 +426,15 @@ Parameters:
       dimension: viewDimension,
     };
     const textureType = 'texture_depth_cube_array';
-    const results = await doTextureCalls(t, texture, viewDescriptor, textureType, sampler, calls);
+    const results = await doTextureCalls(
+      t,
+      texture,
+      viewDescriptor,
+      textureType,
+      sampler,
+      calls,
+      'f'
+    );
     const res = await checkCallResults(
       t,
       { texels, descriptor, viewDescriptor },
@@ -410,7 +442,7 @@ Parameters:
       sampler,
       calls,
       results,
-      'fragment',
+      'f',
       texture
     );
     t.expectOK(res);

--- a/src/webgpu/shader/execution/expression/call/builtin/textureSampleLevel.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureSampleLevel.spec.ts
@@ -12,7 +12,6 @@ import {
   kDepthStencilFormats,
   kEncodableTextureFormats,
 } from '../../../../../format_info.js';
-import { kShaderStages } from '../../../../validation/decl/util.js';
 
 import {
   appendComponentTypeForFormatToTextureType,
@@ -29,6 +28,9 @@ import {
   isSupportedViewFormatCombo,
   kCubeSamplePointMethods,
   kSamplePointMethods,
+  kShortAddressModes,
+  kShortAddressModeToAddressMode,
+  kShortShaderStages,
   SamplePointMethods,
   skipIfNeedsFilteringAndIsUnfilterable,
   skipIfTextureFormatNotSupportedNotAvailableOrNotFilterable,
@@ -68,21 +70,21 @@ Parameters:
   )
   .params(u =>
     u
-      .combine('stage', kShaderStages)
+      .combine('stage', kShortShaderStages)
       .combine('format', kTestableColorFormats)
       .filter(t => isPotentiallyFilterableAndFillable(t.format))
+      .combine('filt', ['nearest', 'linear'] as const)
+      .combine('modeU', kShortAddressModes)
+      .combine('modeV', kShortAddressModes)
       .combine('offset', [false, true] as const)
       .beginSubcases()
       .combine('samplePoints', kSamplePointMethods)
-      .combine('addressModeU', ['clamp-to-edge', 'repeat', 'mirror-repeat'] as const)
-      .combine('addressModeV', ['clamp-to-edge', 'repeat', 'mirror-repeat'] as const)
-      .combine('minFilter', ['nearest', 'linear'] as const)
   )
   .beforeAllSubcases(t =>
     skipIfTextureFormatNotSupportedNotAvailableOrNotFilterable(t, t.params.format)
   )
   .fn(async t => {
-    const { format, stage, samplePoints, addressModeU, addressModeV, minFilter, offset } = t.params;
+    const { format, stage, samplePoints, modeU, modeV, filt: minFilter, offset } = t.params;
     skipIfNeedsFilteringAndIsUnfilterable(t, minFilter, format);
 
     // We want at least 4 blocks or something wide enough for 3 mip levels.
@@ -95,8 +97,8 @@ Parameters:
     };
     const { texels, texture } = await createTextureWithRandomDataAndGetTexels(t, descriptor);
     const sampler: GPUSamplerDescriptor = {
-      addressModeU,
-      addressModeV,
+      addressModeU: kShortAddressModeToAddressMode[modeU],
+      addressModeV: kShortAddressModeToAddressMode[modeV],
       minFilter,
       magFilter: minFilter,
       mipmapFilter: minFilter,
@@ -108,7 +110,7 @@ Parameters:
       descriptor,
       mipLevel: { num: texture.mipLevelCount, type: 'f32' },
       offset,
-      hashInputs: [stage, format, samplePoints, addressModeU, addressModeV, minFilter, offset],
+      hashInputs: [stage, format, samplePoints, modeU, modeV, minFilter, offset],
     }).map(({ coords, mipLevel, offset }) => {
       return {
         builtin: 'textureSampleLevel',
@@ -172,23 +174,22 @@ Parameters:
   )
   .params(u =>
     u
-      .combine('stage', kShaderStages)
+      .combine('stage', kShortShaderStages)
       .combine('format', kTestableColorFormats)
       .filter(t => isPotentiallyFilterableAndFillable(t.format))
+      .combine('filt', ['nearest', 'linear'] as const)
+      .combine('modeU', kShortAddressModes)
+      .combine('modeV', kShortAddressModes)
       .combine('offset', [false, true] as const)
       .beginSubcases()
       .combine('samplePoints', kSamplePointMethods)
       .combine('A', ['i32', 'u32'] as const)
-      .combine('addressModeU', ['clamp-to-edge', 'repeat', 'mirror-repeat'] as const)
-      .combine('addressModeV', ['clamp-to-edge', 'repeat', 'mirror-repeat'] as const)
-      .combine('minFilter', ['nearest', 'linear'] as const)
   )
   .beforeAllSubcases(t =>
     skipIfTextureFormatNotSupportedNotAvailableOrNotFilterable(t, t.params.format)
   )
   .fn(async t => {
-    const { format, stage, samplePoints, A, addressModeU, addressModeV, minFilter, offset } =
-      t.params;
+    const { format, stage, samplePoints, A, modeU, modeV, filt: minFilter, offset } = t.params;
     skipIfNeedsFilteringAndIsUnfilterable(t, minFilter, format);
 
     // We want at least 4 blocks or something wide enough for 3 mip levels.
@@ -203,8 +204,8 @@ Parameters:
     };
     const { texels, texture } = await createTextureWithRandomDataAndGetTexels(t, descriptor);
     const sampler: GPUSamplerDescriptor = {
-      addressModeU,
-      addressModeV,
+      addressModeU: kShortAddressModeToAddressMode[modeU],
+      addressModeV: kShortAddressModeToAddressMode[modeV],
       minFilter,
       magFilter: minFilter,
       mipmapFilter: minFilter,
@@ -217,7 +218,7 @@ Parameters:
       mipLevel: { num: texture.mipLevelCount, type: 'f32' },
       arrayIndex: { num: texture.depthOrArrayLayers, type: A },
       offset,
-      hashInputs: [stage, format, samplePoints, A, addressModeU, addressModeV, minFilter, offset],
+      hashInputs: [stage, format, samplePoints, A, modeU, modeV, minFilter, offset],
     }).map(({ coords, mipLevel, arrayIndex, offset }) => {
       return {
         builtin: 'textureSampleLevel',
@@ -281,24 +282,32 @@ Parameters:
   )
   .params(u =>
     u
-      .combine('stage', kShaderStages)
+      .combine('stage', kShortShaderStages)
       .combine('format', kTestableColorFormats)
       .filter(t => isPotentiallyFilterableAndFillable(t.format))
-      .combine('viewDimension', ['3d', 'cube'] as const)
-      .filter(t => isSupportedViewFormatCombo(t.format, t.viewDimension))
+      .combine('dim', ['3d', 'cube'] as const)
+      .filter(t => isSupportedViewFormatCombo(t.format, t.dim))
+      .combine('filt', ['nearest', 'linear'] as const)
+      .combine('mode', kShortAddressModes)
       .combine('offset', [false, true] as const)
-      .filter(t => t.viewDimension !== 'cube' || t.offset !== true)
+      .filter(t => t.dim !== 'cube' || t.offset !== true)
       .beginSubcases()
       .combine('samplePoints', kCubeSamplePointMethods)
-      .filter(t => t.samplePoints !== 'cube-edges' || t.viewDimension !== '3d')
-      .combine('addressMode', ['clamp-to-edge', 'repeat', 'mirror-repeat'] as const)
-      .combine('minFilter', ['nearest', 'linear'] as const)
+      .filter(t => t.samplePoints !== 'cube-edges' || t.dim !== '3d')
   )
   .beforeAllSubcases(t =>
     skipIfTextureFormatNotSupportedNotAvailableOrNotFilterable(t, t.params.format)
   )
   .fn(async t => {
-    const { format, viewDimension, stage, samplePoints, addressMode, minFilter, offset } = t.params;
+    const {
+      format,
+      dim: viewDimension,
+      stage,
+      samplePoints,
+      mode,
+      filt: minFilter,
+      offset,
+    } = t.params;
     skipIfNeedsFilteringAndIsUnfilterable(t, minFilter, format);
 
     const [width, height] = chooseTextureSize({ minSize: 32, minBlocks: 2, format, viewDimension });
@@ -314,15 +323,15 @@ Parameters:
     };
     const { texels, texture } = await createTextureWithRandomDataAndGetTexels(t, descriptor);
     const sampler: GPUSamplerDescriptor = {
-      addressModeU: addressMode,
-      addressModeV: addressMode,
-      addressModeW: addressMode,
+      addressModeU: kShortAddressModeToAddressMode[mode],
+      addressModeV: kShortAddressModeToAddressMode[mode],
+      addressModeW: kShortAddressModeToAddressMode[mode],
       minFilter,
       magFilter: minFilter,
       mipmapFilter: minFilter,
     };
 
-    const hashInputs = [stage, format, viewDimension, samplePoints, addressMode, minFilter, offset];
+    const hashInputs = [stage, format, viewDimension, samplePoints, mode, minFilter, offset];
     const calls: TextureCall<vec3>[] = (
       viewDimension === '3d'
         ? generateTextureBuiltinInputs3D(50, {
@@ -406,21 +415,21 @@ Parameters:
   )
   .params(u =>
     u
-      .combine('stage', kShaderStages)
+      .combine('stage', kShortShaderStages)
       .combine('format', kTestableColorFormats)
       .filter(t => isPotentiallyFilterableAndFillable(t.format))
+      .combine('filt', ['nearest', 'linear'] as const)
+      .combine('mode', kShortAddressModes)
       .beginSubcases()
       .combine('samplePoints', kCubeSamplePointMethods)
       .combine('A', ['i32', 'u32'] as const)
-      .combine('addressMode', ['clamp-to-edge', 'repeat', 'mirror-repeat'] as const)
-      .combine('minFilter', ['nearest', 'linear'] as const)
   )
   .beforeAllSubcases(t => {
     skipIfTextureFormatNotSupportedNotAvailableOrNotFilterable(t, t.params.format);
     t.skipIfTextureViewDimensionNotSupported('cube-array');
   })
   .fn(async t => {
-    const { format, stage, samplePoints, A, addressMode, minFilter } = t.params;
+    const { format, stage, samplePoints, A, mode, filt: minFilter } = t.params;
     skipIfNeedsFilteringAndIsUnfilterable(t, minFilter, format);
 
     const viewDimension: GPUTextureViewDimension = 'cube-array';
@@ -438,9 +447,9 @@ Parameters:
     };
     const { texels, texture } = await createTextureWithRandomDataAndGetTexels(t, descriptor);
     const sampler: GPUSamplerDescriptor = {
-      addressModeU: addressMode,
-      addressModeV: addressMode,
-      addressModeW: addressMode,
+      addressModeU: kShortAddressModeToAddressMode[mode],
+      addressModeV: kShortAddressModeToAddressMode[mode],
+      addressModeW: kShortAddressModeToAddressMode[mode],
       minFilter,
       magFilter: minFilter,
       mipmapFilter: minFilter,
@@ -452,7 +461,7 @@ Parameters:
       descriptor,
       mipLevel: { num: texture.mipLevelCount, type: 'f32' },
       arrayIndex: { num: texture.depthOrArrayLayers / 6, type: A },
-      hashInputs: [stage, format, viewDimension, A, samplePoints, addressMode, minFilter],
+      hashInputs: [stage, format, viewDimension, A, samplePoints, mode, minFilter],
     }).map(({ coords, mipLevel, arrayIndex }) => {
       return {
         builtin: 'textureSampleLevel',
@@ -518,24 +527,24 @@ Parameters:
   )
   .params(u =>
     u
-      .combine('stage', kShaderStages)
+      .combine('stage', kShortShaderStages)
       .combine('format', kDepthStencilFormats)
       // filter out stencil only formats
       .filter(t => isDepthTextureFormat(t.format))
       // MAINTENANCE_TODO: Remove when support for depth24plus, depth24plus-stencil8, and depth32float-stencil8 is added.
       .filter(t => isEncodableTextureFormat(t.format))
+      .combine('filt', ['nearest', 'linear'] as const)
+      .combine('mode', kShortAddressModes)
       .combine('offset', [false, true] as const)
       .beginSubcases()
       .combine('samplePoints', kSamplePointMethods)
-      .combine('addressMode', ['clamp-to-edge', 'repeat', 'mirror-repeat'] as const)
-      .combine('minFilter', ['nearest', 'linear'] as const)
       .combine('L', ['i32', 'u32'] as const)
   )
   .beforeAllSubcases(t =>
     skipIfTextureFormatNotSupportedNotAvailableOrNotFilterable(t, t.params.format)
   )
   .fn(async t => {
-    const { format, stage, samplePoints, addressMode, minFilter, L, offset } = t.params;
+    const { format, stage, samplePoints, mode, filt: minFilter, L, offset } = t.params;
 
     // We want at least 4 blocks or something wide enough for 3 mip levels.
     const [width, height] = chooseTextureSize({ minSize: 8, minBlocks: 4, format });
@@ -547,8 +556,8 @@ Parameters:
     };
     const { texels, texture } = await createTextureWithRandomDataAndGetTexels(t, descriptor);
     const sampler: GPUSamplerDescriptor = {
-      addressModeU: addressMode,
-      addressModeV: addressMode,
+      addressModeU: kShortAddressModeToAddressMode[mode],
+      addressModeV: kShortAddressModeToAddressMode[mode],
       minFilter,
       magFilter: minFilter,
       mipmapFilter: minFilter,
@@ -560,7 +569,7 @@ Parameters:
       descriptor,
       mipLevel: { num: texture.mipLevelCount, type: L },
       offset,
-      hashInputs: [stage, format, samplePoints, addressMode, minFilter, L, offset],
+      hashInputs: [stage, format, samplePoints, mode, minFilter, L, offset],
     }).map(({ coords, mipLevel, offset }) => {
       return {
         builtin: 'textureSampleLevel',
@@ -625,17 +634,17 @@ Parameters:
   )
   .params(u =>
     u
-      .combine('stage', kShaderStages)
+      .combine('stage', kShortShaderStages)
       .combine('format', kDepthStencilFormats)
       // filter out stencil only formats
       .filter(t => isDepthTextureFormat(t.format))
       // MAINTENANCE_TODO: Remove when support for depth24plus, depth24plus-stencil8, and depth32float-stencil8 is added.
       .filter(t => isEncodableTextureFormat(t.format))
+      .combine('filt', ['nearest', 'linear'] as const)
+      .combine('mode', kShortAddressModes)
       .combine('offset', [false, true] as const)
       .beginSubcases()
       .combine('samplePoints', kSamplePointMethods)
-      .combine('addressMode', ['clamp-to-edge', 'repeat', 'mirror-repeat'] as const)
-      .combine('minFilter', ['nearest', 'linear'] as const)
       .combine('A', ['i32', 'u32'] as const)
       .combine('L', ['i32', 'u32'] as const)
   )
@@ -643,7 +652,7 @@ Parameters:
     skipIfTextureFormatNotSupportedNotAvailableOrNotFilterable(t, t.params.format)
   )
   .fn(async t => {
-    const { format, stage, samplePoints, addressMode, minFilter, A, L, offset } = t.params;
+    const { format, stage, samplePoints, mode, filt: minFilter, A, L, offset } = t.params;
 
     // We want at least 4 blocks or something wide enough for 3 mip levels.
     const [width, height] = chooseTextureSize({ minSize: 8, minBlocks: 4, format });
@@ -656,8 +665,8 @@ Parameters:
     };
     const { texels, texture } = await createTextureWithRandomDataAndGetTexels(t, descriptor);
     const sampler: GPUSamplerDescriptor = {
-      addressModeU: addressMode,
-      addressModeV: addressMode,
+      addressModeU: kShortAddressModeToAddressMode[mode],
+      addressModeV: kShortAddressModeToAddressMode[mode],
       minFilter,
       magFilter: minFilter,
       mipmapFilter: minFilter,
@@ -670,7 +679,7 @@ Parameters:
       arrayIndex: { num: texture.depthOrArrayLayers, type: A },
       mipLevel: { num: texture.mipLevelCount, type: L },
       offset,
-      hashInputs: [stage, format, samplePoints, addressMode, minFilter, L, A, offset],
+      hashInputs: [stage, format, samplePoints, mode, minFilter, L, A, offset],
     }).map(({ coords, mipLevel, arrayIndex, offset }) => {
       return {
         builtin: 'textureSampleLevel',
@@ -736,7 +745,7 @@ Parameters:
   )
   .params(u =>
     u
-      .combine('stage', kShaderStages)
+      .combine('stage', kShortShaderStages)
       .combine('format', kDepthStencilFormats)
       // filter out stencil only formats
       .filter(t => isDepthTextureFormat(t.format))
@@ -747,18 +756,18 @@ Parameters:
         { viewDimension: 'cube-array', A: 'i32' },
         { viewDimension: 'cube-array', A: 'u32' },
       ] as const)
+      .combine('filt', ['nearest', 'linear'] as const)
+      .combine('mode', kShortAddressModes)
       .beginSubcases()
       .combine('samplePoints', kCubeSamplePointMethods)
       .combine('L', ['i32', 'u32'] as const)
-      .combine('addressMode', ['clamp-to-edge', 'repeat', 'mirror-repeat'] as const)
-      .combine('minFilter', ['nearest', 'linear'] as const)
   )
   .beforeAllSubcases(t => {
     skipIfTextureFormatNotSupportedNotAvailableOrNotFilterable(t, t.params.format);
     t.skipIfTextureViewDimensionNotSupported(t.params.viewDimension);
   })
   .fn(async t => {
-    const { format, stage, viewDimension, samplePoints, A, L, addressMode, minFilter } = t.params;
+    const { format, stage, viewDimension, samplePoints, A, L, mode, filt: minFilter } = t.params;
 
     const size = chooseTextureSize({
       minSize: 32,
@@ -775,9 +784,9 @@ Parameters:
     };
     const { texels, texture } = await createTextureWithRandomDataAndGetTexels(t, descriptor);
     const sampler: GPUSamplerDescriptor = {
-      addressModeU: addressMode,
-      addressModeV: addressMode,
-      addressModeW: addressMode,
+      addressModeU: kShortAddressModeToAddressMode[mode],
+      addressModeV: kShortAddressModeToAddressMode[mode],
+      addressModeW: kShortAddressModeToAddressMode[mode],
       minFilter,
       magFilter: minFilter,
       mipmapFilter: minFilter,
@@ -789,7 +798,7 @@ Parameters:
       descriptor,
       mipLevel: { num: texture.mipLevelCount - 1, type: L },
       arrayIndex: A ? { num: texture.depthOrArrayLayers / 6, type: A } : undefined,
-      hashInputs: [stage, format, viewDimension, samplePoints, addressMode, minFilter],
+      hashInputs: [stage, format, viewDimension, samplePoints, mode, minFilter],
     }).map(({ coords, mipLevel, arrayIndex }) => {
       return {
         builtin: 'textureSampleLevel',


### PR DESCRIPTION
addressMode is broken on many GPUs. Moving this from a subcase to a case lets us separate out those failures.

I opted to put the parameters in minFilter, addressMode, offset order which means for some builtins I moved minFilter from subcase to case.

This turned into a massive change because the query strings got too long. so had to change

* addressModeX -> modeX
* filter to filt
* clamp-to-edge -> c
* repeat -> r
* mirror-repeat -> m
* viewDimension -> dim
* fragment -> f
* compute -> c
* vertex -> v

Other option would be to move all the tests from
`webgpu:shader,execution,expression,call,builtin` to `webgpu:texture` though I'm not sure that would be enough on its own

Note: this takes `webgpu:shader,execution,expression,call,builtin,*` from 21738 cases to 113546 cases
