### PR TITLE
Try to relax textureSampleBias

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/textureSampleBias.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureSampleBias.spec.ts
@@ -37,6 +37,10 @@ import {
 
 export const g = makeTestGroup(TextureTestMixin(WGSLTextureSampleTest));
 
+// See comment "Issues with textureSampleBias" in texture_utils.ts
+// 3 was chosen because it shows errors on M1 Mac
+const kMinBlocksForTextureSampleBias = 3;
+
 g.test('sampled_2d_coords')
   .specURL('https://www.w3.org/TR/WGSL/#texturesamplebias')
   .desc(
@@ -76,8 +80,12 @@ Parameters:
     const { format, samplePoints, modeU, modeV, filt: minFilter, offset } = t.params;
     skipIfNeedsFilteringAndIsUnfilterable(t, minFilter, format);
 
-    // We want at least 4 blocks or something wide enough for 3 mip levels.
-    const [width, height] = chooseTextureSize({ minSize: 8, minBlocks: 4, format });
+    // We want at least something wide enough for 3 mip levels with more than 1 pixel at the smallest level
+    const [width, height] = chooseTextureSize({
+      minSize: 8,
+      minBlocks: kMinBlocksForTextureSampleBias,
+      format,
+    });
 
     const descriptor: GPUTextureDescriptor = {
       format,
@@ -314,8 +322,12 @@ Parameters:
     const { format, samplePoints, A, modeU, modeV, filt: minFilter, offset } = t.params;
     skipIfNeedsFilteringAndIsUnfilterable(t, minFilter, format);
 
-    // We want at least 4 blocks or something wide enough for 3 mip levels.
-    const [width, height] = chooseTextureSize({ minSize: 8, minBlocks: 4, format });
+    // We want at least something wide enough for 3 mip levels with more than 1 pixel at the smallest level
+    const [width, height] = chooseTextureSize({
+      minSize: 8,
+      minBlocks: kMinBlocksForTextureSampleBias,
+      format,
+    });
     const depthOrArrayLayers = 4;
 
     const descriptor: GPUTextureDescriptor = {


### PR DESCRIPTION
See CL/diff for details

Also fixed an issue with copyBufferToTextureViaRender that it was using the source format to decide whether to render to a depth or stencil format but it should be using the destination format for that.

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [X] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
