### PR TITLE
Compat: Fix texture-utils to for 0 storage buffers in frag stage

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/texture_utils.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/texture_utils.ts
@@ -5068,7 +5068,7 @@ ${stageWGSL}
         entries: [
           {
             binding: 0,
-            visibility: GPUShaderStage.FRAGMENT | GPUShaderStage.COMPUTE,
+            visibility: GPUShaderStage.COMPUTE,
             buffer: {
               type: 'storage',
             },


### PR DESCRIPTION
The new validation triggered this issue.
