### PR TITLE
Remove unsupoorted alignment in execution tests

### DIFF
--- a/src/webgpu/shader/execution/expression/access/structure/index.spec.ts
+++ b/src/webgpu/shader/execution/expression/access/structure/index.spec.ts
@@ -182,7 +182,6 @@ g.test('buffer_align')
       .beginSubcases()
       .combine('member_index', [0, 1, 2] as const)
       .combine('alignments', [
-        [1, 1, 1],
         [4, 4, 4],
         [4, 8, 16],
         [8, 4, 16],


### PR DESCRIPTION
Given our spec changes on alignment, an alignment of 1 is invalid.
Since this is an execution test we should simply remove these cases.

If needed we can add additional validation test cases
(eg in webgpu/shader/validation/shader_io/align.spec.ts)

crbug.com/375467276 

For reference the error generated when compiling is:
>
EXCEPTION: Error: Unexpected validation error occurred: Error while parsing WGSL: :7:10 error: alignment must be a multiple of '4' bytes for the 'storage' address space
      @align(1) member_0 : i32,
             ^
    
    :3:23 note: 'MyStruct' used in address space 'storage' here
    @group(0) @binding(1) var<storage> input : MyStruct;
