### PR TITLE
Compat: skip 'cube-array' validation tests.

### DIFF
--- a/src/webgpu/api/validation/compute_pipeline.spec.ts
+++ b/src/webgpu/api/validation/compute_pipeline.spec.ts
@@ -718,6 +718,7 @@ g.test('resource_compatibility')
         !t.hasLanguageFeature('readonly_and_readwrite_storage_textures'),
       'Storage textures require language feature'
     );
+    t.skipIfTextureViewDimensionNotSupported(wgslResource.texture?.viewDimension);
 
     const layout = t.device.createPipelineLayout({
       bindGroupLayouts: [

--- a/src/webgpu/api/validation/render_pipeline/resource_compatibility.spec.ts
+++ b/src/webgpu/api/validation/render_pipeline/resource_compatibility.spec.ts
@@ -55,6 +55,7 @@ g.test('resource_compatibility')
             wgslResource.storageTexture.access !== 'read-only')),
       'Storage buffers and textures cannot be used in vertex shaders'
     );
+    t.skipIfTextureViewDimensionNotSupported(wgslResource.texture?.viewDimension);
     const emptyVS = `
 @vertex
 fn main() -> @builtin(position) vec4f {


### PR DESCRIPTION
Cube arrays are unsupported in Compatibility mode.