### PR TITLE
Move MaxLimitsTest to MaxLimitTestMixin

### DIFF
--- a/src/webgpu/api/operation/rendering/draw.spec.ts
+++ b/src/webgpu/api/operation/rendering/draw.spec.ts
@@ -11,10 +11,10 @@ import {
   TypedArrayBufferView,
   TypedArrayBufferViewConstructor,
 } from '../../../../common/util/util.js';
-import { MaxLimitsTest, TextureTestMixin } from '../../../gpu_test.js';
+import { GPUTest, MaxLimitsTestMixin, TextureTestMixin } from '../../../gpu_test.js';
 import { PerPixelComparison } from '../../../util/texture/texture_ok.js';
 
-class DrawTest extends TextureTestMixin(MaxLimitsTest) {
+class DrawTest extends TextureTestMixin(MaxLimitsTestMixin(GPUTest)) {
   checkTriangleDraw(opts: {
     firstIndex: number | undefined;
     count: number;

--- a/src/webgpu/api/operation/sampling/sampler_texture.spec.ts
+++ b/src/webgpu/api/operation/sampling/sampler_texture.spec.ts
@@ -7,10 +7,10 @@ Tests samplers with textures.
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { assert, range } from '../../../../common/util/util.js';
-import { MaxLimitsTest, TextureTestMixin } from '../../../gpu_test.js';
+import { GPUTest, MaxLimitsTestMixin, TextureTestMixin } from '../../../gpu_test.js';
 import { TexelView } from '../../../util/texture/texel_view.js';
 
-export const g = makeTestGroup(TextureTestMixin(MaxLimitsTest));
+export const g = makeTestGroup(TextureTestMixin(MaxLimitsTestMixin(GPUTest)));
 
 g.test('sample_texture_combos')
   .desc(

--- a/src/webgpu/api/validation/render_pipeline/resource_compatibility.spec.ts
+++ b/src/webgpu/api/validation/render_pipeline/resource_compatibility.spec.ts
@@ -1,5 +1,5 @@
 export const description = `
-Tests for resource compatibilty between pipeline layout and shader modules
+Tests for resource compatibility between pipeline layout and shader modules
   `;
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';

--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -1333,16 +1333,27 @@ export class MaxLimitsGPUTestSubcaseBatchState extends GPUTestSubcaseBatchState 
   }
 }
 
-/**
- * A Test that requests all the max limits from the adapter on the device.
- */
-export class MaxLimitsTest extends GPUTest {
-  public static override MakeSharedState(
-    recorder: TestCaseRecorder,
-    params: TestParams
-  ): GPUTestSubcaseBatchState {
-    return new MaxLimitsGPUTestSubcaseBatchState(recorder, params);
+export type MaxLimitsTestMixinType = {
+  // placeholder. Change to an interface if we need MaxLimits specific methods.
+};
+
+export function MaxLimitsTestMixin<F extends FixtureClass<GPUTestBase>>(
+  Base: F
+): FixtureClassWithMixin<F, MaxLimitsTestMixinType> {
+  class MaxLimitsImpl
+    extends (Base as FixtureClassInterface<GPUTestBase>)
+    implements MaxLimitsTestMixinType
+  {
+    //
+    public static override MakeSharedState(
+      recorder: TestCaseRecorder,
+      params: TestParams
+    ): GPUTestSubcaseBatchState {
+      return new MaxLimitsGPUTestSubcaseBatchState(recorder, params);
+    }
   }
+
+  return MaxLimitsImpl as unknown as FixtureClassWithMixin<F, MaxLimitsTestMixinType>;
 }
 
 /**


### PR DESCRIPTION
I wanted to use `MaxLimitsTest` with `resource_compatibility.spec.ts` but that file's tests are based on `CreateRenderPipelineValidationTest` which itself is based on `ValidationTest` and so would force making `ValidationTest` be based on `MaxLimitsTest`. I actually think thats a good idea. The default should be max limits. But, it breaks too many things.

So, max MaxLimitsTest a mixin.
