### PR TITLE
Fix textureSampleCompareLevel sample point code.

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/texture_utils.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/texture_utils.ts
@@ -2567,7 +2567,7 @@ export async function checkCallResults<T extends Dimensionality>(
                     break;
                   case 'textureSampleCompareLevel':
                     debugCall.builtin = 'textureSampleLevel';
-                    debugCall.levelType = 'f';
+                    debugCall.levelType = 'u';
                     debugCall.mipLevel = 0;
                     break;
                   default:


### PR DESCRIPTION
This is bug that surfaced only if the test failed. The issue is that textureSampleLevel, which it uses when textureSampleCompareLevel fails, needs the level parameter to be i32/u32 when the texture is a depth texture.

Again, this only happens when we already know the test failed so this doesn't affect pass/fail. It only affects getting the sample points.


