### PR TITLE
Smoothstep validation changes : No compiler error for anything except low == high (for const/override)

### DIFF
--- a/src/webgpu/shader/validation/expression/call/builtin/smoothstep.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/smoothstep.spec.ts
@@ -52,7 +52,7 @@ Validates that constant evaluation and override evaluation of ${builtin}() rejec
     const type = kValuesTypes[t.params.type];
 
     // We expect to fail if low == high.
-    const expectedResult = t.params.value1 != t.params.value2;
+    const expectedResult = t.params.value1 !== t.params.value2;
 
     validateConstOrOverrideBuiltinEval(
       t,
@@ -127,7 +127,7 @@ fn foo() {
   let tmp = smoothstep(${lowArg}, ${highArg}, x);
 }`;
 
-    const error = t.params.low == t.params.high;
+    const error = t.params.low === t.params.high;
     const shader_error =
       error && t.params.lowStage === 'constant' && t.params.highStage === 'constant';
     const pipeline_error =
@@ -349,7 +349,7 @@ g.test('early_eval_errors')
     validateConstOrOverrideBuiltinEval(
       t,
       builtin,
-      /* expectedResult */ t.params.low != t.params.high,
+      /* expectedResult */ t.params.low !== t.params.high,
       [f32(t.params.low), f32(t.params.high), f32(0)],
       t.params.stage
     );

--- a/src/webgpu/shader/validation/expression/call/builtin/smoothstep.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/smoothstep.spec.ts
@@ -51,8 +51,8 @@ Validates that constant evaluation and override evaluation of ${builtin}() rejec
   .fn(t => {
     const type = kValuesTypes[t.params.type];
 
-    // We expect to fail if low >= high.
-    const expectedResult = t.params.value1 < t.params.value2;
+    // We expect to fail if low == high.
+    const expectedResult = t.params.value1 != t.params.value2;
 
     validateConstOrOverrideBuiltinEval(
       t,
@@ -66,7 +66,7 @@ Validates that constant evaluation and override evaluation of ${builtin}() rejec
 const kStages = [...kConstantAndOverrideStages, 'runtime'] as const;
 
 g.test('partial_eval_errors')
-  .desc('Validates that low < high')
+  .desc('Validates that low != high')
   .params(u =>
     u
       .combine('lowStage', kStages)
@@ -127,7 +127,7 @@ fn foo() {
   let tmp = smoothstep(${lowArg}, ${highArg}, x);
 }`;
 
-    const error = t.params.low >= t.params.high;
+    const error = t.params.low == t.params.high;
     const shader_error =
       error && t.params.lowStage === 'constant' && t.params.highStage === 'constant';
     const pipeline_error =
@@ -349,7 +349,7 @@ g.test('early_eval_errors')
     validateConstOrOverrideBuiltinEval(
       t,
       builtin,
-      /* expectedResult */ t.params.low < t.params.high,
+      /* expectedResult */ t.params.low != t.params.high,
       [f32(t.params.low), f32(t.params.high), f32(0)],
       t.params.stage
     );


### PR DESCRIPTION
This CTS change a follow up to 
https://dawn-review.googlesource.com/c/dawn/+/218175

The spec has changed for Smoothstep to allow low to be greater than high. (edge0 greater than edge1)

crbug.com/379909620
