### PR TITLE
Compat: adjust texture-compression capabilities

### DIFF
--- a/src/webgpu/api/validation/capability_checks/features/texture_formats.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/features/texture_formats.spec.ts
@@ -458,7 +458,8 @@ g.test('check_capability_guarantees')
 
     const features = adapter.features;
     t.expect(
-      features.has('texture-compression-bc') ||
+      t.isCompatibility ||
+        features.has('texture-compression-bc') ||
         (features.has('texture-compression-etc2') && features.has('texture-compression-astc'))
     );
   });


### PR DESCRIPTION
Related spec language: https://gpuweb.github.io/gpuweb/#adapter-capability-guarantees

[GL_EXT_texture_compression_s3tc](https://opengles.gpuinfo.org/listreports.php?extension=GL_EXT_texture_compression_s3tc) Coverage is 4.27%

[GL_KHR_texture_compression_astc_ldr](https://opengles.gpuinfo.org/listreports.php?extension=GL_KHR_texture_compression_astc_ldr) Coverage is 57.04%

Shall we loosen this capability for compat?