### PR TITLE
Add `AllFeaturesMaxLimitsGPUTest`

### DIFF
--- a/src/webgpu/api/operation/command_buffer/programmable/programmable_state_test.ts
+++ b/src/webgpu/api/operation/command_buffer/programmable/programmable_state_test.ts
@@ -1,5 +1,5 @@
 import { unreachable } from '../../../../../common/util/util.js';
-import { GPUTest, GPUTestBase } from '../../../../gpu_test.js';
+import { AllFeaturesMaxLimitsGPUTest, GPUTestBase } from '../../../../gpu_test.js';
 import { EncoderType } from '../../../../util/command_buffer_maker.js';
 
 interface BindGroupIndices {
@@ -12,7 +12,7 @@ type CreateEncoderType = ReturnType<
   typeof GPUTestBase.prototype.createEncoder<'compute pass' | 'render pass' | 'render bundle'>
 >['encoder'];
 
-export class ProgrammableStateTest extends GPUTest {
+export class ProgrammableStateTest extends AllFeaturesMaxLimitsGPUTest {
   private commonBindGroupLayouts: Map<string, GPUBindGroupLayout> = new Map();
 
   skipIfNeedsStorageBuffersInFragmentStageAndHaveNone(

--- a/src/webgpu/api/operation/command_buffer/programmable/state_tracking.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/programmable/state_tracking.spec.ts
@@ -5,12 +5,11 @@ times in different orders) for setBindGroup and setPipeline.
 
 import { makeTestGroup } from '../../../../../common/framework/test_group.js';
 import { GPUConst } from '../../../../constants.js';
-import { MaxLimitsTestMixin } from '../../../../gpu_test.js';
 import { kProgrammableEncoderTypes } from '../../../../util/command_buffer_maker.js';
 
 import { ProgrammableStateTest } from './programmable_state_test.js';
 
-export const g = makeTestGroup(MaxLimitsTestMixin(ProgrammableStateTest));
+export const g = makeTestGroup(ProgrammableStateTest);
 
 const kBufferUsage =
   GPUConst.BufferUsage.COPY_SRC |

--- a/src/webgpu/api/operation/limits/max_combined_limits.spec.ts
+++ b/src/webgpu/api/operation/limits/max_combined_limits.spec.ts
@@ -12,10 +12,10 @@ implementation allows, all of them are useable.
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { range } from '../../../../common/util/util.js';
 import { kTextureFormatInfo } from '../../../format_info.js';
-import { GPUTest, MaxLimitsTestMixin, TextureTestMixin } from '../../../gpu_test.js';
+import { AllFeaturesMaxLimitsGPUTest, TextureTestMixin } from '../../../gpu_test.js';
 import { TexelView } from '../../../util/texture/texel_view.js';
 
-export const g = makeTestGroup(TextureTestMixin(MaxLimitsTestMixin(GPUTest)));
+export const g = makeTestGroup(TextureTestMixin(AllFeaturesMaxLimitsGPUTest));
 
 g.test('max_storage_buffer_texture_frag_outputs')
   .desc(

--- a/src/webgpu/api/operation/memory_sync/buffer/buffer_sync_test.ts
+++ b/src/webgpu/api/operation/memory_sync/buffer/buffer_sync_test.ts
@@ -1,5 +1,5 @@
 import { assert, unreachable } from '../../../../../common/util/util.js';
-import { GPUTest } from '../../../../gpu_test.js';
+import { AllFeaturesMaxLimitsGPUTest } from '../../../../gpu_test.js';
 import { checkElementsEqualEither } from '../../../../util/check_contents.js';
 import { OperationContext, OperationContextHelper } from '../operation_context_helper.js';
 
@@ -150,7 +150,7 @@ const kDummyVertexShader = `
 
 // Note: If it would be useful to have any of these helpers be separate from the fixture,
 // they can be refactored into standalone functions.
-export class BufferSyncTest extends GPUTest {
+export class BufferSyncTest extends AllFeaturesMaxLimitsGPUTest {
   // Vertex and index buffers used in read render pass
   vertexBuffer?: GPUBuffer;
   indexBuffer?: GPUBuffer;

--- a/src/webgpu/api/operation/memory_sync/buffer/multiple_buffers.spec.ts
+++ b/src/webgpu/api/operation/memory_sync/buffer/multiple_buffers.spec.ts
@@ -16,7 +16,6 @@ TODO: Tests with more than one buffer to try to stress implementations a little 
 `;
 
 import { makeTestGroup } from '../../../../../common/framework/test_group.js';
-import { MaxLimitsTestMixin } from '../../../../gpu_test.js';
 import {
   kOperationBoundaries,
   kBoundaryInfo,
@@ -35,7 +34,7 @@ const kSrcValue = 0;
 // The op value is what the read/write operation write into the target buffer.
 const kOpValue = 1;
 
-export const g = makeTestGroup(MaxLimitsTestMixin(BufferSyncTest));
+export const g = makeTestGroup(BufferSyncTest);
 
 g.test('rw')
   .desc(

--- a/src/webgpu/api/operation/memory_sync/buffer/single_buffer.spec.ts
+++ b/src/webgpu/api/operation/memory_sync/buffer/single_buffer.spec.ts
@@ -14,7 +14,6 @@ Wait on another fence, then call expectContents to verify the dst buffer value.
 `;
 
 import { makeTestGroup } from '../../../../../common/framework/test_group.js';
-import { MaxLimitsTestMixin } from '../../../../gpu_test.js';
 import {
   kOperationBoundaries,
   kBoundaryInfo,
@@ -33,7 +32,7 @@ const kSrcValue = 0;
 // The op value is what the read/write operation write into the target buffer.
 const kOpValue = 1;
 
-export const g = makeTestGroup(MaxLimitsTestMixin(BufferSyncTest));
+export const g = makeTestGroup(BufferSyncTest);
 
 g.test('rw')
   .desc(

--- a/src/webgpu/api/operation/memory_sync/texture/same_subresource.spec.ts
+++ b/src/webgpu/api/operation/memory_sync/texture/same_subresource.spec.ts
@@ -9,7 +9,7 @@ Memory Synchronization Tests for Texture: read before write, read after write, a
 import { makeTestGroup } from '../../../../../common/framework/test_group.js';
 import { assert, memcpy, unreachable } from '../../../../../common/util/util.js';
 import { EncodableTextureFormat } from '../../../../format_info.js';
-import { GPUTest, MaxLimitsTestMixin } from '../../../../gpu_test.js';
+import { AllFeaturesMaxLimitsGPUTest, GPUTest } from '../../../../gpu_test.js';
 import { align } from '../../../../util/math.js';
 import { getTextureCopyLayout } from '../../../../util/texture/layout.js';
 import {
@@ -31,7 +31,7 @@ import {
   kOpInfo,
 } from './texture_sync_test.js';
 
-export const g = makeTestGroup(MaxLimitsTestMixin(GPUTest));
+export const g = makeTestGroup(AllFeaturesMaxLimitsGPUTest);
 
 const fullscreenQuadWGSL = `
   struct VertexOutput {

--- a/src/webgpu/api/operation/rendering/depth_clip_clamp.spec.ts
+++ b/src/webgpu/api/operation/rendering/depth_clip_clamp.spec.ts
@@ -6,14 +6,14 @@ depth ranges as well.
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { assert } from '../../../../common/util/util.js';
 import { kDepthStencilFormats, kTextureFormatInfo } from '../../../format_info.js';
-import { GPUTest, MaxLimitsTestMixin } from '../../../gpu_test.js';
+import { AllFeaturesMaxLimitsGPUTest } from '../../../gpu_test.js';
 import {
   checkElementsBetween,
   checkElementsPassPredicate,
   CheckElementsSupplementalTableRows,
 } from '../../../util/check_contents.js';
 
-export const g = makeTestGroup(MaxLimitsTestMixin(GPUTest));
+export const g = makeTestGroup(AllFeaturesMaxLimitsGPUTest);
 
 g.test('depth_clamp_and_clip')
   .desc(

--- a/src/webgpu/api/operation/rendering/draw.spec.ts
+++ b/src/webgpu/api/operation/rendering/draw.spec.ts
@@ -11,10 +11,10 @@ import {
   TypedArrayBufferView,
   TypedArrayBufferViewConstructor,
 } from '../../../../common/util/util.js';
-import { GPUTest, MaxLimitsTestMixin, TextureTestMixin } from '../../../gpu_test.js';
+import { AllFeaturesMaxLimitsGPUTest, TextureTestMixin } from '../../../gpu_test.js';
 import { PerPixelComparison } from '../../../util/texture/texture_ok.js';
 
-class DrawTest extends TextureTestMixin(MaxLimitsTestMixin(GPUTest)) {
+class DrawTest extends TextureTestMixin(AllFeaturesMaxLimitsGPUTest) {
   checkTriangleDraw(opts: {
     firstIndex: number | undefined;
     count: number;

--- a/src/webgpu/api/operation/sampling/sampler_texture.spec.ts
+++ b/src/webgpu/api/operation/sampling/sampler_texture.spec.ts
@@ -7,10 +7,10 @@ Tests samplers with textures.
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { assert, range } from '../../../../common/util/util.js';
-import { GPUTest, MaxLimitsTestMixin, TextureTestMixin } from '../../../gpu_test.js';
+import { AllFeaturesMaxLimitsGPUTest, TextureTestMixin } from '../../../gpu_test.js';
 import { TexelView } from '../../../util/texture/texel_view.js';
 
-export const g = makeTestGroup(TextureTestMixin(MaxLimitsTestMixin(GPUTest)));
+export const g = makeTestGroup(TextureTestMixin(AllFeaturesMaxLimitsGPUTest));
 
 g.test('sample_texture_combos')
   .desc(

--- a/src/webgpu/api/operation/storage_texture/read_only.spec.ts
+++ b/src/webgpu/api/operation/storage_texture/read_only.spec.ts
@@ -15,7 +15,7 @@ import {
   kColorTextureFormats,
   kTextureFormatInfo,
 } from '../../../format_info.js';
-import { GPUTest, MaxLimitsTestMixin } from '../../../gpu_test.js';
+import { AllFeaturesMaxLimitsGPUTest } from '../../../gpu_test.js';
 import { kValidShaderStages, TValidShaderStage } from '../../../util/shader.js';
 
 function ComponentCount(format: ColorTextureFormat): number {
@@ -46,7 +46,7 @@ function ComponentCount(format: ColorTextureFormat): number {
   }
 }
 
-class F extends GPUTest {
+class F extends AllFeaturesMaxLimitsGPUTest {
   initTextureAndGetExpectedOutputBufferData(
     storageTexture: GPUTexture,
     format: ColorTextureFormat
@@ -532,7 +532,7 @@ class F extends GPUTest {
   }
 }
 
-export const g = makeTestGroup(MaxLimitsTestMixin(F));
+export const g = makeTestGroup(F);
 
 g.test('basic')
   .desc(

--- a/src/webgpu/api/operation/storage_texture/read_write.spec.ts
+++ b/src/webgpu/api/operation/storage_texture/read_write.spec.ts
@@ -9,14 +9,14 @@ import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { assert, unreachable } from '../../../../common/util/util.js';
 import { kTextureDimensions } from '../../../capability_info.js';
 import { kColorTextureFormats, kTextureFormatInfo } from '../../../format_info.js';
-import { GPUTest, MaxLimitsTestMixin } from '../../../gpu_test.js';
+import { AllFeaturesMaxLimitsGPUTest } from '../../../gpu_test.js';
 import { align } from '../../../util/math.js';
 
 const kShaderStagesForReadWriteStorageTexture = ['fragment', 'compute'] as const;
 type ShaderStageForReadWriteStorageTexture =
   (typeof kShaderStagesForReadWriteStorageTexture)[number];
 
-class F extends GPUTest {
+class F extends AllFeaturesMaxLimitsGPUTest {
   getInitialData(storageTexture: GPUTexture): ArrayBuffer {
     const format = storageTexture.format;
     const bytesPerBlock = kTextureFormatInfo[format].bytesPerBlock;
@@ -298,7 +298,7 @@ class F extends GPUTest {
   }
 }
 
-export const g = makeTestGroup(MaxLimitsTestMixin(F));
+export const g = makeTestGroup(F);
 
 g.test('basic')
   .desc(

--- a/src/webgpu/api/operation/texture_view/write.spec.ts
+++ b/src/webgpu/api/operation/texture_view/write.spec.ts
@@ -22,11 +22,11 @@ import {
   kTextureFormatInfo,
   RegularTextureFormat,
 } from '../../../format_info.js';
-import { GPUTest, MaxLimitsTestMixin, TextureTestMixin } from '../../../gpu_test.js';
+import { AllFeaturesMaxLimitsGPUTest, GPUTest, TextureTestMixin } from '../../../gpu_test.js';
 import { kFullscreenQuadVertexShaderCode } from '../../../util/shader.js';
 import { TexelView } from '../../../util/texture/texel_view.js';
 
-export const g = makeTestGroup(TextureTestMixin(MaxLimitsTestMixin(GPUTest)));
+export const g = makeTestGroup(TextureTestMixin(AllFeaturesMaxLimitsGPUTest));
 
 const kTextureViewWriteMethods = [
   'storage-write-fragment',

--- a/src/webgpu/api/operation/vertex_state/correctness.spec.ts
+++ b/src/webgpu/api/operation/vertex_state/correctness.spec.ts
@@ -12,7 +12,7 @@ import {
   unreachable,
 } from '../../../../common/util/util.js';
 import { kVertexFormatInfo, kVertexFormats } from '../../../capability_info.js';
-import { GPUTest, MaxLimitsTestMixin } from '../../../gpu_test.js';
+import { AllFeaturesMaxLimitsGPUTest } from '../../../gpu_test.js';
 import { float32ToFloat16Bits, normalizedIntegerAsFloat } from '../../../util/conversion.js';
 import { align, clamp } from '../../../util/math.js';
 
@@ -83,7 +83,7 @@ type TestData = {
   vertexData: ArrayBuffer;
 };
 
-class VertexStateTest extends GPUTest {
+class VertexStateTest extends AllFeaturesMaxLimitsGPUTest {
   // Generate for VS + FS (entrypoints vsMain / fsMain) that for each attribute will check that its
   // value corresponds to what's expected (as provided by a uniform buffer per attribute) and then
   // renders each vertex at position (vertexIndex, instanceindex) with either 1 (success) or
@@ -639,7 +639,7 @@ struct VSOutputs {
   }
 }
 
-export const g = makeTestGroup(MaxLimitsTestMixin(VertexStateTest));
+export const g = makeTestGroup(VertexStateTest);
 
 g.test('vertex_format_to_shader_format_conversion')
   .desc(

--- a/src/webgpu/shader/execution/expression/call/builtin/textureDimensions.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureDimensions.spec.ts
@@ -15,13 +15,12 @@ import {
   sampleTypeForFormatAndAspect,
   textureDimensionAndFormatCompatible,
 } from '../../../../../format_info.js';
-import { MaxLimitsTestMixin } from '../../../../../gpu_test.js';
 import { align } from '../../../../../util/math.js';
 import { kShaderStages, ShaderStage } from '../../../../validation/decl/util.js';
 
 import { WGSLTextureQueryTest } from './texture_utils.js';
 
-export const g = makeTestGroup(MaxLimitsTestMixin(WGSLTextureQueryTest));
+export const g = makeTestGroup(WGSLTextureQueryTest);
 
 /// The maximum number of texture mipmap levels to test.
 /// Keep this small to reduce memory and test permutations.

--- a/src/webgpu/shader/execution/expression/call/builtin/textureLoad.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureLoad.spec.ts
@@ -28,7 +28,7 @@ import {
   kTextureFormatInfo,
   textureDimensionAndFormatCompatible,
 } from '../../../../../format_info.js';
-import { GPUTest, MaxLimitsTestMixin } from '../../../../../gpu_test.js';
+import { AllFeaturesMaxLimitsGPUTest, GPUTest } from '../../../../../gpu_test.js';
 import { maxMipLevelCount, virtualMipSize } from '../../../../../util/texture/base.js';
 import { TexelFormats } from '../../../../types.js';
 
@@ -79,7 +79,7 @@ function skipIfStorageTexturesNotSupportedInStage(t: GPUTest, stage: ShortShader
   }
 }
 
-export const g = makeTestGroup(MaxLimitsTestMixin(GPUTest));
+export const g = makeTestGroup(AllFeaturesMaxLimitsGPUTest);
 
 g.test('sampled_1d')
   .specURL('https://www.w3.org/TR/WGSL/#textureload')

--- a/src/webgpu/shader/execution/expression/call/builtin/textureNumLayers.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureNumLayers.spec.ts
@@ -6,7 +6,6 @@ Returns the number of layers (elements) of an array texture.
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { kTextureFormatInfo } from '../../../../../format_info.js';
-import { MaxLimitsTestMixin } from '../../../../../gpu_test.js';
 import { TexelFormats } from '../../../../types.js';
 import { kShaderStages } from '../../../../validation/decl/util.js';
 
@@ -35,7 +34,7 @@ function getLayerSettingsAndExpected({
       };
 }
 
-export const g = makeTestGroup(MaxLimitsTestMixin(WGSLTextureQueryTest));
+export const g = makeTestGroup(WGSLTextureQueryTest);
 
 g.test('sampled')
   .specURL('https://www.w3.org/TR/WGSL/#texturenumlayers')

--- a/src/webgpu/shader/execution/expression/call/builtin/textureStore.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureStore.spec.ts
@@ -14,7 +14,7 @@ If an out-of-bounds access occurs, the built-in function should not be executed.
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { unreachable, iterRange, range } from '../../../../../../common/util/util.js';
 import { kTextureFormatInfo } from '../../../../../format_info.js';
-import { GPUTest, MaxLimitsTestMixin, TextureTestMixin } from '../../../../../gpu_test.js';
+import { AllFeaturesMaxLimitsGPUTest, TextureTestMixin } from '../../../../../gpu_test.js';
 import {
   kFloat32Format,
   kFloat16Format,
@@ -29,7 +29,7 @@ import { TexelFormats } from '../../../../types.js';
 const kDims = ['1d', '2d', '3d'] as const;
 const kViewDimensions = ['1d', '2d', '2d-array', '3d'] as const;
 
-export const g = makeTestGroup(TextureTestMixin(MaxLimitsTestMixin(GPUTest)));
+export const g = makeTestGroup(TextureTestMixin(AllFeaturesMaxLimitsGPUTest));
 
 // We require a few values that are out of range for a given type
 // so we can check clamping behavior.

--- a/src/webgpu/shader/execution/expression/call/builtin/texture_utils.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/texture_utils.ts
@@ -14,7 +14,11 @@ import {
   kEncodableTextureFormats,
   kTextureFormatInfo,
 } from '../../../../../format_info.js';
-import { GPUTest, GPUTestSubcaseBatchState } from '../../../../../gpu_test.js';
+import {
+  AllFeaturesMaxLimitsGPUTest,
+  GPUTest,
+  GPUTestSubcaseBatchState,
+} from '../../../../../gpu_test.js';
 import {
   align,
   clamp,
@@ -786,7 +790,7 @@ function getWeightForMipLevel(
 /**
  * Used for textureNumSamples, textureNumLevels, textureNumLayers, textureDimension
  */
-export class WGSLTextureQueryTest extends GPUTest {
+export class WGSLTextureQueryTest extends AllFeaturesMaxLimitsGPUTest {
   skipIfNoStorageTexturesInStage(stage: ShaderStage) {
     if (this.isCompatibility) {
       this.skipIf(

--- a/src/webgpu/shader/execution/statement/discard.spec.ts
+++ b/src/webgpu/shader/execution/statement/discard.spec.ts
@@ -15,10 +15,10 @@ Conditions that still occur:
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { iterRange } from '../../../../common/util/util.js';
-import { GPUTest, MaxLimitsTestMixin } from '../../../gpu_test.js';
+import { AllFeaturesMaxLimitsGPUTest, GPUTestBase } from '../../../gpu_test.js';
 import { checkElementsPassPredicate } from '../../../util/check_contents.js';
 
-export const g = makeTestGroup(MaxLimitsTestMixin(GPUTest));
+export const g = makeTestGroup(AllFeaturesMaxLimitsGPUTest);
 
 // Framebuffer dimensions
 const kWidth = 64;
@@ -49,7 +49,7 @@ fn vsMain(@builtin(vertex_index) index : u32) -> @builtin(position) vec4f {
 `;
 
 function drawFullScreen(
-  t: GPUTest,
+  t: GPUTestBase,
   code: string,
   useStorageBuffers: boolean,
   dataChecker: (a: Float32Array) => Error | undefined,

--- a/src/webgpu/web_platform/canvas/configure.spec.ts
+++ b/src/webgpu/web_platform/canvas/configure.spec.ts
@@ -16,10 +16,10 @@ import {
   filterFormatsByFeature,
   viewCompatible,
 } from '../../format_info.js';
-import { GPUTest, MaxLimitsTestMixin } from '../../gpu_test.js';
+import { AllFeaturesMaxLimitsGPUTest } from '../../gpu_test.js';
 import { kAllCanvasTypes, createCanvas } from '../../util/create_elements.js';
 
-export const g = makeTestGroup(MaxLimitsTestMixin(GPUTest));
+export const g = makeTestGroup(AllFeaturesMaxLimitsGPUTest);
 
 g.test('defaults')
   .desc(


### PR DESCRIPTION
This is a test that requests all features and maximum limits. This should be the default test for the majority of tests, otherwise optional features will not be tested. The exceptions are only tests that explicitly test the absence of a feature or specific limits such as the tests under validation/capability_checks.

As a concrete example to demonstrate the issue, texture format `rg11b10ufloat` is optionally renderable and can optionally be used multisampled. Any test that tests texture formats should test this format, skipping only if the feature is missing. So, the default should be that the test tests `kAllTextureFormats` with the appropriate filters from format_info.ts or the various helpers. This way, `rg11b10ufloat` will included in the test and fail if not appropriately filtered. If instead you were to use GPUTest then `rg11b10ufloat` would just be skipped as its never enabled. You could enable it manually but that spreads enabling to every test instead of being centralized in one place, here.

Honestly, I'd prefer to rename `GPUTest` to `SpecialGPUTest` or possibly even `DeprecatedGPUTest` it clear not to use it and where it needs to be fixed and then name this `GPUTest`. But, we can do that later. For now, I just effectively replaced `MaxLimitsTestMixin` with `AllFeaturesMaxLimitsGPUTest` in the places where it could easily be replaced.

The remaining places bring up an issue. All of them are based on `ValidationTest`. I think the same rules apply. For example, if we're validating that textures fail validation for certain reasons we should be checking formats that are optional also pass the same validation rules. The simplest way to do that would be to make `ValidationTest` inherit from `AllFeaturesMaxLimitsGPUTest`.

Unfortunately, the capability_checks/* are all based off `ValidationTest` so they need to be moved to something else before we can make that change.




Issue: #4178

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [X] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
