### PR TITLE
Make ShaderValidationTest inherit from AllFeaturesMaxLimitsGPUTest

### DIFF
--- a/src/webgpu/shader/validation/shader_validation_test.ts
+++ b/src/webgpu/shader/validation/shader_validation_test.ts
@@ -1,11 +1,11 @@
 import { keysOf } from '../../../common/util/data_tables.js';
 import { ErrorWithExtra } from '../../../common/util/util.js';
-import { GPUTest } from '../../gpu_test.js';
+import { AllFeaturesMaxLimitsGPUTest } from '../../gpu_test.js';
 
 /**
  * Base fixture for WGSL shader validation tests.
  */
-export class ShaderValidationTest extends GPUTest {
+export class ShaderValidationTest extends AllFeaturesMaxLimitsGPUTest {
   /**
    * Add a test expectation for whether a createShaderModule call succeeds or not.
    *


### PR DESCRIPTION
This needs to happen before any tests can be refactored under shader/validation.

Issue #4178

I put up PR for shader/validation/decl yesterday but without this PR, shader-f16, is not tested.