### PR TITLE
Remove many test cases that never run because maxColorAttachments=8

### DIFF
--- a/src/webgpu/api/validation/encoding/createRenderBundleEncoder.spec.ts
+++ b/src/webgpu/api/validation/encoding/createRenderBundleEncoder.spec.ts
@@ -1,10 +1,12 @@
 export const description = `
 createRenderBundleEncoder validation tests.
+
+TODO(#3363): Make this into a MaxLimitTest and increase kMaxColorAttachments.
 `;
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { range } from '../../../../common/util/util.js';
-import { kMaxColorAttachmentsToTest } from '../../../capability_info.js';
+import { getDefaultLimits } from '../../../capability_info.js';
 import {
   computeBytesPerSampleFromFormats,
   kAllTextureFormats,
@@ -14,6 +16,10 @@ import {
 } from '../../../format_info.js';
 import { ValidationTest } from '../validation_test.js';
 
+// MAINTENANCE_TODO: This should be changed to kMaxColorAttachmentsToTest
+// when this is made a MaxLimitTest (see above).
+const kMaxColorAttachments = getDefaultLimits('core').maxColorAttachments.default;
+
 export const g = makeTestGroup(ValidationTest);
 
 g.test('attachment_state,limits,maxColorAttachments')
@@ -21,7 +27,7 @@ g.test('attachment_state,limits,maxColorAttachments')
   .params(u =>
     u.beginSubcases().combine(
       'colorFormatCount',
-      range(kMaxColorAttachmentsToTest, i => i + 1)
+      range(kMaxColorAttachments, i => i + 1)
     )
   )
   .fn(t => {
@@ -52,7 +58,7 @@ g.test('attachment_state,limits,maxColorAttachmentBytesPerSample,aligned')
       .beginSubcases()
       .combine(
         'colorFormatCount',
-        range(kMaxColorAttachmentsToTest, i => i + 1)
+        range(kMaxColorAttachments, i => i + 1)
       )
   )
   .beforeAllSubcases(t => {

--- a/src/webgpu/api/validation/render_pass/attachment_compatibility.spec.ts
+++ b/src/webgpu/api/validation/render_pass/attachment_compatibility.spec.ts
@@ -1,10 +1,12 @@
 export const description = `
 Validation for attachment compatibility between render passes, bundles, and pipelines
+
+TODO(#3363): Make this into a MaxLimitTest and increase kMaxColorAttachments.
 `;
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { range } from '../../../../common/util/util.js';
-import { kMaxColorAttachmentsToTest, kTextureSampleCounts } from '../../../capability_info.js';
+import { getDefaultLimits, kTextureSampleCounts } from '../../../capability_info.js';
 import {
   kRegularTextureFormats,
   kSizedDepthStencilFormats,
@@ -15,7 +17,11 @@ import {
 } from '../../../format_info.js';
 import { ValidationTest } from '../validation_test.js';
 
-const kColorAttachmentCounts = range(kMaxColorAttachmentsToTest, i => i + 1);
+// MAINTENANCE_TODO: This should be changed to kMaxColorAttachmentsToTest
+// when this is made a MaxLimitTest (see above).
+const kMaxColorAttachments = getDefaultLimits('core').maxColorAttachments.default;
+
+const kColorAttachmentCounts = range(kMaxColorAttachments, i => i + 1);
 const kColorAttachments = kColorAttachmentCounts
   .map(count => {
     // generate cases with 0..1 null attachments at different location

--- a/src/webgpu/api/validation/render_pass/attachment_compatibility.spec.ts
+++ b/src/webgpu/api/validation/render_pass/attachment_compatibility.spec.ts
@@ -240,26 +240,25 @@ g.test('render_pass_and_bundle,color_sparse')
       // introduce attachmentCount to make it easier to split the test
       .combine('attachmentCount', kColorAttachmentCounts)
       .beginSubcases()
-      .combine('passAttachments', kColorAttachments)
-      .combine('bundleAttachments', kColorAttachments)
-      .filter(
-        p =>
-          p.attachmentCount === p.passAttachments.length &&
-          p.attachmentCount === p.bundleAttachments.length
+      // Indices into kColorAttachments
+      .expand('iPass', p =>
+        range(kColorAttachments.length, i => i).filter(
+          i => kColorAttachments[i].length === p.attachmentCount
+        )
+      )
+      .expand('iBundle', p =>
+        range(kColorAttachments.length, i => i).filter(
+          i => kColorAttachments[i].length === p.attachmentCount
+        )
       )
   )
   .fn(t => {
-    const { passAttachments, bundleAttachments } = t.params;
+    const passAttachments = kColorAttachments[t.params.iPass];
+    const bundleAttachments = kColorAttachments[t.params.iBundle];
 
     const { maxColorAttachments } = t.device.limits;
-    t.skipIf(
-      passAttachments.length > maxColorAttachments,
-      `num passAttachments: ${passAttachments.length} > maxColorAttachments for device: ${maxColorAttachments}`
-    );
-    t.skipIf(
-      bundleAttachments.length > maxColorAttachments,
-      `num bundleAttachments: ${bundleAttachments.length} > maxColorAttachments for device: ${maxColorAttachments}`
-    );
+    t.skipIf(passAttachments.length > maxColorAttachments);
+    t.skipIf(bundleAttachments.length > maxColorAttachments);
 
     const colorFormats = bundleAttachments.map(i => (i ? 'rgba8uint' : null));
     const bundleEncoder = t.device.createRenderBundleEncoder({
@@ -445,25 +444,26 @@ Test that each of color attachments in render passes or bundles match that of th
       // introduce attachmentCount to make it easier to split the test
       .combine('attachmentCount', kColorAttachmentCounts)
       .beginSubcases()
-      .combine('encoderAttachments', kColorAttachments)
-      .combine('pipelineAttachments', kColorAttachments)
-      .filter(
-        p =>
-          p.attachmentCount === p.encoderAttachments.length &&
-          p.attachmentCount === p.pipelineAttachments.length
+      // Indices into kColorAttachments
+      .expand('iEncoder', p =>
+        range(kColorAttachments.length, i => i).filter(
+          i => kColorAttachments[i].length === p.attachmentCount
+        )
+      )
+      .expand('iPipeline', p =>
+        range(kColorAttachments.length, i => i).filter(
+          i => kColorAttachments[i].length === p.attachmentCount
+        )
       )
   )
   .fn(t => {
-    const { encoderType, encoderAttachments, pipelineAttachments } = t.params;
+    const { encoderType } = t.params;
+    const encoderAttachments = kColorAttachments[t.params.iEncoder];
+    const pipelineAttachments = kColorAttachments[t.params.iPipeline];
+
     const { maxColorAttachments } = t.device.limits;
-    t.skipIf(
-      encoderAttachments.length > maxColorAttachments,
-      `num encoderAttachments: ${encoderAttachments.length} > maxColorAttachments for device: ${maxColorAttachments}`
-    );
-    t.skipIf(
-      pipelineAttachments.length > maxColorAttachments,
-      `num pipelineAttachments: ${pipelineAttachments.length} > maxColorAttachments for device: ${maxColorAttachments}`
-    );
+    t.skipIf(encoderAttachments.length > maxColorAttachments);
+    t.skipIf(pipelineAttachments.length > maxColorAttachments);
 
     const colorTargets = pipelineAttachments.map(i =>
       i ? ({ format: 'rgba8uint', writeMask: 0 } as GPUColorTargetState) : null

--- a/src/webgpu/api/validation/render_pass/render_pass_descriptor.spec.ts
+++ b/src/webgpu/api/validation/render_pass/render_pass_descriptor.spec.ts
@@ -1,12 +1,13 @@
 export const description = `
 render pass descriptor validation tests.
 
+TODO(#3363): Make this into a MaxLimitTest and increase kMaxColorAttachments.
 TODO: review for completeness
 `;
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { range } from '../../../../common/util/util.js';
-import { kMaxColorAttachmentsToTest, kQueryTypes } from '../../../capability_info.js';
+import { getDefaultLimits, kQueryTypes } from '../../../capability_info.js';
 import { GPUConst } from '../../../constants.js';
 import {
   computeBytesPerSampleFromFormats,
@@ -15,6 +16,10 @@ import {
   kTextureFormatInfo,
 } from '../../../format_info.js';
 import { ValidationTest } from '../validation_test.js';
+
+// MAINTENANCE_TODO: This should be changed to kMaxColorAttachmentsToTest
+// when this is made a MaxLimitTest (see above).
+const kMaxColorAttachments = getDefaultLimits('core').maxColorAttachments.default;
 
 class F extends ValidationTest {
   createTestTexture(
@@ -201,7 +206,7 @@ g.test('color_attachments,limits,maxColorAttachmentBytesPerSample,aligned')
       .beginSubcases()
       .combine(
         'attachmentCount',
-        range(kMaxColorAttachmentsToTest, i => i + 1)
+        range(kMaxColorAttachments, i => i + 1)
       )
   )
   .beforeAllSubcases(t => {

--- a/src/webgpu/api/validation/render_pipeline/fragment_state.spec.ts
+++ b/src/webgpu/api/validation/render_pipeline/fragment_state.spec.ts
@@ -1,14 +1,16 @@
 export const description = `
 This test dedicatedly tests validation of GPUFragmentState of createRenderPipeline.
+
+TODO(#3363): Make this into a MaxLimitTest and increase kMaxColorAttachments.
 `;
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { assert, range } from '../../../../common/util/util.js';
 import {
+  getDefaultLimits,
   IsDualSourceBlendingFactor,
   kBlendFactors,
   kBlendOperations,
-  kMaxColorAttachmentsToTest,
 } from '../../../capability_info.js';
 import { GPUConst } from '../../../constants.js';
 import {
@@ -27,6 +29,10 @@ import {
 import { kTexelRepresentationInfo } from '../../../util/texture/texel_data.js';
 
 import { ColorTargetState, CreateRenderPipelineValidationTest } from './common.js';
+
+// MAINTENANCE_TODO: This should be changed to kMaxColorAttachmentsToTest
+// when this is made a MaxLimitTest (see above).
+const kMaxColorAttachments = getDefaultLimits('core').maxColorAttachments.default;
 
 export const g = makeTestGroup(CreateRenderPipelineValidationTest);
 
@@ -169,7 +175,7 @@ g.test('limits,maxColorAttachmentBytesPerSample,aligned')
       .beginSubcases()
       .combine(
         'attachmentCount',
-        range(kMaxColorAttachmentsToTest, i => i + 1)
+        range(kMaxColorAttachments, i => i + 1)
       )
       .combine('isAsync', [false, true])
   )


### PR DESCRIPTION
Our team noticed these because they were spamming a ton of output to the test logs.

These cases were trying to test more than 8 color attachments, but all of these tests run against the default adapter so `maxColorAttachments` is _always_ 8.

Unfortunately it's hard to exactly test this because Dawn never exposes more than 8 color attachments. (But it does expose 4 in compat, and those still work.) Anyway I'm pretty certain by inspection that none of these tests ever request higher limits.

As an aside, reduces the verbosity of the subcase names in `attachment_compatibility.spec.ts`.

Issue: None, but introduces some TODOs for #3363

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
