### PR TITLE
Stop trying to filter sint/uint formats.

### DIFF
--- a/src/webgpu/format_info.ts
+++ b/src/webgpu/format_info.ts
@@ -1793,6 +1793,11 @@ export function canUseAsRenderTarget(format: GPUTextureFormat) {
   return kTextureFormatInfo[format].colorRender || isDepthOrStencilTextureFormat(format);
 }
 
+export function isFilterable(format: GPUTextureFormat) {
+  const info = kTextureFormatInfo[format];
+  return info.color?.type === 'float';
+}
+
 export const kCompatModeUnsupportedStorageTextureFormats: readonly GPUTextureFormat[] = [
   'rg32float',
   'rg32sint',

--- a/src/webgpu/shader/execution/expression/call/builtin/textureGather.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureGather.spec.ts
@@ -28,6 +28,7 @@ import { makeTestGroup } from '../../../../../../common/framework/test_group.js'
 import {
   isDepthTextureFormat,
   isEncodableTextureFormat,
+  isFilterable,
   kDepthStencilFormats,
   kAllTextureFormats,
 } from '../../../../../format_info.js';
@@ -87,6 +88,7 @@ Parameters:
       .combine('format', kAllTextureFormats)
       .filter(t => isFillable(t.format))
       .combine('filt', ['nearest', 'linear'] as const)
+      .filter(t => t.filt === 'nearest' || isFilterable(t.format))
       .combine('modeU', kShortAddressModes)
       .combine('modeV', kShortAddressModes)
       .combine('offset', [false, true] as const)
@@ -184,6 +186,7 @@ Parameters:
       .combine('format', kAllTextureFormats)
       .filter(t => isFillable(t.format))
       .combine('filt', ['nearest', 'linear'] as const)
+      .filter(t => t.filt === 'nearest' || isFilterable(t.format))
       .combine('mode', kShortAddressModes)
       .beginSubcases()
       .combine('C', ['i32', 'u32'] as const)
@@ -292,6 +295,7 @@ Parameters:
       .combine('format', kAllTextureFormats)
       .filter(t => isFillable(t.format))
       .combine('filt', ['nearest', 'linear'] as const)
+      .filter(t => t.filt === 'nearest' || isFilterable(t.format))
       .combine('modeU', kShortAddressModes)
       .combine('modeV', kShortAddressModes)
       .combine('offset', [false, true] as const)
@@ -398,6 +402,7 @@ Parameters:
       .combine('format', kAllTextureFormats)
       .filter(t => isFillable(t.format))
       .combine('filt', ['nearest', 'linear'] as const)
+      .filter(t => t.filt === 'nearest' || isFilterable(t.format))
       .combine('mode', kShortAddressModes)
       .beginSubcases()
       .combine('samplePoints', kCubeSamplePointMethods)

--- a/src/webgpu/shader/execution/expression/call/builtin/textureGatherCompare.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureGatherCompare.spec.ts
@@ -76,7 +76,6 @@ Parameters:
       .filter(t => isDepthTextureFormat(t.format))
       // MAINTENANCE_TODO: Remove when support for depth24plus, depth24plus-stencil8, and depth32float-stencil8 is added.
       .filter(t => isEncodableTextureFormat(t.format))
-      .combine('filt', ['nearest', 'linear'] as const)
       .combine('modeU', kShortAddressModes)
       .combine('modeV', kShortAddressModes)
       .combine('offset', [false, true] as const)
@@ -89,17 +88,7 @@ Parameters:
     t.skipIfTextureFormatNotSupported(t.params.format);
   })
   .fn(async t => {
-    const {
-      format,
-      stage,
-      samplePoints,
-      A,
-      modeU,
-      modeV,
-      filt: minFilter,
-      compare,
-      offset,
-    } = t.params;
+    const { format, stage, samplePoints, A, modeU, modeV, compare, offset } = t.params;
 
     const viewDimension = '2d-array';
     const size = chooseTextureSize({ minSize: 8, minBlocks: 4, format, viewDimension });
@@ -116,9 +105,6 @@ Parameters:
       addressModeU: kShortAddressModeToAddressMode[modeU],
       addressModeV: kShortAddressModeToAddressMode[modeV],
       compare,
-      minFilter,
-      magFilter: minFilter,
-      mipmapFilter: minFilter,
     };
 
     const calls: TextureCall<vec2>[] = generateTextureBuiltinInputs2D(50, {
@@ -129,7 +115,7 @@ Parameters:
       arrayIndex: { num: texture.depthOrArrayLayers, type: A },
       depthRef: true,
       offset,
-      hashInputs: [stage, format, samplePoints, A, modeU, modeV, minFilter, offset],
+      hashInputs: [stage, format, samplePoints, A, modeU, modeV, offset],
     }).map(({ coords, arrayIndex, depthRef, offset }) => {
       return {
         builtin: 'textureGatherCompare',
@@ -189,7 +175,6 @@ Parameters:
       .filter(t => isDepthTextureFormat(t.format))
       // MAINTENANCE_TODO: Remove when support for depth24plus, depth24plus-stencil8, and depth32float-stencil8 is added.
       .filter(t => isEncodableTextureFormat(t.format))
-      .combine('filt', ['nearest', 'linear'] as const)
       .combine('mode', kShortAddressModes)
       .beginSubcases()
       .combine('samplePoints', kCubeSamplePointMethods)
@@ -200,7 +185,7 @@ Parameters:
     t.skipIfTextureViewDimensionNotSupported('cube-array');
   })
   .fn(async t => {
-    const { format, A, stage, samplePoints, mode, filt: minFilter, compare } = t.params;
+    const { format, A, stage, samplePoints, mode, compare } = t.params;
 
     const viewDimension: GPUTextureViewDimension = 'cube-array';
     const size = chooseTextureSize({ minSize: 8, minBlocks: 2, format, viewDimension });
@@ -219,9 +204,6 @@ Parameters:
       addressModeV: kShortAddressModeToAddressMode[mode],
       addressModeW: kShortAddressModeToAddressMode[mode],
       compare,
-      minFilter,
-      magFilter: minFilter,
-      mipmapFilter: minFilter,
     };
 
     const calls: TextureCall<vec3>[] = generateSamplePointsCube(50, {
@@ -231,7 +213,7 @@ Parameters:
       textureBuiltin: 'textureGatherCompare',
       arrayIndex: { num: texture.depthOrArrayLayers / 6, type: A },
       depthRef: true,
-      hashInputs: [stage, format, samplePoints, mode, minFilter],
+      hashInputs: [stage, format, samplePoints, mode],
     }).map(({ coords, depthRef, arrayIndex }) => {
       return {
         builtin: 'textureGatherCompare',
@@ -296,7 +278,6 @@ Parameters:
       .filter(t => isDepthTextureFormat(t.format))
       // MAINTENANCE_TODO: Remove when support for depth24plus, depth24plus-stencil8, and depth32float-stencil8 is added.
       .filter(t => isEncodableTextureFormat(t.format))
-      .combine('filt', ['nearest', 'linear'] as const)
       .combine('mode', kShortAddressModes)
       .combine('offset', [false, true] as const)
       .beginSubcases()
@@ -305,7 +286,7 @@ Parameters:
       .combine('compare', kCompareFunctions)
   )
   .fn(async t => {
-    const { format, C, stage, samplePoints, mode, compare, filt: minFilter, offset } = t.params;
+    const { format, C, stage, samplePoints, mode, compare, offset } = t.params;
 
     const size = chooseTextureSize({ minSize: 8, minBlocks: 4, format });
     const descriptor: GPUTextureDescriptor = {
@@ -320,9 +301,6 @@ Parameters:
       addressModeU: kShortAddressModeToAddressMode[mode],
       addressModeV: kShortAddressModeToAddressMode[mode],
       compare,
-      minFilter,
-      magFilter: minFilter,
-      mipmapFilter: minFilter,
     };
 
     const calls: TextureCall<vec2>[] = generateTextureBuiltinInputs2D(50, {
@@ -332,7 +310,7 @@ Parameters:
       descriptor,
       offset,
       depthRef: true,
-      hashInputs: [stage, format, C, samplePoints, mode, minFilter, compare, offset],
+      hashInputs: [stage, format, C, samplePoints, mode, compare, offset],
     }).map(({ coords, depthRef, offset }) => {
       return {
         builtin: 'textureGatherCompare',
@@ -387,14 +365,13 @@ Parameters:
       .filter(t => isDepthTextureFormat(t.format))
       // MAINTENANCE_TODO: Remove when support for depth24plus, depth24plus-stencil8, and depth32float-stencil8 is added.
       .filter(t => isEncodableTextureFormat(t.format))
-      .combine('filt', ['nearest', 'linear'] as const)
       .combine('mode', kShortAddressModes)
       .beginSubcases()
       .combine('samplePoints', kCubeSamplePointMethods)
       .combine('compare', kCompareFunctions)
   )
   .fn(async t => {
-    const { format, stage, samplePoints, mode, filt: minFilter, compare } = t.params;
+    const { format, stage, samplePoints, mode, compare } = t.params;
 
     const viewDimension: GPUTextureViewDimension = 'cube';
     const size = chooseTextureSize({ minSize: 8, minBlocks: 2, format, viewDimension });
@@ -413,9 +390,6 @@ Parameters:
       addressModeV: kShortAddressModeToAddressMode[mode],
       addressModeW: kShortAddressModeToAddressMode[mode],
       compare,
-      minFilter,
-      magFilter: minFilter,
-      mipmapFilter: minFilter,
     };
 
     const calls: TextureCall<vec3>[] = generateSamplePointsCube(50, {
@@ -424,7 +398,7 @@ Parameters:
       descriptor,
       depthRef: true,
       textureBuiltin: 'textureGatherCompare',
-      hashInputs: [stage, format, samplePoints, mode, minFilter, compare],
+      hashInputs: [stage, format, samplePoints, mode, compare],
     }).map(({ coords, depthRef }) => {
       return {
         builtin: 'textureGatherCompare',


### PR DESCRIPTION
The CTS was incorrectly testing textureGather/Compare with sint/uint textures with filtering samplers. Dawn was not catching this error (bug in Dawn) so we didn't notice this invalid usage.