### PR TITLE
Adjust print_environment for node

### DIFF
--- a/src/webgpu/print_environment.spec.ts
+++ b/src/webgpu/print_environment.spec.ts
@@ -54,7 +54,7 @@ WPT disallows console.log and doesn't support logs on passing tests, so this doe
 
     const info = JSON.stringify(
       {
-        userAgent: navigator.userAgent,
+        userAgent: globalThis.navigator?.userAgent,
         globalScope: Object.getPrototypeOf(globalThis).constructor.name,
         globalTestConfig,
         baseResourcePath: getResourcePath(''),


### PR DESCRIPTION
node doesn't have a global `navigator` variable.


