### PR TITLE
Enable depth24plus, depth24plus-stencil8, depth32float-stencil8 in texture builtins

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/textureGather.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureGather.spec.ts
@@ -28,9 +28,8 @@ import { makeTestGroup } from '../../../../../../common/framework/test_group.js'
 import {
   isDepthTextureFormat,
   isEncodableTextureFormat,
-  kCompressedTextureFormats,
   kDepthStencilFormats,
-  kEncodableTextureFormats,
+  kAllTextureFormats,
 } from '../../../../../format_info.js';
 
 import {
@@ -53,8 +52,6 @@ import {
   vec3,
   WGSLTextureSampleTest,
 } from './texture_utils.js';
-
-const kTestableColorFormats = [...kEncodableTextureFormats, ...kCompressedTextureFormats] as const;
 
 export const g = makeTestGroup(WGSLTextureSampleTest);
 
@@ -87,7 +84,7 @@ Parameters:
   .params(u =>
     u
       .combine('stage', kShortShaderStages)
-      .combine('format', kTestableColorFormats)
+      .combine('format', kAllTextureFormats)
       .filter(t => isFillable(t.format))
       .combine('filt', ['nearest', 'linear'] as const)
       .combine('modeU', kShortAddressModes)
@@ -184,7 +181,7 @@ Parameters:
   .params(u =>
     u
       .combine('stage', kShortShaderStages)
-      .combine('format', kTestableColorFormats)
+      .combine('format', kAllTextureFormats)
       .filter(t => isFillable(t.format))
       .combine('filt', ['nearest', 'linear'] as const)
       .combine('mode', kShortAddressModes)
@@ -292,7 +289,7 @@ Parameters:
   .params(u =>
     u
       .combine('stage', kShortShaderStages)
-      .combine('format', kTestableColorFormats)
+      .combine('format', kAllTextureFormats)
       .filter(t => isFillable(t.format))
       .combine('filt', ['nearest', 'linear'] as const)
       .combine('modeU', kShortAddressModes)
@@ -398,7 +395,7 @@ Parameters:
   .params(u =>
     u
       .combine('stage', kShortShaderStages)
-      .combine('format', kTestableColorFormats)
+      .combine('format', kAllTextureFormats)
       .filter(t => isFillable(t.format))
       .combine('filt', ['nearest', 'linear'] as const)
       .combine('mode', kShortAddressModes)

--- a/src/webgpu/shader/execution/expression/call/builtin/textureLoad.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureLoad.spec.ts
@@ -29,9 +29,8 @@ import {
   isEncodableTextureFormat,
   isMultisampledTextureFormat,
   isStencilTextureFormat,
-  kCompressedTextureFormats,
   kDepthStencilFormats,
-  kEncodableTextureFormats,
+  kAllTextureFormats,
   kTextureFormatInfo,
   textureDimensionAndFormatCompatible,
 } from '../../../../../format_info.js';
@@ -57,8 +56,6 @@ import {
   Dimensionality,
   createVideoFrameWithRandomDataAndGetTexels,
 } from './texture_utils.js';
-
-const kTestableColorFormats = [...kEncodableTextureFormats, ...kCompressedTextureFormats] as const;
 
 export function normalizedCoordToTexelLoadTestCoord<T extends Dimensionality>(
   descriptor: GPUTextureDescriptor,
@@ -92,7 +89,7 @@ Parameters:
   .params(u =>
     u
       .combine('stage', kShortShaderStages)
-      .combine('format', kTestableColorFormats)
+      .combine('format', kAllTextureFormats)
       .filter(t => textureDimensionAndFormatCompatible('1d', t.format))
       // 1d textures can't have a height !== 1
       .filter(t => kTextureFormatInfo[t.format].blockHeight === 1)
@@ -179,7 +176,7 @@ Parameters:
   .params(u =>
     u
       .combine('stage', kShortShaderStages)
-      .combine('format', kTestableColorFormats)
+      .combine('format', kAllTextureFormats)
       .filter(t => !isCompressedFloatTextureFormat(t.format))
       .beginSubcases()
       .combine('samplePoints', kSamplePointMethods)
@@ -261,7 +258,7 @@ Parameters:
   .params(u =>
     u
       .combine('stage', kShortShaderStages)
-      .combine('format', kTestableColorFormats)
+      .combine('format', kAllTextureFormats)
       .filter(t => textureDimensionAndFormatCompatible('3d', t.format))
       .beginSubcases()
       .combine('samplePoints', kSamplePointMethods)
@@ -351,7 +348,7 @@ Parameters:
         'texture_multisampled_2d',
         'texture_depth_multisampled_2d',
       ] as const)
-      .combine('format', kTestableColorFormats)
+      .combine('format', kAllTextureFormats)
       .filter(t => isMultisampledTextureFormat(t.format))
       .filter(t => !isStencilTextureFormat(t.format))
       // Filter out texture_depth_multisampled_2d with non-depth formats
@@ -604,7 +601,7 @@ Parameters:
   .params(u =>
     u
       .combine('stage', kShortShaderStages)
-      .combine('format', kTestableColorFormats)
+      .combine('format', kAllTextureFormats)
       // MAINTENANCE_TODO: Update createTextureFromTexelViews to support stencil8 and remove this filter.
       .filter(t => t.format !== 'stencil8' && !isCompressedFloatTextureFormat(t.format))
       .combine('texture_type', ['texture_2d_array', 'texture_depth_2d_array'] as const)

--- a/src/webgpu/shader/execution/expression/call/builtin/textureSample.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureSample.spec.ts
@@ -11,9 +11,8 @@ import { makeTestGroup } from '../../../../../../common/framework/test_group.js'
 import {
   isDepthTextureFormat,
   isEncodableTextureFormat,
-  kCompressedTextureFormats,
   kDepthStencilFormats,
-  kEncodableTextureFormats,
+  kAllTextureFormats,
   textureDimensionAndFormatCompatible,
 } from '../../../../../format_info.js';
 import { TextureTestMixin } from '../../../../../gpu_test.js';
@@ -44,8 +43,6 @@ import {
   skipIfNeedsFilteringAndIsUnfilterable,
 } from './texture_utils.js';
 
-const kTestableColorFormats = [...kEncodableTextureFormats, ...kCompressedTextureFormats] as const;
-
 export const g = makeTestGroup(TextureTestMixin(WGSLTextureSampleTest));
 
 g.test('sampled_1d_coords')
@@ -62,7 +59,7 @@ Parameters:
   )
   .params(u =>
     u
-      .combine('format', kTestableColorFormats)
+      .combine('format', kAllTextureFormats)
       .filter(t => textureDimensionAndFormatCompatible('1d', t.format))
       .filter(t => isPotentiallyFilterableAndFillable(t.format))
       .combine('filt', ['nearest', 'linear'] as const)
@@ -151,7 +148,7 @@ Parameters:
   )
   .params(u =>
     u
-      .combine('format', kTestableColorFormats)
+      .combine('format', kAllTextureFormats)
       .filter(t => isPotentiallyFilterableAndFillable(t.format))
       .combine('filt', ['nearest', 'linear'] as const)
       .combine('modeU', kShortAddressModes)
@@ -249,7 +246,7 @@ Parameters:
   )
   .params(u =>
     u
-      .combine('format', kTestableColorFormats)
+      .combine('format', kAllTextureFormats)
       .filter(t => isPotentiallyFilterableAndFillable(t.format))
       .combine('dim', ['3d', 'cube'] as const)
       .filter(t => isSupportedViewFormatCombo(t.format, t.dim))
@@ -478,7 +475,7 @@ Parameters:
   )
   .params(u =>
     u
-      .combine('format', kTestableColorFormats)
+      .combine('format', kAllTextureFormats)
       .filter(t => isPotentiallyFilterableAndFillable(t.format))
       .combine('filt', ['nearest', 'linear'] as const)
       .combine('modeU', kShortAddressModes)
@@ -574,7 +571,7 @@ Parameters:
   )
   .params(u =>
     u
-      .combine('format', kTestableColorFormats)
+      .combine('format', kAllTextureFormats)
       .filter(t => isPotentiallyFilterableAndFillable(t.format))
       .combine('filt', ['nearest', 'linear'] as const)
       .combine('mode', kShortAddressModes)

--- a/src/webgpu/shader/execution/expression/call/builtin/textureSampleBias.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureSampleBias.spec.ts
@@ -8,7 +8,7 @@ Samples a texture with a bias to the mip level.
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
-import { kCompressedTextureFormats, kEncodableTextureFormats } from '../../../../../format_info.js';
+import { kAllTextureFormats } from '../../../../../format_info.js';
 import { TextureTestMixin } from '../../../../../gpu_test.js';
 
 import {
@@ -35,8 +35,6 @@ import {
   skipIfNeedsFilteringAndIsUnfilterable,
 } from './texture_utils.js';
 
-const kTestableColorFormats = [...kEncodableTextureFormats, ...kCompressedTextureFormats] as const;
-
 export const g = makeTestGroup(TextureTestMixin(WGSLTextureSampleTest));
 
 g.test('sampled_2d_coords')
@@ -61,7 +59,7 @@ Parameters:
   )
   .params(u =>
     u
-      .combine('format', kTestableColorFormats)
+      .combine('format', kAllTextureFormats)
       .filter(t => isPotentiallyFilterableAndFillable(t.format))
       .combine('filt', ['nearest', 'linear'] as const)
       .combine('modeU', kShortAddressModes)
@@ -159,7 +157,7 @@ Parameters:
   )
   .params(u =>
     u
-      .combine('format', kTestableColorFormats)
+      .combine('format', kAllTextureFormats)
       .filter(t => isPotentiallyFilterableAndFillable(t.format))
       .combine('dim', ['3d', 'cube'] as const)
       .filter(t => isSupportedViewFormatCombo(t.format, t.dim))
@@ -296,7 +294,7 @@ Parameters:
   )
   .params(u =>
     u
-      .combine('format', kTestableColorFormats)
+      .combine('format', kAllTextureFormats)
       .filter(t => isPotentiallyFilterableAndFillable(t.format))
       .combine('filt', ['nearest', 'linear'] as const)
       .combine('modeU', kShortAddressModes)
@@ -400,7 +398,7 @@ Parameters:
   )
   .params(u =>
     u
-      .combine('format', kTestableColorFormats)
+      .combine('format', kAllTextureFormats)
       .filter(t => isPotentiallyFilterableAndFillable(t.format))
       .combine('filt', ['nearest', 'linear'] as const)
       .combine('mode', kShortAddressModes)

--- a/src/webgpu/shader/execution/expression/call/builtin/textureSampleGrad.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureSampleGrad.spec.ts
@@ -6,7 +6,7 @@ Samples a texture using explicit gradients.
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
-import { kCompressedTextureFormats, kEncodableTextureFormats } from '../../../../../format_info.js';
+import { kAllTextureFormats } from '../../../../../format_info.js';
 
 import {
   appendComponentTypeForFormatToTextureType,
@@ -34,8 +34,6 @@ import {
   WGSLTextureSampleTest,
 } from './texture_utils.js';
 
-const kTestableColorFormats = [...kEncodableTextureFormats, ...kCompressedTextureFormats] as const;
-
 export const g = makeTestGroup(WGSLTextureSampleTest);
 
 g.test('sampled_2d_coords')
@@ -62,7 +60,7 @@ Parameters:
   .params(u =>
     u
       .combine('stage', kShortShaderStages)
-      .combine('format', kTestableColorFormats)
+      .combine('format', kAllTextureFormats)
       .filter(t => isPotentiallyFilterableAndFillable(t.format))
       .combine('filt', ['nearest', 'linear'] as const)
       .combine('modeU', kShortAddressModes)
@@ -161,7 +159,7 @@ Parameters:
   .params(u =>
     u
       .combine('stage', kShortShaderStages)
-      .combine('format', kTestableColorFormats)
+      .combine('format', kAllTextureFormats)
       .filter(t => isPotentiallyFilterableAndFillable(t.format))
       .combine('dim', ['3d', 'cube'] as const)
       .filter(t => isSupportedViewFormatCombo(t.format, t.dim))
@@ -301,7 +299,7 @@ Parameters:
   .params(u =>
     u
       .combine('stage', kShortShaderStages)
-      .combine('format', kTestableColorFormats)
+      .combine('format', kAllTextureFormats)
       .filter(t => isPotentiallyFilterableAndFillable(t.format))
       .combine('filt', ['nearest', 'linear'] as const)
       .combine('modeU', kShortAddressModes)
@@ -407,7 +405,7 @@ Parameters:
   .params(u =>
     u
       .combine('stage', kShortShaderStages)
-      .combine('format', kTestableColorFormats)
+      .combine('format', kAllTextureFormats)
       .filter(t => isPotentiallyFilterableAndFillable(t.format))
       .combine('filt', ['nearest', 'linear'] as const)
       .combine('mode', kShortAddressModes)

--- a/src/webgpu/shader/execution/expression/call/builtin/textureSampleLevel.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureSampleLevel.spec.ts
@@ -8,9 +8,8 @@ import { makeTestGroup } from '../../../../../../common/framework/test_group.js'
 import {
   isDepthTextureFormat,
   isEncodableTextureFormat,
-  kCompressedTextureFormats,
+  kAllTextureFormats,
   kDepthStencilFormats,
-  kEncodableTextureFormats,
 } from '../../../../../format_info.js';
 
 import {
@@ -39,8 +38,6 @@ import {
   vec3,
   WGSLTextureSampleTest,
 } from './texture_utils.js';
-
-const kTestableColorFormats = [...kEncodableTextureFormats, ...kCompressedTextureFormats] as const;
 
 export const g = makeTestGroup(WGSLTextureSampleTest);
 
@@ -71,7 +68,7 @@ Parameters:
   .params(u =>
     u
       .combine('stage', kShortShaderStages)
-      .combine('format', kTestableColorFormats)
+      .combine('format', kAllTextureFormats)
       .filter(t => isPotentiallyFilterableAndFillable(t.format))
       .combine('filt', ['nearest', 'linear'] as const)
       .combine('modeU', kShortAddressModes)
@@ -175,7 +172,7 @@ Parameters:
   .params(u =>
     u
       .combine('stage', kShortShaderStages)
-      .combine('format', kTestableColorFormats)
+      .combine('format', kAllTextureFormats)
       .filter(t => isPotentiallyFilterableAndFillable(t.format))
       .combine('filt', ['nearest', 'linear'] as const)
       .combine('modeU', kShortAddressModes)
@@ -283,7 +280,7 @@ Parameters:
   .params(u =>
     u
       .combine('stage', kShortShaderStages)
-      .combine('format', kTestableColorFormats)
+      .combine('format', kAllTextureFormats)
       .filter(t => isPotentiallyFilterableAndFillable(t.format))
       .combine('dim', ['3d', 'cube'] as const)
       .filter(t => isSupportedViewFormatCombo(t.format, t.dim))
@@ -416,7 +413,7 @@ Parameters:
   .params(u =>
     u
       .combine('stage', kShortShaderStages)
-      .combine('format', kTestableColorFormats)
+      .combine('format', kAllTextureFormats)
       .filter(t => isPotentiallyFilterableAndFillable(t.format))
       .combine('filt', ['nearest', 'linear'] as const)
       .combine('mode', kShortAddressModes)

--- a/src/webgpu/util/texture.ts
+++ b/src/webgpu/util/texture.ts
@@ -319,24 +319,26 @@ function copyBufferToTextureViaRender(
   t: GPUTest,
   encoder: GPUCommandEncoder,
   source: GPUImageCopyBuffer,
+  sourceFormat: GPUTextureFormat,
   dest: GPUImageCopyTexture,
   size: GPUExtent3D
 ) {
-  const { format, sampleCount } = dest.texture;
+  const { format: textureFormat, sampleCount } = dest.texture;
   const origin = reifyOrigin3D(dest.origin ?? [0]);
   const copySize = reifyExtent3D(size);
 
-  const msInfo = kLoadValueFromStorageInfo[format];
+  const msInfo = kLoadValueFromStorageInfo[sourceFormat];
   assert(!!msInfo);
   const { useFragDepth, discardWithStencil } = msInfo;
 
   const { device } = t;
   const numBlits = discardWithStencil ? 8 : 1;
   for (let blitCount = 0; blitCount < numBlits; ++blitCount) {
-    const code = getCopyBufferToTextureViaRenderCode(format);
+    const code = getCopyBufferToTextureViaRenderCode(sourceFormat);
     const stencilWriteMask = 1 << blitCount;
     const id = JSON.stringify({
-      format,
+      textureFormat,
+      sourceFormat,
       useFragDepth,
       stencilWriteMask,
       discardWithStencil,
@@ -350,7 +352,7 @@ function copyBufferToTextureViaRender(
     if (!pipeline) {
       const module = device.createShaderModule({ code });
       pipeline = device.createRenderPipeline({
-        label: `blitCopyFor-${format}`,
+        label: `blitCopyFor-${textureFormat}`,
         layout: 'auto',
         vertex: { module },
         ...(discardWithStencil
@@ -362,7 +364,7 @@ function copyBufferToTextureViaRender(
               depthStencil: {
                 depthWriteEnabled: false,
                 depthCompare: 'always',
-                format,
+                format: textureFormat,
                 stencilWriteMask,
                 stencilFront: {
                   passOp: 'replace',
@@ -378,13 +380,13 @@ function copyBufferToTextureViaRender(
               depthStencil: {
                 depthWriteEnabled: true,
                 depthCompare: 'always',
-                format,
+                format: textureFormat,
               },
             }
           : {
               fragment: {
                 module,
-                targets: [{ format }],
+                targets: [{ format: textureFormat }],
               },
             }),
         primitive: {
@@ -395,7 +397,7 @@ function copyBufferToTextureViaRender(
       pipelines.set(id, pipeline);
     }
 
-    const info = kTextureFormatInfo[format];
+    const info = kTextureFormatInfo[sourceFormat];
     const uniforms = new Uint32Array([
       copySize.height, //  numTexelRows: u32,
       source.bytesPerRow!, //  bytesPerRow: u32,
@@ -445,6 +447,7 @@ function copyBufferToTextureViaRender(
                 depthClearValue: 0,
                 depthLoadOp: 'clear',
                 depthStoreOp: 'store',
+                stencilReadOnly: true,
               },
             }
           : {
@@ -490,17 +493,19 @@ function copyBufferToTextureViaRender(
 export function createTextureFromTexelViews(
   t: GPUTest,
   texelViews: TexelView[],
-  desc: Omit<GPUTextureDescriptor, 'format'>
+  desc: Omit<GPUTextureDescriptor, 'format'> & { format?: GPUTextureFormat }
 ): GPUTexture {
   // All texel views must be the same format for mipmaps.
   assert(texelViews.length > 0 && texelViews.every(e => e.format === texelViews[0].format));
-  const format = texelViews[0].format;
+  const viewsFormat = texelViews[0].format;
+  const textureFormat = desc.format ?? viewsFormat;
+  const isTextureFormatDifferentThanTexelViewFormat = textureFormat !== viewsFormat;
   const { width, height, depthOrArrayLayers } = reifyExtent3D(desc.size);
 
   // Create the texture and then initialize each mipmap level separately.
   const texture = t.createTextureTracked({
     ...desc,
-    format,
+    format: textureFormat,
     usage: desc.usage | GPUTextureUsage.COPY_DST,
     mipLevelCount: texelViews.length,
   });
@@ -513,9 +518,14 @@ export function createTextureFromTexelViews(
       bytesPerRow,
       rowsPerImage,
       mipSize: [mipWidth, mipHeight, mipDepthOrArray],
-    } = getTextureCopyLayout(format, desc.dimension ?? '2d', [width, height, depthOrArrayLayers], {
-      mipLevel,
-    });
+    } = getTextureCopyLayout(
+      viewsFormat,
+      desc.dimension ?? '2d',
+      [width, height, depthOrArrayLayers],
+      {
+        mipLevel,
+      }
+    );
 
     // Create a staging buffer to upload the texture mip level contents.
     const stagingBuffer = t.createBufferTracked({
@@ -535,11 +545,16 @@ export function createTextureFromTexelViews(
     });
     stagingBuffer.unmap();
 
-    if (texture.sampleCount > 1 || isDepthOrStencilTextureFormat(format)) {
+    if (
+      isTextureFormatDifferentThanTexelViewFormat ||
+      texture.sampleCount > 1 ||
+      isDepthOrStencilTextureFormat(textureFormat)
+    ) {
       copyBufferToTextureViaRender(
         t,
         commandEncoder,
         { buffer: stagingBuffer, bytesPerRow, rowsPerImage },
+        viewsFormat,
         { texture, mipLevel },
         [mipWidth, mipHeight, mipDepthOrArray]
       );


### PR DESCRIPTION

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [X] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
