### PR TITLE
Compat: Refactor subgroup tests for 0 storage buffers in frag

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/quadBroadcast.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/quadBroadcast.spec.ts
@@ -496,7 +496,7 @@ g.test('fragment,all_active')
 enable subgroups;
 
 @group(0) @binding(0)
-var<storage, read_write> inputs : array<u32>; // unused
+var<uniform> inputs : array<vec4u, 1>; // unused
 
 @fragment
 fn main(

--- a/src/webgpu/shader/execution/expression/call/builtin/quadSwap.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/quadSwap.spec.ts
@@ -506,7 +506,7 @@ g.test('fragment,all_active')
 enable subgroups;
 
 @group(0) @binding(0)
-var<storage, read_write> inputs : array<u32>; // unused
+var<uniform> inputs : array<vec4u, 1>; // unused
 
 @fragment
 fn main(

--- a/src/webgpu/shader/execution/expression/call/builtin/subgroupAdd.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/subgroupAdd.spec.ts
@@ -504,7 +504,7 @@ g.test('fragment')
 enable subgroups;
 
 @group(0) @binding(0)
-var<storage> inputs : array<u32>;
+var<uniform> inputs : array<vec4u, 1>;
 
 @fragment
 fn main(

--- a/src/webgpu/shader/execution/expression/call/builtin/subgroupAll.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/subgroupAll.spec.ts
@@ -342,7 +342,7 @@ g.test('fragment,all_active')
 enable subgroups;
 
 @group(0) @binding(0)
-var<storage, read_write> inputs : array<u32>;
+var<uniform> inputs : array<vec4u, ${inputData.length}>;
 
 @fragment
 fn main(
@@ -357,7 +357,7 @@ fn main(
   let x_in_range = u32(pos.x) < (${t.params.size[0]} - 1);
   let y_in_range = u32(pos.y) < (${t.params.size[1]} - 1);
   let in_range = x_in_range && y_in_range;
-  let input = select(1u, inputs[linear], in_range);
+  let input = select(1u, inputs[linear].x, in_range);
 
   let res = select(0u, 1u, subgroupAll(bool(input)));
   return vec2u(res, subgroup_id);

--- a/src/webgpu/shader/execution/expression/call/builtin/subgroupAny.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/subgroupAny.spec.ts
@@ -342,7 +342,7 @@ g.test('fragment,all_active')
 enable subgroups;
 
 @group(0) @binding(0)
-var<storage, read_write> inputs : array<u32>;
+var<uniform> inputs : array<vec4u, ${inputData.length}>;
 
 @fragment
 fn main(
@@ -357,7 +357,7 @@ fn main(
   let x_in_range = u32(pos.x) < (${t.params.size[0]} - 1);
   let y_in_range = u32(pos.y) < (${t.params.size[1]} - 1);
   let in_range = x_in_range && y_in_range;
-  let input = select(0u, inputs[linear], in_range);
+  let input = select(0u, inputs[linear].x, in_range);
 
   let res = select(0u, 1u, subgroupAny(bool(input)));
   return vec2u(res, subgroup_id);

--- a/src/webgpu/shader/execution/expression/call/builtin/subgroupBitwise.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/subgroupBitwise.spec.ts
@@ -561,7 +561,7 @@ g.test('fragment,all_active')
 enable subgroups;
 
 @group(0) @binding(0)
-var<storage, read_write> inputs : array<u32>;
+var<uniform> inputs : array<vec4u, ${inputData.length}>;
 
 @fragment
 fn main(
@@ -575,7 +575,7 @@ fn main(
   let x_in_range = u32(pos.x) < (${t.params.size[0]} - 1);
   let y_in_range = u32(pos.y) < (${t.params.size[1]} - 1);
   let in_range = x_in_range && y_in_range;
-  let input = select(${ident}, inputs[linear], in_range);
+  let input = select(${ident}, inputs[linear].x, in_range);
 
   let res = ${t.params.op}(input);
   return vec2u(res, subgroup_id);

--- a/src/webgpu/shader/execution/expression/call/builtin/subgroupBroadcast.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/subgroupBroadcast.spec.ts
@@ -676,14 +676,16 @@ g.test('fragment')
 
     const broadcast =
       t.params.id === 0
-        ? `subgroupBroadcastFirst(input[linear])`
-        : `subgroupBroadcast(input[linear], ${t.params.id})`;
+        ? `subgroupBroadcastFirst(input[linear].x)`
+        : `subgroupBroadcast(input[linear].x, ${t.params.id})`;
+    const texels = t.params.size[0] * t.params.size[1];
+    const inputData = new Uint32Array([...iterRange(texels, x => x)]);
 
     const fsShader = `
 enable subgroups;
 
 @group(0) @binding(0)
-var<storage> input : array<u32>;
+var<uniform> input : array<vec4u, ${inputData.length}>;
 
 @fragment
 fn main(
@@ -696,8 +698,6 @@ fn main(
   return vec4u(${broadcast}, id, size, linear);
 }`;
 
-    const texels = t.params.size[0] * t.params.size[1];
-    const inputData = new Uint32Array([...iterRange(texels, x => x)]);
     await runFragmentTest(
       t,
       t.params.format,

--- a/src/webgpu/shader/execution/expression/call/builtin/subgroupElect.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/subgroupElect.spec.ts
@@ -351,7 +351,7 @@ g.test('fragment')
 enable subgroups;
 
 @group(0) @binding(0)
-var<storage, read_write> inputs : array<u32>; // unused
+var<uniform> inputs : array<vec4u, 1>; // unused
 
 @fragment
 fn main(

--- a/src/webgpu/shader/execution/expression/call/builtin/subgroupMinMax.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/subgroupMinMax.spec.ts
@@ -598,7 +598,7 @@ g.test('fragment')
 enable subgroups;
 
 @group(0) @binding(0)
-var<storage, read_write> inputs : array<u32>;
+var<uniform> inputs : array<vec4u, ${inputData.length}>;
 
 @fragment
 fn main(
@@ -612,7 +612,7 @@ fn main(
   let x_in_range = u32(pos.x) < (${t.params.size[0]} - 1);
   let y_in_range = u32(pos.y) < (${t.params.size[1]} - 1);
   let in_range = x_in_range && y_in_range;
-  let input = select(${identity}, inputs[linear], in_range);
+  let input = select(${identity}, inputs[linear].x, in_range);
 
   let res = ${t.params.op}(input);
   return vec2u(res, subgroup_id);

--- a/src/webgpu/shader/execution/expression/call/builtin/subgroupShuffle.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/subgroupShuffle.spec.ts
@@ -893,7 +893,7 @@ g.test('fragment')
 enable subgroups;
 
 @group(0) @binding(0)
-var<storage, read_write> inputs : array<u32>; // unused
+var<uniform> inputs : array<vec4u, 1>; // unused
 
 @fragment
 fn main(

--- a/src/webgpu/shader/execution/expression/call/builtin/subgroup_util.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/subgroup_util.ts
@@ -521,9 +521,19 @@ fn vsMain(@builtin(vertex_index) index : u32) -> @builtin(position) vec4f {
   const byteLength = bytesPerRow * blocksPerColumn;
   const uintLength = byteLength / 4;
 
+  const expandedInputData = new (
+    inputData instanceof Uint32Array
+      ? Uint32Array
+      : inputData instanceof Float32Array
+      ? Float32Array
+      : Float16Array
+  )(inputData.length * 4);
+  for (let i = 0; i < inputData.length; ++i) {
+    expandedInputData[i * 4] = inputData[i];
+  }
   const buffer = t.makeBufferWithContents(
-    inputData,
-    GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST
+    expandedInputData,
+    GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST
   );
 
   const bg = t.device.createBindGroup({


### PR DESCRIPTION
Refactor the subgroup tests so they don't use a storage buffer in the fragment shader tests. Switched to using a uniform buffer. Uniform buffers can't have `array<u32>` so switched to `array<vec4u>`.