### PR TITLE
Fix DeviceModifier

### DIFF
--- a/src/webgpu/api/operation/device/all_limits_and_features.spec.ts
+++ b/src/webgpu/api/operation/device/all_limits_and_features.spec.ts
@@ -8,7 +8,7 @@ import {
   GPUTestSubcaseBatchState,
   initUncanonicalizedDeviceDescriptor,
 } from '../../../gpu_test.js';
-import { CanonicalDeviceDescriptor, DescriptorModifierFn } from '../../../util/device_pool.js';
+import { CanonicalDeviceDescriptor, DescriptorModifier } from '../../../util/device_pool.js';
 
 /**
  * Gets the adapter limits as a standard JavaScript object.
@@ -36,18 +36,25 @@ function setAllLimitsToAdapterLimitsAndAddAllFeatures(
 }
 
 /**
- * Used by MaxLimitsTest to request a device with all the max limits of the adapter.
+ * Used to request a device with all the max limits of the adapter.
  */
 export class AllLimitsAndFeaturesGPUTestSubcaseBatchState extends GPUTestSubcaseBatchState {
   override selectDeviceOrSkipTestCase(
     descriptor: DeviceSelectionDescriptor,
-    descriptorModifierFn?: DescriptorModifierFn
+    descriptorModifier?: DescriptorModifier
   ): void {
-    const wrapper = (adapter: GPUAdapter, desc: CanonicalDeviceDescriptor | undefined) => {
-      desc = descriptorModifierFn ? descriptorModifierFn(adapter, desc) : desc;
-      return setAllLimitsToAdapterLimitsAndAddAllFeatures(adapter, desc);
+    const mod: DescriptorModifier = {
+      descriptorModifier(adapter: GPUAdapter, desc: CanonicalDeviceDescriptor | undefined) {
+        desc = descriptorModifier?.descriptorModifier
+          ? descriptorModifier.descriptorModifier(adapter, desc)
+          : desc;
+        return setAllLimitsToAdapterLimitsAndAddAllFeatures(adapter, desc);
+      },
+      keyModifier(baseKey: string) {
+        return `${baseKey}:AllLimitsAndFeaturesTest`;
+      },
     };
-    super.selectDeviceOrSkipTestCase(initUncanonicalizedDeviceDescriptor(descriptor), wrapper);
+    super.selectDeviceOrSkipTestCase(initUncanonicalizedDeviceDescriptor(descriptor), mod);
   }
 }
 

--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -1473,7 +1473,7 @@ export interface TextureTestMixinType {
    * Effectively it's a Uint8Array to Uint8Array copy that
    * does the same thing as `writeTexture` but because the
    * destination is a buffer you have to provide the parameters
-   * of the destination buffer similarly to how you'esc provide them
+   * of the destination buffer similarly to how you'd provide them
    * to `copyTextureToBuffer`
    */
   updateLinearTextureDataSubBox(


### PR DESCRIPTION
The issue is the key is selected before the modification happens which means the devices in the pool will not match the key.

I can't think of a way to fix this using the adaptor so maybe this hacky solution works by letting you modify the key.

Generally you just append a string but I made it function because MaxLimitsTestMixin wants to be able to chain to other modifiers.

Maybe it should all be re-designed

This came up because I notice a test passing that shouldn't have passed. It passsed because a `MaxLimitsTestMixin` test ran first and it's key was `''` which meant that other tests got a max limits device from the pool.


