### PR TITLE
Reapply "Use subgroupMinSize, subgroupMaxSize from GPUAdapterInfo" (#…

### DIFF
--- a/src/webgpu/listing_meta.json
+++ b/src/webgpu/listing_meta.json
@@ -1,6 +1,9 @@
 {
   "_comment": "SEMI AUTO-GENERATED. This list is NOT exhaustive. Please read docs/adding_timing_metadata.md.",
   "webgpu:api,operation,adapter,info:adapter_info:*": { "subcaseMS": 32.901 },
+  "webgpu:api,operation,adapter,info:device_matches_adapter:*": { "subcaseMS": 14.708 },
+  "webgpu:api,operation,adapter,info:same_object:*": { "subcaseMS": 25.153 },
+  "webgpu:api,operation,adapter,info:subgroup_sizes:*": { "subcaseMS": 18.831 },
   "webgpu:api,operation,adapter,requestAdapter:requestAdapter:*": { "subcaseMS": 152.083 },
   "webgpu:api,operation,adapter,requestAdapter:requestAdapter_no_parameters:*": { "subcaseMS": 384.601 },
   "webgpu:api,operation,adapter,requestDevice:always_returns_device:*": { "subcaseMS": 19.450 },

--- a/src/webgpu/shader/execution/expression/call/builtin/subgroupBitwise.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/subgroupBitwise.spec.ts
@@ -547,12 +547,12 @@ g.test('fragment,all_active')
   .fn(async t => {
     const numInputs = t.params.size[0] * t.params.size[1];
 
-    interface SubgroupLimits extends GPUSupportedLimits {
-      minSubgroupSize: number;
+    interface SubgroupProperties extends GPUAdapterInfo {
+      subgroupMinSize: number;
     }
-    const { minSubgroupSize } = t.device.limits as SubgroupLimits;
+    const { subgroupMinSize } = t.device.adapterInfo as SubgroupProperties;
     const innerTexels = (t.params.size[0] - 1) * (t.params.size[1] - 1);
-    t.skipIf(innerTexels < minSubgroupSize, 'Too few texels to be reliable');
+    t.skipIf(innerTexels < subgroupMinSize, 'Too few texels to be reliable');
 
     const inputData = generateInputData(t.params.case, numInputs, identity(t.params.op));
 

--- a/src/webgpu/shader/execution/expression/call/builtin/subgroupBroadcast.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/subgroupBroadcast.spec.ts
@@ -444,12 +444,12 @@ g.test('compute,split')
     const testcase = kPredicateCases[t.params.predicate];
     const wgThreads = t.params.wgSize[0] * t.params.wgSize[1] * t.params.wgSize[2];
 
-    interface SubgroupLimits extends GPUSupportedLimits {
-      minSubgroupSize: number;
-      maxSubgroupSize: number;
+    interface SubgroupProperties extends GPUAdapterInfo {
+      subgroupMinSize: number;
+      subgroupMaxSize: number;
     }
-    const { minSubgroupSize, maxSubgroupSize } = t.device.limits as SubgroupLimits;
-    for (let size = minSubgroupSize; size <= maxSubgroupSize; size *= 2) {
+    const { subgroupMinSize, subgroupMaxSize } = t.device.adapterInfo as SubgroupProperties;
+    for (let size = subgroupMinSize; size <= subgroupMaxSize; size *= 2) {
       t.skipIf(!testcase.filter(t.params.id, size), 'Skipping potential undefined behavior');
     }
 
@@ -669,11 +669,11 @@ g.test('fragment')
   })
   .fn(async t => {
     const innerTexels = (t.params.size[0] - 1) * (t.params.size[1] - 1);
-    interface SubgroupLimits extends GPUSupportedLimits {
-      maxSubgroupSize: number;
+    interface SubgroupProperties extends GPUAdapterInfo {
+      subgroupMaxSize: number;
     }
-    const { maxSubgroupSize } = t.device.limits as SubgroupLimits;
-    t.skipIf(innerTexels < maxSubgroupSize, 'Too few texels to be reliable');
+    const { subgroupMaxSize } = t.device.adapterInfo as SubgroupProperties;
+    t.skipIf(innerTexels < subgroupMaxSize, 'Too few texels to be reliable');
 
     const broadcast =
       t.params.id === 0

--- a/src/webgpu/shader/execution/shader_io/compute_builtins.spec.ts
+++ b/src/webgpu/shader/execution/shader_io/compute_builtins.spec.ts
@@ -398,11 +398,11 @@ g.test('subgroup_size')
     t.selectDeviceOrSkipTestCase('subgroups' as GPUFeatureName);
   })
   .fn(async t => {
-    interface SubgroupLimits extends GPUSupportedLimits {
-      minSubgroupSize: number;
-      maxSubgroupSize: number;
+    interface SubgroupProperties extends GPUAdapterInfo {
+      subgroupMinSize: number;
+      subgroupMaxSize: number;
     }
-    const { minSubgroupSize, maxSubgroupSize } = t.device.limits as SubgroupLimits;
+    const { subgroupMinSize, subgroupMaxSize } = t.device.adapterInfo as SubgroupProperties;
 
     const wgx = t.params.sizes[0];
     const wgy = t.params.sizes[1];
@@ -518,8 +518,8 @@ fn main(@builtin(subgroup_size) size : u32,
       checkSubgroupSizeConsistency(
         sizesData,
         compareData,
-        minSubgroupSize,
-        maxSubgroupSize,
+        subgroupMinSize,
+        subgroupMaxSize,
         wgThreads
       )
     );

--- a/src/webgpu/shader/execution/shader_io/fragment_builtins.spec.ts
+++ b/src/webgpu/shader/execution/shader_io/fragment_builtins.spec.ts
@@ -1655,16 +1655,16 @@ g.test('subgroup_size')
     t.selectDeviceOrSkipTestCase('subgroups' as GPUFeatureName);
   })
   .fn(async t => {
-    interface SubgroupLimits extends GPUSupportedLimits {
-      minSubgroupSize: number;
-      maxSubgroupSize: number;
+    interface SubgroupProperties extends GPUAdapterInfo {
+      subgroupMinSize: number;
+      subgroupMaxSize: number;
     }
-    const { minSubgroupSize, maxSubgroupSize } = t.device.limits as SubgroupLimits;
+    const { subgroupMinSize, subgroupMaxSize } = t.device.adapterInfo as SubgroupProperties;
 
     const fsShader = `
 enable subgroups;
 
-const maxSubgroupSize = ${kMaximiumSubgroupSize}u;
+const subgroupMaxSize = ${kMaximiumSubgroupSize}u;
 const noError = ${kSubgroupShaderNoError}u;
 
 const width = ${t.params.size[0]};
@@ -1686,7 +1686,7 @@ fn fsMain(
 
   var subgroupSizeBallotedInvocations: u32 = 0u;
   var ballotedSubgroupSize: u32 = 0u;
-  for (var i: u32 = 0; i <= maxSubgroupSize; i++) {
+  for (var i: u32 = 0; i <= subgroupMaxSize; i++) {
     let ballotSubgroupSizeEqualI = countOneBits(subgroupBallot(sg_size == i));
     let countSubgroupSizeEqualI = ballotSubgroupSizeEqualI.x + ballotSubgroupSizeEqualI.y + ballotSubgroupSizeEqualI.z + ballotSubgroupSizeEqualI.w;
     subgroupSizeBallotedInvocations += countSubgroupSizeEqualI;
@@ -1716,8 +1716,8 @@ fn fsMain(
         return checkSubgroupSizeConsistency(
           data,
           t.params.format,
-          minSubgroupSize,
-          maxSubgroupSize,
+          subgroupMinSize,
+          subgroupMaxSize,
           t.params.size[0],
           t.params.size[1]
         );
@@ -1816,7 +1816,7 @@ enable subgroups;
 const width = ${t.params.size[0]};
 const height = ${t.params.size[1]};
 
-const maxSubgroupSize = ${kMaximiumSubgroupSize}u;
+const subgroupMaxSize = ${kMaximiumSubgroupSize}u;
 // A non-zero magic number indicating no expectation error, in order to prevent the
 // false no-error result from zero-initialization.
 const noError = ${kSubgroupShaderNoError}u;
@@ -1830,8 +1830,8 @@ fn fsMain(
 
   var error: u32 = noError;
 
-  // Validate that reported subgroup size is no larger than maxSubgroupSize
-  if (sg_size > maxSubgroupSize) {
+  // Validate that reported subgroup size is no larger than subgroupMaxSize
+  if (sg_size > subgroupMaxSize) {
     error++;
   }
 
@@ -1843,7 +1843,7 @@ fn fsMain(
   // Validate that each subgroup id is assigned to at most one active invocation
   // in the subgroup
   var countAssignedId: u32 = 0u;
-  for (var i: u32 = 0; i < maxSubgroupSize; i++) {
+  for (var i: u32 = 0; i < subgroupMaxSize; i++) {
     let ballotIdEqualsI = countOneBits(subgroupBallot(id == i));
     let countInvocationIdEqualsI = ballotIdEqualsI.x + ballotIdEqualsI.y + ballotIdEqualsI.z + ballotIdEqualsI.w;
     // Validate an id assigned at most once


### PR DESCRIPTION
#4079

This reverts commit ed1b78a79ad5220701330e7311b528f174097dfe.

Also: Test adapter.info.subgroupMinSize, subgroupMaxSize




Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
