### PR TITLE
skip in_render_misc related tests for compat mode

### DIFF
--- a/src/webgpu/api/validation/resource_usages/texture/in_render_misc.spec.ts
+++ b/src/webgpu/api/validation/resource_usages/texture/in_render_misc.spec.ts
@@ -89,6 +89,12 @@ g.test('subresources,set_bind_group_on_same_index_color_texture')
       .combine('view1Binding', kTextureBindingTypes)
       .combine('view2Binding', kTextureBindingTypes)
   )
+  .beforeAllSubcases(t => {
+    t.skipIf(
+      t.isCompatibility,
+      'texture views used in bindgroups must consist of the entire array in compatibility mode. textureView0 does not fit.'
+    );
+  })
   .fn(t => {
     const { useDifferentTextureAsTexture2, baseLayer2, view1Binding, view2Binding } = t.params;
 
@@ -232,6 +238,12 @@ g.test('subresources,set_unused_bind_group')
       .combine('textureUsage0', kTextureBindingTypes)
       .combine('textureUsage1', kTextureBindingTypes)
   )
+  .beforeAllSubcases(t => {
+    t.skipIf(
+      t.isCompatibility,
+      'texture views used in bindgroups must consist of the entire array in compatibility mode. textureView0 does not fit.'
+    );
+  })
   .fn(t => {
     const { inRenderPass, textureUsage0, textureUsage1 } = t.params;
 


### PR DESCRIPTION


Issue: https://crbug.com/367440985

(I must messed this with `in_render_common`, so I thought I've fixed that but didn't)

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
