### PR TITLE
Refactor maxStorage(Buffers/Textures)PerShaderStage tests

### DIFF
--- a/src/webgpu/api/validation/capability_checks/limits/limit_utils.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/limit_utils.ts
@@ -343,7 +343,7 @@ export const kMinimumLimitBaseParams = kUnitCaseParamsBuilder
  * Adds a maximum limit upto a dependent limit.
  *
  * Example:
- *   You want to test `maxStorageBuffersPerShaderStage` in fragment stagee
+ *   You want to test `maxStorageBuffersPerShaderStage` in fragment stage
  *   so you need `maxStorageBuffersInFragmentStage` set as well. But, you
  *   don't know exactly what value will be used for `maxStorageBuffersPerShaderStage`
  *   since that is defined by an enum like `underDefault`.

--- a/src/webgpu/api/validation/capability_checks/limits/maxStorageBuffersPerShaderStage.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxStorageBuffersPerShaderStage.spec.ts
@@ -17,13 +17,13 @@ import {
   getPerStageWGSLForBindingCombination,
   LimitsRequest,
   getStageVisibilityForBinidngCombination,
+  addMaximumLimitUpToDependentLimit,
+  MaximumLimitValueTest,
 } from './limit_utils.js';
 
 const kExtraLimits: LimitsRequest = {
   maxBindingsPerBindGroup: 'adapterLimit',
   maxBindGroups: 'adapterLimit',
-  maxStorageBuffersInFragmentStage: 'adapterLimit',
-  maxStorageBuffersInVertexStage: 'adapterLimit',
 };
 
 const limit = 'maxStorageBuffersPerShaderStage';
@@ -47,6 +47,31 @@ function createBindGroupLayout(
     ),
   };
   return device.createBindGroupLayout(bindGroupLayoutDescription);
+}
+
+function addExtraRequiredLimits(
+  adapter: GPUAdapter,
+  limits: LimitsRequest,
+  limitTest: MaximumLimitValueTest
+) {
+  const newLimits: LimitsRequest = { ...limits };
+
+  addMaximumLimitUpToDependentLimit(
+    adapter,
+    newLimits,
+    'maxStorageBuffersInFragmentStage',
+    limit,
+    limitTest
+  );
+  addMaximumLimitUpToDependentLimit(
+    adapter,
+    newLimits,
+    'maxStorageBuffersInVertexStage',
+    limit,
+    limitTest
+  );
+
+  return newLimits;
 }
 
 g.test('createBindGroupLayout,at_over')
@@ -86,7 +111,7 @@ g.test('createBindGroupLayout,at_over')
           createBindGroupLayout(device, visibility, type, order, testValue);
         }, shouldError);
       },
-      kExtraLimits
+      addExtraRequiredLimits(t.adapter, kExtraLimits, limitTest)
     );
   });
 
@@ -141,7 +166,7 @@ g.test('createPipelineLayout,at_over')
           shouldError
         );
       },
-      kExtraLimits
+      addExtraRequiredLimits(t.adapter, kExtraLimits, limitTest)
     );
   });
 
@@ -197,6 +222,6 @@ g.test('createPipeline,at_over')
           `actualLimit: ${actualLimit}, testValue: ${testValue}\n:${code}`
         );
       },
-      kExtraLimits
+      addExtraRequiredLimits(t.adapter, kExtraLimits, limitTest)
     );
   });


### PR DESCRIPTION
These tests can't just set `maxStorage(Buffers/Textures)In(Fragment/Vertex)Stage to the maximum limit because those can't be set above their `..PerShaderStage` counterpart.

Further, these were trying to use writable storage in the vertex stage which is not allowed.


