### PR TITLE
Refactor shader/execution/expression/call/builtin/texture*

### DIFF
--- a/src/webgpu/format_info.ts
+++ b/src/webgpu/format_info.ts
@@ -2094,7 +2094,7 @@ export function is32Float(format: GPUTextureFormat) {
  * * 'depth16unorm' -> false
  * * 'rgba32float' -> true (you need to enable feature 'float32-filterable')
  */
-export function isFilterableAsTextureF32(format: GPUTextureFormat) {
+export function isTextureFormatPossiblyFilterableAsTextureF32(format: GPUTextureFormat) {
   const info = kTextureFormatInfo[format];
   return info.color?.type === 'float' || is32Float(format);
 }

--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -359,7 +359,7 @@ export class GPUTestSubcaseBatchState extends SubcaseBatchState {
   }
 
   /** Skips this test case if a depth texture can not be used with a non-comparison sampler. */
-  skipIfDepthTextureCanNotBeUsedWithNonComparisonSampler() {
+  skipIfDepthTextureCanNotBeUsedWithNonComparisonSamplerDeprecated() {
     this.skipIf(
       this.isCompatibility,
       'depth textures are not usable with non-comparison samplers in compatibility mode'
@@ -547,6 +547,13 @@ export class GPUTestBase extends Fixture<GPUTestSubcaseBatchState> {
         this.skipIfDeviceDoesNotHaveFeature(feature);
       }
     }
+  }
+
+  skipIfDepthTextureCanNotBeUsedWithNonComparisonSampler() {
+    this.skipIf(
+      this.isCompatibility,
+      'depth textures are not usable with non-comparison samplers in compatibility mode'
+    );
   }
 
   /**

--- a/src/webgpu/shader/execution/expression/call/builtin/textureGather.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureGather.spec.ts
@@ -27,7 +27,7 @@ A texture gather operation reads from a 2D, 2D array, cube, or cube array textur
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import {
   isDepthTextureFormat,
-  isFilterableAsTextureF32,
+  isTextureFormatPossiblyFilterableAsTextureF32,
   kDepthStencilFormats,
   kAllTextureFormats,
 } from '../../../../../format_info.js';
@@ -46,7 +46,7 @@ import {
   kShortAddressModes,
   kShortAddressModeToAddressMode,
   kShortShaderStages,
-  skipIfNeedsFilteringAndIsUnfilterableOrSelectDevice,
+  skipIfTextureFormatNotSupportedOrNeedsFilteringAndIsUnfilterable,
   TextureCall,
   vec2,
   vec3,
@@ -87,7 +87,7 @@ Parameters:
       .combine('format', kAllTextureFormats)
       .filter(t => isFillable(t.format))
       .combine('filt', ['nearest', 'linear'] as const)
-      .filter(t => t.filt === 'nearest' || isFilterableAsTextureF32(t.format))
+      .filter(t => t.filt === 'nearest' || isTextureFormatPossiblyFilterableAsTextureF32(t.format))
       .combine('modeU', kShortAddressModes)
       .combine('modeV', kShortAddressModes)
       .combine('offset', [false, true] as const)
@@ -95,12 +95,9 @@ Parameters:
       .combine('C', ['i32', 'u32'] as const)
       .combine('samplePoints', kSamplePointMethods)
   )
-  .beforeAllSubcases(t => {
-    t.skipIfTextureFormatNotSupportedDeprecated(t.params.format);
-    skipIfNeedsFilteringAndIsUnfilterableOrSelectDevice(t, t.params.filt, t.params.format);
-  })
   .fn(async t => {
     const { format, C, samplePoints, stage, modeU, modeV, filt: minFilter, offset } = t.params;
+    skipIfTextureFormatNotSupportedOrNeedsFilteringAndIsUnfilterable(t, minFilter, format);
 
     // We want at least 4 blocks or something wide enough for 3 mip levels.
     const [width, height] = chooseTextureSize({ minSize: 8, minBlocks: 4, format });
@@ -185,18 +182,15 @@ Parameters:
       .combine('format', kAllTextureFormats)
       .filter(t => isFillable(t.format))
       .combine('filt', ['nearest', 'linear'] as const)
-      .filter(t => t.filt === 'nearest' || isFilterableAsTextureF32(t.format))
+      .filter(t => t.filt === 'nearest' || isTextureFormatPossiblyFilterableAsTextureF32(t.format))
       .combine('mode', kShortAddressModes)
       .beginSubcases()
       .combine('C', ['i32', 'u32'] as const)
       .combine('samplePoints', kCubeSamplePointMethods)
   )
-  .beforeAllSubcases(t => {
-    t.skipIfTextureFormatNotSupportedDeprecated(t.params.format);
-    skipIfNeedsFilteringAndIsUnfilterableOrSelectDevice(t, t.params.filt, t.params.format);
-  })
   .fn(async t => {
     const { format, C, stage, samplePoints, mode, filt: minFilter } = t.params;
+    skipIfTextureFormatNotSupportedOrNeedsFilteringAndIsUnfilterable(t, minFilter, format);
 
     const viewDimension: GPUTextureViewDimension = 'cube';
     const [width, height] = chooseTextureSize({ minSize: 8, minBlocks: 2, format, viewDimension });
@@ -294,7 +288,7 @@ Parameters:
       .combine('format', kAllTextureFormats)
       .filter(t => isFillable(t.format))
       .combine('filt', ['nearest', 'linear'] as const)
-      .filter(t => t.filt === 'nearest' || isFilterableAsTextureF32(t.format))
+      .filter(t => t.filt === 'nearest' || isTextureFormatPossiblyFilterableAsTextureF32(t.format))
       .combine('modeU', kShortAddressModes)
       .combine('modeV', kShortAddressModes)
       .combine('offset', [false, true] as const)
@@ -304,10 +298,6 @@ Parameters:
       .combine('A', ['i32', 'u32'] as const)
       .combine('depthOrArrayLayers', [1, 8] as const)
   )
-  .beforeAllSubcases(t => {
-    t.skipIfTextureFormatNotSupportedDeprecated(t.params.format);
-    skipIfNeedsFilteringAndIsUnfilterableOrSelectDevice(t, t.params.filt, t.params.format);
-  })
   .fn(async t => {
     const {
       format,
@@ -321,6 +311,7 @@ Parameters:
       offset,
       depthOrArrayLayers,
     } = t.params;
+    skipIfTextureFormatNotSupportedOrNeedsFilteringAndIsUnfilterable(t, minFilter, format);
 
     // We want at least 4 blocks or something wide enough for 3 mip levels.
     const [width, height] = chooseTextureSize({ minSize: 8, minBlocks: 4, format });
@@ -413,20 +404,17 @@ Parameters:
       .combine('format', kAllTextureFormats)
       .filter(t => isFillable(t.format))
       .combine('filt', ['nearest', 'linear'] as const)
-      .filter(t => t.filt === 'nearest' || isFilterableAsTextureF32(t.format))
+      .filter(t => t.filt === 'nearest' || isTextureFormatPossiblyFilterableAsTextureF32(t.format))
       .combine('mode', kShortAddressModes)
       .beginSubcases()
       .combine('samplePoints', kCubeSamplePointMethods)
       .combine('C', ['i32', 'u32'] as const)
       .combine('A', ['i32', 'u32'] as const)
   )
-  .beforeAllSubcases(t => {
-    t.skipIfTextureFormatNotSupportedDeprecated(t.params.format);
-    t.skipIfTextureViewDimensionNotSupportedDeprecated('cube-array');
-    skipIfNeedsFilteringAndIsUnfilterableOrSelectDevice(t, t.params.filt, t.params.format);
-  })
   .fn(async t => {
     const { format, C, A, stage, samplePoints, mode, filt: minFilter } = t.params;
+    skipIfTextureFormatNotSupportedOrNeedsFilteringAndIsUnfilterable(t, minFilter, format);
+    t.skipIfTextureViewDimensionNotSupported('cube-array');
 
     const viewDimension: GPUTextureViewDimension = 'cube-array';
     const size = chooseTextureSize({ minSize: 8, minBlocks: 2, format, viewDimension });
@@ -524,12 +512,10 @@ Parameters:
       .beginSubcases()
       .combine('samplePoints', kSamplePointMethods)
   )
-  .beforeAllSubcases(t => {
-    t.skipIfDepthTextureCanNotBeUsedWithNonComparisonSampler();
-    t.selectDeviceForTextureFormatOrSkipTestCase(t.params.format);
-  })
   .fn(async t => {
     const { format, stage, samplePoints, modeU, modeV, offset } = t.params;
+    t.skipIfDepthTextureCanNotBeUsedWithNonComparisonSampler();
+    t.skipIfTextureFormatNotSupported(format);
 
     // We want at least 4 blocks or something wide enough for 3 mip levels.
     const [width, height] = chooseTextureSize({ minSize: 8, minBlocks: 4, format });
@@ -606,12 +592,10 @@ Parameters:
       .beginSubcases()
       .combine('samplePoints', kCubeSamplePointMethods)
   )
-  .beforeAllSubcases(t => {
-    t.skipIfDepthTextureCanNotBeUsedWithNonComparisonSampler();
-    t.selectDeviceForTextureFormatOrSkipTestCase(t.params.format);
-  })
   .fn(async t => {
     const { format, stage, samplePoints, mode } = t.params;
+    t.skipIfTextureFormatNotSupported(format);
+    t.skipIfDepthTextureCanNotBeUsedWithNonComparisonSampler();
 
     const viewDimension: GPUTextureViewDimension = 'cube';
     const [width, height] = chooseTextureSize({ minSize: 8, minBlocks: 2, format, viewDimension });
@@ -706,13 +690,10 @@ Parameters:
       .combine('A', ['i32', 'u32'] as const)
       .combine('depthOrArrayLayers', [1, 8] as const)
   )
-  .beforeAllSubcases(t => {
-    t.skipIfDepthTextureCanNotBeUsedWithNonComparisonSampler();
-    t.skipIfTextureFormatNotSupportedDeprecated(t.params.format);
-    t.selectDeviceForTextureFormatOrSkipTestCase(t.params.format);
-  })
   .fn(async t => {
     const { format, stage, samplePoints, A, modeU, modeV, offset, depthOrArrayLayers } = t.params;
+    t.skipIfTextureFormatNotSupported(t.params.format);
+    t.skipIfDepthTextureCanNotBeUsedWithNonComparisonSampler();
 
     // We want at least 4 blocks or something wide enough for 3 mip levels.
     const [width, height] = chooseTextureSize({ minSize: 8, minBlocks: 4, format });
@@ -798,13 +779,11 @@ Parameters:
       .combine('samplePoints', kCubeSamplePointMethods)
       .combine('A', ['i32', 'u32'] as const)
   )
-  .beforeAllSubcases(t => {
-    t.skipIfDepthTextureCanNotBeUsedWithNonComparisonSampler();
-    t.skipIfTextureViewDimensionNotSupportedDeprecated('cube-array');
-    t.selectDeviceForTextureFormatOrSkipTestCase(t.params.format);
-  })
   .fn(async t => {
     const { format, A, stage, samplePoints, mode } = t.params;
+    t.skipIfTextureFormatNotSupported(format);
+    t.skipIfDepthTextureCanNotBeUsedWithNonComparisonSampler();
+    t.skipIfTextureViewDimensionNotSupported('cube-array');
 
     const viewDimension: GPUTextureViewDimension = 'cube-array';
     const size = chooseTextureSize({ minSize: 8, minBlocks: 2, format, viewDimension });

--- a/src/webgpu/shader/execution/expression/call/builtin/textureGatherCompare.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureGatherCompare.spec.ts
@@ -80,10 +80,6 @@ Parameters:
       .combine('compare', kCompareFunctions)
       .combine('depthOrArrayLayers', [1, 8] as const)
   )
-  .beforeAllSubcases(t => {
-    t.skipIfTextureFormatNotSupportedDeprecated(t.params.format);
-    t.selectDeviceForTextureFormatOrSkipTestCase(t.params.format);
-  })
   .fn(async t => {
     const {
       format,
@@ -97,6 +93,7 @@ Parameters:
       offset,
       depthOrArrayLayers,
     } = t.params;
+    t.skipIfTextureFormatNotSupported(format);
 
     const [width, height] = chooseTextureSize({ minSize: 8, minBlocks: 4, format });
     const size = { width, height, depthOrArrayLayers };
@@ -192,12 +189,10 @@ Parameters:
       .combine('A', ['i32', 'u32'] as const)
       .combine('compare', kCompareFunctions)
   )
-  .beforeAllSubcases(t => {
-    t.skipIfTextureViewDimensionNotSupportedDeprecated('cube-array');
-    t.selectDeviceForTextureFormatOrSkipTestCase(t.params.format);
-  })
   .fn(async t => {
     const { format, A, stage, samplePoints, mode, filt: minFilter, compare } = t.params;
+    t.skipIfTextureViewDimensionNotSupported('cube-array');
+    t.skipIfTextureFormatNotSupported(format);
 
     const viewDimension: GPUTextureViewDimension = 'cube-array';
     const size = chooseTextureSize({ minSize: 8, minBlocks: 2, format, viewDimension });
@@ -299,9 +294,9 @@ Parameters:
       .combine('samplePoints', kSamplePointMethods)
       .combine('compare', kCompareFunctions)
   )
-  .beforeAllSubcases(t => t.selectDeviceForTextureFormatOrSkipTestCase(t.params.format))
   .fn(async t => {
     const { format, C, stage, samplePoints, mode, compare, filt: minFilter, offset } = t.params;
+    t.skipIfTextureFormatNotSupported(format);
 
     const size = chooseTextureSize({ minSize: 8, minBlocks: 4, format });
     const descriptor: GPUTextureDescriptor = {
@@ -387,9 +382,9 @@ Parameters:
       .combine('samplePoints', kCubeSamplePointMethods)
       .combine('compare', kCompareFunctions)
   )
-  .beforeAllSubcases(t => t.selectDeviceForTextureFormatOrSkipTestCase(t.params.format))
   .fn(async t => {
     const { format, stage, samplePoints, mode, filt: minFilter, compare } = t.params;
+    t.skipIfTextureFormatNotSupported(format);
 
     const viewDimension: GPUTextureViewDimension = 'cube';
     const size = chooseTextureSize({ minSize: 8, minBlocks: 2, format, viewDimension });

--- a/src/webgpu/shader/execution/expression/call/builtin/textureNumLayers.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureNumLayers.spec.ts
@@ -5,8 +5,10 @@ Returns the number of layers (elements) of an array texture.
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
-import { kTextureFormatInfo } from '../../../../../format_info.js';
-import { TexelFormats } from '../../../../types.js';
+import {
+  isTextureFormatPossiblyStorageReadWritable,
+  kPossibleStorageTextureFormats,
+} from '../../../../../format_info.js';
 import { kShaderStages } from '../../../../validation/decl/util.js';
 
 import { kSampleTypeInfo, WGSLTextureQueryTest } from './texture_utils.js';
@@ -185,13 +187,13 @@ Parameters
   )
   .params(u =>
     u
-      .combineWithParams(TexelFormats)
+      .combine('format', kPossibleStorageTextureFormats)
       .combine('view_type', ['full', 'partial'] as const)
       .beginSubcases()
       .combine('stage', kShaderStages)
       .combine('access_mode', ['read', 'write', 'read_write'] as const)
       .filter(
-        t => t.access_mode !== 'read_write' || kTextureFormatInfo[t.format].color?.readWriteStorage
+        t => t.access_mode !== 'read_write' || !isTextureFormatPossiblyStorageReadWritable(t.format)
       )
       // Vertex stage can not use writable storage textures.
       .unless(t => t.stage === 'vertex' && t.access_mode !== 'read')
@@ -201,12 +203,14 @@ Parameters
       t.isCompatibility && t.params.view_type === 'partial',
       'compatibility mode does not support partial layer views'
     );
-    t.skipIfTextureFormatNotUsableAsStorageTextureDeprecated(t.params.format);
   })
   .fn(t => {
     const { stage, format, access_mode, view_type } = t.params;
-
     t.skipIfNoStorageTexturesInStage(stage);
+    t.skipIfTextureFormatNotUsableAsStorageTexture(format);
+    if (access_mode === 'read_write') {
+      t.skipIfTextureFormatNotUsableAsReadWriteStorageTexture(format);
+    }
 
     const texture = t.createTextureTracked({
       format,

--- a/src/webgpu/shader/execution/expression/call/builtin/textureNumLevels.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureNumLevels.spec.ts
@@ -73,14 +73,10 @@ Parameters
       // 1d textures can't have mipLevelCount > 0
       .filter(t => t.texture_type !== 'texture_1d' || t.view_type !== 'partial')
   )
-  .beforeAllSubcases(t => {
-    t.skipIfTextureViewDimensionNotSupportedDeprecated(
-      kTextureTypeToViewDimension[t.params.texture_type]
-    );
-  })
   .fn(t => {
     const { stage, texture_type, sampled_type, view_type } = t.params;
     const { format } = kSampleTypeInfo[sampled_type];
+    t.skipIfTextureViewDimensionNotSupported(kTextureTypeToViewDimension[t.params.texture_type]);
 
     const viewDimension = kTextureTypeToViewDimension[texture_type];
     const dimension = getTextureDimensionFromView(viewDimension);
@@ -148,13 +144,9 @@ Parameters
       .beginSubcases()
       .combine('stage', kShaderStages)
   )
-  .beforeAllSubcases(t => {
-    t.skipIfTextureViewDimensionNotSupportedDeprecated(
-      kTextureTypeToViewDimension[t.params.texture_type]
-    );
-  })
   .fn(t => {
     const { stage, texture_type, view_type } = t.params;
+    t.skipIfTextureViewDimensionNotSupported(kTextureTypeToViewDimension[t.params.texture_type]);
 
     const viewDimension = kTextureTypeToViewDimension[texture_type];
     const dimension = getTextureDimensionFromView(viewDimension);

--- a/src/webgpu/shader/execution/expression/call/builtin/textureSample.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureSample.spec.ts
@@ -13,7 +13,7 @@ import {
   kDepthStencilFormats,
   kAllTextureFormats,
   textureDimensionAndFormatCompatible,
-  isFilterableAsTextureF32,
+  isTextureFormatPossiblyFilterableAsTextureF32,
 } from '../../../../../format_info.js';
 import { TextureTestMixin } from '../../../../../gpu_test.js';
 
@@ -34,13 +34,12 @@ import {
   SamplePointMethods,
   chooseTextureSize,
   isPotentiallyFilterableAndFillable,
-  skipIfTextureFormatNotSupportedNotAvailableOrNotFilterable,
+  skipIfTextureFormatNotSupportedOrNeedsFilteringAndIsUnfilterable,
   getTextureTypeForTextureViewDimension,
   WGSLTextureSampleTest,
   isSupportedViewFormatCombo,
   vec1,
   generateTextureBuiltinInputs1D,
-  skipIfNeedsFilteringAndIsUnfilterable,
 } from './texture_utils.js';
 
 export const g = makeTestGroup(TextureTestMixin(WGSLTextureSampleTest));
@@ -67,11 +66,9 @@ Parameters:
       .beginSubcases()
       .combine('samplePoints', kSamplePointMethods)
   )
-  .beforeAllSubcases(t =>
-    skipIfTextureFormatNotSupportedNotAvailableOrNotFilterable(t, t.params.format)
-  )
   .fn(async t => {
     const { format, samplePoints, modeU, filt: minFilter } = t.params;
+    skipIfTextureFormatNotSupportedOrNeedsFilteringAndIsUnfilterable(t, minFilter, format);
 
     // We want at least 4 blocks or something wide enough for 3 mip levels.
     const size = chooseTextureSize({ minSize: 8, minBlocks: 4, format, viewDimension: '1d' });
@@ -151,19 +148,16 @@ Parameters:
       .combine('format', kAllTextureFormats)
       .filter(t => isPotentiallyFilterableAndFillable(t.format))
       .combine('filt', ['nearest', 'linear'] as const)
-      .filter(t => t.filt === 'nearest' || isFilterableAsTextureF32(t.format))
+      .filter(t => t.filt === 'nearest' || isTextureFormatPossiblyFilterableAsTextureF32(t.format))
       .combine('modeU', kShortAddressModes)
       .combine('modeV', kShortAddressModes)
       .combine('offset', [false, true] as const)
       .beginSubcases()
       .combine('samplePoints', kSamplePointMethods)
   )
-  .beforeAllSubcases(t => {
-    skipIfTextureFormatNotSupportedNotAvailableOrNotFilterable(t, t.params.format);
-  })
   .fn(async t => {
     const { format, samplePoints, modeU, modeV, filt: minFilter, offset } = t.params;
-    skipIfNeedsFilteringAndIsUnfilterable(t, minFilter, format);
+    skipIfTextureFormatNotSupportedOrNeedsFilteringAndIsUnfilterable(t, minFilter, format);
 
     // We want at least 4 blocks or something wide enough for 3 mip levels.
     const [width, height] = chooseTextureSize({ minSize: 8, minBlocks: 4, format });
@@ -252,7 +246,7 @@ Parameters:
       .combine('dim', ['3d', 'cube'] as const)
       .filter(t => isSupportedViewFormatCombo(t.format, t.dim))
       .combine('filt', ['nearest', 'linear'] as const)
-      .filter(t => t.filt === 'nearest' || isFilterableAsTextureF32(t.format))
+      .filter(t => t.filt === 'nearest' || isTextureFormatPossiblyFilterableAsTextureF32(t.format))
       .combine('modeU', kShortAddressModes)
       .combine('modeV', kShortAddressModes)
       .combine('modeW', kShortAddressModes)
@@ -261,9 +255,6 @@ Parameters:
       .beginSubcases()
       .combine('samplePoints', kCubeSamplePointMethods)
       .filter(t => t.samplePoints !== 'cube-edges' || t.dim !== '3d')
-  )
-  .beforeAllSubcases(t =>
-    skipIfTextureFormatNotSupportedNotAvailableOrNotFilterable(t, t.params.format)
   )
   .fn(async t => {
     const {
@@ -276,7 +267,7 @@ Parameters:
       filt: minFilter,
       offset,
     } = t.params;
-    skipIfNeedsFilteringAndIsUnfilterable(t, minFilter, format);
+    skipIfTextureFormatNotSupportedOrNeedsFilteringAndIsUnfilterable(t, minFilter, format);
 
     const size = chooseTextureSize({ minSize: 8, minBlocks: 2, format, viewDimension });
     const descriptor: GPUTextureDescriptor = {
@@ -389,12 +380,10 @@ Parameters:
       .beginSubcases()
       .combine('samplePoints', kSamplePointMethods)
   )
-  .beforeAllSubcases(t => {
-    t.skipIfDepthTextureCanNotBeUsedWithNonComparisonSampler();
-    t.selectDeviceForTextureFormatOrSkipTestCase(t.params.format);
-  })
   .fn(async t => {
     const { format, samplePoints, modeU, modeV, offset } = t.params;
+    t.skipIfTextureFormatNotSupported(format);
+    t.skipIfDepthTextureCanNotBeUsedWithNonComparisonSampler();
 
     // We want at least 4 blocks or something wide enough for 3 mip levels.
     const [width, height] = chooseTextureSize({ minSize: 8, minBlocks: 4, format });
@@ -478,7 +467,7 @@ Parameters:
       .combine('format', kAllTextureFormats)
       .filter(t => isPotentiallyFilterableAndFillable(t.format))
       .combine('filt', ['nearest', 'linear'] as const)
-      .filter(t => t.filt === 'nearest' || isFilterableAsTextureF32(t.format))
+      .filter(t => t.filt === 'nearest' || isTextureFormatPossiblyFilterableAsTextureF32(t.format))
       .combine('modeU', kShortAddressModes)
       .combine('modeV', kShortAddressModes)
       .combine('offset', [false, true] as const)
@@ -486,9 +475,6 @@ Parameters:
       .combine('samplePoints', kSamplePointMethods)
       .combine('A', ['i32', 'u32'] as const)
       .combine('depthOrArrayLayers', [1, 8] as const)
-  )
-  .beforeAllSubcases(t =>
-    skipIfTextureFormatNotSupportedNotAvailableOrNotFilterable(t, t.params.format)
   )
   .fn(async t => {
     const {
@@ -501,7 +487,7 @@ Parameters:
       offset,
       depthOrArrayLayers,
     } = t.params;
-    skipIfNeedsFilteringAndIsUnfilterable(t, minFilter, format);
+    skipIfTextureFormatNotSupportedOrNeedsFilteringAndIsUnfilterable(t, minFilter, format);
 
     // We want at least 4 blocks or something wide enough for 3 mip levels.
     const [width, height] = chooseTextureSize({ minSize: 8, minBlocks: 4, format });
@@ -585,19 +571,16 @@ Parameters:
       .combine('format', kAllTextureFormats)
       .filter(t => isPotentiallyFilterableAndFillable(t.format))
       .combine('filt', ['nearest', 'linear'] as const)
-      .filter(t => t.filt === 'nearest' || isFilterableAsTextureF32(t.format))
+      .filter(t => t.filt === 'nearest' || isTextureFormatPossiblyFilterableAsTextureF32(t.format))
       .combine('mode', kShortAddressModes)
       .beginSubcases()
       .combine('samplePoints', kCubeSamplePointMethods)
       .combine('A', ['i32', 'u32'] as const)
   )
-  .beforeAllSubcases(t => {
-    skipIfTextureFormatNotSupportedNotAvailableOrNotFilterable(t, t.params.format);
-    t.skipIfTextureViewDimensionNotSupportedDeprecated('cube-array');
-  })
   .fn(async t => {
     const { format, samplePoints, A, mode, filt: minFilter } = t.params;
-    skipIfNeedsFilteringAndIsUnfilterable(t, minFilter, format);
+    t.skipIfTextureViewDimensionNotSupported('cube-array');
+    skipIfTextureFormatNotSupportedOrNeedsFilteringAndIsUnfilterable(t, minFilter, format);
 
     const viewDimension: GPUTextureViewDimension = 'cube-array';
     const size = chooseTextureSize({
@@ -692,13 +675,11 @@ Parameters:
       .beginSubcases()
       .combine('samplePoints', kCubeSamplePointMethods)
   )
-  .beforeAllSubcases(t => {
-    t.skipIfDepthTextureCanNotBeUsedWithNonComparisonSampler();
-    t.skipIfTextureViewDimensionNotSupportedDeprecated(t.params.viewDimension);
-    t.selectDeviceForTextureFormatOrSkipTestCase(t.params.format);
-  })
   .fn(async t => {
     const { format, viewDimension, samplePoints, A, mode } = t.params;
+    t.skipIfTextureFormatNotSupported(format);
+    t.skipIfTextureViewDimensionNotSupported(viewDimension);
+    t.skipIfDepthTextureCanNotBeUsedWithNonComparisonSampler();
 
     const size = chooseTextureSize({
       minSize: 32,
@@ -801,12 +782,10 @@ Parameters:
       .combine('L', ['i32', 'u32'] as const)
       .combine('depthOrArrayLayers', [1, 8] as const)
   )
-  .beforeAllSubcases(t => {
-    t.skipIfDepthTextureCanNotBeUsedWithNonComparisonSampler();
-    t.selectDeviceForTextureFormatOrSkipTestCase(t.params.format);
-  })
   .fn(async t => {
     const { format, samplePoints, mode, A, L, offset, depthOrArrayLayers } = t.params;
+    t.skipIfTextureFormatNotSupported(format);
+    t.skipIfDepthTextureCanNotBeUsedWithNonComparisonSampler();
 
     // We want at least 4 blocks or something wide enough for 3 mip levels.
     const [width, height] = chooseTextureSize({ minSize: 8, minBlocks: 4, format });
@@ -891,13 +870,11 @@ Parameters:
       .combine('samplePoints', kCubeSamplePointMethods)
       .combine('A', ['i32', 'u32'] as const)
   )
-  .beforeAllSubcases(t => {
-    t.skipIfDepthTextureCanNotBeUsedWithNonComparisonSampler();
-    t.skipIfTextureViewDimensionNotSupportedDeprecated('cube-array');
-    t.selectDeviceForTextureFormatOrSkipTestCase(t.params.format);
-  })
   .fn(async t => {
     const { format, samplePoints, A, mode } = t.params;
+    t.skipIfTextureFormatNotSupported(format);
+    t.skipIfDepthTextureCanNotBeUsedWithNonComparisonSampler();
+    t.skipIfTextureViewDimensionNotSupportedDeprecated('cube-array');
 
     const viewDimension: GPUTextureViewDimension = 'cube-array';
     const size = chooseTextureSize({

--- a/src/webgpu/shader/execution/expression/call/builtin/textureSampleBias.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureSampleBias.spec.ts
@@ -8,7 +8,10 @@ Samples a texture with a bias to the mip level.
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
-import { isFilterableAsTextureF32, kAllTextureFormats } from '../../../../../format_info.js';
+import {
+  isTextureFormatPossiblyFilterableAsTextureF32,
+  kAllTextureFormats,
+} from '../../../../../format_info.js';
 import { TextureTestMixin } from '../../../../../gpu_test.js';
 
 import {
@@ -28,11 +31,10 @@ import {
   SamplePointMethods,
   chooseTextureSize,
   isPotentiallyFilterableAndFillable,
-  skipIfTextureFormatNotSupportedNotAvailableOrNotFilterable,
   getTextureTypeForTextureViewDimension,
   WGSLTextureSampleTest,
   isSupportedViewFormatCombo,
-  skipIfNeedsFilteringAndIsUnfilterable,
+  skipIfTextureFormatNotSupportedOrNeedsFilteringAndIsUnfilterable,
 } from './texture_utils.js';
 
 export const g = makeTestGroup(TextureTestMixin(WGSLTextureSampleTest));
@@ -66,19 +68,16 @@ Parameters:
       .combine('format', kAllTextureFormats)
       .filter(t => isPotentiallyFilterableAndFillable(t.format))
       .combine('filt', ['nearest', 'linear'] as const)
-      .filter(t => t.filt === 'nearest' || isFilterableAsTextureF32(t.format))
+      .filter(t => t.filt === 'nearest' || isTextureFormatPossiblyFilterableAsTextureF32(t.format))
       .combine('modeU', kShortAddressModes)
       .combine('modeV', kShortAddressModes)
       .combine('offset', [false, true] as const)
       .beginSubcases()
       .combine('samplePoints', kSamplePointMethods)
   )
-  .beforeAllSubcases(t =>
-    skipIfTextureFormatNotSupportedNotAvailableOrNotFilterable(t, t.params.format)
-  )
   .fn(async t => {
     const { format, samplePoints, modeU, modeV, filt: minFilter, offset } = t.params;
-    skipIfNeedsFilteringAndIsUnfilterable(t, minFilter, format);
+    skipIfTextureFormatNotSupportedOrNeedsFilteringAndIsUnfilterable(t, minFilter, format);
 
     // We want at least something wide enough for 3 mip levels with more than 1 pixel at the smallest level
     const [width, height] = chooseTextureSize({
@@ -171,7 +170,7 @@ Parameters:
       .combine('dim', ['3d', 'cube'] as const)
       .filter(t => isSupportedViewFormatCombo(t.format, t.dim))
       .combine('filt', ['nearest', 'linear'] as const)
-      .filter(t => t.filt === 'nearest' || isFilterableAsTextureF32(t.format))
+      .filter(t => t.filt === 'nearest' || isTextureFormatPossiblyFilterableAsTextureF32(t.format))
       .combine('modeU', kShortAddressModes)
       .combine('modeV', kShortAddressModes)
       .combine('modeW', kShortAddressModes)
@@ -180,9 +179,6 @@ Parameters:
       .beginSubcases()
       .combine('samplePoints', kCubeSamplePointMethods)
       .filter(t => t.samplePoints !== 'cube-edges' || t.dim !== '3d')
-  )
-  .beforeAllSubcases(t =>
-    skipIfTextureFormatNotSupportedNotAvailableOrNotFilterable(t, t.params.format)
   )
   .fn(async t => {
     const {
@@ -195,7 +191,7 @@ Parameters:
       filt: minFilter,
       offset,
     } = t.params;
-    skipIfNeedsFilteringAndIsUnfilterable(t, minFilter, format);
+    skipIfTextureFormatNotSupportedOrNeedsFilteringAndIsUnfilterable(t, minFilter, format);
 
     const size = chooseTextureSize({ minSize: 8, minBlocks: 2, format, viewDimension });
     const descriptor: GPUTextureDescriptor = {
@@ -307,7 +303,7 @@ Parameters:
       .combine('format', kAllTextureFormats)
       .filter(t => isPotentiallyFilterableAndFillable(t.format))
       .combine('filt', ['nearest', 'linear'] as const)
-      .filter(t => t.filt === 'nearest' || isFilterableAsTextureF32(t.format))
+      .filter(t => t.filt === 'nearest' || isTextureFormatPossiblyFilterableAsTextureF32(t.format))
       .combine('modeU', kShortAddressModes)
       .combine('modeV', kShortAddressModes)
       .combine('offset', [false, true] as const)
@@ -315,12 +311,9 @@ Parameters:
       .combine('samplePoints', kSamplePointMethods)
       .combine('A', ['i32', 'u32'] as const)
   )
-  .beforeAllSubcases(t =>
-    skipIfTextureFormatNotSupportedNotAvailableOrNotFilterable(t, t.params.format)
-  )
   .fn(async t => {
     const { format, samplePoints, A, modeU, modeV, filt: minFilter, offset } = t.params;
-    skipIfNeedsFilteringAndIsUnfilterable(t, minFilter, format);
+    skipIfTextureFormatNotSupportedOrNeedsFilteringAndIsUnfilterable(t, minFilter, format);
 
     // We want at least something wide enough for 3 mip levels with more than 1 pixel at the smallest level
     const [width, height] = chooseTextureSize({
@@ -416,19 +409,15 @@ Parameters:
       .combine('format', kAllTextureFormats)
       .filter(t => isPotentiallyFilterableAndFillable(t.format))
       .combine('filt', ['nearest', 'linear'] as const)
-      .filter(t => t.filt === 'nearest' || isFilterableAsTextureF32(t.format))
+      .filter(t => t.filt === 'nearest' || isTextureFormatPossiblyFilterableAsTextureF32(t.format))
       .combine('mode', kShortAddressModes)
       .beginSubcases()
       .combine('samplePoints', kCubeSamplePointMethods)
       .combine('A', ['i32', 'u32'] as const)
   )
-  .beforeAllSubcases(t => {
-    skipIfTextureFormatNotSupportedNotAvailableOrNotFilterable(t, t.params.format);
-    t.skipIfTextureViewDimensionNotSupportedDeprecated('cube-array');
-  })
   .fn(async t => {
     const { format, samplePoints, A, mode, filt: minFilter } = t.params;
-    skipIfNeedsFilteringAndIsUnfilterable(t, minFilter, format);
+    skipIfTextureFormatNotSupportedOrNeedsFilteringAndIsUnfilterable(t, minFilter, format);
 
     const viewDimension: GPUTextureViewDimension = 'cube-array';
     const size = chooseTextureSize({

--- a/src/webgpu/shader/execution/expression/call/builtin/textureSampleCompare.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureSampleCompare.spec.ts
@@ -62,9 +62,9 @@ Parameters:
       .combine('samplePoints', kSamplePointMethods)
       .combine('compare', kCompareFunctions)
   )
-  .beforeAllSubcases(t => t.selectDeviceForTextureFormatOrSkipTestCase(t.params.format))
   .fn(async t => {
     const { format, samplePoints, modeU, modeV, filt: minFilter, compare, offset } = t.params;
+    t.skipIfTextureFormatNotSupported(format);
 
     const size = chooseTextureSize({ minSize: 16, minBlocks: 4, format });
 
@@ -153,9 +153,9 @@ Parameters:
       .combine('samplePoints', kCubeSamplePointMethods)
       .combine('compare', kCompareFunctions)
   )
-  .beforeAllSubcases(t => t.selectDeviceForTextureFormatOrSkipTestCase(t.params.format))
   .fn(async t => {
     const { format, samplePoints, mode, filt: minFilter, compare } = t.params;
+    t.skipIfTextureFormatNotSupported(format);
 
     const viewDimension: GPUTextureViewDimension = 'cube';
     const size = chooseTextureSize({ minSize: 16, minBlocks: 2, format, viewDimension });
@@ -262,10 +262,6 @@ Parameters:
       .combine('compare', kCompareFunctions)
       .combine('depthOrArrayLayers', [1, 8] as const)
   )
-  .beforeAllSubcases(t => {
-    t.skipIfTextureFormatNotSupportedDeprecated(t.params.format);
-    t.selectDeviceForTextureFormatOrSkipTestCase(t.params.format);
-  })
   .fn(async t => {
     const {
       format,
@@ -278,6 +274,7 @@ Parameters:
       offset,
       depthOrArrayLayers,
     } = t.params;
+    t.skipIfTextureFormatNotSupported(format);
 
     const [width, height] = chooseTextureSize({ minSize: 16, minBlocks: 4, format });
     const size = { width, height, depthOrArrayLayers };
@@ -375,12 +372,10 @@ Parameters:
       .combine('A', ['i32', 'u32'] as const)
       .combine('compare', kCompareFunctions)
   )
-  .beforeAllSubcases(t => {
-    t.skipIfTextureViewDimensionNotSupportedDeprecated('cube-array');
-    t.selectDeviceForTextureFormatOrSkipTestCase(t.params.format);
-  })
   .fn(async t => {
     const { format, A, samplePoints, mode, filt: minFilter, compare } = t.params;
+    t.skipIfTextureFormatNotSupported(format);
+    t.skipIfTextureViewDimensionNotSupported('cube-array');
 
     const viewDimension: GPUTextureViewDimension = 'cube-array';
     const size = chooseTextureSize({ minSize: 8, minBlocks: 2, format, viewDimension });

--- a/src/webgpu/shader/execution/expression/call/builtin/textureSampleCompareLevel.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureSampleCompareLevel.spec.ts
@@ -70,7 +70,6 @@ Parameters:
       .combine('samplePoints', kSamplePointMethods)
       .combine('compare', kCompareFunctions)
   )
-  .beforeAllSubcases(t => t.selectDeviceForTextureFormatOrSkipTestCase(t.params.format))
   .fn(async t => {
     const {
       format,
@@ -82,6 +81,7 @@ Parameters:
       compare,
       offset,
     } = t.params;
+    t.skipIfTextureFormatNotSupported(format);
 
     const size = chooseTextureSize({ minSize: 16, minBlocks: 4, format });
 
@@ -171,9 +171,9 @@ Parameters:
       .combine('samplePoints', kCubeSamplePointMethods)
       .combine('compare', kCompareFunctions)
   )
-  .beforeAllSubcases(t => t.selectDeviceForTextureFormatOrSkipTestCase(t.params.format))
   .fn(async t => {
     const { format, stage, samplePoints, mode, filt: minFilter, compare } = t.params;
+    t.skipIfTextureFormatNotSupported(format);
 
     const viewDimension: GPUTextureViewDimension = 'cube';
     const size = chooseTextureSize({ minSize: 16, minBlocks: 2, format, viewDimension });
@@ -281,10 +281,6 @@ Parameters:
       .combine('compare', kCompareFunctions)
       .combine('depthOrArrayLayers', [1, 8] as const)
   )
-  .beforeAllSubcases(t => {
-    t.skipIfTextureFormatNotSupportedDeprecated(t.params.format);
-    t.selectDeviceForTextureFormatOrSkipTestCase(t.params.format);
-  })
   .fn(async t => {
     const {
       format,
@@ -298,6 +294,7 @@ Parameters:
       offset,
       depthOrArrayLayers,
     } = t.params;
+    t.skipIfTextureFormatNotSupported(format);
 
     const [width, height] = chooseTextureSize({ minSize: 16, minBlocks: 4, format });
     const size = { width, height, depthOrArrayLayers };

--- a/src/webgpu/shader/execution/expression/call/builtin/textureSampleGrad.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureSampleGrad.spec.ts
@@ -6,7 +6,10 @@ Samples a texture using explicit gradients.
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
-import { isFilterableAsTextureF32, kAllTextureFormats } from '../../../../../format_info.js';
+import {
+  isTextureFormatPossiblyFilterableAsTextureF32,
+  kAllTextureFormats,
+} from '../../../../../format_info.js';
 
 import {
   appendComponentTypeForFormatToTextureType,
@@ -26,8 +29,7 @@ import {
   kShortAddressModeToAddressMode,
   kShortShaderStages,
   SamplePointMethods,
-  skipIfNeedsFilteringAndIsUnfilterable,
-  skipIfTextureFormatNotSupportedNotAvailableOrNotFilterable,
+  skipIfTextureFormatNotSupportedOrNeedsFilteringAndIsUnfilterable,
   TextureCall,
   vec2,
   vec3,
@@ -63,19 +65,16 @@ Parameters:
       .combine('format', kAllTextureFormats)
       .filter(t => isPotentiallyFilterableAndFillable(t.format))
       .combine('filt', ['nearest', 'linear'] as const)
-      .filter(t => t.filt === 'nearest' || isFilterableAsTextureF32(t.format))
+      .filter(t => t.filt === 'nearest' || isTextureFormatPossiblyFilterableAsTextureF32(t.format))
       .combine('modeU', kShortAddressModes)
       .combine('modeV', kShortAddressModes)
       .combine('offset', [false, true] as const)
       .beginSubcases()
       .combine('samplePoints', kSamplePointMethods)
   )
-  .beforeAllSubcases(t =>
-    skipIfTextureFormatNotSupportedNotAvailableOrNotFilterable(t, t.params.format)
-  )
   .fn(async t => {
     const { format, stage, samplePoints, modeU, modeV, filt: minFilter, offset } = t.params;
-    skipIfNeedsFilteringAndIsUnfilterable(t, minFilter, format);
+    skipIfTextureFormatNotSupportedOrNeedsFilteringAndIsUnfilterable(t, minFilter, format);
 
     // We want at least 4 blocks or something wide enough for 3 mip levels.
     const [width, height] = chooseTextureSize({ minSize: 8, minBlocks: 4, format });
@@ -165,7 +164,7 @@ Parameters:
       .combine('dim', ['3d', 'cube'] as const)
       .filter(t => isSupportedViewFormatCombo(t.format, t.dim))
       .combine('filt', ['nearest', 'linear'] as const)
-      .filter(t => t.filt === 'nearest' || isFilterableAsTextureF32(t.format))
+      .filter(t => t.filt === 'nearest' || isTextureFormatPossiblyFilterableAsTextureF32(t.format))
       .combine('modeU', kShortAddressModes)
       .combine('modeV', kShortAddressModes)
       .combine('modeW', kShortAddressModes)
@@ -174,9 +173,6 @@ Parameters:
       .beginSubcases()
       .combine('samplePoints', kCubeSamplePointMethods)
       .filter(t => t.samplePoints !== 'cube-edges' || t.dim !== '3d')
-  )
-  .beforeAllSubcases(t =>
-    skipIfTextureFormatNotSupportedNotAvailableOrNotFilterable(t, t.params.format)
   )
   .fn(async t => {
     const {
@@ -190,7 +186,7 @@ Parameters:
       filt: minFilter,
       offset,
     } = t.params;
-    skipIfNeedsFilteringAndIsUnfilterable(t, minFilter, format);
+    skipIfTextureFormatNotSupportedOrNeedsFilteringAndIsUnfilterable(t, minFilter, format);
 
     const size = chooseTextureSize({ minSize: 8, minBlocks: 2, format, viewDimension });
     const descriptor: GPUTextureDescriptor = {
@@ -304,7 +300,7 @@ Parameters:
       .combine('format', kAllTextureFormats)
       .filter(t => isPotentiallyFilterableAndFillable(t.format))
       .combine('filt', ['nearest', 'linear'] as const)
-      .filter(t => t.filt === 'nearest' || isFilterableAsTextureF32(t.format))
+      .filter(t => t.filt === 'nearest' || isTextureFormatPossiblyFilterableAsTextureF32(t.format))
       .combine('modeU', kShortAddressModes)
       .combine('modeV', kShortAddressModes)
       .combine('offset', [false, true] as const)
@@ -312,9 +308,6 @@ Parameters:
       .combine('samplePoints', kSamplePointMethods)
       .combine('A', ['i32', 'u32'] as const)
       .combine('depthOrArrayLayers', [1, 8] as const)
-  )
-  .beforeAllSubcases(t =>
-    skipIfTextureFormatNotSupportedNotAvailableOrNotFilterable(t, t.params.format)
   )
   .fn(async t => {
     const {
@@ -328,7 +321,7 @@ Parameters:
       offset,
       depthOrArrayLayers,
     } = t.params;
-    skipIfNeedsFilteringAndIsUnfilterable(t, minFilter, format);
+    skipIfTextureFormatNotSupportedOrNeedsFilteringAndIsUnfilterable(t, minFilter, format);
 
     // We want at least 4 blocks or something wide enough for 3 mip levels.
     const [width, height] = chooseTextureSize({ minSize: 8, minBlocks: 4, format });
@@ -422,19 +415,16 @@ Parameters:
       .combine('format', kAllTextureFormats)
       .filter(t => isPotentiallyFilterableAndFillable(t.format))
       .combine('filt', ['nearest', 'linear'] as const)
-      .filter(t => t.filt === 'nearest' || isFilterableAsTextureF32(t.format))
+      .filter(t => t.filt === 'nearest' || isTextureFormatPossiblyFilterableAsTextureF32(t.format))
       .combine('mode', kShortAddressModes)
       .beginSubcases()
       .combine('samplePoints', kCubeSamplePointMethods)
       .combine('A', ['i32', 'u32'] as const)
   )
-  .beforeAllSubcases(t => {
-    skipIfTextureFormatNotSupportedNotAvailableOrNotFilterable(t, t.params.format);
-    t.skipIfTextureViewDimensionNotSupportedDeprecated('cube-array');
-  })
   .fn(async t => {
     const { format, stage, samplePoints, A, mode, filt: minFilter } = t.params;
-    skipIfNeedsFilteringAndIsUnfilterable(t, minFilter, format);
+    skipIfTextureFormatNotSupportedOrNeedsFilteringAndIsUnfilterable(t, minFilter, format);
+    t.skipIfTextureViewDimensionNotSupported('cube-array');
 
     const viewDimension: GPUTextureViewDimension = 'cube-array';
     const size = chooseTextureSize({

--- a/src/webgpu/shader/execution/expression/call/builtin/textureSampleLevel.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureSampleLevel.spec.ts
@@ -7,7 +7,7 @@ Samples a texture.
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import {
   isDepthTextureFormat,
-  isFilterableAsTextureF32,
+  isTextureFormatPossiblyFilterableAsTextureF32,
   kAllTextureFormats,
   kDepthStencilFormats,
 } from '../../../../../format_info.js';
@@ -31,8 +31,7 @@ import {
   kShortAddressModeToAddressMode,
   kShortShaderStages,
   SamplePointMethods,
-  skipIfNeedsFilteringAndIsUnfilterable,
-  skipIfTextureFormatNotSupportedNotAvailableOrNotFilterable,
+  skipIfTextureFormatNotSupportedOrNeedsFilteringAndIsUnfilterable,
   TextureCall,
   vec2,
   vec3,
@@ -71,19 +70,16 @@ Parameters:
       .combine('format', kAllTextureFormats)
       .filter(t => isPotentiallyFilterableAndFillable(t.format))
       .combine('filt', ['nearest', 'linear'] as const)
-      .filter(t => t.filt === 'nearest' || isFilterableAsTextureF32(t.format))
+      .filter(t => t.filt === 'nearest' || isTextureFormatPossiblyFilterableAsTextureF32(t.format))
       .combine('modeU', kShortAddressModes)
       .combine('modeV', kShortAddressModes)
       .combine('offset', [false, true] as const)
       .beginSubcases()
       .combine('samplePoints', kSamplePointMethods)
   )
-  .beforeAllSubcases(t =>
-    skipIfTextureFormatNotSupportedNotAvailableOrNotFilterable(t, t.params.format)
-  )
   .fn(async t => {
     const { format, stage, samplePoints, modeU, modeV, filt: minFilter, offset } = t.params;
-    skipIfNeedsFilteringAndIsUnfilterable(t, minFilter, format);
+    skipIfTextureFormatNotSupportedOrNeedsFilteringAndIsUnfilterable(t, minFilter, format);
 
     // We want at least 4 blocks or something wide enough for 3 mip levels.
     const [width, height] = chooseTextureSize({ minSize: 8, minBlocks: 4, format });
@@ -176,7 +172,7 @@ Parameters:
       .combine('format', kAllTextureFormats)
       .filter(t => isPotentiallyFilterableAndFillable(t.format))
       .combine('filt', ['nearest', 'linear'] as const)
-      .filter(t => t.filt === 'nearest' || isFilterableAsTextureF32(t.format))
+      .filter(t => t.filt === 'nearest' || isTextureFormatPossiblyFilterableAsTextureF32(t.format))
       .combine('modeU', kShortAddressModes)
       .combine('modeV', kShortAddressModes)
       .combine('offset', [false, true] as const)
@@ -184,9 +180,6 @@ Parameters:
       .combine('samplePoints', kSamplePointMethods)
       .combine('A', ['i32', 'u32'] as const)
       .combine('depthOrArrayLayers', [1, 8] as const)
-  )
-  .beforeAllSubcases(t =>
-    skipIfTextureFormatNotSupportedNotAvailableOrNotFilterable(t, t.params.format)
   )
   .fn(async t => {
     const {
@@ -200,7 +193,7 @@ Parameters:
       offset,
       depthOrArrayLayers,
     } = t.params;
-    skipIfNeedsFilteringAndIsUnfilterable(t, minFilter, format);
+    skipIfTextureFormatNotSupportedOrNeedsFilteringAndIsUnfilterable(t, minFilter, format);
 
     // We want at least 4 blocks or something wide enough for 3 mip levels.
     const [width, height] = chooseTextureSize({ minSize: 8, minBlocks: 4, format });
@@ -298,16 +291,13 @@ Parameters:
       .combine('dim', ['3d', 'cube'] as const)
       .filter(t => isSupportedViewFormatCombo(t.format, t.dim))
       .combine('filt', ['nearest', 'linear'] as const)
-      .filter(t => t.filt === 'nearest' || isFilterableAsTextureF32(t.format))
+      .filter(t => t.filt === 'nearest' || isTextureFormatPossiblyFilterableAsTextureF32(t.format))
       .combine('mode', kShortAddressModes)
       .combine('offset', [false, true] as const)
       .filter(t => t.dim !== 'cube' || t.offset !== true)
       .beginSubcases()
       .combine('samplePoints', kCubeSamplePointMethods)
       .filter(t => t.samplePoints !== 'cube-edges' || t.dim !== '3d')
-  )
-  .beforeAllSubcases(t =>
-    skipIfTextureFormatNotSupportedNotAvailableOrNotFilterable(t, t.params.format)
   )
   .fn(async t => {
     const {
@@ -319,7 +309,7 @@ Parameters:
       filt: minFilter,
       offset,
     } = t.params;
-    skipIfNeedsFilteringAndIsUnfilterable(t, minFilter, format);
+    skipIfTextureFormatNotSupportedOrNeedsFilteringAndIsUnfilterable(t, minFilter, format);
 
     const [width, height] = chooseTextureSize({ minSize: 32, minBlocks: 2, format, viewDimension });
     const depthOrArrayLayers = getDepthOrArrayLayersForViewDimension(viewDimension);
@@ -430,19 +420,16 @@ Parameters:
       .combine('format', kAllTextureFormats)
       .filter(t => isPotentiallyFilterableAndFillable(t.format))
       .combine('filt', ['nearest', 'linear'] as const)
-      .filter(t => t.filt === 'nearest' || isFilterableAsTextureF32(t.format))
+      .filter(t => t.filt === 'nearest' || isTextureFormatPossiblyFilterableAsTextureF32(t.format))
       .combine('mode', kShortAddressModes)
       .beginSubcases()
       .combine('samplePoints', kCubeSamplePointMethods)
       .combine('A', ['i32', 'u32'] as const)
   )
-  .beforeAllSubcases(t => {
-    skipIfTextureFormatNotSupportedNotAvailableOrNotFilterable(t, t.params.format);
-    t.skipIfTextureViewDimensionNotSupportedDeprecated('cube-array');
-  })
   .fn(async t => {
     const { format, stage, samplePoints, A, mode, filt: minFilter } = t.params;
-    skipIfNeedsFilteringAndIsUnfilterable(t, minFilter, format);
+    skipIfTextureFormatNotSupportedOrNeedsFilteringAndIsUnfilterable(t, minFilter, format);
+    t.skipIfTextureViewDimensionNotSupported('cube-array');
 
     const viewDimension: GPUTextureViewDimension = 'cube-array';
     const size = chooseTextureSize({
@@ -549,12 +536,10 @@ Parameters:
       .combine('samplePoints', kSamplePointMethods)
       .combine('L', ['i32', 'u32'] as const)
   )
-  .beforeAllSubcases(t => {
-    t.skipIfDepthTextureCanNotBeUsedWithNonComparisonSampler();
-    skipIfTextureFormatNotSupportedNotAvailableOrNotFilterable(t, t.params.format);
-  })
   .fn(async t => {
     const { format, stage, samplePoints, mode, L, offset } = t.params;
+    t.skipIfTextureFormatNotSupported(format);
+    t.skipIfDepthTextureCanNotBeUsedWithNonComparisonSampler();
 
     // We want at least 4 blocks or something wide enough for 3 mip levels.
     const [width, height] = chooseTextureSize({ minSize: 8, minBlocks: 4, format });
@@ -653,12 +638,10 @@ Parameters:
       .combine('L', ['i32', 'u32'] as const)
       .combine('depthOrArrayLayers', [1, 8] as const)
   )
-  .beforeAllSubcases(t => {
-    t.skipIfDepthTextureCanNotBeUsedWithNonComparisonSampler();
-    skipIfTextureFormatNotSupportedNotAvailableOrNotFilterable(t, t.params.format);
-  })
   .fn(async t => {
     const { format, stage, samplePoints, mode, A, L, offset, depthOrArrayLayers } = t.params;
+    t.skipIfTextureFormatNotSupported(format);
+    t.skipIfDepthTextureCanNotBeUsedWithNonComparisonSampler();
 
     // We want at least 4 blocks or something wide enough for 3 mip levels.
     const [width, height] = chooseTextureSize({ minSize: 8, minBlocks: 4, format });
@@ -762,13 +745,11 @@ Parameters:
       .combine('samplePoints', kCubeSamplePointMethods)
       .combine('L', ['i32', 'u32'] as const)
   )
-  .beforeAllSubcases(t => {
-    t.skipIfDepthTextureCanNotBeUsedWithNonComparisonSampler();
-    skipIfTextureFormatNotSupportedNotAvailableOrNotFilterable(t, t.params.format);
-    t.skipIfTextureViewDimensionNotSupportedDeprecated(t.params.viewDimension);
-  })
   .fn(async t => {
     const { format, stage, viewDimension, samplePoints, A, L, mode } = t.params;
+    t.skipIfTextureFormatNotSupported(format);
+    t.skipIfDepthTextureCanNotBeUsedWithNonComparisonSampler();
+    t.skipIfTextureViewDimensionNotSupported(viewDimension);
 
     const size = chooseTextureSize({
       minSize: 32,

--- a/src/webgpu/shader/execution/expression/call/builtin/textureStore.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureStore.spec.ts
@@ -13,7 +13,10 @@ If an out-of-bounds access occurs, the built-in function should not be executed.
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { unreachable, iterRange, range } from '../../../../../../common/util/util.js';
-import { kTextureFormatInfo } from '../../../../../format_info.js';
+import {
+  isTextureFormatPossiblyStorageReadWritable,
+  kPossibleStorageTextureFormats,
+} from '../../../../../format_info.js';
 import { AllFeaturesMaxLimitsGPUTest, TextureTestMixin } from '../../../../../gpu_test.js';
 import {
   kFloat32Format,
@@ -24,7 +27,8 @@ import {
 } from '../../../../../util/conversion.js';
 import { align, clamp } from '../../../../../util/math.js';
 import { getTextureDimensionFromView, virtualMipSize } from '../../../../../util/texture/base.js';
-import { TexelFormats } from '../../../../types.js';
+
+import { getTextureFormatTypeInfo } from './texture_utils.js';
 
 const kDims = ['1d', '2d', '3d'] as const;
 const kViewDimensions = ['1d', '2d', '2d-array', '3d'] as const;
@@ -82,15 +86,13 @@ g.test('texel_formats')
   )
   .params(u =>
     u
-      .combineWithParams([...TexelFormats, { format: 'bgra8unorm', _shaderType: 'f32' }])
+      .combine('format', kPossibleStorageTextureFormats)
       .combine('viewDimension', kViewDimensions)
       // Note: We can't use writable storage textures in a vertex stage.
       .combine('stage', ['compute', 'fragment'] as const)
       .combine('access', ['write', 'read_write'] as const)
       .unless(
-        t =>
-          t.access === 'read_write' &&
-          !kTextureFormatInfo[t.format as GPUTextureFormat].color?.readWriteStorage
+        t => t.access === 'read_write' && !isTextureFormatPossiblyStorageReadWritable(t.format)
       )
       .combine('mipLevel', [0, 1, 2] as const)
       .unless(t => t.viewDimension === '1d' && t.mipLevel !== 0)
@@ -103,7 +105,8 @@ g.test('texel_formats')
     }
   })
   .fn(t => {
-    const { format, stage, access, viewDimension, _shaderType, mipLevel } = t.params;
+    const { format, stage, access, viewDimension, mipLevel } = t.params;
+    const { componentType } = getTextureFormatTypeInfo(format);
     const values = inputArray(format);
 
     t.skipIf(
@@ -130,7 +133,7 @@ fn setValue(gid: vec3u) {
     range[(ndx + 2) % ${values.length}],
     range[(ndx + 3) % ${values.length}],
   );
-  var val = vec4<${_shaderType}>(vecVal);
+  var val = vec4<${componentType}>(vecVal);
   let coord = gid.${swizzleWGSL};
   textureStore(tex, coord${layerWGSL}, val);
 }

--- a/src/webgpu/shader/execution/expression/call/builtin/texture_utils.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/texture_utils.spec.ts
@@ -5,10 +5,10 @@ Tests for texture_utils.ts
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { assert } from '../../../../../../common/util/util.js';
 import {
-  isMultisampledTextureFormatDeprecated,
+  isTextureFormatPossiblyMultisampled,
   kDepthStencilFormats,
 } from '../../../../../format_info.js';
-import { GPUTest } from '../../../../../gpu_test.js';
+import { AllFeaturesMaxLimitsGPUTest, GPUTest } from '../../../../../gpu_test.js';
 import { getTextureDimensionFromView, virtualMipSize } from '../../../../../util/texture/base.js';
 import {
   kTexelRepresentationInfo,
@@ -29,7 +29,7 @@ import {
   texelsApproximatelyEqual,
 } from './texture_utils.js';
 
-export const g = makeTestGroup(GPUTest);
+export const g = makeTestGroup(AllFeaturesMaxLimitsGPUTest);
 
 function texelFormat(texel: Readonly<PerTexelComponent<number>>, rep: TexelRepresentationInfo) {
   return rep.componentOrder.map(component => `${component}: ${texel[component]}`).join(', ');
@@ -49,12 +49,10 @@ g.test('createTextureWithRandomDataAndGetTexels_with_generator')
       .combine('viewDimension', ['2d', '2d-array', 'cube', 'cube-array'] as const)
       .filter(t => isSupportedViewFormatCombo(t.format, t.viewDimension))
   )
-  .beforeAllSubcases(t => {
-    t.skipIfTextureViewDimensionNotSupportedDeprecated(t.params.viewDimension);
-    t.selectDeviceForTextureFormatOrSkipTestCase(t.params.format);
-  })
   .fn(async t => {
     const { format, viewDimension } = t.params;
+    t.skipIfTextureFormatNotSupported(format);
+    t.skipIfTextureViewDimensionNotSupported(viewDimension);
     // choose an odd size (9) so we're more likely to test alignment issue.
     const size = chooseTextureSize({ minSize: 9, minBlocks: 4, format, viewDimension });
     t.debug(`size: ${size.map(v => v.toString()).join(', ')}`);
@@ -93,16 +91,15 @@ g.test('readTextureToTexelViews')
       .unless(
         t =>
           t.sampleCount > 1 &&
-          (!isMultisampledTextureFormatDeprecated(t.srcFormat, false) || t.viewDimension !== '2d')
+          (!isTextureFormatPossiblyMultisampled(t.srcFormat) || t.viewDimension !== '2d')
       )
   )
-  .beforeAllSubcases(t => {
-    t.skipIfTextureViewDimensionNotSupportedDeprecated(t.params.viewDimension);
-    // recheck if multisampled is supported with compat mode flag
-    t.skipIfMultisampleNotSupportedForFormatDeprecated(t.params.srcFormat);
-  })
   .fn(async t => {
     const { srcFormat, texelViewFormat, viewDimension, sampleCount } = t.params;
+    t.skipIfTextureViewDimensionNotSupported(viewDimension);
+    if (sampleCount > 1) {
+      t.skipIfTextureFormatNotMultisampled(srcFormat);
+    }
     // choose an odd size (9) so we're more likely to test alignment issue.
     const size = chooseTextureSize({ minSize: 9, minBlocks: 4, format: srcFormat, viewDimension });
     t.debug(`size: ${size.map(v => v.toString()).join(', ')}`);

--- a/src/webgpu/shader/execution/expression/call/builtin/texture_utils.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/texture_utils.ts
@@ -2,8 +2,13 @@ import { keysOf } from '../../../../../../common/util/data_tables.js';
 import { assert, range, unreachable } from '../../../../../../common/util/util.js';
 import { Float16Array } from '../../../../../../external/petamoriken/float16/float16.js';
 import {
+  ColorTextureFormat,
   EncodableTextureFormat,
+  getBlockInfoForColorTextureFormat,
+  getBlockInfoForTextureFormat,
+  getTextureFormatType,
   is32Float,
+  isColorTextureFormat,
   isCompressedFloatTextureFormat,
   isCompressedTextureFormat,
   isDepthOrStencilTextureFormat,
@@ -12,13 +17,8 @@ import {
   isSintOrUintFormat,
   isStencilTextureFormat,
   kEncodableTextureFormats,
-  kTextureFormatInfo,
 } from '../../../../../format_info.js';
-import {
-  AllFeaturesMaxLimitsGPUTest,
-  GPUTest,
-  GPUTestSubcaseBatchState,
-} from '../../../../../gpu_test.js';
+import { AllFeaturesMaxLimitsGPUTest, GPUTest } from '../../../../../gpu_test.js';
 import {
   align,
   clamp,
@@ -121,39 +121,20 @@ const isUnencodableDepthFormat = (format: GPUTextureFormat) =>
  * Skips a subcase if the filter === 'linear' and the format is type
  * 'unfilterable-float' and we cannot enable filtering.
  */
-export function skipIfNeedsFilteringAndIsUnfilterableOrSelectDevice(
-  t: GPUTestSubcaseBatchState,
-  filter: GPUFilterMode,
-  format: GPUTextureFormat
-) {
-  const features = new Set<GPUFeatureName | undefined>();
-  features.add(kTextureFormatInfo[format].feature);
-
-  if (filter === 'linear') {
-    t.skipIf(isDepthTextureFormat(format), 'depth texture are unfilterable');
-
-    const type = kTextureFormatInfo[format].color?.type;
-    if (type === 'unfilterable-float') {
-      assert(is32Float(format));
-      features.add('float32-filterable');
-    }
-  }
-
-  if (features.size > 0) {
-    t.selectDeviceOrSkipTestCase(Array.from(features));
-  }
-}
-
-/**
- * Skips a test if filter === 'linear' and the format is not filterable
- */
-export function skipIfNeedsFilteringAndIsUnfilterable(
+export function skipIfTextureFormatNotSupportedOrNeedsFilteringAndIsUnfilterable(
   t: GPUTest,
   filter: GPUFilterMode,
   format: GPUTextureFormat
 ) {
+  t.skipIfTextureFormatNotSupported(format);
   if (filter === 'linear') {
-    t.skipIf(isDepthTextureFormat(format), 'depth textures are unfilterable');
+    t.skipIf(isDepthTextureFormat(format), 'depth texture are unfilterable');
+
+    const type = getTextureFormatType(format);
+    if (type === 'unfilterable-float') {
+      assert(is32Float(format));
+      t.skipIfDeviceDoesNotHaveFeature('float32-filterable');
+    }
   }
 }
 
@@ -170,28 +151,11 @@ export function isFillable(format: GPUTextureFormat) {
  * Returns if a texture format can potentially be filtered and can be filled with random data.
  */
 export function isPotentiallyFilterableAndFillable(format: GPUTextureFormat) {
-  const info = kTextureFormatInfo[format];
-  const type = info.color?.type ?? info.depth?.type;
+  const type = getTextureFormatType(format);
   const canPotentiallyFilter =
     type === 'float' || type === 'unfilterable-float' || type === 'depth';
   const result = canPotentiallyFilter && isFillable(format);
   return result;
-}
-
-/**
- * skips the test if the texture format is not supported or not available or not filterable.
- */
-export function skipIfTextureFormatNotSupportedNotAvailableOrNotFilterable(
-  t: GPUTestSubcaseBatchState,
-  format: GPUTextureFormat
-) {
-  t.skipIfTextureFormatNotSupportedDeprecated(format);
-  const info = kTextureFormatInfo[format];
-  if (info.color?.type === 'unfilterable-float') {
-    t.selectDeviceOrSkipTestCase('float32-filterable');
-  } else {
-    t.selectDeviceForTextureFormatOrSkipTestCase(format);
-  }
 }
 
 const builtinNeedsMipLevelWeights = (builtin: TextureBuiltin) =>
@@ -905,9 +869,9 @@ struct VOut {
           ? 'unfilterable-float'
           : isStencilTextureFormat(texture.format)
           ? 'uint'
-          : texture.sampleCount > 1 && kTextureFormatInfo[texture.format].color?.type === 'float'
+          : texture.sampleCount > 1 && getTextureFormatType(texture.format) === 'float'
           ? 'unfilterable-float'
-          : kTextureFormatInfo[texture.format].color?.type ?? 'unfilterable-float';
+          : getTextureFormatType(texture.format) ?? 'unfilterable-float';
       entries.push({
         binding: 0,
         visibility,
@@ -1046,7 +1010,7 @@ struct VOut {
 /**
  * Used for textureSampleXXX
  */
-export class WGSLTextureSampleTest extends GPUTest {
+export class WGSLTextureSampleTest extends AllFeaturesMaxLimitsGPUTest {
   override async init(): Promise<void> {
     await super.init();
   }
@@ -1127,9 +1091,8 @@ const kTextureTypeInfo = {
   },
 } as const;
 
-function getTextureFormatTypeInfo(format: GPUTextureFormat) {
-  const info = kTextureFormatInfo[format];
-  const type = info.color?.type ?? info.depth?.type ?? info.stencil?.type;
+export function getTextureFormatTypeInfo(format: GPUTextureFormat) {
+  const type = getTextureFormatType(format);
   assert(!!type);
   return kTextureTypeInfo[type];
 }
@@ -1244,11 +1207,11 @@ function createRandomTexelViewViaBytes(info: {
   sampleCount: number;
 }): TexelView {
   const { format } = info;
-  const formatInfo = kTextureFormatInfo[format];
+  const formatInfo = getBlockInfoForTextureFormat(format);
   const rep = kTexelRepresentationInfo[info.format as EncodableTextureFormat];
   assert(!!rep);
-  const bytesPerBlock = (formatInfo.color?.bytes ?? formatInfo.stencil?.bytes)!;
-  assert(bytesPerBlock > 0);
+  const { bytesPerBlock } = formatInfo;
+  assert(bytesPerBlock !== undefined && bytesPerBlock > 0);
   const size = physicalMipSize(reifyExtent3D(info.size), info.format, '2d', 0);
   const blocksAcross = Math.ceil(size.width / formatInfo.blockWidth);
   const blocksDown = Math.ceil(size.height / formatInfo.blockHeight);
@@ -1303,15 +1266,15 @@ function createRandomTexelView(
   },
   options?: RandomTextureOptions | undefined
 ): TexelView {
-  assert(!isCompressedTextureFormat(info.format));
-  const formatInfo = kTextureFormatInfo[info.format];
-  const type = formatInfo.color?.type ?? formatInfo.depth?.type ?? formatInfo.stencil?.type;
+  const { format } = info;
+  assert(!isCompressedTextureFormat(format));
+  const type = getTextureFormatType(format);
   const canFillWithRandomTypedData =
     !options &&
-    isEncodableTextureFormat(info.format) &&
-    ((info.format.includes('norm') && type !== 'depth') ||
-      info.format.includes('16float') ||
-      (info.format.includes('32float') && type !== 'depth') ||
+    isEncodableTextureFormat(format) &&
+    ((format.includes('norm') && type !== 'depth') ||
+      format.includes('16float') ||
+      (format.includes('32float') && type !== 'depth') ||
       type === 'sint' ||
       type === 'uint');
 
@@ -2477,8 +2440,8 @@ export async function checkCallResults<T extends Dimensionality>(
     });
 
     const isFloatType = (format: GPUTextureFormat) => {
-      const info = kTextureFormatInfo[format];
-      return info.color?.type === 'float' || info.depth?.type === 'depth';
+      const type = getTextureFormatType(format);
+      return type === 'float' || type === 'depth';
     };
     const fix5 = (n: number) => (isFloatType(format) ? n.toFixed(5) : n.toString());
     const fix5v = (arr: number[]) => arr.map(v => fix5(v)).join(', ');
@@ -2782,9 +2745,8 @@ const sumOfCharCodesOfString = (s: unknown) =>
  * See Spec:
  * https://registry.khronos.org/OpenGL/extensions/KHR/KHR_texture_compression_astc_hdr.txt
  */
-function makeAstcBlockFiller(format: GPUTextureFormat) {
-  const info = kTextureFormatInfo[format];
-  const bytesPerBlock = info.color!.bytes;
+function makeAstcBlockFiller(format: ColorTextureFormat) {
+  const { bytesPerBlock } = getBlockInfoForColorTextureFormat(format);
   return (data: Uint8Array, offset: number, hashBase: number) => {
     // set the block to be a void-extent block
     data.set(
@@ -2811,9 +2773,8 @@ function makeAstcBlockFiller(format: GPUTextureFormat) {
 /**
  * Makes a function that fills a block portion of a Uint8Array with random bytes.
  */
-function makeRandomBytesBlockFiller(format: GPUTextureFormat) {
-  const info = kTextureFormatInfo[format];
-  const bytesPerBlock = info.color!.bytes;
+function makeRandomBytesBlockFiller(format: ColorTextureFormat) {
+  const { bytesPerBlock } = getBlockInfoForColorTextureFormat(format);
   return (data: Uint8Array, offset: number, hashBase: number) => {
     const end = offset + bytesPerBlock;
     for (let i = offset; i < end; ++i) {
@@ -2822,7 +2783,7 @@ function makeRandomBytesBlockFiller(format: GPUTextureFormat) {
   };
 }
 
-function getBlockFiller(format: GPUTextureFormat) {
+function getBlockFiller(format: ColorTextureFormat) {
   if (format.startsWith('astc')) {
     return makeAstcBlockFiller(format);
   } else {
@@ -2834,8 +2795,9 @@ function getBlockFiller(format: GPUTextureFormat) {
  * Fills a texture with random data.
  */
 function fillTextureWithRandomData(device: GPUDevice, texture: GPUTexture) {
+  assert(isColorTextureFormat(texture.format));
   assert(!isCompressedFloatTextureFormat(texture.format));
-  const info = kTextureFormatInfo[texture.format];
+  const info = getBlockInfoForColorTextureFormat(texture.format as ColorTextureFormat);
   const hashBase =
     sumOfCharCodesOfString(texture.format) +
     sumOfCharCodesOfString(texture.dimension) +
@@ -2843,8 +2805,8 @@ function fillTextureWithRandomData(device: GPUDevice, texture: GPUTexture) {
     texture.height +
     texture.depthOrArrayLayers +
     texture.mipLevelCount;
-  const bytesPerBlock = info.color!.bytes;
-  const fillBlock = getBlockFiller(texture.format);
+  const bytesPerBlock = info.bytesPerBlock;
+  const fillBlock = getBlockFiller(texture.format as ColorTextureFormat);
   for (let mipLevel = 0; mipLevel < texture.mipLevelCount; ++mipLevel) {
     const size = physicalMipSizeFromTexture(texture, mipLevel);
     const blocksAcross = Math.ceil(size[0] / info.blockWidth);
@@ -3011,14 +2973,14 @@ export async function readTextureToTexelViews(
         }
       `,
     });
-    const info = kTextureFormatInfo[texture.format];
-    const sampleType = info.depth
+    const type = getTextureFormatType(texture.format);
+    const sampleType = isDepthTextureFormat(texture.format)
       ? 'unfilterable-float' // depth only supports unfilterable-float if not a comparison.
-      : info.stencil
+      : isStencilTextureFormat(texture.format)
       ? 'uint'
-      : info.color.type === 'float'
+      : type === 'float'
       ? 'unfilterable-float'
-      : info.color.type;
+      : type;
     const bindGroupLayout = device.createBindGroupLayout({
       entries: [
         {
@@ -3488,7 +3450,7 @@ async function identifySamplePoints<T extends Dimensionality>(
   const letter = (idx: number) => String.fromCodePoint(idx < 30 ? 97 + idx : idx + 9600 - 30); // 97: 'a'
   let idCount = 0;
 
-  const { blockWidth, blockHeight } = kTextureFormatInfo[texture.descriptor.format];
+  const { blockWidth, blockHeight } = getBlockInfoForTextureFormat(texture.descriptor.format);
   // range + concatenate results.
   const rangeCat = <T>(num: number, fn: (i: number) => T) => range(num, fn).join('');
   const joinFn = (arr: string[], fn: (i: number) => string) => {
@@ -3696,7 +3658,7 @@ export function chooseTextureSize({
   format: GPUTextureFormat;
   viewDimension?: GPUTextureViewDimension;
 }) {
-  const { blockWidth, blockHeight } = kTextureFormatInfo[format];
+  const { blockWidth, blockHeight } = getBlockInfoForTextureFormat(format);
   const width = align(Math.max(minSize, blockWidth * minBlocks), blockWidth);
   const height =
     viewDimension === '1d' ? 1 : align(Math.max(minSize, blockHeight * minBlocks), blockHeight);
@@ -4982,7 +4944,7 @@ ${stageWGSL}
   // So, if we don't need filtering, don't request a filtering sampler. If we require
   // filtering then check if the format is 32float format and if float32-filterable
   // is enabled.
-  const info = kTextureFormatInfo[format ?? 'rgba8unorm'];
+  const type = getTextureFormatType(format ?? 'rgba8unorm');
   const isFiltering =
     !!sampler &&
     (sampler.minFilter === 'linear' ||
@@ -4994,7 +4956,7 @@ ${stageWGSL}
     ? 'unfilterable-float'
     : isStencilTextureFormat(format)
     ? 'uint'
-    : info.color?.type ?? 'float';
+    : type ?? 'float';
   if (isFiltering && sampleType === 'unfilterable-float') {
     assert(is32Float(format));
     assert(t.device.features.has('float32-filterable'));

--- a/src/webgpu/shader/types.ts
+++ b/src/webgpu/shader/types.ts
@@ -181,37 +181,6 @@ export const kAddressSpaceInfo: Record<string, AddressSpaceInfo> = {
 } as const;
 
 /**
- * List of texel formats and their shader representation
- * MAINTENANCE_TODO: It's not clear what this table is used for but being static we should
- * check that it's used correctly and not missing formats. For example the textureLoad tests
- * were using this table and then manually adding in bgra8unorm but doing that at every
- * test means that if a new format is added it will have to be added at every test.
- * If this table is useful, say for a list of storage texture formats, it should probably
- * be validated with the data in format_info.ts and visa versa so that adding a new format
- * to one or the other asserts if it's missing in the other. Marking as deprecated for now
- * to highlight where it's used.
- */
-/** @deprecated */
-export const TexelFormats = [
-  { format: 'rgba8unorm', _shaderType: 'f32' },
-  { format: 'rgba8snorm', _shaderType: 'f32' },
-  { format: 'rgba8uint', _shaderType: 'u32' },
-  { format: 'rgba8sint', _shaderType: 'i32' },
-  { format: 'rgba16uint', _shaderType: 'u32' },
-  { format: 'rgba16sint', _shaderType: 'i32' },
-  { format: 'rgba16float', _shaderType: 'f32' },
-  { format: 'r32uint', _shaderType: 'u32' },
-  { format: 'r32sint', _shaderType: 'i32' },
-  { format: 'r32float', _shaderType: 'f32' },
-  { format: 'rg32uint', _shaderType: 'u32' },
-  { format: 'rg32sint', _shaderType: 'i32' },
-  { format: 'rg32float', _shaderType: 'f32' },
-  { format: 'rgba32uint', _shaderType: 'u32' },
-  { format: 'rgba32sint', _shaderType: 'i32' },
-  { format: 'rgba32float', _shaderType: 'f32' },
-] as const;
-
-/**
  * Generate a bunch types (vec, mat, sized/unsized array) for testing.
  */
 export function* generateTypes({

--- a/src/webgpu/shader/validation/extension/readonly_and_readwrite_storage_textures.spec.ts
+++ b/src/webgpu/shader/validation/extension/readonly_and_readwrite_storage_textures.spec.ts
@@ -3,7 +3,7 @@ Validation tests for the readonly_and_readwrite_storage_textures language featur
 `;
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
-import { TexelFormats } from '../../types.js';
+import { kPossibleStorageTextureFormats } from '../../../format_info.js';
 import { ShaderValidationTest } from '../shader_validation_test.js';
 
 export const g = makeTestGroup(ShaderValidationTest);
@@ -22,14 +22,13 @@ g.test('var_decl')
         'texture_storage_2d_array',
         'texture_storage_3d',
       ])
-      .combine('format', TexelFormats)
+      .combine('format', kPossibleStorageTextureFormats)
       .combine('access', ['read', 'write', 'read_write'])
   )
   .fn(t => {
     const { type, format, access } = t.params;
-    t.skipIfTextureFormatNotUsableAsStorageTextureDeprecated(format.format);
 
-    const source = `@group(0) @binding(0) var t : ${type}<${format.format}, ${access}>;`;
+    const source = `@group(0) @binding(0) var t : ${type}<${format}, ${access}>;`;
     const requiresFeature = access !== 'write';
     t.expectCompileResult(t.hasLanguageFeature(kFeatureName) || !requiresFeature, source);
   });


### PR DESCRIPTION
Note: I wanted to get rid of TexelFormats as in didn't include bgra8unorm. It was used in only one file outside of built/texture* so I included it in this PR.

Also, some of the conditions were out of date as the a written before we realized that depth textures can use linear sampling so those have been updated to the correct checks.

Issue #4178 
Issue #4181 