### PR TITLE
Don't test texture_depth_xxx with linear

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/textureGather.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureGather.spec.ts
@@ -27,7 +27,6 @@ A texture gather operation reads from a 2D, 2D array, cube, or cube array textur
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import {
   isDepthTextureFormat,
-  isEncodableTextureFormat,
   isFilterableAsTextureF32,
   kDepthStencilFormats,
   kAllTextureFormats,
@@ -507,17 +506,15 @@ Parameters:
       .combine('format', kDepthStencilFormats)
       // filter out stencil only formats
       .filter(t => isDepthTextureFormat(t.format))
-      // MAINTENANCE_TODO: Remove when support for depth24plus, depth24plus-stencil8, and depth32float-stencil8 is added.
-      .filter(t => isEncodableTextureFormat(t.format))
-      .combine('filt', ['nearest', 'linear'] as const)
       .combine('modeU', kShortAddressModes)
       .combine('modeV', kShortAddressModes)
       .combine('offset', [false, true] as const)
       .beginSubcases()
       .combine('samplePoints', kSamplePointMethods)
   )
+  .beforeAllSubcases(t => t.selectDeviceForTextureFormatOrSkipTestCase(t.params.format))
   .fn(async t => {
-    const { format, stage, samplePoints, modeU, modeV, filt: minFilter, offset } = t.params;
+    const { format, stage, samplePoints, modeU, modeV, offset } = t.params;
 
     // We want at least 4 blocks or something wide enough for 3 mip levels.
     const [width, height] = chooseTextureSize({ minSize: 8, minBlocks: 4, format });
@@ -531,9 +528,6 @@ Parameters:
     const sampler: GPUSamplerDescriptor = {
       addressModeU: kShortAddressModeToAddressMode[modeU],
       addressModeV: kShortAddressModeToAddressMode[modeV],
-      minFilter,
-      magFilter: minFilter,
-      mipmapFilter: minFilter,
     };
 
     const calls: TextureCall<vec2>[] = generateTextureBuiltinInputs2D(50, {
@@ -542,7 +536,7 @@ Parameters:
       sampler,
       descriptor,
       offset,
-      hashInputs: [stage, format, samplePoints, modeU, modeV, minFilter, offset],
+      hashInputs: [stage, format, samplePoints, modeU, modeV, offset],
     }).map(({ coords, offset }) => {
       return {
         builtin: 'textureGather',
@@ -593,15 +587,13 @@ Parameters:
       .combine('format', kDepthStencilFormats)
       // filter out stencil only formats
       .filter(t => isDepthTextureFormat(t.format))
-      // MAINTENANCE_TODO: Remove when support for depth24plus, depth24plus-stencil8, and depth32float-stencil8 is added.
-      .filter(t => isEncodableTextureFormat(t.format))
-      .combine('filt', ['nearest', 'linear'] as const)
       .combine('mode', kShortAddressModes)
       .beginSubcases()
       .combine('samplePoints', kCubeSamplePointMethods)
   )
+  .beforeAllSubcases(t => t.selectDeviceForTextureFormatOrSkipTestCase(t.params.format))
   .fn(async t => {
-    const { format, stage, samplePoints, mode, filt: minFilter } = t.params;
+    const { format, stage, samplePoints, mode } = t.params;
 
     const viewDimension: GPUTextureViewDimension = 'cube';
     const [width, height] = chooseTextureSize({ minSize: 8, minBlocks: 2, format, viewDimension });
@@ -619,9 +611,6 @@ Parameters:
       addressModeU: kShortAddressModeToAddressMode[mode],
       addressModeV: kShortAddressModeToAddressMode[mode],
       addressModeW: kShortAddressModeToAddressMode[mode],
-      minFilter,
-      magFilter: minFilter,
-      mipmapFilter: minFilter,
     };
 
     const calls: TextureCall<vec3>[] = generateSamplePointsCube(50, {
@@ -629,7 +618,7 @@ Parameters:
       sampler,
       descriptor,
       textureBuiltin: 'textureGather',
-      hashInputs: [stage, format, samplePoints, mode, minFilter],
+      hashInputs: [stage, format, samplePoints, mode],
     }).map(({ coords, component }) => {
       return {
         builtin: 'textureGather',
@@ -691,9 +680,6 @@ Parameters:
       .combine('format', kDepthStencilFormats)
       // filter out stencil only formats
       .filter(t => isDepthTextureFormat(t.format))
-      // MAINTENANCE_TODO: Remove when support for depth24plus, depth24plus-stencil8, and depth32float-stencil8 is added.
-      .filter(t => isEncodableTextureFormat(t.format))
-      .combine('filt', ['nearest', 'linear'] as const)
       .combine('modeU', kShortAddressModes)
       .combine('modeV', kShortAddressModes)
       .combine('offset', [false, true] as const)
@@ -703,10 +689,10 @@ Parameters:
   )
   .beforeAllSubcases(t => {
     t.skipIfTextureFormatNotSupported(t.params.format);
-    skipIfNeedsFilteringAndIsUnfilterableOrSelectDevice(t, t.params.filt, t.params.format);
+    t.selectDeviceForTextureFormatOrSkipTestCase(t.params.format);
   })
   .fn(async t => {
-    const { format, stage, samplePoints, A, modeU, modeV, filt: minFilter, offset } = t.params;
+    const { format, stage, samplePoints, A, modeU, modeV, offset } = t.params;
 
     // We want at least 4 blocks or something wide enough for 3 mip levels.
     const [width, height] = chooseTextureSize({ minSize: 8, minBlocks: 4, format });
@@ -722,9 +708,6 @@ Parameters:
     const sampler: GPUSamplerDescriptor = {
       addressModeU: kShortAddressModeToAddressMode[modeU],
       addressModeV: kShortAddressModeToAddressMode[modeV],
-      minFilter,
-      magFilter: minFilter,
-      mipmapFilter: minFilter,
     };
 
     const calls: TextureCall<vec2>[] = generateTextureBuiltinInputs2D(50, {
@@ -734,7 +717,7 @@ Parameters:
       descriptor,
       arrayIndex: { num: texture.depthOrArrayLayers, type: A },
       offset,
-      hashInputs: [stage, format, samplePoints, A, modeU, modeV, minFilter, offset],
+      hashInputs: [stage, format, samplePoints, A, modeU, modeV, offset],
     }).map(({ coords, arrayIndex, offset }) => {
       return {
         builtin: 'textureGather',
@@ -790,9 +773,6 @@ Parameters:
       .combine('format', kDepthStencilFormats)
       // filter out stencil only formats
       .filter(t => isDepthTextureFormat(t.format))
-      // MAINTENANCE_TODO: Remove when support for depth24plus, depth24plus-stencil8, and depth32float-stencil8 is added.
-      .filter(t => isEncodableTextureFormat(t.format))
-      .combine('filt', ['nearest', 'linear'] as const)
       .combine('mode', kShortAddressModes)
       .beginSubcases()
       .combine('samplePoints', kCubeSamplePointMethods)
@@ -800,9 +780,10 @@ Parameters:
   )
   .beforeAllSubcases(t => {
     t.skipIfTextureViewDimensionNotSupported('cube-array');
+    t.selectDeviceForTextureFormatOrSkipTestCase(t.params.format);
   })
   .fn(async t => {
-    const { format, A, stage, samplePoints, mode, filt: minFilter } = t.params;
+    const { format, A, stage, samplePoints, mode } = t.params;
 
     const viewDimension: GPUTextureViewDimension = 'cube-array';
     const size = chooseTextureSize({ minSize: 8, minBlocks: 2, format, viewDimension });
@@ -819,9 +800,6 @@ Parameters:
       addressModeU: kShortAddressModeToAddressMode[mode],
       addressModeV: kShortAddressModeToAddressMode[mode],
       addressModeW: kShortAddressModeToAddressMode[mode],
-      minFilter,
-      magFilter: minFilter,
-      mipmapFilter: minFilter,
     };
 
     const calls: TextureCall<vec3>[] = generateSamplePointsCube(50, {
@@ -830,7 +808,7 @@ Parameters:
       descriptor,
       textureBuiltin: 'textureGather',
       arrayIndex: { num: texture.depthOrArrayLayers / 6, type: A },
-      hashInputs: [stage, format, samplePoints, mode, minFilter],
+      hashInputs: [stage, format, samplePoints, mode],
     }).map(({ coords, arrayIndex }) => {
       return {
         builtin: 'textureGather',

--- a/src/webgpu/shader/execution/expression/call/builtin/textureGatherCompare.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureGatherCompare.spec.ts
@@ -18,11 +18,7 @@ A texture gather compare operation performs a depth comparison on four texels in
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { kCompareFunctions } from '../../../../../capability_info.js';
-import {
-  isDepthTextureFormat,
-  isEncodableTextureFormat,
-  kDepthStencilFormats,
-} from '../../../../../format_info.js';
+import { isDepthTextureFormat, kDepthStencilFormats } from '../../../../../format_info.js';
 
 import {
   checkCallResults,
@@ -74,8 +70,6 @@ Parameters:
       .combine('format', kDepthStencilFormats)
       // filter out stencil only formats
       .filter(t => isDepthTextureFormat(t.format))
-      // MAINTENANCE_TODO: Remove when support for depth24plus, depth24plus-stencil8, and depth32float-stencil8 is added.
-      .filter(t => isEncodableTextureFormat(t.format))
       .combine('filt', ['nearest', 'linear'] as const)
       .combine('modeU', kShortAddressModes)
       .combine('modeV', kShortAddressModes)
@@ -87,6 +81,7 @@ Parameters:
   )
   .beforeAllSubcases(t => {
     t.skipIfTextureFormatNotSupported(t.params.format);
+    t.selectDeviceForTextureFormatOrSkipTestCase(t.params.format);
   })
   .fn(async t => {
     const {
@@ -187,8 +182,6 @@ Parameters:
       .combine('format', kDepthStencilFormats)
       // filter out stencil only formats
       .filter(t => isDepthTextureFormat(t.format))
-      // MAINTENANCE_TODO: Remove when support for depth24plus, depth24plus-stencil8, and depth32float-stencil8 is added.
-      .filter(t => isEncodableTextureFormat(t.format))
       .combine('filt', ['nearest', 'linear'] as const)
       .combine('mode', kShortAddressModes)
       .beginSubcases()
@@ -198,6 +191,7 @@ Parameters:
   )
   .beforeAllSubcases(t => {
     t.skipIfTextureViewDimensionNotSupported('cube-array');
+    t.selectDeviceForTextureFormatOrSkipTestCase(t.params.format);
   })
   .fn(async t => {
     const { format, A, stage, samplePoints, mode, filt: minFilter, compare } = t.params;
@@ -294,8 +288,6 @@ Parameters:
       .combine('format', kDepthStencilFormats)
       // filter out stencil only formats
       .filter(t => isDepthTextureFormat(t.format))
-      // MAINTENANCE_TODO: Remove when support for depth24plus, depth24plus-stencil8, and depth32float-stencil8 is added.
-      .filter(t => isEncodableTextureFormat(t.format))
       .combine('filt', ['nearest', 'linear'] as const)
       .combine('mode', kShortAddressModes)
       .combine('offset', [false, true] as const)
@@ -304,6 +296,7 @@ Parameters:
       .combine('samplePoints', kSamplePointMethods)
       .combine('compare', kCompareFunctions)
   )
+  .beforeAllSubcases(t => t.selectDeviceForTextureFormatOrSkipTestCase(t.params.format))
   .fn(async t => {
     const { format, C, stage, samplePoints, mode, compare, filt: minFilter, offset } = t.params;
 
@@ -385,14 +378,13 @@ Parameters:
       .combine('format', kDepthStencilFormats)
       // filter out stencil only formats
       .filter(t => isDepthTextureFormat(t.format))
-      // MAINTENANCE_TODO: Remove when support for depth24plus, depth24plus-stencil8, and depth32float-stencil8 is added.
-      .filter(t => isEncodableTextureFormat(t.format))
       .combine('filt', ['nearest', 'linear'] as const)
       .combine('mode', kShortAddressModes)
       .beginSubcases()
       .combine('samplePoints', kCubeSamplePointMethods)
       .combine('compare', kCompareFunctions)
   )
+  .beforeAllSubcases(t => t.selectDeviceForTextureFormatOrSkipTestCase(t.params.format))
   .fn(async t => {
     const { format, stage, samplePoints, mode, filt: minFilter, compare } = t.params;
 

--- a/src/webgpu/shader/execution/expression/call/builtin/textureLoad.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureLoad.spec.ts
@@ -26,7 +26,6 @@ import {
   canUseAsRenderTarget,
   isCompressedFloatTextureFormat,
   isDepthTextureFormat,
-  isEncodableTextureFormat,
   isMultisampledTextureFormat,
   isStencilTextureFormat,
   kDepthStencilFormats,
@@ -442,8 +441,6 @@ Parameters:
       .combine('format', kDepthStencilFormats)
       // filter out stencil only formats
       .filter(t => isDepthTextureFormat(t.format))
-      // MAINTENANCE_TODO: Remove when support for depth24plus, depth24plus-stencil8, and depth32float-stencil8 is added.
-      .filter(t => isEncodableTextureFormat(t.format))
       .beginSubcases()
       .combine('samplePoints', kSamplePointMethods)
       .combine('C', ['i32', 'u32'] as const)
@@ -451,6 +448,7 @@ Parameters:
   )
   .beforeAllSubcases(t => {
     t.skipIfTextureLoadNotSupportedForTextureType('texture_depth_2d');
+    t.selectDeviceForTextureFormatOrSkipTestCase(t.params.format);
   })
   .fn(async t => {
     const { format, stage, samplePoints, C, L } = t.params;

--- a/src/webgpu/shader/execution/expression/call/builtin/textureSample.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureSample.spec.ts
@@ -10,10 +10,10 @@ note: uniformity validation is covered in src/webgpu/shader/validation/uniformit
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import {
   isDepthTextureFormat,
-  isEncodableTextureFormat,
   kDepthStencilFormats,
   kAllTextureFormats,
   textureDimensionAndFormatCompatible,
+  isFilterableAsTextureF32,
 } from '../../../../../format_info.js';
 import { TextureTestMixin } from '../../../../../gpu_test.js';
 
@@ -151,6 +151,7 @@ Parameters:
       .combine('format', kAllTextureFormats)
       .filter(t => isPotentiallyFilterableAndFillable(t.format))
       .combine('filt', ['nearest', 'linear'] as const)
+      .filter(t => t.filt === 'nearest' || isFilterableAsTextureF32(t.format))
       .combine('modeU', kShortAddressModes)
       .combine('modeV', kShortAddressModes)
       .combine('offset', [false, true] as const)
@@ -251,6 +252,7 @@ Parameters:
       .combine('dim', ['3d', 'cube'] as const)
       .filter(t => isSupportedViewFormatCombo(t.format, t.dim))
       .combine('filt', ['nearest', 'linear'] as const)
+      .filter(t => t.filt === 'nearest' || isFilterableAsTextureF32(t.format))
       .combine('modeU', kShortAddressModes)
       .combine('modeV', kShortAddressModes)
       .combine('modeW', kShortAddressModes)
@@ -381,17 +383,15 @@ Parameters:
       .combine('format', kDepthStencilFormats)
       // filter out stencil only formats
       .filter(t => isDepthTextureFormat(t.format))
-      // MAINTENANCE_TODO: Remove when support for depth24plus, depth24plus-stencil8, and depth32float-stencil8 is added.
-      .filter(t => isEncodableTextureFormat(t.format))
-      .combine('filt', ['nearest', 'linear'] as const)
       .combine('modeU', kShortAddressModes)
       .combine('modeV', kShortAddressModes)
       .combine('offset', [false, true] as const)
       .beginSubcases()
       .combine('samplePoints', kSamplePointMethods)
   )
+  .beforeAllSubcases(t => t.selectDeviceForTextureFormatOrSkipTestCase(t.params.format))
   .fn(async t => {
-    const { format, samplePoints, modeU, modeV, filt: minFilter, offset } = t.params;
+    const { format, samplePoints, modeU, modeV, offset } = t.params;
 
     // We want at least 4 blocks or something wide enough for 3 mip levels.
     const [width, height] = chooseTextureSize({ minSize: 8, minBlocks: 4, format });
@@ -405,9 +405,6 @@ Parameters:
     const sampler: GPUSamplerDescriptor = {
       addressModeU: kShortAddressModeToAddressMode[modeU],
       addressModeV: kShortAddressModeToAddressMode[modeV],
-      minFilter,
-      magFilter: minFilter,
-      mipmapFilter: minFilter,
     };
 
     const calls: TextureCall<vec2>[] = generateTextureBuiltinInputs2D(50, {
@@ -416,7 +413,7 @@ Parameters:
       descriptor,
       derivatives: true,
       offset,
-      hashInputs: [format, samplePoints, modeU, modeV, minFilter, offset],
+      hashInputs: [format, samplePoints, modeU, modeV, offset],
     }).map(({ coords, derivativeMult, offset }) => {
       return {
         builtin: 'textureSample',
@@ -478,6 +475,7 @@ Parameters:
       .combine('format', kAllTextureFormats)
       .filter(t => isPotentiallyFilterableAndFillable(t.format))
       .combine('filt', ['nearest', 'linear'] as const)
+      .filter(t => t.filt === 'nearest' || isFilterableAsTextureF32(t.format))
       .combine('modeU', kShortAddressModes)
       .combine('modeV', kShortAddressModes)
       .combine('offset', [false, true] as const)
@@ -574,6 +572,7 @@ Parameters:
       .combine('format', kAllTextureFormats)
       .filter(t => isPotentiallyFilterableAndFillable(t.format))
       .combine('filt', ['nearest', 'linear'] as const)
+      .filter(t => t.filt === 'nearest' || isFilterableAsTextureF32(t.format))
       .combine('mode', kShortAddressModes)
       .beginSubcases()
       .combine('samplePoints', kCubeSamplePointMethods)
@@ -671,23 +670,21 @@ Parameters:
       .combine('format', kDepthStencilFormats)
       // filter out stencil only formats
       .filter(t => isDepthTextureFormat(t.format))
-      // MAINTENANCE_TODO: Remove when support for depth24plus, depth24plus-stencil8, and depth32float-stencil8 is added.
-      .filter(t => isEncodableTextureFormat(t.format))
       .combineWithParams([
         { viewDimension: 'cube' },
         { viewDimension: 'cube-array', A: 'i32' },
         { viewDimension: 'cube-array', A: 'u32' },
       ] as const)
-      .combine('filt', ['nearest', 'linear'] as const)
       .combine('mode', kShortAddressModes)
       .beginSubcases()
       .combine('samplePoints', kCubeSamplePointMethods)
   )
   .beforeAllSubcases(t => {
     t.skipIfTextureViewDimensionNotSupported(t.params.viewDimension);
+    t.selectDeviceForTextureFormatOrSkipTestCase(t.params.format);
   })
   .fn(async t => {
-    const { format, viewDimension, samplePoints, A, mode, filt: minFilter } = t.params;
+    const { format, viewDimension, samplePoints, A, mode } = t.params;
 
     const size = chooseTextureSize({
       minSize: 32,
@@ -708,9 +705,6 @@ Parameters:
       addressModeU: kShortAddressModeToAddressMode[mode],
       addressModeV: kShortAddressModeToAddressMode[mode],
       addressModeW: kShortAddressModeToAddressMode[mode],
-      minFilter,
-      magFilter: minFilter,
-      mipmapFilter: minFilter,
     };
 
     const calls: TextureCall<vec3>[] = generateSamplePointsCube(50, {
@@ -719,7 +713,7 @@ Parameters:
       descriptor,
       derivatives: true,
       arrayIndex: A ? { num: texture.depthOrArrayLayers / 6, type: A } : undefined,
-      hashInputs: [format, viewDimension, samplePoints, mode, minFilter],
+      hashInputs: [format, viewDimension, samplePoints, mode],
     }).map(({ coords, derivativeMult, arrayIndex }) => {
       return {
         builtin: 'textureSample',
@@ -785,9 +779,6 @@ Parameters:
       .combine('format', kDepthStencilFormats)
       // filter out stencil only formats
       .filter(t => isDepthTextureFormat(t.format))
-      // MAINTENANCE_TODO: Remove when support for depth24plus, depth24plus-stencil8, and depth32float-stencil8 is added.
-      .filter(t => isEncodableTextureFormat(t.format))
-      .combine('filt', ['nearest', 'linear'] as const)
       .combine('mode', kShortAddressModes)
       .combine('offset', [false, true] as const)
       .beginSubcases()
@@ -795,8 +786,9 @@ Parameters:
       .combine('A', ['i32', 'u32'] as const)
       .combine('L', ['i32', 'u32'] as const)
   )
+  .beforeAllSubcases(t => t.selectDeviceForTextureFormatOrSkipTestCase(t.params.format))
   .fn(async t => {
-    const { format, samplePoints, mode, filt: minFilter, A, L, offset } = t.params;
+    const { format, samplePoints, mode, A, L, offset } = t.params;
 
     // We want at least 4 blocks or something wide enough for 3 mip levels.
     const [width, height] = chooseTextureSize({ minSize: 8, minBlocks: 4, format });
@@ -811,9 +803,6 @@ Parameters:
     const sampler: GPUSamplerDescriptor = {
       addressModeU: kShortAddressModeToAddressMode[mode],
       addressModeV: kShortAddressModeToAddressMode[mode],
-      minFilter,
-      magFilter: minFilter,
-      mipmapFilter: minFilter,
     };
 
     const calls: TextureCall<vec2>[] = generateTextureBuiltinInputs2D(50, {
@@ -823,7 +812,7 @@ Parameters:
       derivatives: true,
       arrayIndex: { num: texture.depthOrArrayLayers, type: A },
       offset,
-      hashInputs: [format, samplePoints, mode, minFilter, L, A, offset],
+      hashInputs: [format, samplePoints, mode, L, A, offset],
     }).map(({ coords, derivativeMult, arrayIndex, offset }) => {
       return {
         builtin: 'textureSample',
@@ -879,9 +868,6 @@ Parameters:
       .combine('format', kDepthStencilFormats)
       // filter out stencil only formats
       .filter(t => isDepthTextureFormat(t.format))
-      // MAINTENANCE_TODO: Remove when support for depth24plus, depth24plus-stencil8, and depth32float-stencil8 is added.
-      .filter(t => isEncodableTextureFormat(t.format))
-      .combine('filt', ['nearest', 'linear'] as const)
       .combine('mode', kShortAddressModes)
       .beginSubcases()
       .combine('samplePoints', kCubeSamplePointMethods)
@@ -889,9 +875,10 @@ Parameters:
   )
   .beforeAllSubcases(t => {
     t.skipIfTextureViewDimensionNotSupported('cube-array');
+    t.selectDeviceForTextureFormatOrSkipTestCase(t.params.format);
   })
   .fn(async t => {
-    const { format, samplePoints, A, mode, filt: minFilter } = t.params;
+    const { format, samplePoints, A, mode } = t.params;
 
     const viewDimension: GPUTextureViewDimension = 'cube-array';
     const size = chooseTextureSize({
@@ -913,9 +900,6 @@ Parameters:
       addressModeU: kShortAddressModeToAddressMode[mode],
       addressModeV: kShortAddressModeToAddressMode[mode],
       addressModeW: kShortAddressModeToAddressMode[mode],
-      minFilter,
-      magFilter: minFilter,
-      mipmapFilter: minFilter,
     };
 
     const calls: TextureCall<vec3>[] = generateSamplePointsCube(50, {
@@ -924,7 +908,7 @@ Parameters:
       descriptor,
       derivatives: true,
       arrayIndex: A ? { num: texture.depthOrArrayLayers / 6, type: A } : undefined,
-      hashInputs: [format, viewDimension, samplePoints, mode, minFilter],
+      hashInputs: [format, viewDimension, samplePoints, mode],
     }).map(({ coords, derivativeMult, arrayIndex }) => {
       return {
         builtin: 'textureSample',

--- a/src/webgpu/shader/execution/expression/call/builtin/textureSampleBias.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureSampleBias.spec.ts
@@ -8,7 +8,7 @@ Samples a texture with a bias to the mip level.
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
-import { kAllTextureFormats } from '../../../../../format_info.js';
+import { isFilterableAsTextureF32, kAllTextureFormats } from '../../../../../format_info.js';
 import { TextureTestMixin } from '../../../../../gpu_test.js';
 
 import {
@@ -62,6 +62,7 @@ Parameters:
       .combine('format', kAllTextureFormats)
       .filter(t => isPotentiallyFilterableAndFillable(t.format))
       .combine('filt', ['nearest', 'linear'] as const)
+      .filter(t => t.filt === 'nearest' || isFilterableAsTextureF32(t.format))
       .combine('modeU', kShortAddressModes)
       .combine('modeV', kShortAddressModes)
       .combine('offset', [false, true] as const)
@@ -162,6 +163,7 @@ Parameters:
       .combine('dim', ['3d', 'cube'] as const)
       .filter(t => isSupportedViewFormatCombo(t.format, t.dim))
       .combine('filt', ['nearest', 'linear'] as const)
+      .filter(t => t.filt === 'nearest' || isFilterableAsTextureF32(t.format))
       .combine('modeU', kShortAddressModes)
       .combine('modeV', kShortAddressModes)
       .combine('modeW', kShortAddressModes)
@@ -297,6 +299,7 @@ Parameters:
       .combine('format', kAllTextureFormats)
       .filter(t => isPotentiallyFilterableAndFillable(t.format))
       .combine('filt', ['nearest', 'linear'] as const)
+      .filter(t => t.filt === 'nearest' || isFilterableAsTextureF32(t.format))
       .combine('modeU', kShortAddressModes)
       .combine('modeV', kShortAddressModes)
       .combine('offset', [false, true] as const)
@@ -401,6 +404,7 @@ Parameters:
       .combine('format', kAllTextureFormats)
       .filter(t => isPotentiallyFilterableAndFillable(t.format))
       .combine('filt', ['nearest', 'linear'] as const)
+      .filter(t => t.filt === 'nearest' || isFilterableAsTextureF32(t.format))
       .combine('mode', kShortAddressModes)
       .beginSubcases()
       .combine('samplePoints', kCubeSamplePointMethods)

--- a/src/webgpu/shader/execution/expression/call/builtin/textureSampleCompare.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureSampleCompare.spec.ts
@@ -7,11 +7,7 @@ Samples a depth texture and compares the sampled depth values against a referenc
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { kCompareFunctions } from '../../../../../capability_info.js';
-import {
-  isDepthTextureFormat,
-  isEncodableTextureFormat,
-  kDepthStencilFormats,
-} from '../../../../../format_info.js';
+import { isDepthTextureFormat, kDepthStencilFormats } from '../../../../../format_info.js';
 
 import {
   checkCallResults,
@@ -58,8 +54,6 @@ Parameters:
       .combine('format', kDepthStencilFormats)
       // filter out stencil only formats
       .filter(t => isDepthTextureFormat(t.format))
-      // MAINTENANCE_TODO: Remove when support for depth24plus, depth24plus-stencil8, and depth32float-stencil8 is added.
-      .filter(t => isEncodableTextureFormat(t.format))
       .combine('filt', ['nearest', 'linear'] as const)
       .combine('modeU', kShortAddressModes)
       .combine('modeV', kShortAddressModes)
@@ -68,6 +62,7 @@ Parameters:
       .combine('samplePoints', kSamplePointMethods)
       .combine('compare', kCompareFunctions)
   )
+  .beforeAllSubcases(t => t.selectDeviceForTextureFormatOrSkipTestCase(t.params.format))
   .fn(async t => {
     const { format, samplePoints, modeU, modeV, filt: minFilter, compare, offset } = t.params;
 
@@ -152,14 +147,13 @@ Parameters:
       .combine('format', kDepthStencilFormats)
       // filter out stencil only formats
       .filter(t => isDepthTextureFormat(t.format))
-      // MAINTENANCE_TODO: Remove when support for depth24plus, depth24plus-stencil8, and depth32float-stencil8 is added.
-      .filter(t => isEncodableTextureFormat(t.format))
       .combine('filt', ['nearest', 'linear'] as const)
       .combine('mode', kShortAddressModes)
       .beginSubcases()
       .combine('samplePoints', kCubeSamplePointMethods)
       .combine('compare', kCompareFunctions)
   )
+  .beforeAllSubcases(t => t.selectDeviceForTextureFormatOrSkipTestCase(t.params.format))
   .fn(async t => {
     const { format, samplePoints, mode, filt: minFilter, compare } = t.params;
 
@@ -258,8 +252,6 @@ Parameters:
       .combine('format', kDepthStencilFormats)
       // filter out stencil only formats
       .filter(t => isDepthTextureFormat(t.format))
-      // MAINTENANCE_TODO: Remove when support for depth24plus, depth24plus-stencil8, and depth32float-stencil8 is added.
-      .filter(t => isEncodableTextureFormat(t.format))
       .combine('filt', ['nearest', 'linear'] as const)
       .combine('modeU', kShortAddressModes)
       .combine('modeV', kShortAddressModes)
@@ -271,6 +263,7 @@ Parameters:
   )
   .beforeAllSubcases(t => {
     t.skipIfTextureFormatNotSupported(t.params.format);
+    t.selectDeviceForTextureFormatOrSkipTestCase(t.params.format);
   })
   .fn(async t => {
     const { format, samplePoints, A, modeU, modeV, filt: minFilter, compare, offset } = t.params;
@@ -363,8 +356,6 @@ Parameters:
       .combine('format', kDepthStencilFormats)
       // filter out stencil only formats
       .filter(t => isDepthTextureFormat(t.format))
-      // MAINTENANCE_TODO: Remove when support for depth24plus, depth24plus-stencil8, and depth32float-stencil8 is added.
-      .filter(t => isEncodableTextureFormat(t.format))
       .combine('filt', ['nearest', 'linear'] as const)
       .combine('mode', kShortAddressModes)
       .beginSubcases()
@@ -374,6 +365,7 @@ Parameters:
   )
   .beforeAllSubcases(t => {
     t.skipIfTextureViewDimensionNotSupported('cube-array');
+    t.selectDeviceForTextureFormatOrSkipTestCase(t.params.format);
   })
   .fn(async t => {
     const { format, A, samplePoints, mode, filt: minFilter, compare } = t.params;

--- a/src/webgpu/shader/execution/expression/call/builtin/textureSampleCompareLevel.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureSampleCompareLevel.spec.ts
@@ -13,11 +13,7 @@ The textureSampleCompareLevel function is the same as textureSampleCompare, exce
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { kCompareFunctions } from '../../../../../capability_info.js';
-import {
-  isDepthTextureFormat,
-  isEncodableTextureFormat,
-  kDepthStencilFormats,
-} from '../../../../../format_info.js';
+import { isDepthTextureFormat, kDepthStencilFormats } from '../../../../../format_info.js';
 
 import {
   checkCallResults,
@@ -66,8 +62,6 @@ Parameters:
       .combine('format', kDepthStencilFormats)
       // filter out stencil only formats
       .filter(t => isDepthTextureFormat(t.format))
-      // MAINTENANCE_TODO: Remove when support for depth24plus, depth24plus-stencil8, and depth32float-stencil8 is added.
-      .filter(t => isEncodableTextureFormat(t.format))
       .combine('filt', ['nearest', 'linear'] as const)
       .combine('modeU', kShortAddressModes)
       .combine('modeV', kShortAddressModes)
@@ -76,6 +70,7 @@ Parameters:
       .combine('samplePoints', kSamplePointMethods)
       .combine('compare', kCompareFunctions)
   )
+  .beforeAllSubcases(t => t.selectDeviceForTextureFormatOrSkipTestCase(t.params.format))
   .fn(async t => {
     const {
       format,
@@ -170,14 +165,13 @@ Parameters:
       .combine('format', kDepthStencilFormats)
       // filter out stencil only formats
       .filter(t => isDepthTextureFormat(t.format))
-      // MAINTENANCE_TODO: Remove when support for depth24plus, depth24plus-stencil8, and depth32float-stencil8 is added.
-      .filter(t => isEncodableTextureFormat(t.format))
       .combine('filt', ['nearest', 'linear'] as const)
       .combine('mode', kShortAddressModes)
       .beginSubcases()
       .combine('samplePoints', kCubeSamplePointMethods)
       .combine('compare', kCompareFunctions)
   )
+  .beforeAllSubcases(t => t.selectDeviceForTextureFormatOrSkipTestCase(t.params.format))
   .fn(async t => {
     const { format, stage, samplePoints, mode, filt: minFilter, compare } = t.params;
 
@@ -277,8 +271,6 @@ Parameters:
       .combine('format', kDepthStencilFormats)
       // filter out stencil only formats
       .filter(t => isDepthTextureFormat(t.format))
-      // MAINTENANCE_TODO: Remove when support for depth24plus, depth24plus-stencil8, and depth32float-stencil8 is added.
-      .filter(t => isEncodableTextureFormat(t.format))
       .combine('filt', ['nearest', 'linear'] as const)
       .combine('modeU', kShortAddressModes)
       .combine('modeV', kShortAddressModes)
@@ -290,6 +282,7 @@ Parameters:
   )
   .beforeAllSubcases(t => {
     t.skipIfTextureFormatNotSupported(t.params.format);
+    t.selectDeviceForTextureFormatOrSkipTestCase(t.params.format);
   })
   .fn(async t => {
     const {
@@ -393,8 +386,6 @@ Parameters:
       .combine('format', kDepthStencilFormats)
       // filter out stencil only formats
       .filter(t => isDepthTextureFormat(t.format))
-      // MAINTENANCE_TODO: Remove when support for depth24plus, depth24plus-stencil8, and depth32float-stencil8 is added.
-      .filter(t => isEncodableTextureFormat(t.format))
       .combine('filt', ['nearest', 'linear'] as const)
       .combine('mode', kShortAddressModes)
       .beginSubcases()
@@ -404,6 +395,7 @@ Parameters:
   )
   .beforeAllSubcases(t => {
     t.skipIfTextureViewDimensionNotSupported('cube-array');
+    t.selectDeviceForTextureFormatOrSkipTestCase(t.params.format);
   })
   .fn(async t => {
     const { format, A, stage, samplePoints, mode, filt: minFilter, compare } = t.params;

--- a/src/webgpu/shader/execution/expression/call/builtin/textureSampleGrad.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureSampleGrad.spec.ts
@@ -6,7 +6,7 @@ Samples a texture using explicit gradients.
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
-import { kAllTextureFormats } from '../../../../../format_info.js';
+import { isFilterableAsTextureF32, kAllTextureFormats } from '../../../../../format_info.js';
 
 import {
   appendComponentTypeForFormatToTextureType,
@@ -63,6 +63,7 @@ Parameters:
       .combine('format', kAllTextureFormats)
       .filter(t => isPotentiallyFilterableAndFillable(t.format))
       .combine('filt', ['nearest', 'linear'] as const)
+      .filter(t => t.filt === 'nearest' || isFilterableAsTextureF32(t.format))
       .combine('modeU', kShortAddressModes)
       .combine('modeV', kShortAddressModes)
       .combine('offset', [false, true] as const)
@@ -164,6 +165,7 @@ Parameters:
       .combine('dim', ['3d', 'cube'] as const)
       .filter(t => isSupportedViewFormatCombo(t.format, t.dim))
       .combine('filt', ['nearest', 'linear'] as const)
+      .filter(t => t.filt === 'nearest' || isFilterableAsTextureF32(t.format))
       .combine('modeU', kShortAddressModes)
       .combine('modeV', kShortAddressModes)
       .combine('modeW', kShortAddressModes)
@@ -302,6 +304,7 @@ Parameters:
       .combine('format', kAllTextureFormats)
       .filter(t => isPotentiallyFilterableAndFillable(t.format))
       .combine('filt', ['nearest', 'linear'] as const)
+      .filter(t => t.filt === 'nearest' || isFilterableAsTextureF32(t.format))
       .combine('modeU', kShortAddressModes)
       .combine('modeV', kShortAddressModes)
       .combine('offset', [false, true] as const)
@@ -408,6 +411,7 @@ Parameters:
       .combine('format', kAllTextureFormats)
       .filter(t => isPotentiallyFilterableAndFillable(t.format))
       .combine('filt', ['nearest', 'linear'] as const)
+      .filter(t => t.filt === 'nearest' || isFilterableAsTextureF32(t.format))
       .combine('mode', kShortAddressModes)
       .beginSubcases()
       .combine('samplePoints', kCubeSamplePointMethods)


### PR DESCRIPTION
texture_depth_xxx can only be used with non-filtering samplers or comparison samples, not with filtering samplers.

see table in #4026

Also added a bunch of depth formats. Sorry it's so large but both issues were editing the same lines.