### PR TITLE
Fix limits tests with new extra limits

### DIFF
--- a/src/webgpu/api/validation/capability_checks/limits/limit_utils.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/limit_utils.ts
@@ -417,10 +417,12 @@ export class LimitTestsImpl extends GPUTestBase {
     if (extraLimits) {
       for (const [extraLimitStr, limitMode] of Object.entries(extraLimits)) {
         const extraLimit = extraLimitStr as GPUSupportedLimit;
-        requiredLimits[extraLimit] =
-          limitMode === 'defaultLimit'
-            ? getDefaultLimitForAdapter(adapter, extraLimit)
-            : (adapter.limits[extraLimit] as number);
+        if (adapter.limits[extraLimit] !== undefined) {
+          requiredLimits[extraLimit] =
+            limitMode === 'defaultLimit'
+              ? getDefaultLimitForAdapter(adapter, extraLimit)
+              : (adapter.limits[extraLimit] as number);
+        }
       }
     }
 


### PR DESCRIPTION
The code was not checking if the limits actually exist. If they don't then the test would fail. Since these limits have not been added to the spec, they're still being discussed, they are not required and therefore the tests should still run without them.

Fixes: https://github.com/gpuweb/cts/pull/4122