### PR TITLE
Compat: remove select device for float16(32)-renderable features

### DIFF
--- a/src/webgpu/api/operation/render_pass/storeOp.spec.ts
+++ b/src/webgpu/api/operation/render_pass/storeOp.spec.ts
@@ -152,7 +152,6 @@ g.test('render_pass_store_op,color_attachment_only')
   )
   .beforeAllSubcases(t => {
     t.skipIfTextureFormatNotSupported(t.params.colorFormat);
-    t.selectDeviceForRenderableColorFormatOrSkipTestCase(t.params.colorFormat);
   })
   .fn(t => {
     const colorAttachment = t.createTextureTracked({

--- a/src/webgpu/api/operation/render_pass/storeOp.spec.ts
+++ b/src/webgpu/api/operation/render_pass/storeOp.spec.ts
@@ -152,6 +152,7 @@ g.test('render_pass_store_op,color_attachment_only')
   )
   .beforeAllSubcases(t => {
     t.skipIfTextureFormatNotSupported(t.params.colorFormat);
+    t.skipIfColorRenderableNotSupportedForFormat(t.params.colorFormat);
   })
   .fn(t => {
     const colorAttachment = t.createTextureTracked({

--- a/src/webgpu/api/operation/render_pipeline/overrides.spec.ts
+++ b/src/webgpu/api/operation/render_pipeline/overrides.spec.ts
@@ -191,9 +191,6 @@ g.test('precision')
         },
       ])
   )
-  .beforeAllSubcases(t => {
-    t.selectDeviceForRenderableColorFormatOrSkipTestCase(kPrecisionTestFormat);
-  })
   .fn(async t => {
     const format = kPrecisionTestFormat;
     await t.ExpectShaderOutputWithConstants(

--- a/src/webgpu/api/operation/render_pipeline/overrides.spec.ts
+++ b/src/webgpu/api/operation/render_pipeline/overrides.spec.ts
@@ -191,6 +191,9 @@ g.test('precision')
         },
       ])
   )
+  .beforeAllSubcases(t => {
+    t.skipIfColorRenderableNotSupportedForFormat(kPrecisionTestFormat);
+  })
   .fn(async t => {
     const format = kPrecisionTestFormat;
     await t.ExpectShaderOutputWithConstants(

--- a/src/webgpu/api/operation/render_pipeline/pipeline_output_targets.spec.ts
+++ b/src/webgpu/api/operation/render_pipeline/pipeline_output_targets.spec.ts
@@ -58,6 +58,7 @@ g.test('color,attachments')
   .beforeAllSubcases(t => {
     const info = kTextureFormatInfo[t.params.format];
     t.skipIfTextureFormatNotSupported(t.params.format);
+    t.skipIfColorRenderableNotSupportedForFormat(t.params.format);
     t.selectDeviceOrSkipTestCase(info.feature);
   })
   .fn(t => {
@@ -160,6 +161,7 @@ g.test('color,component_count')
   .beforeAllSubcases(t => {
     const info = kTextureFormatInfo[t.params.format];
     t.skipIfTextureFormatNotSupported(t.params.format);
+    t.skipIfColorRenderableNotSupportedForFormat(t.params.format);
     t.selectDeviceOrSkipTestCase(info.feature);
   })
   .fn(t => {

--- a/src/webgpu/api/operation/render_pipeline/pipeline_output_targets.spec.ts
+++ b/src/webgpu/api/operation/render_pipeline/pipeline_output_targets.spec.ts
@@ -58,7 +58,6 @@ g.test('color,attachments')
   .beforeAllSubcases(t => {
     const info = kTextureFormatInfo[t.params.format];
     t.skipIfTextureFormatNotSupported(t.params.format);
-    t.selectDeviceForRenderableColorFormatOrSkipTestCase(t.params.format);
     t.selectDeviceOrSkipTestCase(info.feature);
   })
   .fn(t => {
@@ -161,7 +160,6 @@ g.test('color,component_count')
   .beforeAllSubcases(t => {
     const info = kTextureFormatInfo[t.params.format];
     t.skipIfTextureFormatNotSupported(t.params.format);
-    t.selectDeviceForRenderableColorFormatOrSkipTestCase(t.params.format);
     t.selectDeviceOrSkipTestCase(info.feature);
   })
   .fn(t => {

--- a/src/webgpu/api/operation/rendering/color_target_state.spec.ts
+++ b/src/webgpu/api/operation/rendering/color_target_state.spec.ts
@@ -209,6 +209,7 @@ g.test('blending,GPUBlendComponent')
     ) {
       t.selectDeviceOrSkipTestCase('dual-source-blending');
     }
+    t.skipIfColorRenderableNotSupportedForFormat(kBlendingGPUBlendComponentFormat);
   })
   .fn(t => {
     const textureFormat: GPUTextureFormat = kBlendingGPUBlendComponentFormat;
@@ -394,6 +395,7 @@ g.test('blending,formats')
   )
   .beforeAllSubcases(t => {
     t.skipIfTextureFormatNotSupported(t.params.format);
+    t.skipIfColorRenderableNotSupportedForFormat(t.params.format);
   })
   .fn(t => {
     const { format } = t.params;
@@ -798,6 +800,9 @@ g.test('blending,clamping')
       .combine('srcValue', [0.4, 0.6, 0.8, 1.0])
       .combine('dstValue', [0.2, 0.4])
   )
+  .beforeAllSubcases(t => {
+    t.skipIfColorRenderableNotSupportedForFormat(t.params.format);
+  })
   .fn(t => {
     const { format, srcValue, dstValue } = t.params;
 

--- a/src/webgpu/api/operation/rendering/color_target_state.spec.ts
+++ b/src/webgpu/api/operation/rendering/color_target_state.spec.ts
@@ -209,7 +209,6 @@ g.test('blending,GPUBlendComponent')
     ) {
       t.selectDeviceOrSkipTestCase('dual-source-blending');
     }
-    t.selectDeviceForRenderableColorFormatOrSkipTestCase(kBlendingGPUBlendComponentFormat);
   })
   .fn(t => {
     const textureFormat: GPUTextureFormat = kBlendingGPUBlendComponentFormat;
@@ -395,7 +394,6 @@ g.test('blending,formats')
   )
   .beforeAllSubcases(t => {
     t.skipIfTextureFormatNotSupported(t.params.format);
-    t.selectDeviceForRenderableColorFormatOrSkipTestCase(t.params.format);
   })
   .fn(t => {
     const { format } = t.params;
@@ -800,9 +798,6 @@ g.test('blending,clamping')
       .combine('srcValue', [0.4, 0.6, 0.8, 1.0])
       .combine('dstValue', [0.2, 0.4])
   )
-  .beforeAllSubcases(t => {
-    t.selectDeviceForRenderableColorFormatOrSkipTestCase(t.params.format);
-  })
   .fn(t => {
     const { format, srcValue, dstValue } = t.params;
 

--- a/src/webgpu/api/operation/resource_init/texture_zero.spec.ts
+++ b/src/webgpu/api/operation/resource_init/texture_zero.spec.ts
@@ -43,7 +43,6 @@ g.test('uninitialized_texture_is_zero')
   .params(kTestParams)
   .beforeAllSubcases(t => {
     t.skipIfTextureFormatNotSupported(t.params.format);
-    t.selectDeviceForRenderableColorFormatOrSkipTestCase(t.params.format);
     t.selectDeviceOrSkipTestCase(kTextureFormatInfo[t.params.format].feature);
   })
   .fn(t => {

--- a/src/webgpu/api/operation/resource_init/texture_zero.spec.ts
+++ b/src/webgpu/api/operation/resource_init/texture_zero.spec.ts
@@ -43,6 +43,7 @@ g.test('uninitialized_texture_is_zero')
   .params(kTestParams)
   .beforeAllSubcases(t => {
     t.skipIfTextureFormatNotSupported(t.params.format);
+    t.skipIfColorRenderableNotSupportedForFormat(t.params.format);
     t.selectDeviceOrSkipTestCase(kTextureFormatInfo[t.params.format].feature);
   })
   .fn(t => {

--- a/src/webgpu/api/operation/sampling/filter_mode.spec.ts
+++ b/src/webgpu/api/operation/sampling/filter_mode.spec.ts
@@ -481,7 +481,6 @@ g.test('magFilter,nearest')
   )
   .beforeAllSubcases(t => {
     t.skipIfTextureFormatNotSupported(t.params.format);
-    t.selectDeviceForRenderableColorFormatOrSkipTestCase(t.params.format);
     if (kTextureFormatInfo[t.params.format].color.type === 'unfilterable-float') {
       t.selectDeviceOrSkipTestCase('float32-filterable');
     }
@@ -605,7 +604,6 @@ g.test('magFilter,linear')
   )
   .beforeAllSubcases(t => {
     t.skipIfTextureFormatNotSupported(t.params.format);
-    t.selectDeviceForRenderableColorFormatOrSkipTestCase(t.params.format);
     if (kTextureFormatInfo[t.params.format].color.type === 'unfilterable-float') {
       t.selectDeviceOrSkipTestCase('float32-filterable');
     }
@@ -741,7 +739,6 @@ g.test('minFilter,nearest')
   )
   .beforeAllSubcases(t => {
     t.skipIfTextureFormatNotSupported(t.params.format);
-    t.selectDeviceForRenderableColorFormatOrSkipTestCase(t.params.format);
     if (kTextureFormatInfo[t.params.format].color.type === 'unfilterable-float') {
       t.selectDeviceOrSkipTestCase('float32-filterable');
     }
@@ -875,7 +872,6 @@ g.test('minFilter,linear')
   )
   .beforeAllSubcases(t => {
     t.skipIfTextureFormatNotSupported(t.params.format);
-    t.selectDeviceForRenderableColorFormatOrSkipTestCase(t.params.format);
     if (kTextureFormatInfo[t.params.format].color.type === 'unfilterable-float') {
       t.selectDeviceOrSkipTestCase('float32-filterable');
     }
@@ -972,7 +968,6 @@ g.test('mipmapFilter')
   )
   .beforeAllSubcases(t => {
     t.skipIfTextureFormatNotSupported(t.params.format);
-    t.selectDeviceForRenderableColorFormatOrSkipTestCase(t.params.format);
     if (kTextureFormatInfo[t.params.format].color.type === 'unfilterable-float') {
       t.selectDeviceOrSkipTestCase('float32-filterable');
     }

--- a/src/webgpu/api/operation/sampling/filter_mode.spec.ts
+++ b/src/webgpu/api/operation/sampling/filter_mode.spec.ts
@@ -481,6 +481,7 @@ g.test('magFilter,nearest')
   )
   .beforeAllSubcases(t => {
     t.skipIfTextureFormatNotSupported(t.params.format);
+    t.skipIfColorRenderableNotSupportedForFormat(t.params.format);
     if (kTextureFormatInfo[t.params.format].color.type === 'unfilterable-float') {
       t.selectDeviceOrSkipTestCase('float32-filterable');
     }
@@ -604,6 +605,7 @@ g.test('magFilter,linear')
   )
   .beforeAllSubcases(t => {
     t.skipIfTextureFormatNotSupported(t.params.format);
+    t.skipIfColorRenderableNotSupportedForFormat(t.params.format);
     if (kTextureFormatInfo[t.params.format].color.type === 'unfilterable-float') {
       t.selectDeviceOrSkipTestCase('float32-filterable');
     }
@@ -739,6 +741,7 @@ g.test('minFilter,nearest')
   )
   .beforeAllSubcases(t => {
     t.skipIfTextureFormatNotSupported(t.params.format);
+    t.skipIfColorRenderableNotSupportedForFormat(t.params.format);
     if (kTextureFormatInfo[t.params.format].color.type === 'unfilterable-float') {
       t.selectDeviceOrSkipTestCase('float32-filterable');
     }
@@ -872,6 +875,7 @@ g.test('minFilter,linear')
   )
   .beforeAllSubcases(t => {
     t.skipIfTextureFormatNotSupported(t.params.format);
+    t.skipIfColorRenderableNotSupportedForFormat(t.params.format);
     if (kTextureFormatInfo[t.params.format].color.type === 'unfilterable-float') {
       t.selectDeviceOrSkipTestCase('float32-filterable');
     }
@@ -968,6 +972,7 @@ g.test('mipmapFilter')
   )
   .beforeAllSubcases(t => {
     t.skipIfTextureFormatNotSupported(t.params.format);
+    t.skipIfColorRenderableNotSupportedForFormat(t.params.format);
     if (kTextureFormatInfo[t.params.format].color.type === 'unfilterable-float') {
       t.selectDeviceOrSkipTestCase('float32-filterable');
     }

--- a/src/webgpu/api/operation/texture_view/write.spec.ts
+++ b/src/webgpu/api/operation/texture_view/write.spec.ts
@@ -350,13 +350,13 @@ TODO: Test rgb10a2uint when TexelRepresentation.numericRange is made per-compone
         // Still need to filter again for compat mode.
         t.skipIfTextureFormatNotUsableAsStorageTexture(format);
         if (sampleCount > 1) {
-          t.skipIfMultisampleNotSupportedForFormatOrSelectDevice(format);
+          t.skipIfMultisampleNotSupportedForFormat(format);
         }
         break;
       case 'render-pass-resolve':
       case 'render-pass-store':
         // Requires multisample in `writeTextureAndGetExpectedTexelView`
-        t.skipIfMultisampleNotSupportedForFormatOrSelectDevice(format);
+        t.skipIfMultisampleNotSupportedForFormat(format);
         break;
     }
   })

--- a/src/webgpu/api/validation/createBindGroup.spec.ts
+++ b/src/webgpu/api/validation/createBindGroup.spec.ts
@@ -205,9 +205,6 @@ g.test('texture_binding_must_have_correct_usage')
         return usage === GPUConst.TextureUsage.STORAGE_BINDING && info.resource === 'sampledTexMS';
       })
   )
-  .beforeAllSubcases(t => {
-    t.selectDeviceForRenderableColorFormatOrSkipTestCase(kTestFormat);
-  })
   .fn(t => {
     const { entry, usage } = t.params;
     const info = texBindingTypeInfo(entry);

--- a/src/webgpu/api/validation/createBindGroup.spec.ts
+++ b/src/webgpu/api/validation/createBindGroup.spec.ts
@@ -205,6 +205,9 @@ g.test('texture_binding_must_have_correct_usage')
         return usage === GPUConst.TextureUsage.STORAGE_BINDING && info.resource === 'sampledTexMS';
       })
   )
+  .beforeAllSubcases(t => {
+    t.skipIfColorRenderableNotSupportedForFormat(kTestFormat);
+  })
   .fn(t => {
     const { entry, usage } = t.params;
     const info = texBindingTypeInfo(entry);

--- a/src/webgpu/api/validation/createTexture.spec.ts
+++ b/src/webgpu/api/validation/createTexture.spec.ts
@@ -282,7 +282,6 @@ g.test('sampleCount,various_sampleCount_with_all_formats')
     const { format } = t.params;
     const info = kTextureFormatInfo[format];
     t.skipIfTextureFormatNotSupported(format);
-    t.selectDeviceForRenderableColorFormatOrSkipTestCase(format);
     t.selectDeviceOrSkipTestCase(info.feature);
   })
   .fn(t => {
@@ -359,7 +358,6 @@ g.test('sampleCount,valid_sampleCount_with_other_parameter_varies')
     const info = kTextureFormatInfo[format];
     t.skipIfTextureFormatNotSupported(format);
     t.selectDeviceOrSkipTestCase(info.feature);
-    t.selectDeviceForRenderableColorFormatOrSkipTestCase(format);
   })
   .fn(t => {
     const { dimension, sampleCount, format, mipLevelCount, arrayLayerCount, usage } = t.params;
@@ -1053,7 +1051,6 @@ g.test('texture_usage')
     const info = kTextureFormatInfo[format];
     t.skipIfTextureFormatNotSupported(format);
     t.selectDeviceOrSkipTestCase(info.feature);
-    t.selectDeviceForRenderableColorFormatOrSkipTestCase(format);
   })
   .fn(t => {
     const { dimension, format, usage0, usage1 } = t.params;

--- a/src/webgpu/api/validation/createTexture.spec.ts
+++ b/src/webgpu/api/validation/createTexture.spec.ts
@@ -282,6 +282,7 @@ g.test('sampleCount,various_sampleCount_with_all_formats')
     const { format } = t.params;
     const info = kTextureFormatInfo[format];
     t.skipIfTextureFormatNotSupported(format);
+    t.skipIfColorRenderableNotSupportedForFormat(format);
     t.selectDeviceOrSkipTestCase(info.feature);
   })
   .fn(t => {
@@ -358,6 +359,7 @@ g.test('sampleCount,valid_sampleCount_with_other_parameter_varies')
     const info = kTextureFormatInfo[format];
     t.skipIfTextureFormatNotSupported(format);
     t.selectDeviceOrSkipTestCase(info.feature);
+    t.skipIfColorRenderableNotSupportedForFormat(format);
   })
   .fn(t => {
     const { dimension, sampleCount, format, mipLevelCount, arrayLayerCount, usage } = t.params;
@@ -1051,6 +1053,7 @@ g.test('texture_usage')
     const info = kTextureFormatInfo[format];
     t.skipIfTextureFormatNotSupported(format);
     t.selectDeviceOrSkipTestCase(info.feature);
+    t.skipIfColorRenderableNotSupportedForFormat(format);
   })
   .fn(t => {
     const { dimension, format, usage0, usage1 } = t.params;

--- a/src/webgpu/api/validation/createView.spec.ts
+++ b/src/webgpu/api/validation/createView.spec.ts
@@ -378,9 +378,6 @@ g.test('texture_view_usage')
     if (textureUsage & GPUTextureUsage.STORAGE_BINDING) {
       t.skipIfTextureFormatNotUsableAsStorageTexture(format);
     }
-    if (textureUsage & GPUTextureUsage.RENDER_ATTACHMENT) {
-      t.selectDeviceForRenderableColorFormatOrSkipTestCase(format);
-    }
   })
   .fn(t => {
     const { format, textureUsage0, textureUsage1, textureViewUsage0, textureViewUsage1 } = t.params;

--- a/src/webgpu/api/validation/createView.spec.ts
+++ b/src/webgpu/api/validation/createView.spec.ts
@@ -378,6 +378,9 @@ g.test('texture_view_usage')
     if (textureUsage & GPUTextureUsage.STORAGE_BINDING) {
       t.skipIfTextureFormatNotUsableAsStorageTexture(format);
     }
+    if (textureUsage & GPUTextureUsage.RENDER_ATTACHMENT) {
+      t.skipIfColorRenderableNotSupportedForFormat(format);
+    }
   })
   .fn(t => {
     const { format, textureUsage0, textureUsage1, textureViewUsage0, textureViewUsage1 } = t.params;

--- a/src/webgpu/api/validation/encoding/createRenderBundleEncoder.spec.ts
+++ b/src/webgpu/api/validation/encoding/createRenderBundleEncoder.spec.ts
@@ -63,7 +63,6 @@ g.test('attachment_state,limits,maxColorAttachmentBytesPerSample,aligned')
   )
   .beforeAllSubcases(t => {
     t.skipIfTextureFormatNotSupported(t.params.format);
-    t.selectDeviceForRenderableColorFormatOrSkipTestCase(t.params.format);
   })
   .fn(t => {
     const { format, colorFormatCount } = t.params;
@@ -119,9 +118,6 @@ g.test('attachment_state,limits,maxColorAttachmentBytesPerSample,unaligned')
       },
     ])
   )
-  .beforeAllSubcases(t => {
-    t.selectDeviceForRenderableColorFormatOrSkipTestCase('r32float');
-  })
   .fn(t => {
     const { formats } = t.params;
 
@@ -172,7 +168,6 @@ g.test('valid_texture_formats')
   .beforeAllSubcases(t => {
     const { format } = t.params;
     t.selectDeviceForTextureFormatOrSkipTestCase(format);
-    t.selectDeviceForRenderableColorFormatOrSkipTestCase(format);
   })
   .fn(t => {
     const { format, attachment } = t.params;

--- a/src/webgpu/api/validation/encoding/createRenderBundleEncoder.spec.ts
+++ b/src/webgpu/api/validation/encoding/createRenderBundleEncoder.spec.ts
@@ -63,6 +63,7 @@ g.test('attachment_state,limits,maxColorAttachmentBytesPerSample,aligned')
   )
   .beforeAllSubcases(t => {
     t.skipIfTextureFormatNotSupported(t.params.format);
+    t.skipIfColorRenderableNotSupportedForFormat(t.params.format);
   })
   .fn(t => {
     const { format, colorFormatCount } = t.params;
@@ -118,6 +119,9 @@ g.test('attachment_state,limits,maxColorAttachmentBytesPerSample,unaligned')
       },
     ])
   )
+  .beforeAllSubcases(t => {
+    t.skipIfColorRenderableNotSupportedForFormat('r32float');
+  })
   .fn(t => {
     const { formats } = t.params;
 
@@ -168,6 +172,7 @@ g.test('valid_texture_formats')
   .beforeAllSubcases(t => {
     const { format } = t.params;
     t.selectDeviceForTextureFormatOrSkipTestCase(format);
+    t.skipIfColorRenderableNotSupportedForFormat(format);
   })
   .fn(t => {
     const { format, attachment } = t.params;

--- a/src/webgpu/api/validation/queue/copyToTexture/CopyExternalImageToTexture.spec.ts
+++ b/src/webgpu/api/validation/queue/copyToTexture/CopyExternalImageToTexture.spec.ts
@@ -682,7 +682,6 @@ g.test('destination_texture,format')
     const { format } = t.params;
     t.skipIfTextureFormatNotSupported(format);
     t.selectDeviceOrSkipTestCase(kTextureFormatInfo[format].feature);
-    t.selectDeviceForRenderableColorFormatOrSkipTestCase(format);
   })
   .fn(async t => {
     const { format, copySize } = t.params;

--- a/src/webgpu/api/validation/queue/copyToTexture/CopyExternalImageToTexture.spec.ts
+++ b/src/webgpu/api/validation/queue/copyToTexture/CopyExternalImageToTexture.spec.ts
@@ -682,6 +682,7 @@ g.test('destination_texture,format')
     const { format } = t.params;
     t.skipIfTextureFormatNotSupported(format);
     t.selectDeviceOrSkipTestCase(kTextureFormatInfo[format].feature);
+    t.skipIfColorRenderableNotSupportedForFormat(format);
   })
   .fn(async t => {
     const { format, copySize } = t.params;

--- a/src/webgpu/api/validation/render_pass/render_pass_descriptor.spec.ts
+++ b/src/webgpu/api/validation/render_pass/render_pass_descriptor.spec.ts
@@ -1170,7 +1170,7 @@ g.test('resolveTarget,format_supports_resolve')
   .beforeAllSubcases(t => {
     const { format } = t.params;
     t.skipIfTextureFormatNotSupported(format);
-    t.skipIfMultisampleNotSupportedForFormatOrSelectDevice(format);
+    t.skipIfMultisampleNotSupportedForFormat(format);
   })
   .fn(t => {
     const { format } = t.params;

--- a/src/webgpu/api/validation/render_pass/render_pass_descriptor.spec.ts
+++ b/src/webgpu/api/validation/render_pass/render_pass_descriptor.spec.ts
@@ -211,7 +211,6 @@ g.test('color_attachments,limits,maxColorAttachmentBytesPerSample,aligned')
   )
   .beforeAllSubcases(t => {
     t.skipIfTextureFormatNotSupported(t.params.format);
-    t.selectDeviceForRenderableColorFormatOrSkipTestCase(t.params.format);
   })
   .fn(t => {
     const { format, attachmentCount } = t.params;
@@ -268,9 +267,6 @@ g.test('color_attachments,limits,maxColorAttachmentBytesPerSample,unaligned')
       },
     ])
   )
-  .beforeAllSubcases(t => {
-    t.selectDeviceForRenderableColorFormatOrSkipTestCase('r32float');
-  })
   .fn(t => {
     const { formats } = t.params;
 

--- a/src/webgpu/api/validation/render_pass/render_pass_descriptor.spec.ts
+++ b/src/webgpu/api/validation/render_pass/render_pass_descriptor.spec.ts
@@ -211,6 +211,7 @@ g.test('color_attachments,limits,maxColorAttachmentBytesPerSample,aligned')
   )
   .beforeAllSubcases(t => {
     t.skipIfTextureFormatNotSupported(t.params.format);
+    t.skipIfColorRenderableNotSupportedForFormat(t.params.format);
   })
   .fn(t => {
     const { format, attachmentCount } = t.params;
@@ -267,6 +268,9 @@ g.test('color_attachments,limits,maxColorAttachmentBytesPerSample,unaligned')
       },
     ])
   )
+  .beforeAllSubcases(t => {
+    t.skipIfColorRenderableNotSupportedForFormat('r32float');
+  })
   .fn(t => {
     const { formats } = t.params;
 

--- a/src/webgpu/api/validation/render_pipeline/float32_blendable.spec.ts
+++ b/src/webgpu/api/validation/render_pipeline/float32_blendable.spec.ts
@@ -30,7 +30,6 @@ pipeline that uses blending with any float32-format attachment.
     if (t.params.enabled) {
       t.selectDeviceOrSkipTestCase('float32-blendable');
     }
-    t.selectDeviceForRenderableColorFormatOrSkipTestCase('r32float');
   })
   .fn(t => {
     const { isAsync, enabled, hasBlend, format } = t.params;

--- a/src/webgpu/api/validation/render_pipeline/float32_blendable.spec.ts
+++ b/src/webgpu/api/validation/render_pipeline/float32_blendable.spec.ts
@@ -30,6 +30,7 @@ pipeline that uses blending with any float32-format attachment.
     if (t.params.enabled) {
       t.selectDeviceOrSkipTestCase('float32-blendable');
     }
+    t.skipIfColorRenderableNotSupportedForFormat('r32float');
   })
   .fn(t => {
     const { isAsync, enabled, hasBlend, format } = t.params;

--- a/src/webgpu/api/validation/render_pipeline/fragment_state.spec.ts
+++ b/src/webgpu/api/validation/render_pipeline/fragment_state.spec.ts
@@ -181,6 +181,7 @@ g.test('limits,maxColorAttachmentBytesPerSample,aligned')
   )
   .beforeAllSubcases(t => {
     t.skipIfTextureFormatNotSupported(t.params.format);
+    t.skipIfColorRenderableNotSupportedForFormat(t.params.format);
   })
   .fn(t => {
     const { format, attachmentCount, isAsync } = t.params;
@@ -228,6 +229,9 @@ g.test('limits,maxColorAttachmentBytesPerSample,unaligned')
       .beginSubcases()
       .combine('isAsync', [false, true])
   )
+  .beforeAllSubcases(t => {
+    t.skipIfColorRenderableNotSupportedForFormat('r32float');
+  })
   .fn(t => {
     const { formats, isAsync } = t.params;
 
@@ -265,6 +269,7 @@ g.test('targets_format_filterable')
     const { format } = t.params;
     const info = kTextureFormatInfo[format];
     t.skipIfTextureFormatNotSupported(format);
+    t.skipIfColorRenderableNotSupportedForFormat(format);
     t.selectDeviceOrSkipTestCase(info.feature);
   })
   .fn(t => {
@@ -394,6 +399,7 @@ g.test('pipeline_output_targets')
   )
   .beforeAllSubcases(t => {
     t.selectDeviceForTextureFormatOrSkipTestCase(t.params.format);
+    t.skipIfColorRenderableNotSupportedForFormat(t.params.format);
   })
   .fn(t => {
     const { isAsync, format, writeMask, shaderOutput } = t.params;

--- a/src/webgpu/api/validation/render_pipeline/fragment_state.spec.ts
+++ b/src/webgpu/api/validation/render_pipeline/fragment_state.spec.ts
@@ -181,7 +181,6 @@ g.test('limits,maxColorAttachmentBytesPerSample,aligned')
   )
   .beforeAllSubcases(t => {
     t.skipIfTextureFormatNotSupported(t.params.format);
-    t.selectDeviceForRenderableColorFormatOrSkipTestCase(t.params.format);
   })
   .fn(t => {
     const { format, attachmentCount, isAsync } = t.params;
@@ -229,9 +228,6 @@ g.test('limits,maxColorAttachmentBytesPerSample,unaligned')
       .beginSubcases()
       .combine('isAsync', [false, true])
   )
-  .beforeAllSubcases(t => {
-    t.selectDeviceForRenderableColorFormatOrSkipTestCase('r32float');
-  })
   .fn(t => {
     const { formats, isAsync } = t.params;
 
@@ -269,7 +265,6 @@ g.test('targets_format_filterable')
     const { format } = t.params;
     const info = kTextureFormatInfo[format];
     t.skipIfTextureFormatNotSupported(format);
-    t.selectDeviceForRenderableColorFormatOrSkipTestCase(format);
     t.selectDeviceOrSkipTestCase(info.feature);
   })
   .fn(t => {
@@ -399,7 +394,6 @@ g.test('pipeline_output_targets')
   )
   .beforeAllSubcases(t => {
     t.selectDeviceForTextureFormatOrSkipTestCase(t.params.format);
-    t.selectDeviceForRenderableColorFormatOrSkipTestCase(t.params.format);
   })
   .fn(t => {
     const { isAsync, format, writeMask, shaderOutput } = t.params;

--- a/src/webgpu/api/validation/resource_usages/texture/in_render_common.spec.ts
+++ b/src/webgpu/api/validation/resource_usages/texture/in_render_common.spec.ts
@@ -115,9 +115,6 @@ g.test('subresources,color_attachments')
       .combine('inSamePass', [true, false])
       .unless(t => t.inSamePass && t.level0 !== t.level1)
   )
-  .beforeAllSubcases(t => {
-    t.selectDeviceForRenderableColorFormatOrSkipTestCase('r32float');
-  })
   .fn(t => {
     const { layer0, level0, layer1, level1, inSamePass } = t.params;
 
@@ -197,7 +194,6 @@ g.test('subresources,color_attachment_and_bind_group')
         t.params.bgLayerCount !== kTextureLayers,
         'view array layers must equal texture array layers in compatibility mode'
       );
-      t.selectDeviceForRenderableColorFormatOrSkipTestCase('r32float');
     }
   })
   .fn(t => {
@@ -476,7 +472,6 @@ g.test('subresources,multiple_bind_groups')
         t.params.bg0Layers.count !== kTextureLayers || t.params.bg1Layers.count !== kTextureLayers,
         'view array layers must equal texture array layers in compatibility mode'
       );
-      t.selectDeviceForRenderableColorFormatOrSkipTestCase('r32float');
     }
   })
   .fn(t => {

--- a/src/webgpu/api/validation/resource_usages/texture/in_render_common.spec.ts
+++ b/src/webgpu/api/validation/resource_usages/texture/in_render_common.spec.ts
@@ -115,6 +115,9 @@ g.test('subresources,color_attachments')
       .combine('inSamePass', [true, false])
       .unless(t => t.inSamePass && t.level0 !== t.level1)
   )
+  .beforeAllSubcases(t => {
+    t.skipIfColorRenderableNotSupportedForFormat('r32float');
+  })
   .fn(t => {
     const { layer0, level0, layer1, level1, inSamePass } = t.params;
 
@@ -194,6 +197,7 @@ g.test('subresources,color_attachment_and_bind_group')
         t.params.bgLayerCount !== kTextureLayers,
         'view array layers must equal texture array layers in compatibility mode'
       );
+      t.skipIfColorRenderableNotSupportedForFormat('r32float');
     }
   })
   .fn(t => {
@@ -472,6 +476,7 @@ g.test('subresources,multiple_bind_groups')
         t.params.bg0Layers.count !== kTextureLayers || t.params.bg1Layers.count !== kTextureLayers,
         'view array layers must equal texture array layers in compatibility mode'
       );
+      t.skipIfColorRenderableNotSupportedForFormat('r32float');
     }
   })
   .fn(t => {

--- a/src/webgpu/api/validation/resource_usages/texture/in_render_misc.spec.ts
+++ b/src/webgpu/api/validation/resource_usages/texture/in_render_misc.spec.ts
@@ -520,9 +520,6 @@ g.test('subresources,texture_usages_in_copy_and_render_pass')
           usage1 === 'copy-dst'
       )
   )
-  .beforeAllSubcases(t => {
-    t.selectDeviceForRenderableColorFormatOrSkipTestCase('r32float');
-  })
   .fn(t => {
     const { usage0, usage1 } = t.params;
 
@@ -618,11 +615,6 @@ g.test('subresources,texture_view_usages')
       .combine('bindingType', ['color-attachment', ...kTextureBindingTypes] as const)
       .combine('viewUsage', [0, ...kTextureUsages])
   )
-  .beforeAllSubcases(t => {
-    if (t.params.bindingType === 'color-attachment') {
-      t.selectDeviceForRenderableColorFormatOrSkipTestCase('r32float');
-    }
-  })
   .fn(t => {
     const { bindingType, viewUsage } = t.params;
 

--- a/src/webgpu/api/validation/resource_usages/texture/in_render_misc.spec.ts
+++ b/src/webgpu/api/validation/resource_usages/texture/in_render_misc.spec.ts
@@ -520,6 +520,9 @@ g.test('subresources,texture_usages_in_copy_and_render_pass')
           usage1 === 'copy-dst'
       )
   )
+  .beforeAllSubcases(t => {
+    t.skipIfColorRenderableNotSupportedForFormat('r32float');
+  })
   .fn(t => {
     const { usage0, usage1 } = t.params;
 
@@ -615,6 +618,11 @@ g.test('subresources,texture_view_usages')
       .combine('bindingType', ['color-attachment', ...kTextureBindingTypes] as const)
       .combine('viewUsage', [0, ...kTextureUsages])
   )
+  .beforeAllSubcases(t => {
+    if (t.params.bindingType === 'color-attachment') {
+      t.skipIfColorRenderableNotSupportedForFormat('r32float');
+    }
+  })
   .fn(t => {
     const { bindingType, viewUsage } = t.params;
 

--- a/src/webgpu/compat/api/validation/encoding/cmds/copyTextureToTexture.spec.ts
+++ b/src/webgpu/compat/api/validation/encoding/cmds/copyTextureToTexture.spec.ts
@@ -58,9 +58,6 @@ g.test('multisample')
         return info.multisample && !info.feature;
       })
   )
-  .beforeAllSubcases(t => {
-    t.selectDeviceForRenderableColorFormatOrSkipTestCase(t.params.format);
-  })
   .fn(t => {
     const { format } = t.params;
     const { blockWidth, blockHeight } = kTextureFormatInfo[format];

--- a/src/webgpu/compat/api/validation/encoding/cmds/copyTextureToTexture.spec.ts
+++ b/src/webgpu/compat/api/validation/encoding/cmds/copyTextureToTexture.spec.ts
@@ -58,6 +58,9 @@ g.test('multisample')
         return info.multisample && !info.feature;
       })
   )
+  .beforeAllSubcases(t => {
+    t.skipIfMultisampleNotSupportedForFormat(t.params.format);
+  })
   .fn(t => {
     const { format } = t.params;
     const { blockWidth, blockHeight } = kTextureFormatInfo[format];

--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -282,9 +282,7 @@ export class GPUTestSubcaseBatchState extends SubcaseBatchState {
     }
   }
 
-  skipIfMultisampleNotSupportedForFormatOrSelectDevice(
-    ...formats: (GPUTextureFormat | undefined)[]
-  ) {
+  skipIfMultisampleNotSupportedForFormat(...formats: (GPUTextureFormat | undefined)[]) {
     for (const format of formats) {
       if (format === undefined) continue;
       if (!isMultisampledTextureFormat(format, this.isCompatibility)) {

--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -32,8 +32,6 @@ import {
   isCompressedTextureFormat,
   ColorTextureFormat,
   isTextureFormatUsableAsStorageFormat,
-  is32Float,
-  is16Float,
   isMultisampledTextureFormat,
 } from './format_info.js';
 import { checkElementsEqual, checkElementsBetween } from './util/check_contents.js';

--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -230,13 +230,6 @@ export class GPUTestSubcaseBatchState extends SubcaseBatchState {
     this.selectDeviceOrSkipTestCase(features);
   }
 
-  /** Skips test if format is float16 or float32 and not color renderable based on device feature availability. */
-  selectDeviceForRenderableColorFormatOrSkipTestCase(...formats: (GPUTextureFormat | undefined)[]) {
-    this.selectDeviceOrSkipTestCase({
-      requiredFeatures: this.getFloatTextureFormatColorRenderableFeatures(...formats),
-    });
-  }
-
   /** @internal MAINTENANCE_TODO: Make this not visible to test code? */
   acquireMismatchedProvider(): Promise<DeviceProvider> | undefined {
     return this.mismatchedProvider;
@@ -297,26 +290,7 @@ export class GPUTestSubcaseBatchState extends SubcaseBatchState {
       if (!isMultisampledTextureFormat(format, this.isCompatibility)) {
         this.skip(`texture format '${format}' is not supported to be multisampled`);
       }
-      // float16 and float32 format need to be color renderable first to support multisampled in compat mode
-      if (is16Float(format) || is32Float(format)) {
-        this.selectDeviceForRenderableColorFormatOrSkipTestCase(format);
-      }
     }
-  }
-
-  getFloatTextureFormatColorRenderableFeatures(...formats: (GPUTextureFormat | undefined)[]) {
-    const requiredFeatures: GPUFeatureName[] = [];
-    if (this.isCompatibility) {
-      for (const format of formats) {
-        if (format === undefined) continue;
-        if (is32Float(format)) {
-          requiredFeatures.push('float32-renderable' as GPUFeatureName);
-        } else if (is16Float(format)) {
-          requiredFeatures.push('float16-renderable' as GPUFeatureName);
-        }
-      }
-    }
-    return requiredFeatures;
   }
 
   skipIfCopyTextureToTextureNotSupportedForFormat(...formats: (GPUTextureFormat | undefined)[]) {

--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -532,20 +532,6 @@ export class GPUTestBase extends Fixture<GPUTestSubcaseBatchState> {
   }
 
   skipIfColorRenderableNotSupportedForFormat(...formats: (GPUTextureFormat | undefined)[]) {
-    if (this.isCompatibility) {
-      const is16FloatRenderable = this.device.features.has('float16-renderable');
-      const is32FloatRenderable = this.device.features.has('float32-renderable');
-      for (const format of formats) {
-        if (format === undefined) continue;
-        if (
-          (is16Float(format) && !is16FloatRenderable) ||
-          (is32Float(format) && !is32FloatRenderable)
-        ) {
-          this.skip(`texture format '${format} is not color renderable in compat mode`);
-        }
-      }
-    }
-
     for (const format of formats) {
       if (format === undefined) continue;
       if (!kTextureFormatInfo[format].color) {

--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -287,6 +287,17 @@ export class GPUTestSubcaseBatchState extends SubcaseBatchState {
         this.skip(`texture format '${format}' is not supported to be multisampled`);
       }
     }
+
+    this.skipIfColorRenderableNotSupportedForFormat(...formats);
+  }
+
+  skipIfColorRenderableNotSupportedForFormat(...formats: (GPUTextureFormat | undefined)[]) {
+    for (const format of formats) {
+      if (format === undefined) continue;
+      if (!kTextureFormatInfo[format].color) {
+        this.skip(`texture format '${format} is not color renderable`);
+      }
+    }
   }
 
   skipIfCopyTextureToTextureNotSupportedForFormat(...formats: (GPUTextureFormat | undefined)[]) {

--- a/src/webgpu/shader/execution/expression/call/builtin/textureDimensions.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureDimensions.spec.ts
@@ -302,7 +302,7 @@ Parameters:
     t.skipIfTextureFormatNotSupported(t.params.format);
     if (t.params.samples > 1) {
       // multisampled texture requires GPUTextureUsage.RENDER_ATTACHMENT usage
-      t.skipIfMultisampleNotSupportedForFormatOrSelectDevice(t.params.format);
+      t.skipIfMultisampleNotSupportedForFormat(t.params.format);
     }
     t.selectDeviceOrSkipTestCase(info.feature);
   })

--- a/src/webgpu/shader/execution/expression/call/builtin/textureLoad.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureLoad.spec.ts
@@ -375,7 +375,7 @@ Parameters:
     const { format, texture_type } = t.params;
     t.skipIfTextureFormatNotSupported(format);
     t.skipIfTextureLoadNotSupportedForTextureType(texture_type);
-    t.skipIfMultisampleNotSupportedForFormatOrSelectDevice(format);
+    t.skipIfMultisampleNotSupportedForFormat(format);
   })
   .fn(async t => {
     const { texture_type, format, stage, samplePoints, C, S } = t.params;

--- a/src/webgpu/shader/execution/expression/call/builtin/texture_utils.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/texture_utils.spec.ts
@@ -96,7 +96,7 @@ g.test('readTextureToTexelViews')
   .beforeAllSubcases(t => {
     t.skipIfTextureViewDimensionNotSupported(t.params.viewDimension);
     // recheck if multisampled is supported with compat mode flag
-    t.skipIfMultisampleNotSupportedForFormatOrSelectDevice(t.params.srcFormat);
+    t.skipIfMultisampleNotSupportedForFormat(t.params.srcFormat);
   })
   .fn(async t => {
     const { srcFormat, texelViewFormat, viewDimension, sampleCount } = t.params;

--- a/src/webgpu/web_platform/canvas/configure.spec.ts
+++ b/src/webgpu/web_platform/canvas/configure.spec.ts
@@ -157,7 +157,6 @@ g.test('format')
   )
   .beforeAllSubcases(t => {
     t.selectDeviceForTextureFormatOrSkipTestCase(t.params.format);
-    t.selectDeviceForRenderableColorFormatOrSkipTestCase(t.params.format);
   })
   .fn(t => {
     const { canvasType, format } = t.params;
@@ -447,7 +446,6 @@ g.test('viewFormats')
       )
   )
   .beforeAllSubcases(t => {
-    t.selectDeviceForRenderableColorFormatOrSkipTestCase(t.params.format);
     t.selectDeviceOrSkipTestCase([t.params.viewFormatFeature]);
   })
   .fn(t => {

--- a/src/webgpu/web_platform/canvas/configure.spec.ts
+++ b/src/webgpu/web_platform/canvas/configure.spec.ts
@@ -157,6 +157,7 @@ g.test('format')
   )
   .beforeAllSubcases(t => {
     t.selectDeviceForTextureFormatOrSkipTestCase(t.params.format);
+    t.skipIfColorRenderableNotSupportedForFormat(t.params.format);
   })
   .fn(t => {
     const { canvasType, format } = t.params;
@@ -446,6 +447,7 @@ g.test('viewFormats')
       )
   )
   .beforeAllSubcases(t => {
+    t.skipIfColorRenderableNotSupportedForFormat(t.params.format);
     t.selectDeviceOrSkipTestCase([t.params.viewFormatFeature]);
   })
   .fn(t => {

--- a/src/webgpu/web_platform/canvas/readbackFromWebGPUCanvas.spec.ts
+++ b/src/webgpu/web_platform/canvas/readbackFromWebGPUCanvas.spec.ts
@@ -261,10 +261,6 @@ g.test('onscreenCanvas,snapshot')
       .combine('colorSpace', kCanvasColorSpaces)
       .combine('snapshotType', ['toDataURL', 'toBlob', 'imageBitmap'])
   )
-  .beforeAllSubcases(t => {
-    // rgba16float may not be color-renderable in compat mode
-    t.selectDeviceForRenderableColorFormatOrSkipTestCase(t.params.format);
-  })
   .fn(async t => {
     const canvas = initWebGPUCanvasContent(
       t,
@@ -327,10 +323,6 @@ g.test('offscreenCanvas,snapshot')
       .combine('colorSpace', kCanvasColorSpaces)
       .combine('snapshotType', ['convertToBlob', 'transferToImageBitmap', 'imageBitmap'] as const)
   )
-  .beforeAllSubcases(t => {
-    // rgba16float may not be color-renderable in compat mode
-    t.selectDeviceForRenderableColorFormatOrSkipTestCase(t.params.format);
-  })
   .fn(async t => {
     const offscreenCanvas = initWebGPUCanvasContent(
       t,
@@ -386,10 +378,6 @@ g.test('onscreenCanvas,uploadToWebGL')
       .combine('webgl', ['webgl', 'webgl2'])
       .combine('upload', ['texImage2D', 'texSubImage2D'])
   )
-  .beforeAllSubcases(t => {
-    // rgba16float may not be color-renderable in compat mode
-    t.selectDeviceForRenderableColorFormatOrSkipTestCase(t.params.format);
-  })
   .fn(t => {
     const { format, webgl, upload } = t.params;
     const canvas = initWebGPUCanvasContent(t, format, t.params.alphaMode, 'srgb', 'onscreen');
@@ -471,10 +459,6 @@ g.test('drawTo2DCanvas')
       .combine('webgpuCanvasType', kAllCanvasTypes)
       .combine('canvas2DType', kAllCanvasTypes)
   )
-  .beforeAllSubcases(t => {
-    // rgba16float may not be color-renderable in compat mode
-    t.selectDeviceForRenderableColorFormatOrSkipTestCase(t.params.format);
-  })
   .fn(t => {
     const { format, webgpuCanvasType, alphaMode, colorSpace, canvas2DType } = t.params;
 

--- a/src/webgpu/web_platform/canvas/readbackFromWebGPUCanvas.spec.ts
+++ b/src/webgpu/web_platform/canvas/readbackFromWebGPUCanvas.spec.ts
@@ -261,6 +261,10 @@ g.test('onscreenCanvas,snapshot')
       .combine('colorSpace', kCanvasColorSpaces)
       .combine('snapshotType', ['toDataURL', 'toBlob', 'imageBitmap'])
   )
+  .beforeAllSubcases(t => {
+    // rgba16float may not be color-renderable in compat mode
+    t.skipIfColorRenderableNotSupportedForFormat(t.params.format);
+  })
   .fn(async t => {
     const canvas = initWebGPUCanvasContent(
       t,
@@ -323,6 +327,10 @@ g.test('offscreenCanvas,snapshot')
       .combine('colorSpace', kCanvasColorSpaces)
       .combine('snapshotType', ['convertToBlob', 'transferToImageBitmap', 'imageBitmap'] as const)
   )
+  .beforeAllSubcases(t => {
+    // rgba16float may not be color-renderable in compat mode
+    t.skipIfColorRenderableNotSupportedForFormat(t.params.format);
+  })
   .fn(async t => {
     const offscreenCanvas = initWebGPUCanvasContent(
       t,
@@ -378,6 +386,10 @@ g.test('onscreenCanvas,uploadToWebGL')
       .combine('webgl', ['webgl', 'webgl2'])
       .combine('upload', ['texImage2D', 'texSubImage2D'])
   )
+  .beforeAllSubcases(t => {
+    // rgba16float may not be color-renderable in compat mode
+    t.skipIfColorRenderableNotSupportedForFormat(t.params.format);
+  })
   .fn(t => {
     const { format, webgl, upload } = t.params;
     const canvas = initWebGPUCanvasContent(t, format, t.params.alphaMode, 'srgb', 'onscreen');
@@ -459,6 +471,10 @@ g.test('drawTo2DCanvas')
       .combine('webgpuCanvasType', kAllCanvasTypes)
       .combine('canvas2DType', kAllCanvasTypes)
   )
+  .beforeAllSubcases(t => {
+    // rgba16float may not be color-renderable in compat mode
+    t.skipIfColorRenderableNotSupportedForFormat(t.params.format);
+  })
   .fn(t => {
     const { format, webgpuCanvasType, alphaMode, colorSpace, canvas2DType } = t.params;
 

--- a/src/webgpu/web_platform/copyToTexture/ImageBitmap.spec.ts
+++ b/src/webgpu/web_platform/copyToTexture/ImageBitmap.spec.ts
@@ -61,6 +61,7 @@ g.test('from_ImageData')
   .beforeAllSubcases(t => {
     t.skipIf(typeof ImageData === 'undefined', 'ImageData does not exist in this environment');
     t.skipIfTextureFormatNotSupported(t.params.dstFormat);
+    t.skipIfColorRenderableNotSupportedForFormat(t.params.dstFormat);
   })
   .fn(async t => {
     const {
@@ -182,6 +183,7 @@ g.test('from_canvas')
   .beforeAllSubcases(t => {
     t.skipIf(typeof ImageData === 'undefined', 'ImageData does not exist in this environment');
     t.skipIfTextureFormatNotSupported(t.params.dstFormat);
+    t.skipIfColorRenderableNotSupportedForFormat(t.params.dstFormat);
   })
   .fn(async t => {
     const {

--- a/src/webgpu/web_platform/copyToTexture/ImageBitmap.spec.ts
+++ b/src/webgpu/web_platform/copyToTexture/ImageBitmap.spec.ts
@@ -61,7 +61,6 @@ g.test('from_ImageData')
   .beforeAllSubcases(t => {
     t.skipIf(typeof ImageData === 'undefined', 'ImageData does not exist in this environment');
     t.skipIfTextureFormatNotSupported(t.params.dstFormat);
-    t.selectDeviceForRenderableColorFormatOrSkipTestCase(t.params.dstFormat);
   })
   .fn(async t => {
     const {
@@ -183,7 +182,6 @@ g.test('from_canvas')
   .beforeAllSubcases(t => {
     t.skipIf(typeof ImageData === 'undefined', 'ImageData does not exist in this environment');
     t.skipIfTextureFormatNotSupported(t.params.dstFormat);
-    t.selectDeviceForRenderableColorFormatOrSkipTestCase(t.params.dstFormat);
   })
   .fn(async t => {
     const {

--- a/src/webgpu/web_platform/copyToTexture/ImageData.spec.ts
+++ b/src/webgpu/web_platform/copyToTexture/ImageData.spec.ts
@@ -49,6 +49,7 @@ g.test('from_ImageData')
   .beforeAllSubcases(t => {
     t.skipIf(typeof ImageData === 'undefined', 'ImageData does not exist in this environment');
     t.skipIfTextureFormatNotSupported(t.params.dstColorFormat);
+    t.skipIfColorRenderableNotSupportedForFormat(t.params.dstColorFormat);
   })
   .fn(t => {
     const { width, height, dstColorFormat, dstPremultiplied, srcDoFlipYDuringCopy } = t.params;

--- a/src/webgpu/web_platform/copyToTexture/ImageData.spec.ts
+++ b/src/webgpu/web_platform/copyToTexture/ImageData.spec.ts
@@ -49,7 +49,6 @@ g.test('from_ImageData')
   .beforeAllSubcases(t => {
     t.skipIf(typeof ImageData === 'undefined', 'ImageData does not exist in this environment');
     t.skipIfTextureFormatNotSupported(t.params.dstColorFormat);
-    t.selectDeviceForRenderableColorFormatOrSkipTestCase(t.params.dstColorFormat);
   })
   .fn(t => {
     const { width, height, dstColorFormat, dstPremultiplied, srcDoFlipYDuringCopy } = t.params;

--- a/src/webgpu/web_platform/copyToTexture/canvas.spec.ts
+++ b/src/webgpu/web_platform/copyToTexture/canvas.spec.ts
@@ -495,6 +495,7 @@ g.test('copy_contents_from_2d_context_canvas')
   )
   .beforeAllSubcases(t => {
     t.skipIfTextureFormatNotSupported(t.params.dstColorFormat);
+    t.skipIfColorRenderableNotSupportedForFormat(t.params.dstColorFormat);
   })
   .fn(t => {
     const { width, height, canvasType, dstAlphaMode } = t.params;
@@ -559,6 +560,7 @@ g.test('copy_contents_from_gl_context_canvas')
   )
   .beforeAllSubcases(t => {
     t.skipIfTextureFormatNotSupported(t.params.dstColorFormat);
+    t.skipIfColorRenderableNotSupportedForFormat(t.params.dstColorFormat);
   })
   .fn(t => {
     const { width, height, canvasType, contextName, srcPremultiplied, dstAlphaMode } = t.params;
@@ -628,6 +630,7 @@ g.test('copy_contents_from_gpu_context_canvas')
   )
   .beforeAllSubcases(t => {
     t.skipIfTextureFormatNotSupported(t.params.dstColorFormat);
+    t.skipIfColorRenderableNotSupportedForFormat(t.params.dstColorFormat);
     t.selectMismatchedDeviceOrSkipTestCase(undefined);
   })
   .fn(t => {
@@ -694,6 +697,7 @@ g.test('copy_contents_from_bitmaprenderer_context_canvas')
   )
   .beforeAllSubcases(t => {
     t.skipIfTextureFormatNotSupported(t.params.dstColorFormat);
+    t.skipIfColorRenderableNotSupportedForFormat(t.params.dstColorFormat);
   })
   .fn(async t => {
     const { width, height, canvasType, dstAlphaMode } = t.params;
@@ -770,6 +774,7 @@ g.test('color_space_conversion')
   )
   .beforeAllSubcases(t => {
     t.skipIfTextureFormatNotSupported(t.params.dstColorFormat);
+    t.skipIfColorRenderableNotSupportedForFormat(t.params.dstColorFormat);
   })
   .fn(t => {
     const {

--- a/src/webgpu/web_platform/copyToTexture/canvas.spec.ts
+++ b/src/webgpu/web_platform/copyToTexture/canvas.spec.ts
@@ -495,7 +495,6 @@ g.test('copy_contents_from_2d_context_canvas')
   )
   .beforeAllSubcases(t => {
     t.skipIfTextureFormatNotSupported(t.params.dstColorFormat);
-    t.selectDeviceForRenderableColorFormatOrSkipTestCase(t.params.dstColorFormat);
   })
   .fn(t => {
     const { width, height, canvasType, dstAlphaMode } = t.params;
@@ -560,7 +559,6 @@ g.test('copy_contents_from_gl_context_canvas')
   )
   .beforeAllSubcases(t => {
     t.skipIfTextureFormatNotSupported(t.params.dstColorFormat);
-    t.selectDeviceForRenderableColorFormatOrSkipTestCase(t.params.dstColorFormat);
   })
   .fn(t => {
     const { width, height, canvasType, contextName, srcPremultiplied, dstAlphaMode } = t.params;
@@ -630,7 +628,6 @@ g.test('copy_contents_from_gpu_context_canvas')
   )
   .beforeAllSubcases(t => {
     t.skipIfTextureFormatNotSupported(t.params.dstColorFormat);
-    t.selectDeviceForRenderableColorFormatOrSkipTestCase(t.params.dstColorFormat);
     t.selectMismatchedDeviceOrSkipTestCase(undefined);
   })
   .fn(t => {
@@ -697,7 +694,6 @@ g.test('copy_contents_from_bitmaprenderer_context_canvas')
   )
   .beforeAllSubcases(t => {
     t.skipIfTextureFormatNotSupported(t.params.dstColorFormat);
-    t.selectDeviceForRenderableColorFormatOrSkipTestCase(t.params.dstColorFormat);
   })
   .fn(async t => {
     const { width, height, canvasType, dstAlphaMode } = t.params;
@@ -774,7 +770,6 @@ g.test('color_space_conversion')
   )
   .beforeAllSubcases(t => {
     t.skipIfTextureFormatNotSupported(t.params.dstColorFormat);
-    t.selectDeviceForRenderableColorFormatOrSkipTestCase(t.params.dstColorFormat);
   })
   .fn(t => {
     const {

--- a/src/webgpu/web_platform/copyToTexture/image.spec.ts
+++ b/src/webgpu/web_platform/copyToTexture/image.spec.ts
@@ -63,6 +63,7 @@ g.test('from_image')
   .beforeAllSubcases(t => {
     t.skipIfTextureFormatNotSupported(t.params.dstColorFormat);
     if (typeof HTMLImageElement === 'undefined') t.skip('HTMLImageElement not available');
+    t.skipIfColorRenderableNotSupportedForFormat(t.params.dstColorFormat);
   })
   .fn(async t => {
     const { width, height, dstColorFormat, dstPremultiplied, srcDoFlipYDuringCopy } = t.params;

--- a/src/webgpu/web_platform/copyToTexture/image.spec.ts
+++ b/src/webgpu/web_platform/copyToTexture/image.spec.ts
@@ -63,7 +63,6 @@ g.test('from_image')
   .beforeAllSubcases(t => {
     t.skipIfTextureFormatNotSupported(t.params.dstColorFormat);
     if (typeof HTMLImageElement === 'undefined') t.skip('HTMLImageElement not available');
-    t.selectDeviceForRenderableColorFormatOrSkipTestCase(t.params.dstColorFormat);
   })
   .fn(async t => {
     const { width, height, dstColorFormat, dstPremultiplied, srcDoFlipYDuringCopy } = t.params;


### PR DESCRIPTION
Issue: [#4417](https://github.com/gpuweb/gpuweb/issues/4417)

As discussed in working group meeting, support for float16/32 are required for compat. 

Removed: extra logic in `skipIfColorRenderableNotSupportedForFormat` and `skipIfMultisampleNotSupportedForFormat`
Replaced: `selectDeviceForRenderableColorFormatOrSkipTestCase` -> `skipIfColorRenderableNotSupportedForFormat`, 
Preserved: multisample detection update for compat mode and rgba16float/r32float format: `skipIfMultisampleNotSupportedForFormat`/`isMultisampledTextureFormat`