### PR TITLE
Test non-filterable textures can't be used with filtering sampler.

### DIFF
--- a/src/webgpu/api/validation/non_filterable_texture.spec.ts
+++ b/src/webgpu/api/validation/non_filterable_texture.spec.ts
@@ -1,0 +1,126 @@
+export const description = `
+Tests that non-filterable textures used with filtering samplers generate a validation error.
+`;
+
+import { makeTestGroup } from '../../../common/framework/test_group.js';
+import { keysOf } from '../../../common/util/data_tables.js';
+
+import { ValidationTest } from './validation_test.js';
+
+const kNonFilterableCaseInfo: Record<GPUTextureSampleType, { type: string; component: string }> = {
+  sint: { type: 'i32', component: '0,' },
+  uint: { type: 'u32', component: '0,' },
+  float: { type: 'f32', component: '0,' }, // no error for f32
+  'unfilterable-float': { type: 'f32', component: '0,' }, // no error for f32
+  depth: { type: 'depth', component: '' },
+};
+const kNonFilterableCases = keysOf(kNonFilterableCaseInfo);
+
+export const g = makeTestGroup(ValidationTest);
+
+g.test('non_filterable_texture_with_filtering_sampler')
+  .desc(
+    'test that createXXXPipeline generates a validation error if a depth/u32/i32 texture binding is used with a filtering sampler binding'
+  )
+  .params(u =>
+    u
+      .combine('pipeline', ['compute', 'render'])
+      .combine('async', [true, false] as const)
+      .combine('sampleType', kNonFilterableCases)
+      .combine('viewDimension', ['2d', '2d-array', 'cube', 'cube-array'] as const)
+      .combine('sameGroup', [true, false] as const)
+  )
+  .beforeAllSubcases(t => t.skipIfTextureViewDimensionNotSupported(t.params.viewDimension))
+  .fn(t => {
+    const { device } = t;
+    const { pipeline, async, sampleType, viewDimension, sameGroup } = t.params;
+    const { type, component } = kNonFilterableCaseInfo[sampleType];
+
+    const coord = viewDimension.startsWith('2d') ? 'vec2f(0)' : 'vec3f(0)';
+    const dimensionSuffix = viewDimension.replace('-', '_');
+    const textureType =
+      type === 'depth' ? `texture_depth_${dimensionSuffix}` : `texture_${dimensionSuffix}<${type}>`;
+    const layer = viewDimension.endsWith('-array') ? ', 0' : '';
+
+    const groupNdx = sameGroup ? 0 : 1;
+
+    const module = device.createShaderModule({
+      code: `
+      @group(0) @binding(0) var t: ${textureType};
+      @group(${groupNdx}) @binding(1) var s: sampler;
+
+      fn test() {
+        _ = textureGather(${component} t, s, ${coord}${layer});
+      }
+
+      @compute @workgroup_size(1) fn cs() {
+        test();
+      }
+
+      @vertex fn vs() -> @builtin(position) vec4f {
+        return vec4f(0);
+      }
+
+      @fragment fn fs() -> @location(0) vec4f {
+        test();
+        return vec4f(0);
+      }
+      `,
+    });
+
+    const bindGroup0LayoutEntries: GPUBindGroupLayoutEntry[] = [
+      {
+        binding: 0,
+        visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+        texture: {
+          sampleType,
+          viewDimension,
+          multisampled: false,
+        },
+      },
+    ];
+
+    const samplerBGLEntry: GPUBindGroupLayoutEntry = {
+      binding: 1,
+      visibility: GPUShaderStage.COMPUTE | GPUShaderStage.FRAGMENT,
+      sampler: {
+        type: 'filtering',
+      },
+    };
+
+    if (sameGroup) {
+      bindGroup0LayoutEntries.push(samplerBGLEntry);
+    }
+
+    const bindGroupLayout0 = device.createBindGroupLayout({
+      entries: bindGroup0LayoutEntries,
+    });
+
+    const pipelineLayoutDesc = {
+      bindGroupLayouts: [bindGroupLayout0],
+    };
+
+    if (!sameGroup) {
+      const bindGroupLayout1 = device.createBindGroupLayout({
+        entries: [samplerBGLEntry],
+      });
+      pipelineLayoutDesc.bindGroupLayouts.push(bindGroupLayout1);
+    }
+
+    const layout = device.createPipelineLayout(pipelineLayoutDesc);
+
+    const success = sampleType === 'float';
+
+    if (pipeline === 'compute') {
+      t.doCreateComputePipelineTest(async, success, {
+        layout,
+        compute: { module },
+      });
+    } else {
+      t.doCreateRenderPipelineTest(async, success, {
+        layout,
+        vertex: { module },
+        fragment: { module, targets: [{ format: 'rgba8unorm' }] },
+      });
+    }
+  });


### PR DESCRIPTION
IIUC these tests are missing from the CTS

Note that if `u32`/`i32` are removed from `textureGather` then there is no other texture builtin that uses `u32`/`i32` except `textureLoad`

Testing locally on Chrome with [this patch check does this validation](https://dawn-review.googlesource.com/c/dawn/+/213176/4/src/dawn/native/ShaderModule.cpp) they pass. 
With [this patch that does this validation but allows depth with a deprecation warning](https://dawn-review.googlesource.com/c/dawn/+/213176/5/src/dawn/native/ShaderModule.cpp) they all pass except for depth. On Chrome Canary with neither patch they all fail except for the `f32` tests which are supposed to work.

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [X] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
