### PR TITLE
Vertex state correctness

### DIFF
--- a/src/webgpu/api/operation/vertex_state/correctness.spec.ts
+++ b/src/webgpu/api/operation/vertex_state/correctness.spec.ts
@@ -16,7 +16,7 @@ import {
   kVertexFormatInfo,
   kVertexFormats,
 } from '../../../capability_info.js';
-import { GPUTest } from '../../../gpu_test.js';
+import { GPUTest, MaxLimitsTestMixin } from '../../../gpu_test.js';
 import { float32ToFloat16Bits, normalizedIntegerAsFloat } from '../../../util/conversion.js';
 import { align, clamp } from '../../../util/math.js';
 
@@ -655,7 +655,7 @@ struct VSOutputs {
   }
 }
 
-export const g = makeTestGroup(VertexStateTest);
+export const g = makeTestGroup(MaxLimitsTestMixin(VertexStateTest));
 
 g.test('vertex_format_to_shader_format_conversion')
   .desc(


### PR DESCRIPTION
Refactor these tests so they don't use storage buffers.

The tests were using one uniform or storage buffer per
vertex attribute. Switched to using just a single uniform
buffer for all attributes.

Note: There was a note about increasing the vertex count
by +1 in vertex_buffer_used_multiple_times_interleaved.
I don't know if that's old because removing the +1 there
and a few lines below does not break the test nor generate
any validation errors.

The reason I needed to remove it was the code that packs
the data into a single buffer needed the size of each buffer
to match kVertexCount but that particular test was passing
+1 in some places and not in others.