### PR TITLE
Add MaxLimitsTest that sets all limits to the adapter's

### DIFF
--- a/src/webgpu/api/operation/rendering/draw.spec.ts
+++ b/src/webgpu/api/operation/rendering/draw.spec.ts
@@ -11,10 +11,10 @@ import {
   TypedArrayBufferView,
   TypedArrayBufferViewConstructor,
 } from '../../../../common/util/util.js';
-import { GPUTest, TextureTestMixin } from '../../../gpu_test.js';
+import { MaxLimitsTest, TextureTestMixin } from '../../../gpu_test.js';
 import { PerPixelComparison } from '../../../util/texture/texture_ok.js';
 
-class DrawTest extends TextureTestMixin(GPUTest) {
+class DrawTest extends TextureTestMixin(MaxLimitsTest) {
   checkTriangleDraw(opts: {
     firstIndex: number | undefined;
     count: number;

--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -41,7 +41,13 @@ import {
 import { checkElementsEqual, checkElementsBetween } from './util/check_contents.js';
 import { CommandBufferMaker, EncoderType } from './util/command_buffer_maker.js';
 import { ScalarType } from './util/conversion.js';
-import { DevicePool, DeviceProvider, UncanonicalizedDeviceDescriptor } from './util/device_pool.js';
+import {
+  CanonicalDeviceDescriptor,
+  DescriptorModifierFn,
+  DevicePool,
+  DeviceProvider,
+  UncanonicalizedDeviceDescriptor,
+} from './util/device_pool.js';
 import { align, roundDown } from './util/math.js';
 import { physicalMipSizeFromTexture, virtualMipSize } from './util/texture/base.js';
 import {
@@ -137,11 +143,15 @@ export class GPUTestSubcaseBatchState extends SubcaseBatchState {
    *
    * If the request isn't supported, throws a SkipTestCase exception to skip the entire test case.
    */
-  selectDeviceOrSkipTestCase(descriptor: DeviceSelectionDescriptor): void {
+  selectDeviceOrSkipTestCase(
+    descriptor: DeviceSelectionDescriptor,
+    descriptorModifierFn?: DescriptorModifierFn
+  ): void {
     assert(this.provider === undefined, "Can't selectDeviceOrSkipTestCase() multiple times");
     this.provider = devicePool.acquire(
       this.recorder,
-      initUncanonicalizedDeviceDescriptor(descriptor)
+      initUncanonicalizedDeviceDescriptor(descriptor),
+      descriptorModifierFn
     );
     // Suppress uncaught promise rejection (we'll catch it later).
     this.provider.catch(() => {});
@@ -202,7 +212,8 @@ export class GPUTestSubcaseBatchState extends SubcaseBatchState {
 
     this.mismatchedProvider = mismatchedDevicePool.acquire(
       this.recorder,
-      initUncanonicalizedDeviceDescriptor(descriptor)
+      initUncanonicalizedDeviceDescriptor(descriptor),
+      undefined
     );
     // Suppress uncaught promise rejection (we'll catch it later).
     this.mismatchedProvider.catch(() => {});
@@ -1277,6 +1288,82 @@ export class GPUTest extends GPUTestBase {
 }
 
 /**
+ * Gets the adapter limits as a standard JavaScript object.
+ */
+function getAdapterLimitsAsDeviceRequiredLimits(adapter: GPUAdapter) {
+  const requiredLimits: Record<string, GPUSize64> = {};
+  const adapterLimits = adapter.limits as unknown as Record<string, GPUSize64>;
+  for (const key in adapter.limits) {
+    requiredLimits[key] = adapterLimits[key];
+  }
+  return requiredLimits;
+}
+
+function setAllLimitsToAdapterLimits(
+  adapter: GPUAdapter,
+  desc: CanonicalDeviceDescriptor | undefined
+) {
+  const descWithMaxLimits: CanonicalDeviceDescriptor = {
+    requiredFeatures: [],
+    defaultQueue: {},
+    ...(desc ?? desc),
+    requiredLimits: getAdapterLimitsAsDeviceRequiredLimits(adapter),
+  };
+  return descWithMaxLimits;
+}
+
+/**
+ * Used by MaxLimitsTest to request a device with all the max limits of the adapter.
+ */
+export class MaxLimitsGPUTestSubcaseBatchState extends GPUTestSubcaseBatchState {
+  override selectDeviceOrSkipTestCase(
+    descriptor: DeviceSelectionDescriptor,
+    descriptorModifierFn?: DescriptorModifierFn
+  ): void {
+    const wrapper = (adapter: GPUAdapter, desc: CanonicalDeviceDescriptor | undefined) => {
+      desc = descriptorModifierFn ? descriptorModifierFn(adapter, desc) : desc;
+      return setAllLimitsToAdapterLimits(adapter, desc);
+    };
+    super.selectDeviceOrSkipTestCase(initUncanonicalizedDeviceDescriptor(descriptor), wrapper);
+  }
+}
+
+/**
+ * A Test that requests all the max limits from the adapter on the device.
+ */
+export class MaxLimitsTest extends GPUTestBase {
+  // Should never be undefined in a test. If it is, init() must not have run/finished.
+  private provider: DeviceProvider | undefined;
+
+  public static override MakeSharedState(
+    recorder: TestCaseRecorder,
+    params: TestParams
+  ): GPUTestSubcaseBatchState {
+    return new MaxLimitsGPUTestSubcaseBatchState(recorder, params);
+  }
+
+  override async init() {
+    await super.init();
+
+    this.provider = await this.sharedState.acquireProvider();
+  }
+
+  /** GPUAdapter that the device was created from. */
+  get adapter(): GPUAdapter {
+    assert(this.provider !== undefined, 'internal error: DeviceProvider missing');
+    return this.provider.adapter;
+  }
+
+  /**
+   * GPUDevice for the test to use.
+   */
+  override get device(): GPUDevice {
+    assert(this.provider !== undefined, 'internal error: DeviceProvider missing');
+    return this.provider.device;
+  }
+}
+
+/**
  * Texture expectation mixin can be applied on top of GPUTest to add texture
  * related expectation helpers.
  */
@@ -1494,11 +1581,11 @@ type LinearCopyParameters = {
   data: Uint8Array;
 };
 
-export function TextureTestMixin<F extends FixtureClass<GPUTest>>(
+export function TextureTestMixin<F extends FixtureClass<GPUTestBase>>(
   Base: F
 ): FixtureClassWithMixin<F, TextureTestMixinType> {
   class TextureExpectations
-    extends (Base as FixtureClassInterface<GPUTest>)
+    extends (Base as FixtureClassInterface<GPUTestBase>)
     implements TextureTestMixinType
   {
     /**

--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -1306,7 +1306,7 @@ function setAllLimitsToAdapterLimits(
   const descWithMaxLimits: CanonicalDeviceDescriptor = {
     requiredFeatures: [],
     defaultQueue: {},
-    ...(desc ?? desc),
+    ...desc,
     requiredLimits: getAdapterLimitsAsDeviceRequiredLimits(adapter),
   };
   return descWithMaxLimits;
@@ -1331,35 +1331,12 @@ export class MaxLimitsGPUTestSubcaseBatchState extends GPUTestSubcaseBatchState 
 /**
  * A Test that requests all the max limits from the adapter on the device.
  */
-export class MaxLimitsTest extends GPUTestBase {
-  // Should never be undefined in a test. If it is, init() must not have run/finished.
-  private provider: DeviceProvider | undefined;
-
+export class MaxLimitsTest extends GPUTest {
   public static override MakeSharedState(
     recorder: TestCaseRecorder,
     params: TestParams
   ): GPUTestSubcaseBatchState {
     return new MaxLimitsGPUTestSubcaseBatchState(recorder, params);
-  }
-
-  override async init() {
-    await super.init();
-
-    this.provider = await this.sharedState.acquireProvider();
-  }
-
-  /** GPUAdapter that the device was created from. */
-  get adapter(): GPUAdapter {
-    assert(this.provider !== undefined, 'internal error: DeviceProvider missing');
-    return this.provider.adapter;
-  }
-
-  /**
-   * GPUDevice for the test to use.
-   */
-  override get device(): GPUDevice {
-    assert(this.provider !== undefined, 'internal error: DeviceProvider missing');
-    return this.provider.device;
   }
 }
 

--- a/src/webgpu/util/texture.ts
+++ b/src/webgpu/util/texture.ts
@@ -5,7 +5,7 @@ import {
   isStencilTextureFormat,
   kTextureFormatInfo,
 } from '../format_info.js';
-import { GPUTest } from '../gpu_test.js';
+import { GPUTestBase } from '../gpu_test.js';
 
 import { getTextureCopyLayout } from './texture/layout.js';
 import { TexelView } from './texture/texel_view.js';
@@ -328,7 +328,7 @@ const s_copyBufferToTextureViaRenderPipelines = new WeakMap<
 >();
 
 function copyBufferToTextureViaRender(
-  t: GPUTest,
+  t: GPUTestBase,
   encoder: GPUCommandEncoder,
   source: GPUTexelCopyBufferInfo,
   sourceFormat: GPUTextureFormat,
@@ -500,7 +500,7 @@ function copyBufferToTextureViaRender(
  * from `texelViews[i]`.
  */
 export function createTextureFromTexelViews(
-  t: GPUTest,
+  t: GPUTestBase,
   texelViews: TexelView[],
   desc: Omit<GPUTextureDescriptor, 'format'> & { format?: GPUTextureFormat }
 ): GPUTexture {

--- a/src/webgpu/util/texture/texture_ok.ts
+++ b/src/webgpu/util/texture/texture_ok.ts
@@ -1,6 +1,6 @@
 import { assert, ErrorWithExtra, unreachable } from '../../../common/util/util.js';
 import { kTextureFormatInfo, EncodableTextureFormat } from '../../format_info.js';
-import { GPUTest } from '../../gpu_test.js';
+import { GPUTestBase } from '../../gpu_test.js';
 import { numbersApproximatelyEqual } from '../conversion.js';
 import { generatePrettyTable, numericToStringBuilder } from '../pretty_diff_tables.js';
 import { reifyExtent3D, reifyOrigin3D } from '../unions.js';
@@ -166,7 +166,7 @@ function comparePerComponent(
 
 /** Create a new mappable GPUBuffer, and copy a subrectangle of GPUTexture data into it. */
 function createTextureCopyForMapRead(
-  t: GPUTest,
+  t: GPUTestBase,
   source: GPUTexelCopyTextureInfo,
   copySize: GPUExtent3D,
   { format }: { format: EncodableTextureFormat }
@@ -297,7 +297,7 @@ ${generatePrettyTable(opts, [
  * subnormal numbers (where ULP is defined for float, normalized, and integer formats).
  */
 export async function textureContentIsOKByT2B(
-  t: GPUTest,
+  t: GPUTestBase,
   source: GPUTexelCopyTextureInfo,
   copySize_: GPUExtent3D,
   { expTexelView }: { expTexelView: TexelView },


### PR DESCRIPTION
This is what I came up with. Without a major refactor the issue is the adapter is requested at an extremely low level but a test needs access to an adapter to select limits.

So, made `selectDeviceOrSkipTestCase` pass an optional callback all the way down that gets passed the adapter and a `CanonicalDeviceDescriptor`, giving it a chance to modify it down at the level where an adapter is available.

More of the CTS tests need to be testing with max limits.

Issue: #3363

