### PR TITLE
fix(diagnostic): expect success on duplicate validation if severities are the same

### DIFF
--- a/src/webgpu/shader/validation/parse/diagnostic.spec.ts
+++ b/src/webgpu/shader/validation/parse/diagnostic.spec.ts
@@ -163,7 +163,9 @@ g.test('conflicting_directive')
 
 g.test('duplicate_attribute_same_location')
   .specURL('https://gpuweb.github.io/gpuweb/wgsl/#diagnostics')
-  .desc(`Tests duplicate diagnostics at the same location must be on different rules`)
+  .desc(
+    `Tests duplicate diagnostics at the same location must be on different rules unless the severity is the same`
+  )
   .params(u =>
     u
       .combine('loc', keysOf(kValidLocations))
@@ -181,7 +183,7 @@ g.test('duplicate_attribute_same_location')
     const d1 = generateDiagnostic('attribute', t.params.s1, rule1);
     const d2 = generateDiagnostic('attribute', t.params.s2, t.params.same_rule ? rule1 : rule2);
     const code = `${kValidLocations[t.params.loc](`${d1} ${d2}`)}`;
-    t.expectCompileResult(!t.params.same_rule, code);
+    t.expectCompileResult(!t.params.same_rule || t.params.s1 === t.params.s2, code);
   });
 
 g.test('conflicting_attribute_different_location')


### PR DESCRIPTION
Issue: #4041

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
