### PR TITLE
Test reading mip levels with textureLoad and 2d textures.

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/textureLoad.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureLoad.spec.ts
@@ -215,6 +215,7 @@ Parameters:
     const calls: TextureCall<vec2>[] = generateTextureBuiltinInputs2D(50, {
       method: samplePoints,
       descriptor,
+      mipLevel: { num: texture.mipLevelCount, type: L },
       hashInputs: [stage, format, samplePoints, C, L],
     }).map(({ coords, mipLevel }) => {
       return {


### PR DESCRIPTION
This line is only missing from the 2d version.
Without it only level 0 is read.


I think `textureSampleCompareLevel` might also have this issue but I'll do that in another PR. `textureSampleLevel` appears to be fine.