### PR TITLE
Compat: Validate non-comparsion sampler + depth texture fails.

### DIFF
--- a/src/webgpu/compat/api/validation/pipeline_creation.spec.ts
+++ b/src/webgpu/compat/api/validation/pipeline_creation.spec.ts
@@ -1,0 +1,146 @@
+export const description = `
+Tests that createComputePipeline(async), and createRenderPipeline(async)
+reject pipelines that are invalid in compat mode
+
+- test that depth textures can not be used with non-comparison samplers
+
+TODO:
+- test that a shader that has more than min(maxSamplersPerShaderStage, maxSampledTexturesPerShaderStage)
+  texture+sampler combinations generates a validation error.
+`;
+
+import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { kShaderStages } from '../../../shader/validation/decl/util.js';
+import { CompatibilityTest } from '../../compatibility_test.js';
+
+export const g = makeTestGroup(CompatibilityTest);
+
+g.test('depth_textures')
+  .desc('Tests that depth textures can not be used with non-comparison samplers in compat mode.')
+  .params(u =>
+    u //
+      .combineWithParams([
+        {
+          sampleWGSL: 'textureSample(t, s, vec2f(0))', // should pass
+          textureType: 'texture_2d<f32>',
+        },
+        {
+          sampleWGSL: 'textureSample(t, s, vec2f(0))',
+          textureType: 'texture_depth_2d',
+        },
+        {
+          sampleWGSL: 'textureSample(t, s, vec3f(0))',
+          textureType: 'texture_depth_cube',
+        },
+        {
+          sampleWGSL: 'textureSample(t, s, vec2f(0), 0)',
+          textureType: 'texture_depth_2d_array',
+        },
+        {
+          sampleWGSL: 'textureSample(t, s, vec2f(0), vec2i(0, 0))',
+          textureType: 'texture_depth_2d',
+        },
+        {
+          sampleWGSL: 'textureSample(t, s, vec2f(0), 0, vec2i(0, 0))',
+          textureType: 'texture_depth_2d_array',
+        },
+        {
+          sampleWGSL: 'textureSampleLevel(t, s, vec2f(0), 0)',
+          textureType: 'texture_depth_2d',
+        },
+        {
+          sampleWGSL: 'textureSampleLevel(t, s, vec3f(0), 0)',
+          textureType: 'texture_depth_cube',
+        },
+        {
+          sampleWGSL: 'textureSampleLevel(t, s, vec2f(0), 0, 0)',
+          textureType: 'texture_depth_2d_array',
+        },
+        {
+          sampleWGSL: 'textureSampleLevel(t, s, vec2f(0), 0, vec2i(0, 0))',
+          textureType: 'texture_depth_2d',
+        },
+        {
+          sampleWGSL: 'textureSampleLevel(t, s, vec2f(0), 0, 0, vec2i(0, 0))',
+          textureType: 'texture_depth_2d_array',
+        },
+        {
+          sampleWGSL: 'textureGather(t, s, vec2f(0))',
+          textureType: 'texture_depth_2d',
+        },
+        {
+          sampleWGSL: 'textureGather(t, s, vec3f(0))',
+          textureType: 'texture_depth_cube',
+        },
+        {
+          sampleWGSL: 'textureGather(t, s, vec2f(0), 0)',
+          textureType: 'texture_depth_2d_array',
+        },
+        {
+          sampleWGSL: 'textureGather(t, s, vec2f(0), vec2i(0, 0))',
+          textureType: 'texture_depth_2d',
+        },
+        {
+          sampleWGSL: 'textureGather(t, s, vec2f(0), 0, vec2i(0, 0))',
+          textureType: 'texture_depth_2d_array',
+        },
+      ])
+      .combine('stage', kShaderStages)
+      .filter(t => t.sampleWGSL.startsWith('textureGather') || t.stage === 'fragment')
+      .combine('async', [false, true] as const)
+  )
+  .fn(t => {
+    const { sampleWGSL, textureType, stage, async } = t.params;
+
+    const usageWGSL = `_ = ${sampleWGSL};`;
+    const module = t.device.createShaderModule({
+      code: `
+        @group(0) @binding(0) var t: ${textureType};
+        @group(1) @binding(0) var s: sampler;
+
+        // make sure it's fine such a combination exists but it's not used.
+        fn unused() {
+          ${usageWGSL};
+        }
+
+        @vertex fn vs() -> @builtin(position) vec4f {
+            ${stage === 'vertex' ? usageWGSL : ''}
+            return vec4f(0);
+        }
+
+        @fragment fn fs() -> @location(0) vec4f {
+            ${stage === 'fragment' ? usageWGSL : ''}
+            return vec4f(0);
+        }
+
+        @compute @workgroup_size(1) fn cs() {
+            ${stage === 'compute' ? usageWGSL : ''};
+        }
+      `,
+    });
+
+    const success = !t.isCompatibility || textureType === 'texture_2d<f32>';
+    switch (stage) {
+      case 'compute':
+        t.doCreateComputePipelineTest(async, success, {
+          layout: 'auto',
+          compute: {
+            module,
+          },
+        });
+        break;
+      case 'fragment':
+      case 'vertex':
+        t.doCreateRenderPipelineTest(async, success, {
+          layout: 'auto',
+          vertex: {
+            module,
+          },
+          fragment: {
+            module,
+            targets: [{ format: 'rgba8unorm' }],
+          },
+        });
+        break;
+    }
+  });


### PR DESCRIPTION
Using a depth texture with a non-comparison sampler should generate a validation error in compat but not in core.

Note: this PR should probably wait for https://github.com/gpuweb/gpuweb/pull/4988 to be approved in case this is not where the validation error should happen.

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [X] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
