### PR TITLE
Fix fragment shader subgroup builtin io test

### DIFF
--- a/src/webgpu/shader/execution/shader_io/fragment_builtins.spec.ts
+++ b/src/webgpu/shader/execution/shader_io/fragment_builtins.spec.ts
@@ -1537,7 +1537,7 @@ function checkSubgroupSizeConsistency(
  * @param height The framebuffer height
  * @param checker A functor to check the framebuffer values
  */
- async function runSubgroupTest(
+async function runSubgroupTest(
   t: FragmentBuiltinTest,
   format: GPUTextureFormat,
   fsShader: string,
@@ -1818,7 +1818,7 @@ fn fsMain(
   var repId = atomicAdd(&counter, 1);
   repId = subgroupBroadcast(repId, 0);
 
-  return vec4u(id, ballotSize, repId, 0);
+  return vec4u(id, sg_size, ballotSize, repId);
 }`;
 
     await runSubgroupTest(

--- a/src/webgpu/shader/execution/shader_io/fragment_builtins.spec.ts
+++ b/src/webgpu/shader/execution/shader_io/fragment_builtins.spec.ts
@@ -1742,6 +1742,12 @@ function checkSubgroupInvocationIdConsistency(
       const repId = data[offset + 3];
 
       if (repId === 0) {
+        // repId of 0 indicates inactivate fragment, and all output should be zero.
+        if ((id !== 0) || (sgSize !== 0) || (ballotSize !== 0)) {
+          return new Error(
+            `Unexpected zero repId with non-zero outputs for (${row}, ${col}): got output [${id}, ${sgSize}, ${ballotSize}, ${repId}]`
+          );
+        }
         continue;
       }
 


### PR DESCRIPTION
This PR fix the expectation of fragment shader `subgroup_invocation_id`, which can be assigned to inactivate invocations between active ones and therefore go larger than active subgroup invocations number but still smaller than subgroup size. This PR also fix the draw call for fragment subgroup tests. With this PR, tests can passed on Intel devices.