### PR TITLE
Fix rgba32float on compat related comment

### DIFF
--- a/src/webgpu/shader/execution/shader_io/fragment_builtins.spec.ts
+++ b/src/webgpu/shader/execution/shader_io/fragment_builtins.spec.ts
@@ -528,9 +528,8 @@ function computeSampleMask({ sampleMask }: FragData) {
  * backends like M1 Mac so it seems better to stick to rgba8unorm here and test
  * using a storage buffer in a fragment shader separately.
  *
- * We can't use rgba32float because it's optional. We can't use rgba16float
- * because it's optional in compat. We can't we use rgba32uint as that can't be
- * multisampled.
+ * We can't use rgba32float, nor rgba16float, nor rgba32uint as they can't be
+ * multisampled in all feature levels.
  */
 async function renderFragmentShaderInputsTo4TexturesAndReadbackValues(
   t: GPUTest,


### PR DESCRIPTION
At a glance I didn't find any comments related to all the changes about bitcasting into rgba32uint when we refactored lots of tests assuming we could not render to rgba32float in compat.

Maybe the only comments are in the commit messages.

This is the only one I found.


