### PR TITLE
Fix validation tests on the index range of `getBindGroupLayout()`

### DIFF
--- a/src/webgpu/api/validation/getBindGroupLayout.spec.ts
+++ b/src/webgpu/api/validation/getBindGroupLayout.spec.ts
@@ -12,8 +12,8 @@ export const g = makeTestGroup(ValidationTest);
 g.test('index_range,explicit_layout')
   .desc(
     `
-  Test that a validation error is generated if the index exceeds the size of the bind group layouts
-  using a pipeline with an explicit layout.
+  Test that a validation error is generated if the index is greater than the maximum number of bind
+  groups.
   `
   )
   .params(u => u.combine('index', [0, 1, 2, 3, 4, 5]))
@@ -24,7 +24,6 @@ g.test('index_range,explicit_layout')
       entries: [],
     });
 
-    const kBindGroupLayoutsSizeInPipelineLayout = 1;
     const pipelineLayout = t.device.createPipelineLayout({
       bindGroupLayouts: [pipelineBindGroupLayouts],
     });
@@ -54,7 +53,7 @@ g.test('index_range,explicit_layout')
       },
     });
 
-    const shouldError = index >= kBindGroupLayoutsSizeInPipelineLayout;
+    const shouldError = index >= t.device.limits.maxBindGroups;
 
     t.expectValidationError(() => {
       pipeline.getBindGroupLayout(index);
@@ -64,15 +63,13 @@ g.test('index_range,explicit_layout')
 g.test('index_range,auto_layout')
   .desc(
     `
-  Test that a validation error is generated if the index exceeds the size of the bind group layouts
-  using a pipeline with an auto layout.
+  Test that a validation error is generated if the index is greater than the maximum number of bind
+  groups.
   `
   )
   .params(u => u.combine('index', [0, 1, 2, 3, 4, 5]))
   .fn(t => {
     const { index } = t.params;
-
-    const kBindGroupLayoutsSizeInPipelineLayout = 1;
 
     const pipeline = t.device.createRenderPipeline({
       layout: 'auto',
@@ -101,7 +98,7 @@ g.test('index_range,auto_layout')
       },
     });
 
-    const shouldError = index >= kBindGroupLayoutsSizeInPipelineLayout;
+    const shouldError = index >= t.device.limits.maxBindGroups;
 
     t.expectValidationError(() => {
       pipeline.getBindGroupLayout(index);


### PR DESCRIPTION
This patch allows using an index less than the maximum number of bind groups as a parameter of `getBindGroupLayout()` to follow the latest WebGPU SPEC.




Issue: #4075 

<hr>

**Requirements for PR author:**

- [*] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [*] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [*] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [*] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
