### PR TITLE
Refactor copyTextureToTexture test for texture formats

### DIFF
--- a/src/webgpu/format_info.ts
+++ b/src/webgpu/format_info.ts
@@ -1772,6 +1772,32 @@ export function textureFormatsAreViewCompatible(
     : a === b || a + '-srgb' === b || b + '-srgb' === a;
 }
 
+/**
+ * Gets the block width, height, and bytes per block for a color texture format.
+ */
+export function getBlockInfoForColorTextureFormat(format: ColorTextureFormat) {
+  const info = kTextureFormatInfo[format];
+  return {
+    blockWidth: info.blockWidth,
+    blockHeight: info.blockHeight,
+    bytesPerBlock: info.color.bytes,
+  };
+}
+
+/**
+ * Gets the baseFormat for a texture format.
+ */
+export function getBaseFormatForTextureFormat(format: GPUTextureFormat) {
+  return kTextureFormatInfo[format].baseFormat;
+}
+
+/**
+ * Gets the feature needed for a give texture format or undefined if none.
+ */
+export function getRequiredFeatureForTextureFormat(format: GPUTextureFormat) {
+  return kTextureFormatInfo[format].feature;
+}
+
 export function getFeaturesForFormats<T>(
   formats: readonly (T & (GPUTextureFormat | undefined))[]
 ): readonly (GPUFeatureName | undefined)[] {

--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -528,18 +528,19 @@ export class GPUTestBase extends Fixture<GPUTestSubcaseBatchState> {
    */
   skipIfTextureFormatNotSupported(...formats: (GPUTextureFormat | undefined)[]) {
     for (const format of formats) {
-      if (format) {
-        if (isCompatibilityDevice(this.device)) {
-          if (format === 'bgra8unorm-srgb') {
-            this.skip(`texture format '${format} is not supported`);
-          }
-        }
-        const feature = getRequiredFeatureForTextureFormat(format);
-        this.skipIf(
-          !!feature && !this.device.features.has(feature),
-          `texture format '${format}' requires feature: '${feature}`
-        );
+      if (!format) {
+        continue;
       }
+      if (format === 'bgra8unorm-srgb') {
+        if (isCompatibilityDevice(this.device)) {
+          this.skip(`texture format '${format}' is not supported`);
+        }
+      }
+      const feature = getRequiredFeatureForTextureFormat(format);
+      this.skipIf(
+        !!feature && !this.device.features.has(feature),
+        `texture format '${format}' requires feature: '${feature}`
+      );
     }
   }
 

--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -31,6 +31,7 @@ import {
   EncodableTextureFormat,
   isCompressedTextureFormat,
   ColorTextureFormat,
+  getRequiredFeatureForTextureFormat,
   isTextureFormatUsableAsStorageFormatDeprecated,
   isMultisampledTextureFormatDeprecated,
   isTextureFormatUsableAsStorageFormat,
@@ -526,11 +527,18 @@ export class GPUTestBase extends Fixture<GPUTestSubcaseBatchState> {
    * Skips test if any format is not supported.
    */
   skipIfTextureFormatNotSupported(...formats: (GPUTextureFormat | undefined)[]) {
-    if (isCompatibilityDevice(this.device)) {
-      for (const format of formats) {
-        if (format === 'bgra8unorm-srgb') {
-          this.skip(`texture format '${format} is not supported`);
+    for (const format of formats) {
+      if (format) {
+        if (isCompatibilityDevice(this.device)) {
+          if (format === 'bgra8unorm-srgb') {
+            this.skip(`texture format '${format} is not supported`);
+          }
         }
+        const feature = getRequiredFeatureForTextureFormat(format);
+        this.skipIf(
+          !!feature && !this.device.features.has(feature),
+          `texture format '${format}' requires feature: '${feature}`
+        );
       }
     }
   }


### PR DESCRIPTION
Also expanded the multisample depth test and add
multisample stencil placeholder.

Issue: #4181



