### PR TITLE
Fix makeRandomDepthComparisonTexelGenerator

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/texture_utils.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/texture_utils.ts
@@ -1195,7 +1195,8 @@ export function makeRandomDepthComparisonTexelGenerator(
   },
   comparison: GPUCompareFunction
 ) {
-  const rep = kTexelRepresentationInfo[info.format as EncodableTextureFormat];
+  const format = isUnencodableDepthFormat(info.format) ? 'depth32float' : info.format;
+  const rep = kTexelRepresentationInfo[format as EncodableTextureFormat];
   const size = reifyExtent3D(info.size);
 
   const comparisonIsEqualOrNotEqual = comparison === 'equal' || comparison === 'not-equal';
@@ -1207,7 +1208,7 @@ export function makeRandomDepthComparisonTexelGenerator(
   // The problem with comparing equal is other than 0.0 and 1.0, no other
   // values are guaranteed to be equal.
   const fixedValues = [0, 0.6, 1, 1];
-  const format = comparisonIsEqualOrNotEqual
+  const encode = comparisonIsEqualOrNotEqual
     ? (norm: number) => fixedValues[(norm * (fixedValues.length - 1)) | 0]
     : (norm: number) => norm;
 
@@ -1225,7 +1226,7 @@ export function makeRandomDepthComparisonTexelGenerator(
         size.depthOrArrayLayers
       );
       const normalized = clamp(rnd / 0xffffffff, { min: 0, max: 1 });
-      texel[component] = format(normalized);
+      texel[component] = encode(normalized);
     }
     return quantize(texel, rep);
   };


### PR DESCRIPTION
This bug broke `textureXXCompare` tests with unencodable depth formats which were added recently.

https://github.com/gpuweb/cts/pull/4012