### PR TITLE
Expand valid input for smoothstep to include low > high

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/smoothstep.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/smoothstep.spec.ts
@@ -28,7 +28,7 @@ export const g = makeTestGroup(GPUTest);
 function validForConst(c: Case): boolean {
   const low = (c.input as Value[])[0] as ScalarValue;
   const high = (c.input as Value[])[1] as ScalarValue;
-  return low.value < high.value;
+  return low.value !== high.value;
 }
 
 g.test('abstract_float')


### PR DESCRIPTION
Smoothstep now supports low > high so extend the execution testing to include this range.

Relevant change in dawn:
https://dawn-review.googlesource.com/c/dawn/+/218175

crbug.com/379909620