### PR TITLE
Assert GPUAdapterInfo instances

### DIFF
--- a/src/webgpu/api/operation/adapter/info.spec.ts
+++ b/src/webgpu/api/operation/adapter/info.spec.ts
@@ -51,6 +51,7 @@ but different objects from one another.`
     const gpu = getGPU(t.rec);
     const adapter = await gpu.requestAdapter();
     assert(adapter !== null);
+    assert(adapter.info instanceof GPUAdapterInfo);
 
     const adapterInfo1 = adapter.info;
     const adapterInfo2 = adapter.info;
@@ -58,6 +59,7 @@ but different objects from one another.`
 
     const device = await t.requestDeviceTracked(adapter);
     assert(device !== null);
+    assert(device.adapterInfo instanceof GPUAdapterInfo);
 
     const deviceAdapterInfo1 = device.adapterInfo;
     const deviceAdapterInfo2 = device.adapterInfo;


### PR DESCRIPTION
Without this fix, Chrome Stable passes https://gpuweb.github.io/cts/standalone/?q=webgpu:api,operation,adapter,info:same_object:* even if GPUDevice.adapterInfo is not implemented and returns `undefined`.

@kainino0x Please review.