### PR TITLE
Special case `minSubgroupSize` and `maxSubgroupSize`

### DIFF
--- a/src/webgpu/api/operation/device/all_limits_and_features.spec.ts
+++ b/src/webgpu/api/operation/device/all_limits_and_features.spec.ts
@@ -1,0 +1,95 @@
+export const description = `Test you can request an device with all features and limits`;
+
+import { TestCaseRecorder, TestParams } from '../../../../common/framework/fixture.js';
+import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import {
+  DeviceSelectionDescriptor,
+  GPUTest,
+  GPUTestSubcaseBatchState,
+  initUncanonicalizedDeviceDescriptor,
+} from '../../../gpu_test.js';
+import { CanonicalDeviceDescriptor, DescriptorModifierFn } from '../../../util/device_pool.js';
+
+/**
+ * Gets the adapter limits as a standard JavaScript object.
+ */
+function getAdapterLimitsAsDeviceRequiredLimits(adapter: GPUAdapter) {
+  const requiredLimits: Record<string, GPUSize64> = {};
+  const adapterLimits = adapter.limits as unknown as Record<string, GPUSize64>;
+  for (const key in adapter.limits) {
+    requiredLimits[key] = adapterLimits[key];
+  }
+  return requiredLimits;
+}
+
+function setAllLimitsToAdapterLimitsAndAddAllFeatures(
+  adapter: GPUAdapter,
+  desc: CanonicalDeviceDescriptor | undefined
+) {
+  const descWithMaxLimits: CanonicalDeviceDescriptor = {
+    defaultQueue: {},
+    ...desc,
+    requiredFeatures: [...adapter.features] as GPUFeatureName[],
+    requiredLimits: getAdapterLimitsAsDeviceRequiredLimits(adapter),
+  };
+  return descWithMaxLimits;
+}
+
+/**
+ * Used by MaxLimitsTest to request a device with all the max limits of the adapter.
+ */
+export class AllLimitsAndFeaturesGPUTestSubcaseBatchState extends GPUTestSubcaseBatchState {
+  override selectDeviceOrSkipTestCase(
+    descriptor: DeviceSelectionDescriptor,
+    descriptorModifierFn?: DescriptorModifierFn
+  ): void {
+    const wrapper = (adapter: GPUAdapter, desc: CanonicalDeviceDescriptor | undefined) => {
+      desc = descriptorModifierFn ? descriptorModifierFn(adapter, desc) : desc;
+      return setAllLimitsToAdapterLimitsAndAddAllFeatures(adapter, desc);
+    };
+    super.selectDeviceOrSkipTestCase(initUncanonicalizedDeviceDescriptor(descriptor), wrapper);
+  }
+}
+
+/**
+ * A Test that requests all the max limits from the adapter on the device.
+ */
+export class AllLimitsAndFeaturesLimitsTest extends GPUTest {
+  public static override MakeSharedState(
+    recorder: TestCaseRecorder,
+    params: TestParams
+  ): GPUTestSubcaseBatchState {
+    return new AllLimitsAndFeaturesGPUTestSubcaseBatchState(recorder, params);
+  }
+}
+
+export const g = makeTestGroup(AllLimitsAndFeaturesLimitsTest);
+
+g.test('everything')
+  .desc(
+    `
+Test we can request all features and limits.
+
+It is expected that, even though this is generally not recommended, because
+it is possible, make sure it works and continues to work going forward so that
+changes to WebGPU do not break sites requesting everything.
+`
+  )
+  .fn(t => {
+    // Test that all the limits on the device match the adapter.
+    const adapterLimits = t.adapter.limits as unknown as Record<string, GPUSize64>;
+    const deviceLimits = t.device.limits as unknown as Record<string, GPUSize64>;
+    for (const key in t.adapter.limits) {
+      const deviceLimit = deviceLimits[key];
+      const adapterLimit = adapterLimits[key];
+      t.expect(
+        deviceLimit === adapterLimit,
+        `device.limits.${key} (${deviceLimit}) === adapter.limits.${key} (${adapterLimit})`
+      );
+    }
+
+    // Test that all the adapter features are on the device.
+    for (const feature of t.adapter.features) {
+      t.expect(t.device.features.has(feature), `device has feature: ${feature}`);
+    }
+  });

--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -78,7 +78,7 @@ export type ResourceState = (typeof kResourceStateValues)[number];
 export const kResourceStates: readonly ResourceState[] = kResourceStateValues;
 
 /** Various "convenient" shorthands for GPUDeviceDescriptors for selectDevice functions. */
-type DeviceSelectionDescriptor =
+export type DeviceSelectionDescriptor =
   | UncanonicalizedDeviceDescriptor
   | GPUFeatureName
   | undefined
@@ -1294,6 +1294,11 @@ function getAdapterLimitsAsDeviceRequiredLimits(adapter: GPUAdapter) {
   const requiredLimits: Record<string, GPUSize64> = {};
   const adapterLimits = adapter.limits as unknown as Record<string, GPUSize64>;
   for (const key in adapter.limits) {
+    // MAINTENANCE_TODO: Remove this once minSubgroupSize is removed from
+    // chromium.
+    if (key === 'maxSubgroupSize' || key === 'minSubgroupSize') {
+      continue;
+    }
     requiredLimits[key] = adapterLimits[key];
   }
   return requiredLimits;


### PR DESCRIPTION
These are problematic at the moment and prevent `MaxLimitsTest` from functioning. We'll remove them once subgroups switches to it's new specification.

Also added an all features and limits test so there is something that fails now until subgroups is refactored.


<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [X] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
