### PR TITLE
index.html: Remove CSS attribute that did nothing and now breaks layout

### DIFF
--- a/standalone/index.html
+++ b/standalone/index.html
@@ -183,7 +183,6 @@
       /* tree nodes */
 
       .nodeheader {
-        display: flex;
         width: 100%;
         padding: 0px 2px 0px 1px;
       }


### PR DESCRIPTION
It starts breaking with the current Chrome Canary.

See https://crbug.com/374115881