### PR TITLE
Add back unicode for texture diagrams

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/texture_utils.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/texture_utils.ts
@@ -3430,25 +3430,72 @@ async function identifySamplePoints<T extends Dimensionality>(
   // example when blockWidth = 2, blockHeight = 2
   //
   //     0   1   2   3
-  //   +===+===+===+===+
-  // 0 # a |   #   |   #
-  //   +---+---+---+---+
-  // 1 #   |   #   |   #
-  //   +===+===+===+===+
-  // 2 #   |   #   |   #
-  //   +---+---+---+---+
-  // 3 #   |   #   | b #
-  //   +===+===+===+===+
+  //   ╔═══╤═══╦═══╤═══╗
+  // 0 ║ a │   ║   │   ║
+  //   ╟───┼───╫───┼───╢
+  // 1 ║   │   ║   │   ║
+  //   ╠═══╪═══╬═══╪═══╣
+  // 2 ║   │   ║   │   ║
+  //   ╟───┼───╫───┼───╢
+  // 3 ║   │   ║   │ b ║
+  //   ╚═══╧═══╩═══╧═══╝
+
+  /* prettier-ignore */
+  const blockParts = {
+    top:      { left: '╔', fill: '═══', right: '╗', block: '╦', texel: '╤' },
+    mid:      { left: '╠', fill: '═══', right: '╣', block: '╬', texel: '╪' },
+    bot:      { left: '╚', fill: '═══', right: '╝', block: '╩', texel: '╧' },
+    texelMid: { left: '╟', fill: '───', right: '╢', block: '╫', texel: '┼' },
+    value:    { left: '║', fill: '   ', right: '║', block: '║', texel: '│' },
+  } as const;
+  /* prettier-ignore */
+  const nonBlockParts = {
+    top:      { left: '┌', fill: '───', right: '┐', block: '┬', texel: '┬' },
+    mid:      { left: '├', fill: '───', right: '┤', block: '┼', texel: '┼' },
+    bot:      { left: '└', fill: '───', right: '┘', block: '┴', texel: '┴' },
+    texelMid: { left: '├', fill: '───', right: '┤', block: '┼', texel: '┼' },
+    value:    { left: '│', fill: '   ', right: '│', block: '│', texel: '│' },
+  } as const;
 
   const lines: string[] = [];
   const letter = (idx: number) => String.fromCodePoint(idx < 30 ? 97 + idx : idx + 9600 - 30); // 97: 'a'
   let idCount = 0;
 
   const { blockWidth, blockHeight } = kTextureFormatInfo[texture.descriptor.format];
-  const [blockHChar, blockVChar] = Math.max(blockWidth, blockHeight) > 1 ? ['=', '#'] : ['-', '|'];
-  const blockHCell = '+'.padStart(4, blockHChar); // generates ---+ or ===+
   // range + concatenate results.
   const rangeCat = <T>(num: number, fn: (i: number) => T) => range(num, fn).join('');
+  const joinFn = (arr: string[], fn: (i: number) => string) => {
+    const joins = range(arr.length - 1, fn);
+    return arr.map((s, i) => `${s}${joins[i] ?? ''}`).join('');
+  };
+  const parts = Math.max(blockWidth, blockHeight) > 1 ? blockParts : nonBlockParts;
+  /**
+   * Makes a row that's [left, fill, texel, fill, block, fill, texel, fill, right]
+   * except if `contents` is supplied then it would be
+   * [left, contents[0], texel, contents[1], block, contents[2], texel, contents[3], right]
+   */
+  const makeRow = (
+    blockPaddedWidth: number,
+    width: number,
+    {
+      left,
+      fill,
+      right,
+      block,
+      texel,
+    }: {
+      left: string;
+      fill: string;
+      right: string;
+      block: string;
+      texel: string;
+    },
+    contents?: string[]
+  ) => {
+    return `${left}${joinFn(contents ?? range(blockPaddedWidth, x => fill), x => {
+      return (x + 1) % blockWidth === 0 ? block : texel;
+    })}${right}`;
+  };
 
   for (let mipLevel = 0; mipLevel < mipLevelCount; ++mipLevel) {
     const level = levels[mipLevel];
@@ -3478,31 +3525,39 @@ async function identifySamplePoints<T extends Dimensionality>(
         continue;
       }
 
+      const blockPaddedHeight = align(height, blockHeight);
+      const blockPaddedWidth = align(width, blockWidth);
       lines.push(`   ${rangeCat(width, x => `  ${x.toString().padEnd(2)}`)}`);
-      lines.push(`   +${rangeCat(width, () => blockHCell)}`);
-      for (let y = 0; y < height; y++) {
-        {
-          let line = `${y.toString().padStart(2)} ${blockVChar}`;
-          for (let x = 0; x < width; x++) {
-            const colChar = (x + 1) % blockWidth === 0 ? blockVChar : '|';
-            const texelIdx = x + y * texelsPerRow;
-            const weight = layerEntries.get(texelIdx);
-            if (weight !== undefined) {
-              line += ` ${letter(idCount + orderedTexelIndices.length)} ${colChar}`;
-              orderedTexelIndices.push(texelIdx);
-            } else {
-              line += `   ${colChar}`;
-            }
-          }
-          lines.push(line);
-        }
-        if (y < height - 1) {
-          lines.push(
-            `   +${rangeCat(width, () => ((y + 1) % blockHeight === 0 ? blockHCell : '---+'))}`
-          );
-        }
+      lines.push(`   ${makeRow(blockPaddedWidth, width, parts.top)}`);
+      for (let y = 0; y < blockPaddedHeight; y++) {
+        lines.push(
+          `${y.toString().padStart(2)} ${makeRow(
+            blockPaddedWidth,
+            width,
+            parts.value,
+            range(blockPaddedWidth, x => {
+              const texelIdx = x + y * texelsPerRow;
+              const weight = layerEntries.get(texelIdx);
+              const outside = y >= height || x >= width;
+              if (outside || weight === undefined) {
+                return outside ? '░░░' : '   ';
+              } else {
+                const id = letter(idCount + orderedTexelIndices.length);
+                orderedTexelIndices.push(texelIdx);
+                return ` ${id} `;
+              }
+            })
+          )}`
+        );
+        // It's either a block row, a texel row, or the last row.
+        const end = y < blockPaddedHeight - 1;
+        const lineParts = end
+          ? (y + 1) % blockHeight === 0
+            ? parts.mid
+            : parts.texelMid
+          : parts.bot;
+        lines.push(`   ${makeRow(blockPaddedWidth, width, lineParts)}`);
       }
-      lines.push(`   +${range(width, () => blockHCell).join('')}`);
 
       const pad2 = (n: number) => n.toString().padStart(2);
       const pad3 = (n: number) => n.toString().padStart(3);


### PR DESCRIPTION
Example:

```
       0   1   2   3
     ╔═══╤═══╦═══╤═══╗
   0 ║ a │   ║   │   ║
     ╟───┼───╫───┼───╢
   1 ║   │   ║   │   ║
     ╠═══╪═══╬═══╪═══╣
   2 ║   │   ║   │   ║
     ╟───┼───╫───┼───╢
   3 ║   │   ║   │ b ║
     ╚═══╧═══╩═══╧═══╝
```

Unicode was removed here: https://github.com/gpuweb/cts/pull/4008
Since then, outlining blocks was added here: https://github.com/gpuweb/cts/pull/4053
So it's not just a revert.

Chrome's CQ appears to be happy with this now. [example1](https://ci.chromium.org/ui/p/chromium/builders/try/mac-arm64-dawn-rel/11826/test-results?q=ExactID%3Aninja%3A%2F%2Fchrome%2Ftest%3Atelemetry_gpu_integration_test%2Fgpu_tests.webgpu_cts_integration_test.WebGpuCtsIntegrationTest.webgpu%3Ashader%2Cexecution%2Cexpression%2Ccall%2Cbuiltin%2CtextureSampleBias%3Aarrayed_2d_coords%3Aformat%3D%22astc-4x4-unorm%22%3Bfilt%3D%22linear%22%3BmodeU%3D%22m%22%3BmodeV%3D%22m%22%3Boffset%3Dtrue+VHash%3A76746c96c754b537&sortby=&groupby=) [example2](https://results.usercontent.cr.dev/invocations/task-chromium-swarm.appspot.com-6db3c9c657dea011/tests/ninja:%2F%2Fchrome%2Ftest:telemetry_gpu_integration_test%2Fgpu_tests.webgpu_cts_integration_test.WebGpuCtsIntegrationTest.webgpu:shader,execution,expression,call,builtin,textureSampleBias:arrayed_2d_coords:format=%22astc-4x4-unorm%22%3Bfilt=%22linear%22%3BmodeU=%22m%22%3BmodeV=%22m%22%3Boffset=true/results/34b75cea-10196/artifacts/typ_stderr?token=AXsiX2kiOiIxNzMzNzI0MTgzNTQyIiwiX3giOiIzNjAwMDAwIn0Qf-XEoq2TOMEs7wbeOdoqZ8qT7Sv5Enb8eC0aIxoF0A) [example3 (search for "got: above")](https://chromium-swarm.appspot.com/task?id=6db3c9c657dea011&o=true&w=true)
