### PR TITLE
Allow unknown limits to be requested with value undefined

### DIFF
--- a/src/webgpu/api/operation/adapter/requestDevice.spec.ts
+++ b/src/webgpu/api/operation/adapter/requestDevice.spec.ts
@@ -224,16 +224,22 @@ g.test('limits,unknown')
   .desc(
     `
     Test that specifying limits that aren't part of the supported limit set causes
-    requestDevice to reject.`
+    requestDevice to reject unless the value is undefined`
   )
   .fn(async t => {
     const gpu = getGPU(t.rec);
     const adapter = await gpu.requestAdapter();
     assert(adapter !== null);
 
-    const requiredLimits: Record<string, number> = { unknownLimitName: 9000 };
+    t.shouldReject(
+      'OperationError',
+      t.requestDeviceTracked(adapter, { requiredLimits: { unknownLimitName: 9000 } })
+    );
 
-    t.shouldReject('OperationError', t.requestDeviceTracked(adapter, { requiredLimits }));
+    const device = await t.requestDeviceTracked(adapter, {
+      requiredLimits: { unknownLimitName: undefined },
+    });
+    assert(device !== null);
   });
 
 g.test('limits,supported')
@@ -241,10 +247,14 @@ g.test('limits,supported')
     `
     Test that each supported limit can be specified with valid values.
     - Tests each limit with the default values given by the spec
-    - Tests each limit with the supported values given by the adapter`
+    - Tests each limit with the supported values given by the adapter
+    - Tests each limit with undefined`
   )
   .params(u =>
-    u.combine('limit', kLimits).beginSubcases().combine('limitValue', ['default', 'adapter'])
+    u
+      .combine('limit', kLimits)
+      .beginSubcases()
+      .combine('limitValue', ['default', 'adapter', 'undefined'])
   )
   .fn(async t => {
     const { limit, limitValue } = t.params;
@@ -254,20 +264,27 @@ g.test('limits,supported')
     assert(adapter !== null);
 
     const limitInfo = getDefaultLimitsForAdapter(adapter);
-    let value: number = -1;
+    let value: number | undefined = -1;
+    let result: number = -1;
     switch (limitValue) {
       case 'default':
         value = limitInfo[limit].default;
+        result = value;
         break;
       case 'adapter':
         value = adapter.limits[limit];
+        result = value;
+        break;
+      case 'undefined':
+        value = undefined;
+        result = limitInfo[limit].default;
         break;
     }
 
     const device = await t.requestDeviceTracked(adapter, { requiredLimits: { [limit]: value } });
     assert(device !== null);
     t.expect(
-      device.limits[limit] === value,
+      device.limits[limit] === result,
       'Devices reported limit should match the required limit'
     );
   });

--- a/src/webgpu/api/operation/adapter/requestDevice.spec.ts
+++ b/src/webgpu/api/operation/adapter/requestDevice.spec.ts
@@ -224,7 +224,8 @@ g.test('limits,unknown')
   .desc(
     `
     Test that specifying limits that aren't part of the supported limit set causes
-    requestDevice to reject unless the value is undefined`
+    requestDevice to reject unless the value is undefined.
+    Also tests that the invalid requestDevice() call does not expire the adapter.`
   )
   .fn(async t => {
     const gpu = getGPU(t.rec);
@@ -235,6 +236,7 @@ g.test('limits,unknown')
       'OperationError',
       t.requestDeviceTracked(adapter, { requiredLimits: { unknownLimitName: 9000 } })
     );
+    // Adapter is still alive because the requestDevice() call was invalid.
 
     const device = await t.requestDeviceTracked(adapter, {
       requiredLimits: { unknownLimitName: undefined },


### PR DESCRIPTION
Spec PR: https://github.com/gpuweb/gpuweb/pull/4781

<img width="1840" alt="image" src="https://github.com/user-attachments/assets/234deff9-7dd2-4970-9b18-66c069ae673a">

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.) https://chromium-review.googlesource.com/c/chromium/src/+/6035406
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
