### PR TITLE
Refactor selectDeviceOrSkipTest system

### DIFF
--- a/src/webgpu/api/operation/device/all_limits_and_features.spec.ts
+++ b/src/webgpu/api/operation/device/all_limits_and_features.spec.ts
@@ -12,6 +12,9 @@ import { CanonicalDeviceDescriptor, DescriptorModifier } from '../../../util/dev
 
 /**
  * Gets the adapter limits as a standard JavaScript object.
+ * MAINTENANCE_TODO: Remove this and use the same function from gpu_test.ts once minSubgroupSize is removed
+ * The reason this is separate now is we want this test to fail. `mnSubgroupSize` should never have
+ * be added and this test exists to see that the same mistake doesn't happen in the future.
  */
 function getAdapterLimitsAsDeviceRequiredLimits(adapter: GPUAdapter) {
   const requiredLimits: Record<string, GPUSize64> = {};
@@ -39,7 +42,7 @@ function setAllLimitsToAdapterLimitsAndAddAllFeatures(
  * Used to request a device with all the max limits of the adapter.
  */
 export class AllLimitsAndFeaturesGPUTestSubcaseBatchState extends GPUTestSubcaseBatchState {
-  override selectDeviceOrSkipTestCase(
+  override requestDeviceWithRequiredParametersOrSkip(
     descriptor: DeviceSelectionDescriptor,
     descriptorModifier?: DescriptorModifier
   ): void {
@@ -54,7 +57,10 @@ export class AllLimitsAndFeaturesGPUTestSubcaseBatchState extends GPUTestSubcase
         return `${baseKey}:AllLimitsAndFeaturesTest`;
       },
     };
-    super.selectDeviceOrSkipTestCase(initUncanonicalizedDeviceDescriptor(descriptor), mod);
+    super.requestDeviceWithRequiredParametersOrSkip(
+      initUncanonicalizedDeviceDescriptor(descriptor),
+      mod
+    );
   }
 }
 

--- a/src/webgpu/util/device_pool.ts
+++ b/src/webgpu/util/device_pool.ts
@@ -233,14 +233,6 @@ class DescriptorToHolderMap {
 export type UncanonicalizedDeviceDescriptor = {
   requiredFeatures?: Iterable<GPUFeatureName>;
   requiredLimits?: Record<string, GPUSize32>;
-  /** @deprecated this field cannot be used */
-  nonGuaranteedFeatures?: undefined;
-  /** @deprecated this field cannot be used */
-  nonGuaranteedLimits?: undefined;
-  /** @deprecated this field cannot be used */
-  extensions?: undefined;
-  /** @deprecated this field cannot be used */
-  features?: undefined;
 };
 export type CanonicalDeviceDescriptor = Omit<
   Required<GPUDeviceDescriptor>,


### PR DESCRIPTION
The existing system selected the device immediately which means code like this

    t.selectDeviceOrSkipTest('timestamp-query');
    t.selectDeviceOrSkipTesT('float32-renderable'); // fail!

would fail on the 2nd line because a device had already been requested on the first line.

Refactored so that the various requirements are merged and only at the end is a device requested.

Tested here:
https://github.com/greggman/cts/commit/d4abf411a78ba4d79f712fa2ad3d82a324b99719



