### PR TITLE
Skip web_platform tests if API does not exist

### DIFF
--- a/src/webgpu/web_platform/canvas/getCurrentTexture.spec.ts
+++ b/src/webgpu/web_platform/canvas/getCurrentTexture.spec.ts
@@ -172,9 +172,14 @@ g.test('multiple_frames')
   )
   .beforeAllSubcases(t => {
     const { canvasType } = t.params;
-    if (canvasType === 'offscreen' && !('transferToImageBitmap' in OffscreenCanvas.prototype)) {
-      throw new SkipTestCase('transferToImageBitmap not supported');
-    }
+    t.skipIf(
+      canvasType === 'offscreen' && typeof OffscreenCanvas === 'undefined',
+      'OffscreenCanvas does not exist in this environment'
+    );
+    t.skipIf(
+      canvasType === 'offscreen' && !('transferToImageBitmap' in OffscreenCanvas.prototype),
+      'transferToImageBitmap not supported'
+    );
   })
   .fn(t => {
     const { canvasType, clearTexture } = t.params;

--- a/src/webgpu/web_platform/canvas/getPreferredCanvasFormat.spec.ts
+++ b/src/webgpu/web_platform/canvas/getPreferredCanvasFormat.spec.ts
@@ -2,7 +2,7 @@ export const description = `
 Tests for navigator.gpu.getPreferredCanvasFormat.
 `;
 
-import { Fixture } from '../../../common/framework/fixture.js';
+import { Fixture, SkipTestCase } from '../../../common/framework/fixture.js';
 import { makeTestGroup } from '../../../common/framework/test_group.js';
 
 export const g = makeTestGroup(Fixture);
@@ -13,6 +13,11 @@ g.test('value')
     Ensure getPreferredCanvasFormat returns one of the valid values.
     `
   )
+  .beforeAllSubcases(t => {
+    if (typeof navigator === 'undefined') {
+      throw new SkipTestCase('navigator does not exist in this environment');
+    }
+  })
   .fn(t => {
     const preferredFormat = navigator.gpu.getPreferredCanvasFormat();
     t.expect(preferredFormat === 'bgra8unorm' || preferredFormat === 'rgba8unorm');

--- a/src/webgpu/web_platform/copyToTexture/ImageBitmap.spec.ts
+++ b/src/webgpu/web_platform/copyToTexture/ImageBitmap.spec.ts
@@ -59,6 +59,7 @@ g.test('from_ImageData')
       .combine('height', [1, 2, 4, 15, 255, 256])
   )
   .beforeAllSubcases(t => {
+    t.skipIf(typeof ImageData === 'undefined', 'ImageData does not exist in this environment');
     t.skipIfTextureFormatNotSupported(t.params.dstFormat);
   })
   .fn(async t => {
@@ -179,6 +180,7 @@ g.test('from_canvas')
       .combine('height', [1, 2, 4, 15, 255, 256])
   )
   .beforeAllSubcases(t => {
+    t.skipIf(typeof ImageData === 'undefined', 'ImageData does not exist in this environment');
     t.skipIfTextureFormatNotSupported(t.params.dstFormat);
   })
   .fn(async t => {
@@ -208,7 +210,7 @@ g.test('from_canvas')
     } else {
       imageCanvas = new OffscreenCanvas(width, height);
     }
-    const imageCanvasContext = imageCanvas.getContext('2d');
+    const imageCanvasContext = imageCanvas.getContext('2d') as OffscreenCanvasRenderingContext2D;
     if (imageCanvasContext === null) {
       t.skip('OffscreenCanvas "2d" context not available');
       return;
@@ -326,6 +328,9 @@ g.test('copy_subrect_from_ImageData')
       .beginSubcases()
       .combine('copySubRectInfo', kCopySubrectInfo)
   )
+  .beforeAllSubcases(t => {
+    t.skipIf(typeof ImageData === 'undefined', 'ImageData does not exist in this environment');
+  })
   .fn(async t => {
     const {
       copySubRectInfo,

--- a/src/webgpu/web_platform/copyToTexture/ImageData.spec.ts
+++ b/src/webgpu/web_platform/copyToTexture/ImageData.spec.ts
@@ -47,6 +47,7 @@ g.test('from_ImageData')
       .combine('height', [1, 2, 4, 15, 255, 256])
   )
   .beforeAllSubcases(t => {
+    t.skipIf(typeof ImageData === 'undefined', 'ImageData does not exist in this environment');
     t.skipIfTextureFormatNotSupported(t.params.dstColorFormat);
   })
   .fn(t => {
@@ -152,6 +153,9 @@ g.test('copy_subrect_from_ImageData')
       .beginSubcases()
       .combine('copySubRectInfo', kCopySubrectInfo)
   )
+  .beforeAllSubcases(t => {
+    t.skipIf(typeof ImageData === 'undefined', 'ImageData does not exist in this environment');
+  })
   .fn(t => {
     const { copySubRectInfo, dstPremultiplied, srcDoFlipYDuringCopy } = t.params;
 

--- a/src/webgpu/web_platform/copyToTexture/image_file.spec.ts
+++ b/src/webgpu/web_platform/copyToTexture/image_file.spec.ts
@@ -6,7 +6,7 @@ import { makeTestGroup } from '../../../common/framework/test_group.js';
 import { TextureUploadingUtils } from '../../util/copy_to_texture.js';
 import {
   convertToUnorm8,
-  GetSourceFromEXIFImageFile,
+  getSourceFromEXIFImageFile,
   kImageNames,
   kImageInfo,
   kImageExpectedColors,
@@ -50,7 +50,7 @@ g.test('from_orientation_metadata_file')
     const kColorFormat = 'rgba8unorm';
 
     // Load image file.
-    const source = await GetSourceFromEXIFImageFile(t, imageName, objectTypeFromFile);
+    const source = await getSourceFromEXIFImageFile(t, imageName, objectTypeFromFile);
     const width = source.width;
     const height = source.height;
 


### PR DESCRIPTION
Skip tests if `navigator`, `OffscreenCanvas`, `ImageData`, etc... do not exist.

This is mostly for dawn.node and similar environments.

If these tests are supposed to fail then that's fine. We can discard this PR