### PR TITLE
Use getGPU instead of navigator.gpu in maxStorageTexturesPerShaderSta…

### DIFF
--- a/src/webgpu/api/validation/capability_checks/limits/maxStorageTexturesPerShaderStage.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxStorageTexturesPerShaderStage.spec.ts
@@ -1,3 +1,4 @@
+import { getGPU } from '../../../../../common/util/navigator_gpu.js';
 import {
   range,
   reorder,
@@ -88,7 +89,7 @@ function skipIfNotEnoughStorageTexturesInStage(
 function skipIfAccessNotSupported(t: LimitTestsImpl, access: GPUStorageTextureAccess) {
   t.skipIf(
     (access === 'read-only' || access === 'read-write') &&
-      !navigator.gpu.wgslLanguageFeatures.has('readonly_and_readwrite_storage_textures'),
+      !getGPU(t.rec).wgslLanguageFeatures.has('readonly_and_readwrite_storage_textures'),
     `access = ${access} but navigator.gpu.wsglLanguageFeatures does not contain 'readonly_and_readwrite_storage_textures'`
   );
 }


### PR DESCRIPTION
…ge.spec.ts




Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [X] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
