### PR TITLE
Fix tests related to subgroup uniformity diagnostics

### DIFF
--- a/src/webgpu/listing_meta.json
+++ b/src/webgpu/listing_meta.json
@@ -1567,6 +1567,7 @@
   "webgpu:shader,execution,expression,call,builtin,subgroupBitwise:compute,split:*": { "subcaseMS": 1743.045 },
   "webgpu:shader,execution,expression,call,builtin,subgroupBitwise:data_types:*": { "subcaseMS": 5081.792 },
   "webgpu:shader,execution,expression,call,builtin,subgroupBitwise:fragment,all_active:*": { "subcaseMS": 9079.446 },
+  "webgpu:shader,execution,expression,call,builtin,subgroupBitwise:fragment,split:*": { "subcaseMS": 0.347 },
   "webgpu:shader,execution,expression,call,builtin,subgroupBroadcast:data_types:*": { "subcaseMS": 252.374 },
   "webgpu:shader,execution,expression,call,builtin,subgroupBroadcast:fragment:*": { "subcaseMS": 0.108 },
   "webgpu:shader,execution,expression,call,builtin,subgroupBroadcast:workgroup_uniform_load:*": { "subcaseMS": 109.832 },

--- a/src/webgpu/shader/execution/expression/call/builtin/quadBroadcast.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/quadBroadcast.spec.ts
@@ -447,6 +447,9 @@ predication filters are skipped.
     const wgsl = `
 enable subgroups;
 
+diagnostic(off, subgroup_uniformity);
+diagnostic(off, subgroup_branching);
+
 @group(0) @binding(0)
 var<storage> inputs : u32; // unused
 

--- a/src/webgpu/shader/execution/expression/call/builtin/quadSwap.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/quadSwap.spec.ts
@@ -466,6 +466,9 @@ predication filters are skipped.
     const wgsl = `
 enable subgroups;
 
+diagnostic(off, subgroup_uniformity);
+diagnostic(off, subgroup_branching);
+
 @group(0) @binding(0)
 var<storage> inputs : u32; // unused
 

--- a/src/webgpu/shader/execution/expression/call/builtin/subgroupAdd.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/subgroupAdd.spec.ts
@@ -311,6 +311,9 @@ g.test('compute,split')
     const wgsl = `
 enable subgroups;
 
+diagnostic(off, subgroup_uniformity);
+diagnostic(off, subgroup_branching);
+
 @group(0) @binding(0)
 var<storage> input : array<u32>;
 

--- a/src/webgpu/shader/execution/expression/call/builtin/subgroupAll.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/subgroupAll.spec.ts
@@ -208,6 +208,9 @@ g.test('compute,split')
     const wgsl = `
 enable subgroups;
 
+diagnostic(off, subgroup_uniformity);
+diagnostic(off, subgroup_branching);
+
 @group(0) @binding(0)
 var<storage> inputs : array<u32>;
 

--- a/src/webgpu/shader/execution/expression/call/builtin/subgroupAny.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/subgroupAny.spec.ts
@@ -208,6 +208,9 @@ g.test('compute,split')
     const wgsl = `
 enable subgroups;
 
+diagnostic(off, subgroup_uniformity);
+diagnostic(off, subgroup_branching);
+
 @group(0) @binding(0)
 var<storage> inputs : array<u32>;
 

--- a/src/webgpu/shader/execution/expression/call/builtin/subgroupBallot.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/subgroupBallot.spec.ts
@@ -188,6 +188,9 @@ g.test('compute,split')
     const wgsl = `
 enable subgroups;
 
+diagnostic(off, subgroup_uniformity);
+diagnostic(off, subgroup_branching);
+
 @group(0) @binding(0)
 var<storage, read_write> size : u32;
 
@@ -223,6 +226,8 @@ g.test('predicate')
     const testcase = kCases[t.params.case];
     const wgsl = `
 enable subgroups;
+
+diagnostic(off, subgroup_branching);
 
 @group(0) @binding(0)
 var<storage, read_write> size : u32;
@@ -312,6 +317,9 @@ g.test('predicate_and_control_flow')
     const testcase = kBothCases[t.params.case];
     const wgsl = `
 enable subgroups;
+
+diagnostic(off, subgroup_branching);
+diagnostic(off, subgroup_uniformity);
 
 @group(0) @binding(0)
 var<storage, read_write> size : u32;

--- a/src/webgpu/shader/execution/expression/call/builtin/subgroupBitwise.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/subgroupBitwise.spec.ts
@@ -378,6 +378,9 @@ g.test('compute,split')
     const wgsl = `
 enable subgroups;
 
+diagnostic(off, subgroup_uniformity);
+diagnostic(off, subgroup_branching);
+
 @group(0) @binding(0)
 var<storage> inputs : array<u32>;
 

--- a/src/webgpu/shader/execution/expression/call/builtin/subgroupBroadcast.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/subgroupBroadcast.spec.ts
@@ -242,6 +242,8 @@ g.test('workgroup_uniform_load')
     const wgsl = `
 enable subgroups;
 
+diagnostic(off, subgroup_branching);
+
 var<workgroup> wgmem : u32;
 
 @group(0) @binding(0)

--- a/src/webgpu/shader/execution/expression/call/builtin/subgroupMul.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/subgroupMul.spec.ts
@@ -334,6 +334,9 @@ g.test('compute,split')
     const wgsl = `
 enable subgroups;
 
+diagnostic(off, subgroup_uniformity);
+diagnostic(off, subgroup_branching);
+
 @group(0) @binding(0)
 var<storage> input : array<u32>;
 

--- a/src/webgpu/shader/execution/shader_io/fragment_builtins.spec.ts
+++ b/src/webgpu/shader/execution/shader_io/fragment_builtins.spec.ts
@@ -1691,11 +1691,8 @@ fn fsMain(
     let countSubgroupSizeEqualI = ballotSubgroupSizeEqualI.x + ballotSubgroupSizeEqualI.y + ballotSubgroupSizeEqualI.z + ballotSubgroupSizeEqualI.w;
     subgroupSizeBallotedInvocations += countSubgroupSizeEqualI;
     // Validate that all active invocations see the same subgroup size, i.e. ballotedSubgroupSize
-    if (countSubgroupSizeEqualI == countActive) {
-      ballotedSubgroupSize = i;
-    } else if (countSubgroupSizeEqualI != 0) {
-      error++;
-    }
+    ballotedSubgroupSize = select(ballotedSubgroupSize, i, countSubgroupSizeEqualI == countActive);
+    error = select(error, error + 1, countSubgroupSizeEqualI != countActive && countSubgroupSizeEqualI != 0);
   }
   // Validate that all active invocations balloted in previous loop
   if (subgroupSizeBallotedInvocations != countActive) {


### PR DESCRIPTION
* Change fragment builtin tests to avoid non-uniform branches around subgroup operations
* Add diagnostic filters to execution tests relying on non-uniformity




Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [ ] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [ ] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [ ] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
