### PR TITLE
Compat: fix float16(32)-renderable tests (validation)

### DIFF
--- a/src/webgpu/api/validation/capability_checks/limits/maxColorAttachmentBytesPerSample.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxColorAttachmentBytesPerSample.spec.ts
@@ -11,16 +11,16 @@ import {
 } from './limit_utils.js';
 
 const kFormatsToUseBySize: GPUTextureFormat[] = [
-  'rgba32float',
-  'rgba16float',
+  'rgba32uint',
+  'rgba16uint',
   'rgba8unorm',
   'rg8unorm',
   'r8unorm',
 ];
 
 const kInterleaveFormats: GPUTextureFormat[] = [
-  'rgba16float',
-  'rg16float',
+  'rgba16uint',
+  'rg16uint',
   'rgba8unorm',
   'rg8unorm',
   'r8unorm',

--- a/src/webgpu/api/validation/createBindGroup.spec.ts
+++ b/src/webgpu/api/validation/createBindGroup.spec.ts
@@ -30,6 +30,8 @@ import { getTextureDimensionFromView } from '../../util/texture/base.js';
 
 import { ValidationTest } from './validation_test.js';
 
+const kTestFormat: GPUTextureFormat = 'r32float';
+
 function clone<T extends GPUTextureDescriptor>(descriptor: T): T {
   return JSON.parse(JSON.stringify(descriptor));
 }
@@ -144,7 +146,7 @@ g.test('binding_must_contain_resource_defined_in_layout')
   .params(u =>
     u //
       .combine('resourceType', kBindableResources)
-      .combine('entry', allBindingEntries(false))
+      .combine('entry', allBindingEntries(false, kTestFormat))
   )
   .fn(t => {
     const { resourceType, entry } = t.params;
@@ -195,7 +197,7 @@ g.test('texture_binding_must_have_correct_usage')
   .desc('Tests that texture bindings must have the correct usage.')
   .paramsSubcasesOnly(u =>
     u //
-      .combine('entry', sampledAndStorageBindingEntries(false))
+      .combine('entry', sampledAndStorageBindingEntries(false, kTestFormat))
       .combine('usage', kTextureUsages)
       .unless(({ entry, usage }) => {
         const info = texBindingTypeInfo(entry);
@@ -203,6 +205,12 @@ g.test('texture_binding_must_have_correct_usage')
         return usage === GPUConst.TextureUsage.STORAGE_BINDING && info.resource === 'sampledTexMS';
       })
   )
+  .beforeAllSubcases(t => {
+    t.skipIf(
+      t.isCompatibility,
+      "The test requires 'r32float' renderable and multisampled support which compat mode doesn't guarantee."
+    );
+  })
   .fn(t => {
     const { entry, usage } = t.params;
     const info = texBindingTypeInfo(entry);
@@ -217,7 +225,7 @@ g.test('texture_binding_must_have_correct_usage')
 
     const descriptor = {
       size: { width: 16, height: 16, depthOrArrayLayers: 1 },
-      format: 'r32float' as const,
+      format: kTestFormat,
       usage: appliedUsage,
       sampleCount: info.resource === 'sampledTexMS' ? 4 : 1,
     };
@@ -601,7 +609,7 @@ g.test('texture,resource_state')
   .paramsSubcasesOnly(u =>
     u
       .combine('state', kResourceStates)
-      .combine('entry', sampledAndStorageBindingEntries(true))
+      .combine('entry', sampledAndStorageBindingEntries(true, kTestFormat))
       .combine('visibilityMask', [kAllShaderStages, GPUConst.ShaderStage.COMPUTE] as const)
   )
   .fn(t => {

--- a/src/webgpu/api/validation/createBindGroup.spec.ts
+++ b/src/webgpu/api/validation/createBindGroup.spec.ts
@@ -206,14 +206,16 @@ g.test('texture_binding_must_have_correct_usage')
       })
   )
   .beforeAllSubcases(t => {
-    t.skipIf(
-      t.isCompatibility,
-      "The test requires 'r32float' renderable and multisampled support which compat mode doesn't guarantee."
-    );
+    t.selectDeviceForRenderableColorFormatOrSkipTestCase(kTestFormat);
   })
   .fn(t => {
     const { entry, usage } = t.params;
     const info = texBindingTypeInfo(entry);
+
+    t.skipIf(
+      t.isCompatibility && info.resource === 'sampledTexMS',
+      "The test requires 'r32float' multisampled support which compat mode doesn't guarantee."
+    );
 
     const bindGroupLayout = t.device.createBindGroupLayout({
       entries: [{ binding: 0, visibility: GPUShaderStage.COMPUTE, ...entry }],

--- a/src/webgpu/api/validation/createTexture.spec.ts
+++ b/src/webgpu/api/validation/createTexture.spec.ts
@@ -16,6 +16,7 @@ import {
   viewCompatible,
   textureDimensionAndFormatCompatible,
   isTextureFormatUsableAsStorageFormat,
+  is32Float,
 } from '../../format_info.js';
 import { maxMipLevelCount } from '../../util/texture/base.js';
 
@@ -355,10 +356,16 @@ g.test('sampleCount,valid_sampleCount_with_other_parameter_varies')
     const info = kTextureFormatInfo[format];
     t.skipIfTextureFormatNotSupported(format);
     t.selectDeviceOrSkipTestCase(info.feature);
+    t.selectDeviceForRenderableColorFormatOrSkipTestCase(format);
   })
   .fn(t => {
     const { dimension, sampleCount, format, mipLevelCount, arrayLayerCount, usage } = t.params;
     const { blockWidth, blockHeight } = kTextureFormatInfo[format];
+
+    t.skipIf(
+      sampleCount === 4 && t.isCompatibility && (format === 'rgba16float' || is32Float(format)),
+      'Multisample support for this format is not guaranteed in comapt mode'
+    );
 
     const size =
       dimension === '1d'
@@ -1047,6 +1054,7 @@ g.test('texture_usage')
     const info = kTextureFormatInfo[format];
     t.skipIfTextureFormatNotSupported(format);
     t.selectDeviceOrSkipTestCase(info.feature);
+    t.selectDeviceForRenderableColorFormatOrSkipTestCase(format);
   })
   .fn(t => {
     const { dimension, format, usage0, usage1 } = t.params;

--- a/src/webgpu/api/validation/createTexture.spec.ts
+++ b/src/webgpu/api/validation/createTexture.spec.ts
@@ -16,7 +16,6 @@ import {
   viewCompatible,
   textureDimensionAndFormatCompatible,
   isTextureFormatUsableAsStorageFormat,
-  is32Float,
 } from '../../format_info.js';
 import { maxMipLevelCount } from '../../util/texture/base.js';
 
@@ -362,10 +361,9 @@ g.test('sampleCount,valid_sampleCount_with_other_parameter_varies')
     const { dimension, sampleCount, format, mipLevelCount, arrayLayerCount, usage } = t.params;
     const { blockWidth, blockHeight } = kTextureFormatInfo[format];
 
-    t.skipIf(
-      sampleCount === 4 && t.isCompatibility && (format === 'rgba16float' || is32Float(format)),
-      'Multisample support for this format is not guaranteed in comapt mode'
-    );
+    if (sampleCount > 1) {
+      t.skipIfMultisampleNotSupportedForFormat(format);
+    }
 
     const size =
       dimension === '1d'

--- a/src/webgpu/api/validation/createView.spec.ts
+++ b/src/webgpu/api/validation/createView.spec.ts
@@ -378,6 +378,9 @@ g.test('texture_view_usage')
     if (textureUsage & GPUTextureUsage.STORAGE_BINDING) {
       t.skipIfTextureFormatNotUsableAsStorageTexture(format);
     }
+    if (textureUsage & GPUTextureUsage.RENDER_ATTACHMENT) {
+      t.selectDeviceForRenderableColorFormatOrSkipTestCase(format);
+    }
   })
   .fn(t => {
     const { format, textureUsage0, textureUsage1, textureViewUsage0, textureViewUsage1 } = t.params;

--- a/src/webgpu/api/validation/encoding/createRenderBundleEncoder.spec.ts
+++ b/src/webgpu/api/validation/encoding/createRenderBundleEncoder.spec.ts
@@ -63,6 +63,7 @@ g.test('attachment_state,limits,maxColorAttachmentBytesPerSample,aligned')
   )
   .beforeAllSubcases(t => {
     t.skipIfTextureFormatNotSupported(t.params.format);
+    t.selectDeviceForRenderableColorFormatOrSkipTestCase(t.params.format);
   })
   .fn(t => {
     const { format, colorFormatCount } = t.params;
@@ -118,6 +119,9 @@ g.test('attachment_state,limits,maxColorAttachmentBytesPerSample,unaligned')
       },
     ])
   )
+  .beforeAllSubcases(t => {
+    t.selectDeviceForRenderableColorFormatOrSkipTestCase('r32float');
+  })
   .fn(t => {
     const { formats } = t.params;
 
@@ -168,6 +172,7 @@ g.test('valid_texture_formats')
   .beforeAllSubcases(t => {
     const { format } = t.params;
     t.selectDeviceForTextureFormatOrSkipTestCase(format);
+    t.selectDeviceForRenderableColorFormatOrSkipTestCase(format);
   })
   .fn(t => {
     const { format, attachment } = t.params;

--- a/src/webgpu/api/validation/queue/copyToTexture/CopyExternalImageToTexture.spec.ts
+++ b/src/webgpu/api/validation/queue/copyToTexture/CopyExternalImageToTexture.spec.ts
@@ -682,6 +682,7 @@ g.test('destination_texture,format')
     const { format } = t.params;
     t.skipIfTextureFormatNotSupported(format);
     t.selectDeviceOrSkipTestCase(kTextureFormatInfo[format].feature);
+    t.selectDeviceForRenderableColorFormatOrSkipTestCase(format);
   })
   .fn(async t => {
     const { format, copySize } = t.params;

--- a/src/webgpu/api/validation/render_pass/attachment_compatibility.spec.ts
+++ b/src/webgpu/api/validation/render_pass/attachment_compatibility.spec.ts
@@ -184,14 +184,7 @@ g.test('render_pass_and_bundle,color_format')
     const { passFormat, bundleFormat } = t.params;
 
     t.skipIfTextureFormatNotSupported(passFormat, bundleFormat);
-    // float16 and float32 might miss color renderablity under compat mode
-    t.skipIf(
-      t.isCompatibility &&
-        (is16Float(passFormat) ||
-          is32Float(passFormat) ||
-          is16Float(bundleFormat) ||
-          is32Float(bundleFormat))
-    );
+    t.skipIfMultisampleNotSupportedForFormat(passFormat, bundleFormat);
 
     const bundleEncoder = t.device.createRenderBundleEncoder({
       colorFormats: [bundleFormat],
@@ -400,14 +393,7 @@ Test that color attachment formats in render passes or bundles match the pipelin
     const { encoderType, encoderFormat, pipelineFormat } = t.params;
 
     t.skipIfTextureFormatNotSupported(encoderFormat, pipelineFormat);
-    // float16 and float32 might miss color renderablity under compat mode
-    t.skipIf(
-      t.isCompatibility &&
-        (is16Float(encoderFormat) ||
-          is32Float(encoderFormat) ||
-          is16Float(pipelineFormat) ||
-          is32Float(pipelineFormat))
-    );
+    t.skipIfMultisampleNotSupportedForFormat(encoderFormat, pipelineFormat);
 
     const pipeline = t.createRenderPipeline([{ format: pipelineFormat, writeMask: 0 }]);
 

--- a/src/webgpu/api/validation/render_pass/attachment_compatibility.spec.ts
+++ b/src/webgpu/api/validation/render_pass/attachment_compatibility.spec.ts
@@ -14,8 +14,6 @@ import {
   kTextureFormatInfo,
   filterFormatsByFeature,
   getFeaturesForFormats,
-  is16Float,
-  is32Float,
 } from '../../../format_info.js';
 import { ValidationTest } from '../validation_test.js';
 
@@ -184,7 +182,7 @@ g.test('render_pass_and_bundle,color_format')
     const { passFormat, bundleFormat } = t.params;
 
     t.skipIfTextureFormatNotSupported(passFormat, bundleFormat);
-    t.skipIfMultisampleNotSupportedForFormat(passFormat, bundleFormat);
+    t.skipIfColorRenderableNotSupportedForFormat(passFormat, bundleFormat);
 
     const bundleEncoder = t.device.createRenderBundleEncoder({
       colorFormats: [bundleFormat],
@@ -393,7 +391,7 @@ Test that color attachment formats in render passes or bundles match the pipelin
     const { encoderType, encoderFormat, pipelineFormat } = t.params;
 
     t.skipIfTextureFormatNotSupported(encoderFormat, pipelineFormat);
-    t.skipIfMultisampleNotSupportedForFormat(encoderFormat, pipelineFormat);
+    t.skipIfColorRenderableNotSupportedForFormat(encoderFormat, pipelineFormat);
 
     const pipeline = t.createRenderPipeline([{ format: pipelineFormat, writeMask: 0 }]);
 

--- a/src/webgpu/api/validation/render_pass/attachment_compatibility.spec.ts
+++ b/src/webgpu/api/validation/render_pass/attachment_compatibility.spec.ts
@@ -14,6 +14,8 @@ import {
   kTextureFormatInfo,
   filterFormatsByFeature,
   getFeaturesForFormats,
+  is16Float,
+  is32Float,
 } from '../../../format_info.js';
 import { ValidationTest } from '../validation_test.js';
 
@@ -182,6 +184,14 @@ g.test('render_pass_and_bundle,color_format')
     const { passFormat, bundleFormat } = t.params;
 
     t.skipIfTextureFormatNotSupported(passFormat, bundleFormat);
+    // float16 and float32 might miss color renderablity under compat mode
+    t.skipIf(
+      t.isCompatibility &&
+        (is16Float(passFormat) ||
+          is32Float(passFormat) ||
+          is16Float(bundleFormat) ||
+          is32Float(bundleFormat))
+    );
 
     const bundleEncoder = t.device.createRenderBundleEncoder({
       colorFormats: [bundleFormat],
@@ -358,7 +368,7 @@ g.test('render_pass_and_bundle,device_mismatch')
     const { mismatched } = t.params;
     const sourceDevice = mismatched ? t.mismatchedDevice : t.device;
 
-    const format = 'r16float';
+    const format = 'r16uint';
     const bundleEncoder = sourceDevice.createRenderBundleEncoder({
       colorFormats: [format],
     });
@@ -390,6 +400,14 @@ Test that color attachment formats in render passes or bundles match the pipelin
     const { encoderType, encoderFormat, pipelineFormat } = t.params;
 
     t.skipIfTextureFormatNotSupported(encoderFormat, pipelineFormat);
+    // float16 and float32 might miss color renderablity under compat mode
+    t.skipIf(
+      t.isCompatibility &&
+        (is16Float(encoderFormat) ||
+          is32Float(encoderFormat) ||
+          is16Float(pipelineFormat) ||
+          is32Float(pipelineFormat))
+    );
 
     const pipeline = t.createRenderPipeline([{ format: pipelineFormat, writeMask: 0 }]);
 

--- a/src/webgpu/api/validation/render_pass/render_pass_descriptor.spec.ts
+++ b/src/webgpu/api/validation/render_pass/render_pass_descriptor.spec.ts
@@ -11,6 +11,7 @@ import { getDefaultLimits, kQueryTypes } from '../../../capability_info.js';
 import { GPUConst } from '../../../constants.js';
 import {
   computeBytesPerSampleFromFormats,
+  is32Float,
   kDepthStencilFormats,
   kRenderableColorTextureFormats,
   kTextureFormatInfo,
@@ -211,6 +212,7 @@ g.test('color_attachments,limits,maxColorAttachmentBytesPerSample,aligned')
   )
   .beforeAllSubcases(t => {
     t.skipIfTextureFormatNotSupported(t.params.format);
+    t.selectDeviceForRenderableColorFormatOrSkipTestCase(t.params.format);
   })
   .fn(t => {
     const { format, attachmentCount } = t.params;
@@ -267,6 +269,9 @@ g.test('color_attachments,limits,maxColorAttachmentBytesPerSample,unaligned')
       },
     ])
   )
+  .beforeAllSubcases(t => {
+    t.selectDeviceForRenderableColorFormatOrSkipTestCase('r32float');
+  })
   .fn(t => {
     const { formats } = t.params;
 
@@ -1168,7 +1173,13 @@ g.test('resolveTarget,format_supports_resolve')
       .filter(t => kTextureFormatInfo[t.format].multisample)
   )
   .beforeAllSubcases(t => {
-    t.skipIfTextureFormatNotSupported(t.params.format);
+    const { format } = t.params;
+    t.skipIfTextureFormatNotSupported(format);
+    t.selectDeviceForRenderableColorFormatOrSkipTestCase(format);
+    t.skipIf(
+      t.isCompatibility && (format === 'rgba16float' || is32Float(format)),
+      'Multisample support for this format is not guaranteed in comapt mode'
+    );
   })
   .fn(t => {
     const { format } = t.params;

--- a/src/webgpu/api/validation/render_pass/render_pass_descriptor.spec.ts
+++ b/src/webgpu/api/validation/render_pass/render_pass_descriptor.spec.ts
@@ -11,7 +11,6 @@ import { getDefaultLimits, kQueryTypes } from '../../../capability_info.js';
 import { GPUConst } from '../../../constants.js';
 import {
   computeBytesPerSampleFromFormats,
-  is32Float,
   kDepthStencilFormats,
   kRenderableColorTextureFormats,
   kTextureFormatInfo,
@@ -1175,11 +1174,8 @@ g.test('resolveTarget,format_supports_resolve')
   .beforeAllSubcases(t => {
     const { format } = t.params;
     t.skipIfTextureFormatNotSupported(format);
+    t.skipIfMultisampleNotSupportedForFormat(format);
     t.selectDeviceForRenderableColorFormatOrSkipTestCase(format);
-    t.skipIf(
-      t.isCompatibility && (format === 'rgba16float' || is32Float(format)),
-      'Multisample support for this format is not guaranteed in comapt mode'
-    );
   })
   .fn(t => {
     const { format } = t.params;

--- a/src/webgpu/api/validation/render_pipeline/float32_blendable.spec.ts
+++ b/src/webgpu/api/validation/render_pipeline/float32_blendable.spec.ts
@@ -30,6 +30,7 @@ pipeline that uses blending with any float32-format attachment.
     if (t.params.enabled) {
       t.selectDeviceOrSkipTestCase('float32-blendable');
     }
+    t.selectDeviceForRenderableColorFormatOrSkipTestCase('r32float');
   })
   .fn(t => {
     const { isAsync, enabled, hasBlend, format } = t.params;

--- a/src/webgpu/api/validation/render_pipeline/fragment_state.spec.ts
+++ b/src/webgpu/api/validation/render_pipeline/fragment_state.spec.ts
@@ -181,6 +181,7 @@ g.test('limits,maxColorAttachmentBytesPerSample,aligned')
   )
   .beforeAllSubcases(t => {
     t.skipIfTextureFormatNotSupported(t.params.format);
+    t.selectDeviceForRenderableColorFormatOrSkipTestCase(t.params.format);
   })
   .fn(t => {
     const { format, attachmentCount, isAsync } = t.params;
@@ -228,6 +229,9 @@ g.test('limits,maxColorAttachmentBytesPerSample,unaligned')
       .beginSubcases()
       .combine('isAsync', [false, true])
   )
+  .beforeAllSubcases(t => {
+    t.selectDeviceForRenderableColorFormatOrSkipTestCase('r32float');
+  })
   .fn(t => {
     const { formats, isAsync } = t.params;
 
@@ -394,6 +398,7 @@ g.test('pipeline_output_targets')
   )
   .beforeAllSubcases(t => {
     t.selectDeviceForTextureFormatOrSkipTestCase(t.params.format);
+    t.selectDeviceForRenderableColorFormatOrSkipTestCase(t.params.format);
   })
   .fn(t => {
     const { isAsync, format, writeMask, shaderOutput } = t.params;

--- a/src/webgpu/capability_info.ts
+++ b/src/webgpu/capability_info.ts
@@ -592,16 +592,22 @@ export function textureBindingEntries(includeUndefined: boolean): readonly BGLEn
  *
  * Note: Generates different `access` options, but not `format` or `viewDimension` options.
  */
-export function storageTextureBindingEntries(): readonly BGLEntry[] {
+export function storageTextureBindingEntries(format: GPUTextureFormat): readonly BGLEntry[] {
   return [
-    { storageTexture: { access: 'write-only', format: 'r32float' } },
-    { storageTexture: { access: 'read-only', format: 'r32float' } },
-    { storageTexture: { access: 'read-write', format: 'r32float' } },
+    { storageTexture: { access: 'write-only', format } },
+    { storageTexture: { access: 'read-only', format } },
+    { storageTexture: { access: 'read-write', format } },
   ] as const;
 }
 /** Generate a list of possible texture-or-storageTexture-typed BGLEntry values. */
-export function sampledAndStorageBindingEntries(includeUndefined: boolean): readonly BGLEntry[] {
-  return [...textureBindingEntries(includeUndefined), ...storageTextureBindingEntries()] as const;
+export function sampledAndStorageBindingEntries(
+  includeUndefined: boolean,
+  format: GPUTextureFormat = 'r32float'
+): readonly BGLEntry[] {
+  return [
+    ...textureBindingEntries(includeUndefined),
+    ...storageTextureBindingEntries(format),
+  ] as const;
 }
 /**
  * Generate a list of possible BGLEntry values of every type, but not variants with different:
@@ -610,11 +616,14 @@ export function sampledAndStorageBindingEntries(includeUndefined: boolean): read
  * - texture.viewDimension
  * - storageTexture.viewDimension
  */
-export function allBindingEntries(includeUndefined: boolean): readonly BGLEntry[] {
+export function allBindingEntries(
+  includeUndefined: boolean,
+  format: GPUTextureFormat = 'r32float'
+): readonly BGLEntry[] {
   return [
     ...bufferBindingEntries(includeUndefined),
     ...samplerBindingEntries(includeUndefined),
-    ...sampledAndStorageBindingEntries(includeUndefined),
+    ...sampledAndStorageBindingEntries(includeUndefined, format),
   ] as const;
 }
 

--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -323,7 +323,7 @@ export class GPUTestSubcaseBatchState extends SubcaseBatchState {
 
     for (const format of formats) {
       if (format === undefined) continue;
-      if (!kAllTextureFormatInfo[format].color) {
+      if (!kTextureFormatInfo[format].color) {
         this.skip(`texture format '${format} is not color renderable`);
       }
     }
@@ -618,7 +618,7 @@ export class GPUTestBase extends Fixture<GPUTestSubcaseBatchState> {
 
     for (const format of formats) {
       if (format === undefined) continue;
-      if (!kAllTextureFormatInfo[format].color) {
+      if (!kTextureFormatInfo[format].color) {
         this.skip(`texture format '${format} is not color renderable`);
       }
     }

--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -309,6 +309,26 @@ export class GPUTestSubcaseBatchState extends SubcaseBatchState {
     }
   }
 
+  skipIfColorRenderableNotSupportedForFormat(...formats: (GPUTextureFormat | undefined)[]) {
+    if (this.isCompatibility) {
+      for (const format of formats) {
+        if (format === undefined) continue;
+        if (is16Float(format) || is32Float(format)) {
+          this.skip(
+            `texture format '${format} is not guaranteed to be color renderable in compat mode`
+          );
+        }
+      }
+    }
+
+    for (const format of formats) {
+      if (format === undefined) continue;
+      if (!kAllTextureFormatInfo[format].color) {
+        this.skip(`texture format '${format} is not color renderable`);
+      }
+    }
+  }
+
   getFloatTextureFormatColorRenderableFeatures(...formats: (GPUTextureFormat | undefined)[]) {
     const requiredFeatures: GPUFeatureName[] = [];
     if (this.isCompatibility) {
@@ -580,6 +600,26 @@ export class GPUTestBase extends Fixture<GPUTestSubcaseBatchState> {
       if (format === undefined) continue;
       if (!isMultisampledTextureFormat(format)) {
         this.skip(`texture format '${format} is not supported to be multisampled`);
+      }
+    }
+  }
+
+  skipIfColorRenderableNotSupportedForFormat(...formats: (GPUTextureFormat | undefined)[]) {
+    if (this.isCompatibility) {
+      for (const format of formats) {
+        if (format === undefined) continue;
+        if (is16Float(format) || is32Float(format)) {
+          this.skip(
+            `texture format '${format} is not guaranteed to be color renderable in compat mode`
+          );
+        }
+      }
+    }
+
+    for (const format of formats) {
+      if (format === undefined) continue;
+      if (!kAllTextureFormatInfo[format].color) {
+        this.skip(`texture format '${format} is not color renderable`);
       }
     }
   }

--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -34,6 +34,7 @@ import {
   isTextureFormatUsableAsStorageFormat,
   is32Float,
   is16Float,
+  isMultisampledTextureFormat,
 } from './format_info.js';
 import { checkElementsEqual, checkElementsBetween } from './util/check_contents.js';
 import { CommandBufferMaker, EncoderType } from './util/command_buffer_maker.js';
@@ -284,6 +285,26 @@ export class GPUTestSubcaseBatchState extends SubcaseBatchState {
         if (format === 'bgra8unorm-srgb') {
           this.skip(`texture format '${format} is not supported`);
         }
+      }
+    }
+  }
+
+  skipIfMultisampleNotSupportedForFormat(...formats: (GPUTextureFormat | undefined)[]) {
+    if (this.isCompatibility) {
+      for (const format of formats) {
+        if (format === undefined) continue;
+        if (format === 'rgba16float' || is32Float(format)) {
+          this.skip(
+            `texture format '${format} is not guaranteed to be multisampled support in compat mode`
+          );
+        }
+      }
+    }
+
+    for (const format of formats) {
+      if (format === undefined) continue;
+      if (!isMultisampledTextureFormat(format)) {
+        this.skip(`texture format '${format} is not supported to be multisampled`);
       }
     }
   }
@@ -539,6 +560,26 @@ export class GPUTestBase extends Fixture<GPUTestSubcaseBatchState> {
         if (format === 'bgra8unorm-srgb') {
           this.skip(`texture format '${format} is not supported`);
         }
+      }
+    }
+  }
+
+  skipIfMultisampleNotSupportedForFormat(...formats: (GPUTextureFormat | undefined)[]) {
+    if (this.isCompatibility) {
+      for (const format of formats) {
+        if (format === undefined) continue;
+        if (format === 'rgba16float' || is32Float(format)) {
+          this.skip(
+            `texture format '${format} is not guaranteed to be multisampled support in compat mode`
+          );
+        }
+      }
+    }
+
+    for (const format of formats) {
+      if (format === undefined) continue;
+      if (!isMultisampledTextureFormat(format)) {
+        this.skip(`texture format '${format} is not supported to be multisampled`);
       }
     }
   }


### PR DESCRIPTION
Following https://github.com/gpuweb/cts/pull/4148 fixing operation tests

This CL fixes validation tests

There are mainly 3 categories:

* Regular ones: add `t.selectDeviceForRenderableColorFormatOrSkipTestCase(format);` to require float16(32)-renderable features
    - For those requiring multisample support ,simply skip those as compat doesn't guarantee multiple support for rgba16float and *32float.
* (Example: `maxColorAttachmentBytesPerSample.spec.ts`): They aren't really testing float16, 32 format, they simply pick a random format to test storages, etc. Change them to another format (*uint) that still fits the need
    - Can't do that for `createBindGroup.spec.ts`, it's testing all usages: render_attachment, multisample, all 3 storage binding, there's no other format having full support of these like that of r32float.
* (Example: `attachment_compatibility.spec.ts`): They are testing if formatA === formatB. and the params.format is subcase. Simply skip 16float and 32float on these (regardless of float16(32)renderable availability). I think it's okay given what they are testing against.