### PR TITLE
Revert "Use subgroupMinSize, subgroupMaxSize from GPUAdapterInfo"

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/subgroupBitwise.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/subgroupBitwise.spec.ts
@@ -547,12 +547,12 @@ g.test('fragment,all_active')
   .fn(async t => {
     const numInputs = t.params.size[0] * t.params.size[1];
 
-    interface SubgroupProperties extends GPUAdapterInfo {
-      subgroupMinSize: number;
+    interface SubgroupLimits extends GPUSupportedLimits {
+      minSubgroupSize: number;
     }
-    const { subgroupMinSize } = t.device.adapterInfo as SubgroupProperties;
+    const { minSubgroupSize } = t.device.limits as SubgroupLimits;
     const innerTexels = (t.params.size[0] - 1) * (t.params.size[1] - 1);
-    t.skipIf(innerTexels < subgroupMinSize, 'Too few texels to be reliable');
+    t.skipIf(innerTexels < minSubgroupSize, 'Too few texels to be reliable');
 
     const inputData = generateInputData(t.params.case, numInputs, identity(t.params.op));
 

--- a/src/webgpu/shader/execution/expression/call/builtin/subgroupBroadcast.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/subgroupBroadcast.spec.ts
@@ -444,12 +444,12 @@ g.test('compute,split')
     const testcase = kPredicateCases[t.params.predicate];
     const wgThreads = t.params.wgSize[0] * t.params.wgSize[1] * t.params.wgSize[2];
 
-    interface SubgroupProperties extends GPUAdapterInfo {
-      subgroupMinSize: number;
-      subgroupMaxSize: number;
+    interface SubgroupLimits extends GPUSupportedLimits {
+      minSubgroupSize: number;
+      maxSubgroupSize: number;
     }
-    const { subgroupMinSize, subgroupMaxSize } = t.device.adapterInfo as SubgroupProperties;
-    for (let size = subgroupMinSize; size <= subgroupMaxSize; size *= 2) {
+    const { minSubgroupSize, maxSubgroupSize } = t.device.limits as SubgroupLimits;
+    for (let size = minSubgroupSize; size <= maxSubgroupSize; size *= 2) {
       t.skipIf(!testcase.filter(t.params.id, size), 'Skipping potential undefined behavior');
     }
 
@@ -669,11 +669,11 @@ g.test('fragment')
   })
   .fn(async t => {
     const innerTexels = (t.params.size[0] - 1) * (t.params.size[1] - 1);
-    interface SubgroupProperties extends GPUAdapterInfo {
-      subgroupMaxSize: number;
+    interface SubgroupLimits extends GPUSupportedLimits {
+      maxSubgroupSize: number;
     }
-    const { subgroupMaxSize } = t.device.adapterInfo as SubgroupProperties;
-    t.skipIf(innerTexels < subgroupMaxSize, 'Too few texels to be reliable');
+    const { maxSubgroupSize } = t.device.limits as SubgroupLimits;
+    t.skipIf(innerTexels < maxSubgroupSize, 'Too few texels to be reliable');
 
     const broadcast =
       t.params.id === 0

--- a/src/webgpu/shader/execution/shader_io/compute_builtins.spec.ts
+++ b/src/webgpu/shader/execution/shader_io/compute_builtins.spec.ts
@@ -398,11 +398,11 @@ g.test('subgroup_size')
     t.selectDeviceOrSkipTestCase('subgroups' as GPUFeatureName);
   })
   .fn(async t => {
-    interface SubgroupProperties extends GPUAdapterInfo {
-      subgroupMinSize: number;
-      subgroupMaxSize: number;
+    interface SubgroupLimits extends GPUSupportedLimits {
+      minSubgroupSize: number;
+      maxSubgroupSize: number;
     }
-    const { subgroupMinSize, subgroupMaxSize } = t.device.adapterInfo as SubgroupProperties;
+    const { minSubgroupSize, maxSubgroupSize } = t.device.limits as SubgroupLimits;
 
     const wgx = t.params.sizes[0];
     const wgy = t.params.sizes[1];
@@ -518,8 +518,8 @@ fn main(@builtin(subgroup_size) size : u32,
       checkSubgroupSizeConsistency(
         sizesData,
         compareData,
-        subgroupMinSize,
-        subgroupMaxSize,
+        minSubgroupSize,
+        maxSubgroupSize,
         wgThreads
       )
     );

--- a/src/webgpu/shader/execution/shader_io/fragment_builtins.spec.ts
+++ b/src/webgpu/shader/execution/shader_io/fragment_builtins.spec.ts
@@ -1655,16 +1655,16 @@ g.test('subgroup_size')
     t.selectDeviceOrSkipTestCase('subgroups' as GPUFeatureName);
   })
   .fn(async t => {
-    interface SubgroupProperties extends GPUAdapterInfo {
-      subgroupMinSize: number;
-      subgroupMaxSize: number;
+    interface SubgroupLimits extends GPUSupportedLimits {
+      minSubgroupSize: number;
+      maxSubgroupSize: number;
     }
-    const { subgroupMinSize, subgroupMaxSize } = t.device.adapterInfo as SubgroupProperties;
+    const { minSubgroupSize, maxSubgroupSize } = t.device.limits as SubgroupLimits;
 
     const fsShader = `
 enable subgroups;
 
-const subgroupMaxSize = ${kMaximiumSubgroupSize}u;
+const maxSubgroupSize = ${kMaximiumSubgroupSize}u;
 const noError = ${kSubgroupShaderNoError}u;
 
 const width = ${t.params.size[0]};
@@ -1686,7 +1686,7 @@ fn fsMain(
 
   var subgroupSizeBallotedInvocations: u32 = 0u;
   var ballotedSubgroupSize: u32 = 0u;
-  for (var i: u32 = 0; i <= subgroupMaxSize; i++) {
+  for (var i: u32 = 0; i <= maxSubgroupSize; i++) {
     let ballotSubgroupSizeEqualI = countOneBits(subgroupBallot(sg_size == i));
     let countSubgroupSizeEqualI = ballotSubgroupSizeEqualI.x + ballotSubgroupSizeEqualI.y + ballotSubgroupSizeEqualI.z + ballotSubgroupSizeEqualI.w;
     subgroupSizeBallotedInvocations += countSubgroupSizeEqualI;
@@ -1716,8 +1716,8 @@ fn fsMain(
         return checkSubgroupSizeConsistency(
           data,
           t.params.format,
-          subgroupMinSize,
-          subgroupMaxSize,
+          minSubgroupSize,
+          maxSubgroupSize,
           t.params.size[0],
           t.params.size[1]
         );
@@ -1816,7 +1816,7 @@ enable subgroups;
 const width = ${t.params.size[0]};
 const height = ${t.params.size[1]};
 
-const subgroupMaxSize = ${kMaximiumSubgroupSize}u;
+const maxSubgroupSize = ${kMaximiumSubgroupSize}u;
 // A non-zero magic number indicating no expectation error, in order to prevent the
 // false no-error result from zero-initialization.
 const noError = ${kSubgroupShaderNoError}u;
@@ -1830,8 +1830,8 @@ fn fsMain(
 
   var error: u32 = noError;
 
-  // Validate that reported subgroup size is no larger than subgroupMaxSize
-  if (sg_size > subgroupMaxSize) {
+  // Validate that reported subgroup size is no larger than maxSubgroupSize
+  if (sg_size > maxSubgroupSize) {
     error++;
   }
 
@@ -1843,7 +1843,7 @@ fn fsMain(
   // Validate that each subgroup id is assigned to at most one active invocation
   // in the subgroup
   var countAssignedId: u32 = 0u;
-  for (var i: u32 = 0; i < subgroupMaxSize; i++) {
+  for (var i: u32 = 0; i < maxSubgroupSize; i++) {
     let ballotIdEqualsI = countOneBits(subgroupBallot(id == i));
     let countInvocationIdEqualsI = ballotIdEqualsI.x + ballotIdEqualsI.y + ballotIdEqualsI.z + ballotIdEqualsI.w;
     // Validate an id assigned at most once


### PR DESCRIPTION
This reverts commit aa0b241a871ba24c35d38e0df97705e231298280.




Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [ ] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [ ] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [ ] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
