### PR TITLE
Improve fragment shader checks in subgroupBitwise

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/subgroupBitwise.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/subgroupBitwise.spec.ts
@@ -433,7 +433,7 @@ fn main(
 /**
  * Checks bitwise ops results from a fragment shader.
  *
- * Avoids the last row and column to skip potential helper invocations.
+ * Avoids subgroups in last row or column to skip potential helper invocations.
  * @param data Framebuffer output
  *             * component 0 is result
  *             * component 1 is generated subgroup id
@@ -453,16 +453,48 @@ function checkBitwiseFragment(
 ): Error | undefined {
   const { uintsPerRow, uintsPerTexel } = getUintsPerFramebuffer(format, width, height);
 
-  // Iteration skips last row and column to avoid helper invocations because it is not
-  // guaranteed whether or not they participate in the subgroup operation.
+  // Determine if the subgroup should be included in the checks.
+  const inBounds = new Map<number, boolean>();
+  for (let row = 0; row < height; row++) {
+    for (let col = 0; col < width; col++) {
+      const offset = uintsPerRow * row + col * uintsPerTexel;
+      const subgroup_id = data[offset + 1];
+      if (subgroup_id === 0) {
+        return new Error(`Internal error: helper invocation at (${col}, ${row})`);
+      }
+
+      let ok = inBounds.get(subgroup_id) ?? true;
+      ok = ok && (row !== height - 1) && (col !== width - 1);
+      inBounds.set(subgroup_id, ok);
+    }
+  }
+
+  let anyInBounds = false;
+  for (let [key, value] of inBounds) {
+    const ok = Boolean(value);
+    anyInBounds = anyInBounds || ok;
+  }
+  if (!anyInBounds) {
+    // This variant would not reliably test behavior.
+    return undefined;
+  }
+
+  // Iteration skips subgroups in the last row or column to avoid helper
+  // invocations because it is not guaranteed whether or not they participate
+  // in the subgroup operation.
   const expected = new Map<number, number>();
-  for (let row = 0; row < height - 1; row++) {
-    for (let col = 0; col < width - 1; col++) {
+  for (let row = 0; row < height; row++) {
+    for (let col = 0; col < width; col++) {
       const offset = uintsPerRow * row + col * uintsPerTexel;
       const subgroup_id = data[offset + 1];
 
       if (subgroup_id === 0) {
         return new Error(`Internal error: helper invocation at (${col}, ${row})`);
+      }
+
+      const subgroupInBounds = inBounds.get(subgroup_id) ?? true;
+      if (!subgroupInBounds) {
+        continue;
       }
 
       let v = expected.get(subgroup_id) ?? identity(op);
@@ -471,14 +503,19 @@ function checkBitwiseFragment(
     }
   }
 
-  for (let row = 0; row < height - 1; row++) {
-    for (let col = 0; col < width - 1; col++) {
+  for (let row = 0; row < height; row++) {
+    for (let col = 0; col < width; col++) {
       const offset = uintsPerRow * row + col * uintsPerTexel;
       const res = data[offset];
       const subgroup_id = data[offset + 1];
 
       if (subgroup_id === 0) {
         // Inactive in the fragment.
+        continue;
+      }
+
+      const subgroupInBounds = inBounds.get(subgroup_id) ?? true;
+      if (!subgroupInBounds) {
         continue;
       }
 
@@ -509,6 +546,14 @@ g.test('fragment,all_active')
   })
   .fn(async t => {
     const numInputs = t.params.size[0] * t.params.size[1];
+
+    interface SubgroupLimits extends GPUSupportedLimits {
+      minSubgroupSize: number;
+    }
+    const { minSubgroupSize } = t.device.limits as SubgroupLimits;
+    const innerTexels = (t.params.size[0] - 1) * (t.params.size[1] - 1);
+    t.skipIf(innerTexels < minSubgroupSize, 'Too few texels to be reliable');
+
     const inputData = generateInputData(t.params.case, numInputs, identity(t.params.op));
 
     const ident = identity(t.params.op) === 0 ? '0' : '0xffffffff';

--- a/src/webgpu/shader/execution/expression/call/builtin/subgroupBitwise.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/subgroupBitwise.spec.ts
@@ -464,13 +464,13 @@ function checkBitwiseFragment(
       }
 
       let ok = inBounds.get(subgroup_id) ?? true;
-      ok = ok && (row !== height - 1) && (col !== width - 1);
+      ok = ok && row !== height - 1 && col !== width - 1;
       inBounds.set(subgroup_id, ok);
     }
   }
 
   let anyInBounds = false;
-  for (let [key, value] of inBounds) {
+  for (const [_, value] of inBounds) {
     const ok = Boolean(value);
     anyInBounds = anyInBounds || ok;
   }


### PR DESCRIPTION
* Modifies the fragment tests in subgroupBitwise to avoid any subgroup in the last row or column
  * this fixes failures seen on some devices performing subgroupXor when helpers are in bounds, but not on the edge of the framebuffer
* Tests skip cases that could not possibly yield useful results, but checking is also terminated early if no useful results can be found
  * Enough framebuffer variants are swept to ensure some tests will cover useful subgroups, but the sizes are only known after a pipeline compile

This fixes the errors I was seeing in small framebuffer sizes on Apple silicon. 


Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [ ] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [ ] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [ ] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
