### PR TITLE
Re-enable linear with comparisons.

### DIFF
--- a/src/webgpu/format_info.ts
+++ b/src/webgpu/format_info.ts
@@ -1793,9 +1793,21 @@ export function canUseAsRenderTarget(format: GPUTextureFormat) {
   return kTextureFormatInfo[format].colorRender || isDepthOrStencilTextureFormat(format);
 }
 
-export function isFilterable(format: GPUTextureFormat) {
+export function is32Float(format: GPUTextureFormat) {
+  return format === 'r32float' || format === 'rg32float' || format === 'rgba32float';
+}
+
+/**
+ * Returns true if texture is filterable as `texture_xxx<f32>`
+ *
+ * examples:
+ * * 'rgba8unorm' -> true
+ * * 'depth16unorm' -> false
+ * * 'rgba32float' -> true (you need to enable feature 'float32-filterable')
+ */
+export function isFilterableAsTextureF32(format: GPUTextureFormat) {
   const info = kTextureFormatInfo[format];
-  return info.color?.type === 'float';
+  return info.color?.type === 'float' || is32Float(format);
 }
 
 export const kCompatModeUnsupportedStorageTextureFormats: readonly GPUTextureFormat[] = [

--- a/src/webgpu/shader/execution/expression/call/builtin/textureGather.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureGather.spec.ts
@@ -28,7 +28,7 @@ import { makeTestGroup } from '../../../../../../common/framework/test_group.js'
 import {
   isDepthTextureFormat,
   isEncodableTextureFormat,
-  isFilterable,
+  isFilterableAsTextureF32,
   kDepthStencilFormats,
   kAllTextureFormats,
 } from '../../../../../format_info.js';
@@ -88,7 +88,7 @@ Parameters:
       .combine('format', kAllTextureFormats)
       .filter(t => isFillable(t.format))
       .combine('filt', ['nearest', 'linear'] as const)
-      .filter(t => t.filt === 'nearest' || isFilterable(t.format))
+      .filter(t => t.filt === 'nearest' || isFilterableAsTextureF32(t.format))
       .combine('modeU', kShortAddressModes)
       .combine('modeV', kShortAddressModes)
       .combine('offset', [false, true] as const)
@@ -186,7 +186,7 @@ Parameters:
       .combine('format', kAllTextureFormats)
       .filter(t => isFillable(t.format))
       .combine('filt', ['nearest', 'linear'] as const)
-      .filter(t => t.filt === 'nearest' || isFilterable(t.format))
+      .filter(t => t.filt === 'nearest' || isFilterableAsTextureF32(t.format))
       .combine('mode', kShortAddressModes)
       .beginSubcases()
       .combine('C', ['i32', 'u32'] as const)
@@ -295,7 +295,7 @@ Parameters:
       .combine('format', kAllTextureFormats)
       .filter(t => isFillable(t.format))
       .combine('filt', ['nearest', 'linear'] as const)
-      .filter(t => t.filt === 'nearest' || isFilterable(t.format))
+      .filter(t => t.filt === 'nearest' || isFilterableAsTextureF32(t.format))
       .combine('modeU', kShortAddressModes)
       .combine('modeV', kShortAddressModes)
       .combine('offset', [false, true] as const)
@@ -402,7 +402,7 @@ Parameters:
       .combine('format', kAllTextureFormats)
       .filter(t => isFillable(t.format))
       .combine('filt', ['nearest', 'linear'] as const)
-      .filter(t => t.filt === 'nearest' || isFilterable(t.format))
+      .filter(t => t.filt === 'nearest' || isFilterableAsTextureF32(t.format))
       .combine('mode', kShortAddressModes)
       .beginSubcases()
       .combine('samplePoints', kCubeSamplePointMethods)

--- a/src/webgpu/shader/execution/expression/call/builtin/textureGatherCompare.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureGatherCompare.spec.ts
@@ -76,6 +76,7 @@ Parameters:
       .filter(t => isDepthTextureFormat(t.format))
       // MAINTENANCE_TODO: Remove when support for depth24plus, depth24plus-stencil8, and depth32float-stencil8 is added.
       .filter(t => isEncodableTextureFormat(t.format))
+      .combine('filt', ['nearest', 'linear'] as const)
       .combine('modeU', kShortAddressModes)
       .combine('modeV', kShortAddressModes)
       .combine('offset', [false, true] as const)
@@ -88,7 +89,17 @@ Parameters:
     t.skipIfTextureFormatNotSupported(t.params.format);
   })
   .fn(async t => {
-    const { format, stage, samplePoints, A, modeU, modeV, compare, offset } = t.params;
+    const {
+      format,
+      stage,
+      samplePoints,
+      A,
+      modeU,
+      modeV,
+      filt: minFilter,
+      compare,
+      offset,
+    } = t.params;
 
     const viewDimension = '2d-array';
     const size = chooseTextureSize({ minSize: 8, minBlocks: 4, format, viewDimension });
@@ -105,6 +116,9 @@ Parameters:
       addressModeU: kShortAddressModeToAddressMode[modeU],
       addressModeV: kShortAddressModeToAddressMode[modeV],
       compare,
+      minFilter,
+      magFilter: minFilter,
+      mipmapFilter: minFilter,
     };
 
     const calls: TextureCall<vec2>[] = generateTextureBuiltinInputs2D(50, {
@@ -115,7 +129,7 @@ Parameters:
       arrayIndex: { num: texture.depthOrArrayLayers, type: A },
       depthRef: true,
       offset,
-      hashInputs: [stage, format, samplePoints, A, modeU, modeV, offset],
+      hashInputs: [stage, format, samplePoints, A, modeU, modeV, minFilter, offset],
     }).map(({ coords, arrayIndex, depthRef, offset }) => {
       return {
         builtin: 'textureGatherCompare',
@@ -175,6 +189,7 @@ Parameters:
       .filter(t => isDepthTextureFormat(t.format))
       // MAINTENANCE_TODO: Remove when support for depth24plus, depth24plus-stencil8, and depth32float-stencil8 is added.
       .filter(t => isEncodableTextureFormat(t.format))
+      .combine('filt', ['nearest', 'linear'] as const)
       .combine('mode', kShortAddressModes)
       .beginSubcases()
       .combine('samplePoints', kCubeSamplePointMethods)
@@ -185,7 +200,7 @@ Parameters:
     t.skipIfTextureViewDimensionNotSupported('cube-array');
   })
   .fn(async t => {
-    const { format, A, stage, samplePoints, mode, compare } = t.params;
+    const { format, A, stage, samplePoints, mode, filt: minFilter, compare } = t.params;
 
     const viewDimension: GPUTextureViewDimension = 'cube-array';
     const size = chooseTextureSize({ minSize: 8, minBlocks: 2, format, viewDimension });
@@ -204,6 +219,9 @@ Parameters:
       addressModeV: kShortAddressModeToAddressMode[mode],
       addressModeW: kShortAddressModeToAddressMode[mode],
       compare,
+      minFilter,
+      magFilter: minFilter,
+      mipmapFilter: minFilter,
     };
 
     const calls: TextureCall<vec3>[] = generateSamplePointsCube(50, {
@@ -213,7 +231,7 @@ Parameters:
       textureBuiltin: 'textureGatherCompare',
       arrayIndex: { num: texture.depthOrArrayLayers / 6, type: A },
       depthRef: true,
-      hashInputs: [stage, format, samplePoints, mode],
+      hashInputs: [stage, format, samplePoints, mode, minFilter],
     }).map(({ coords, depthRef, arrayIndex }) => {
       return {
         builtin: 'textureGatherCompare',
@@ -278,6 +296,7 @@ Parameters:
       .filter(t => isDepthTextureFormat(t.format))
       // MAINTENANCE_TODO: Remove when support for depth24plus, depth24plus-stencil8, and depth32float-stencil8 is added.
       .filter(t => isEncodableTextureFormat(t.format))
+      .combine('filt', ['nearest', 'linear'] as const)
       .combine('mode', kShortAddressModes)
       .combine('offset', [false, true] as const)
       .beginSubcases()
@@ -286,7 +305,7 @@ Parameters:
       .combine('compare', kCompareFunctions)
   )
   .fn(async t => {
-    const { format, C, stage, samplePoints, mode, compare, offset } = t.params;
+    const { format, C, stage, samplePoints, mode, compare, filt: minFilter, offset } = t.params;
 
     const size = chooseTextureSize({ minSize: 8, minBlocks: 4, format });
     const descriptor: GPUTextureDescriptor = {
@@ -301,6 +320,9 @@ Parameters:
       addressModeU: kShortAddressModeToAddressMode[mode],
       addressModeV: kShortAddressModeToAddressMode[mode],
       compare,
+      minFilter,
+      magFilter: minFilter,
+      mipmapFilter: minFilter,
     };
 
     const calls: TextureCall<vec2>[] = generateTextureBuiltinInputs2D(50, {
@@ -310,7 +332,7 @@ Parameters:
       descriptor,
       offset,
       depthRef: true,
-      hashInputs: [stage, format, C, samplePoints, mode, compare, offset],
+      hashInputs: [stage, format, C, samplePoints, mode, minFilter, compare, offset],
     }).map(({ coords, depthRef, offset }) => {
       return {
         builtin: 'textureGatherCompare',
@@ -365,13 +387,14 @@ Parameters:
       .filter(t => isDepthTextureFormat(t.format))
       // MAINTENANCE_TODO: Remove when support for depth24plus, depth24plus-stencil8, and depth32float-stencil8 is added.
       .filter(t => isEncodableTextureFormat(t.format))
+      .combine('filt', ['nearest', 'linear'] as const)
       .combine('mode', kShortAddressModes)
       .beginSubcases()
       .combine('samplePoints', kCubeSamplePointMethods)
       .combine('compare', kCompareFunctions)
   )
   .fn(async t => {
-    const { format, stage, samplePoints, mode, compare } = t.params;
+    const { format, stage, samplePoints, mode, filt: minFilter, compare } = t.params;
 
     const viewDimension: GPUTextureViewDimension = 'cube';
     const size = chooseTextureSize({ minSize: 8, minBlocks: 2, format, viewDimension });
@@ -390,6 +413,9 @@ Parameters:
       addressModeV: kShortAddressModeToAddressMode[mode],
       addressModeW: kShortAddressModeToAddressMode[mode],
       compare,
+      minFilter,
+      magFilter: minFilter,
+      mipmapFilter: minFilter,
     };
 
     const calls: TextureCall<vec3>[] = generateSamplePointsCube(50, {
@@ -398,7 +424,7 @@ Parameters:
       descriptor,
       depthRef: true,
       textureBuiltin: 'textureGatherCompare',
-      hashInputs: [stage, format, samplePoints, mode, compare],
+      hashInputs: [stage, format, samplePoints, mode, minFilter, compare],
     }).map(({ coords, depthRef }) => {
       return {
         builtin: 'textureGatherCompare',

--- a/src/webgpu/shader/execution/expression/call/builtin/texture_utils.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/texture_utils.ts
@@ -3,6 +3,7 @@ import { assert, range, unreachable } from '../../../../../../common/util/util.j
 import { Float16Array } from '../../../../../../external/petamoriken/float16/float16.js';
 import {
   EncodableTextureFormat,
+  is32Float,
   isCompressedFloatTextureFormat,
   isCompressedTextureFormat,
   isDepthOrStencilTextureFormat,
@@ -106,9 +107,6 @@ export function getTextureTypeForTextureViewDimension(viewDimension: GPUTextureV
       unreachable();
   }
 }
-
-const is32Float = (format: GPUTextureFormat) =>
-  format === 'r32float' || format === 'rg32float' || format === 'rgba32float';
 
 const isUnencodableDepthFormat = (format: GPUTextureFormat) =>
   format === 'depth24plus' ||
@@ -4729,12 +4727,11 @@ ${stageWGSL}
   }
 
   if (sampler) {
+    const type = isCompare ? 'comparison' : isFiltering ? 'filtering' : 'non-filtering';
     entries.push({
       binding: 1,
       visibility,
-      sampler: {
-        type: isCompare ? 'comparison' : isFiltering ? 'filtering' : 'non-filtering',
-      },
+      sampler: { type },
     });
   }
 


### PR DESCRIPTION
It's a little confusing but depth textures used for "sampling" are not filterable but used for "comparisons" they are.

|                               | texture_?d<f32> with depth texture | texture_depth_?? |
| ----------------------------- | ---------------------------------- | ---------------- |
| sampler `'linear'`            |                bad                 |      bad         |
| sampler_comparison `'linear'` |                N/A                 |      OK          |

