### PR TITLE
Fix textureSample:sampled_2d_coords offset

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/textureSample.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureSample.spec.ts
@@ -190,7 +190,7 @@ Parameters:
       method: samplePoints,
       descriptor,
       derivatives: true,
-      offset: true,
+      offset,
       hashInputs: [format, samplePoints, modeU, modeV, minFilter, offset],
     }).map(({ coords, derivativeMult, offset }) => {
       return {


### PR DESCRIPTION
textureSample:sampled_2d_coords had offset always on


