### PR TITLE
Fix bug: fragment output type mismatch

### DIFF
--- a/src/webgpu/api/validation/capability_checks/limits/maxColorAttachmentBytesPerSample.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxColorAttachmentBytesPerSample.spec.ts
@@ -95,14 +95,16 @@ function getPipelineDescriptor(
     return;
   }
 
+  const typedVec = interleaveFormat.includes('uint') ? 'vec4u' : 'vec4f';
+
   const code = `
     ${getDescription(testValue, actualLimit, sampleCount, targets)}
     @vertex fn vs() -> @builtin(position) vec4f {
       return vec4f(0);
     }
 
-    @fragment fn fs() -> @location(0) vec4f {
-      return vec4f(0);
+    @fragment fn fs() -> @location(0) ${typedVec} {
+      return ${typedVec}(0);
     }
   `;
   const module = device.createShaderModule({ code });


### PR DESCRIPTION
Fix a bug introduced in https://github.com/gpuweb/cts/pull/4152

When format is *16uint/*32uint, fragment output type should be vec4u instead of vec4f