### PR TITLE
Fix file path too long error

### DIFF
--- a/src/webgpu/compat/api/validation/pipeline_creation.spec.ts
+++ b/src/webgpu/compat/api/validation/pipeline_creation.spec.ts
@@ -10,7 +10,10 @@ TODO:
 `;
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
-import { kShaderStages } from '../../../shader/validation/decl/util.js';
+import {
+  kShortShaderStages,
+  kShortShaderStageToShaderStage,
+} from '../../../shader/execution/expression/call/builtin/texture_utils.js';
 import { CompatibilityTest } from '../../compatibility_test.js';
 
 export const g = makeTestGroup(CompatibilityTest);
@@ -85,12 +88,13 @@ g.test('depth_textures')
           textureType: 'texture_depth_2d_array',
         },
       ])
-      .combine('stage', kShaderStages)
-      .filter(t => t.sampleWGSL.startsWith('textureGather') || t.stage === 'fragment')
+      .combine('stage', kShortShaderStages)
+      .filter(t => t.sampleWGSL.startsWith('textureGather') || t.stage === 'f')
       .combine('async', [false, true] as const)
   )
   .fn(t => {
-    const { sampleWGSL, textureType, stage, async } = t.params;
+    const { sampleWGSL, textureType, stage: shortStage, async } = t.params;
+    const stage = kShortShaderStageToShaderStage[shortStage];
 
     const usageWGSL = `_ = ${sampleWGSL};`;
     const module = t.device.createShaderModule({


### PR DESCRIPTION
    Running "run:write-out-wpt-cts-html-chunked2sec" (run) task
    Error: Generated test variant would produce too-long -actual.txt filename. Possible solutions:
      - Reduce the length of the parts of the test query
      - Reduce the parameterization of the test - Make the test function faster and regenerate the listing_meta entry - Reduce the specificity of test expectations (if you're using them) |<------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------>| webgpu:compat,api,validation,pipeline_creation:depth_textures:sampleWGSL="textureGather(t,%20s,%20vec2f(0),%200,%20vec2i(0,%200))";textureType="texture_depth_2d_array";stage="fragment";* webgpu:compat,api,validation,pipeline_creation:depth_textures:sampleWGSL="textureGather(t,%20s,%20vec2f(0),%200,%20vec2i(0,%200))";textureType="texture_depth_2d_array";stage="compute";*


I'm curious how this passed submission. 🤷‍♂️