### PR TITLE
Compat: adjust for 0 vert/frag storage buffers/textures

### DIFF
--- a/src/webgpu/api/validation/capability_checks/limits/maxStorageBuffersPerShaderStage.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxStorageBuffersPerShaderStage.spec.ts
@@ -21,6 +21,8 @@ import {
 const kExtraLimits: LimitsRequest = {
   maxBindingsPerBindGroup: 'adapterLimit',
   maxBindGroups: 'adapterLimit',
+  maxStorageBuffersInFragmentStage: 'adapterLimit',
+  maxStorageBuffersInVertexStage: 'adapterLimit',
 };
 
 const limit = 'maxStorageBuffersPerShaderStage';
@@ -163,6 +165,22 @@ g.test('createPipeline,at_over')
         t.skipIf(
           bindGroupTest === 'sameGroup' && testValue > device.limits.maxBindingsPerBindGroup,
           `can not test ${testValue} bindings in same group because maxBindingsPerBindGroup = ${device.limits.maxBindingsPerBindGroup}`
+        );
+
+        t.skipIf(
+          (bindingCombination === 'fragment' ||
+            bindingCombination === 'vertexAndFragmentWithPossibleVertexStageOverflow' ||
+            bindingCombination === 'vertexAndFragmentWithPossibleFragmentStageOverflow') &&
+            testValue > device.limits.maxStorageBuffersInFragmentStage,
+          `can not test ${testValue} bindings as it is more than maxStorageBuffersInFragmentStage(${device.limits.maxStorageBuffersInFragmentStage})`
+        );
+
+        t.skipIf(
+          (bindingCombination === 'vertex' ||
+            bindingCombination === 'vertexAndFragmentWithPossibleVertexStageOverflow' ||
+            bindingCombination === 'vertexAndFragmentWithPossibleFragmentStageOverflow') &&
+            testValue > device.limits.maxStorageBuffersInVertexStage,
+          `can not test ${testValue} bindings as it is more than maxStorageBuffersInVertexStage(${device.limits.maxStorageBuffersInVertexStage})`
         );
 
         const code = getPerStageWGSLForBindingCombination(

--- a/src/webgpu/api/validation/capability_checks/limits/maxStorageBuffersPerShaderStage.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxStorageBuffersPerShaderStage.spec.ts
@@ -167,21 +167,23 @@ g.test('createPipeline,at_over')
           `can not test ${testValue} bindings in same group because maxBindingsPerBindGroup = ${device.limits.maxBindingsPerBindGroup}`
         );
 
-        t.skipIf(
-          (bindingCombination === 'fragment' ||
-            bindingCombination === 'vertexAndFragmentWithPossibleVertexStageOverflow' ||
-            bindingCombination === 'vertexAndFragmentWithPossibleFragmentStageOverflow') &&
-            testValue > (device.limits.maxStorageBuffersInFragmentStage ?? actualLimit),
-          `can not test ${testValue} bindings as it is more than maxStorageBuffersInFragmentStage(${device.limits.maxStorageBuffersInFragmentStage})`
-        );
+        if (t.isCompatibility) {
+          t.skipIf(
+            (bindingCombination === 'fragment' ||
+              bindingCombination === 'vertexAndFragmentWithPossibleVertexStageOverflow' ||
+              bindingCombination === 'vertexAndFragmentWithPossibleFragmentStageOverflow') &&
+              testValue > device.limits.maxStorageBuffersInFragmentStage!,
+            `can not test ${testValue} bindings as it is more than maxStorageBuffersInFragmentStage(${device.limits.maxStorageBuffersInFragmentStage})`
+          );
 
-        t.skipIf(
-          (bindingCombination === 'vertex' ||
-            bindingCombination === 'vertexAndFragmentWithPossibleVertexStageOverflow' ||
-            bindingCombination === 'vertexAndFragmentWithPossibleFragmentStageOverflow') &&
-            testValue > (device.limits.maxStorageBuffersInVertexStage ?? actualLimit),
-          `can not test ${testValue} bindings as it is more than maxStorageBuffersInVertexStage(${device.limits.maxStorageBuffersInVertexStage})`
-        );
+          t.skipIf(
+            (bindingCombination === 'vertex' ||
+              bindingCombination === 'vertexAndFragmentWithPossibleVertexStageOverflow' ||
+              bindingCombination === 'vertexAndFragmentWithPossibleFragmentStageOverflow') &&
+              testValue > device.limits.maxStorageBuffersInVertexStage!,
+            `can not test ${testValue} bindings as it is more than maxStorageBuffersInVertexStage(${device.limits.maxStorageBuffersInVertexStage})`
+          );
+        }
 
         const code = getPerStageWGSLForBindingCombination(
           bindingCombination,

--- a/src/webgpu/api/validation/capability_checks/limits/maxStorageBuffersPerShaderStage.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxStorageBuffersPerShaderStage.spec.ts
@@ -171,7 +171,7 @@ g.test('createPipeline,at_over')
           (bindingCombination === 'fragment' ||
             bindingCombination === 'vertexAndFragmentWithPossibleVertexStageOverflow' ||
             bindingCombination === 'vertexAndFragmentWithPossibleFragmentStageOverflow') &&
-            testValue > device.limits.maxStorageBuffersInFragmentStage,
+            testValue > (device.limits.maxStorageBuffersInFragmentStage ?? actualLimit),
           `can not test ${testValue} bindings as it is more than maxStorageBuffersInFragmentStage(${device.limits.maxStorageBuffersInFragmentStage})`
         );
 
@@ -179,7 +179,7 @@ g.test('createPipeline,at_over')
           (bindingCombination === 'vertex' ||
             bindingCombination === 'vertexAndFragmentWithPossibleVertexStageOverflow' ||
             bindingCombination === 'vertexAndFragmentWithPossibleFragmentStageOverflow') &&
-            testValue > device.limits.maxStorageBuffersInVertexStage,
+            testValue > (device.limits.maxStorageBuffersInVertexStage ?? actualLimit),
           `can not test ${testValue} bindings as it is more than maxStorageBuffersInVertexStage(${device.limits.maxStorageBuffersInVertexStage})`
         );
 

--- a/src/webgpu/api/validation/render_pipeline/resource_compatibility.spec.ts
+++ b/src/webgpu/api/validation/render_pipeline/resource_compatibility.spec.ts
@@ -4,6 +4,7 @@ Tests for resource compatibility between pipeline layout and shader modules
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { keysOf } from '../../../../common/util/data_tables.js';
+import { MaxLimitsTestMixin } from '../../../gpu_test.js';
 import {
   kAPIResources,
   getWGSLShaderForResource,
@@ -13,7 +14,7 @@ import {
 
 import { CreateRenderPipelineValidationTest } from './common.js';
 
-export const g = makeTestGroup(CreateRenderPipelineValidationTest);
+export const g = makeTestGroup(MaxLimitsTestMixin(CreateRenderPipelineValidationTest));
 
 g.test('resource_compatibility')
   .desc(
@@ -53,8 +54,36 @@ g.test('resource_compatibility')
         ((wgslResource.buffer !== undefined && wgslResource.buffer.type === 'storage') ||
           (wgslResource.storageTexture !== undefined &&
             wgslResource.storageTexture.access !== 'read-only')),
-      'Storage buffers and textures cannot be used in vertex shaders'
+      'Read-Write Storage buffers and textures cannot be used in vertex shaders'
     );
+    if (t.isCompatibility) {
+      t.skipIf(
+        t.params.stage === 'vertex' &&
+          (apiResource.buffer?.type === 'storage' ||
+            apiResource.buffer?.type === 'read-only-storage') &&
+          t.device.limits.maxStorageBuffersInVertexStage === 0,
+        'Storage buffers can not be used in vertex shaders because maxStorageBuffersInVertexStage === 0'
+      );
+      t.skipIf(
+        t.params.stage === 'vertex' &&
+          apiResource.storageTexture !== undefined &&
+          t.device.limits.maxStorageTexturesInVertexStage === 0,
+        'Storage textures can not be used in vertex shaders because maxStorageTexturesInVertexStage === 0'
+      );
+      t.skipIf(
+        t.params.stage === 'fragment' &&
+          (apiResource.buffer?.type === 'storage' ||
+            apiResource.buffer?.type === 'read-only-storage') &&
+          t.device.limits.maxStorageBuffersInFragmentStage === 0,
+        'Storage buffers can not be used in fragment shaders because maxStorageBuffersInFragmentStage === 0'
+      );
+      t.skipIf(
+        t.params.stage === 'fragment' &&
+          apiResource.storageTexture !== undefined &&
+          t.device.limits.maxStorageTexturesInFragmentStage === 0,
+        'Storage textures can not be used in fragment shaders because maxStorageTexturesInFragmentStage === 0'
+      );
+    }
     t.skipIfTextureViewDimensionNotSupported(wgslResource.texture?.viewDimension);
     const emptyVS = `
 @vertex

--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -67,6 +67,17 @@ import {
 import { createTextureFromTexelViews } from './util/texture.js';
 import { reifyExtent3D, reifyOrigin3D } from './util/unions.js';
 
+// Declarations for WebGPU items we want tests for that are not yet officially part of the spec.
+declare global {
+  // MAINTENANCE_TODO: remove once added to @webgpu/types
+  interface GPUSupportedLimits {
+    readonly maxStorageBuffersInFragmentStage: number;
+    readonly maxStorageTexturesInFragmentStage: number;
+    readonly maxStorageBuffersInVertexStage: number;
+    readonly maxStorageTexturesInVertexStage: number;
+  }
+}
+
 const devicePool = new DevicePool();
 
 // MAINTENANCE_TODO: When DevicePool becomes able to provide multiple devices at once, use the

--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -71,10 +71,10 @@ import { reifyExtent3D, reifyOrigin3D } from './util/unions.js';
 declare global {
   // MAINTENANCE_TODO: remove once added to @webgpu/types
   interface GPUSupportedLimits {
-    readonly maxStorageBuffersInFragmentStage: number;
-    readonly maxStorageTexturesInFragmentStage: number;
-    readonly maxStorageBuffersInVertexStage: number;
-    readonly maxStorageTexturesInVertexStage: number;
+    readonly maxStorageBuffersInFragmentStage?: number;
+    readonly maxStorageTexturesInFragmentStage?: number;
+    readonly maxStorageBuffersInVertexStage?: number;
+    readonly maxStorageTexturesInVertexStage?: number;
   }
 }
 


### PR DESCRIPTION
Compat allows supporting 0 storage buffers and storage textures in fragment shaders. Update some tests for this situation.



