### PR TITLE
[wgsl] Add two more statement behavior test cases

### DIFF
--- a/src/webgpu/shader/validation/statement/statement_behavior.spec.ts
+++ b/src/webgpu/shader/validation/statement/statement_behavior.spec.ts
@@ -86,7 +86,7 @@ const kValidStatements = {
   while3: `while true { continue; break; }`,
 
   switch1: `switch 1 { default { } }`,
-  swtich2: `switch 1 { case 1 { } default { } }`,
+  switch2: `switch 1 { case 1 { } default { } }`,
   switch3: `switch 1 { default { break; } }`,
   switch4: `switch 1 { default { } case 1 { break; } }`,
 
@@ -130,7 +130,9 @@ g.test('invalid_functions')
 const kValidFunctions = {
   empty: `fn foo() { }`,
   next_return: `fn foo() { if true { return; } }`,
+  unreachable_code_after_return_with_value: `fn foo() -> bool { return false; _ = 0; }`,
   no_final_return: `fn foo() -> bool { if true { return true; } else { return false; } }`,
+  no_final_return_unreachable_code: `fn foo() -> bool { if true { return true; } else { return false; } _ = 0; _ = 1; }`,
 };
 
 g.test('valid_functions')


### PR DESCRIPTION
These cover unreachable code after statements with `return` behavior for functions that have non-void return types, which were not previously covered and not handled correctly in Tint.

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [X] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
