### PR TITLE
Fix readTextureToTexelViews for cubemaps

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/texture_utils.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/texture_utils.ts
@@ -2961,7 +2961,11 @@ export async function readTextureToTexelViews(
       fn textureLoadCubeAs2DArray(tex: texture_cube<${componentType}>, coord: vec2u, layer: u32) -> ${resultType} {
         // convert texel coord normalized coord
         let size = textureDimensions(tex, 0);
-        let uv = (vec2f(coord) + 0.5) / vec2f(size.xy);
+
+        // Offset by 0.75 instead of the more common 0.5 for converting from texel to normalized texture coordinate
+        // because we're using textureGather. 0.5 would indicate the center of a texel but based on precision issues
+        // the "gather" could go in any direction from that center. Off center it should go in an expected direction.
+        let uv = (vec2f(coord) + 0.75) / vec2f(size.xy);
 
         // convert uv + layer into cube coord
         let cubeCoord = faceMat[layer] * vec3f(uv, 1.0);


### PR DESCRIPTION
The issue was that the code that reads back the texture uses textureGather for cubemaps. It has to use textureGather because it's the only way to load from cubemaps with integer formats. It was computing a texel coord and then doing the common conversion to normalized texture coord

normalizedCoord = (integerTexelCoord + 0.5) / dimension

But, for textureGather, 0.5 is the center of the texel and so it's an edge case. The gather could go in any direction from the center. Moving it off center should fix that issue.

Given coord C in the center of a texel

```
+-------+-------+-------+
|       |       |       |
|       |       |       |
|       |       |       |
+-------+-------+-------+
|       |       |       |
|       |   C   |       |
|       |       |       |
+-------+-------+-------+
|       |       |       |
|       |       |       |
|       |       |       |
+-------+-------+-------+
```

textureGather could return any of these 4 results

```
+-------+-------+-------+      +-------+-------+-------+
|.......|.......|       |      |       |.......|.......|
|.......|.......|       |      |       |.......|.......|
|.......|.......|       |      |       |.......|.......|
+-------+-------+-------+      +-------+-------+-------+
|.......|.......|       |      |       |.......|.......|
|.......|...C...|       |      |       |...C...|.......|
|.......|.......|       |      |       |.......|.......|
+-------+-------+-------+      +-------+-------+-------+
|       |       |       |      |       |       |       |
|       |       |       |      |       |       |       |
|       |       |       |      |       |       |       |
+-------+-------+-------+      +-------+-------+-------+




+-------+-------+-------+      +-------+-------+-------+
|       |       |       |      |       |       |       |
|       |       |       |      |       |       |       |
|       |       |       |      |       |       |       |
+-------+-------+-------+      +-------+-------+-------+
|.......|.......|       |      |       |.......|.......|
|.......|...C...|       |      |       |...C...|.......|
|.......|.......|       |      |       |.......|.......|
+-------+-------+-------+      +-------+-------+-------+
|.......|.......|       |      |       |.......|.......|
|.......|.......|       |      |       |.......|.......|
|.......|.......|       |      |       |.......|.......|
+-------+-------+-------+      +-------+-------+-------+
```

if we move it off center

```
+-------+-------+-------+
|       |       |       |
|       |       |       |
|       |       |       |
+-------+-------+-------+
|       |       |       |
|       |       |       |
|       |     C |       |
+-------+-------+-------+
|       |       |       |
|       |       |       |
|       |       |       |
+-------+-------+-------+
```

Then it will always return the same result

```
+-------+-------+-------+
|       |       |       |
|       |       |       |
|       |       |       |
+-------+-------+-------+
|       |.......|.......|
|       |.......|.......|
|       |.....c.|.......|
+-------+-------+-------+
|       |.......|.......|
|       |.......|.......|
|       |.......|.......|
+-------+-------+-------+
```


