### PR TITLE
Fix maxDynamic(Storage|Uniform)BuffersPerPipelineLayout tests

### DIFF
--- a/src/webgpu/api/validation/capability_checks/limits/maxDynamicStorageBuffersPerPipelineLayout.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxDynamicStorageBuffersPerPipelineLayout.spec.ts
@@ -1,4 +1,4 @@
-import { assert, range } from '../../../../../common/util/util.js';
+import { range } from '../../../../../common/util/util.js';
 import { kShaderStageCombinationsWithStage } from '../../../../capability_info.js';
 import { GPUConst } from '../../../../constants.js';
 
@@ -51,47 +51,60 @@ g.test('createBindGroupLayout,at_over')
     );
   });
 
-// MAINTENANCE_TODO: Update this test - this test wants to test the maxDynamicStorageBuffersPerPipelineLayout
-// but to get the max it should split them between stages so that it's less likely to hit the per stage limit.
 g.test('createPipelineLayout,at_over')
   .desc(`Test using at and over ${limit} limit in createPipelineLayout`)
   .params(
-    kMaximumLimitBaseParams
-      .combine('visibility', kShaderStageCombinationsWithStage)
-      .combine('type', ['storage', 'read-only-storage'] as GPUBufferBindingType[])
-      .filter(
-        ({ visibility, type }) =>
-          (visibility & GPUConst.ShaderStage.VERTEX) === 0 || type !== 'storage'
-      )
+    kMaximumLimitBaseParams.combine('type', [
+      'storage',
+      'read-only-storage',
+    ] as GPUBufferBindingType[])
   )
   .fn(async t => {
-    const { limitTest, testValueName, visibility, type } = t.params;
+    const { limitTest, testValueName, type } = t.params;
 
     await t.testDeviceWithRequestedMaximumLimits(
       limitTest,
       testValueName,
       async ({ device, testValue, shouldError, actualLimit }) => {
-        t.skipIfNotEnoughStorageBuffersInStage(visibility, testValue);
-
-        const maxBindingsPerBindGroup = Math.min(
-          t.device.limits.maxBindingsPerBindGroup,
+        // We need to make the largest binding groups we can that don't exceed maxDynamicStorageBuffersPerPipelineLayout
+        // otherwise, createBindGroupLayout will fail.
+        const maxComputeBindings = Math.min(
+          device.limits.maxStorageBuffersPerShaderStage,
           actualLimit
         );
+        const maxFragmentBindings = Math.min(
+          device.limits.maxStorageBuffersInFragmentStage ?? maxComputeBindings,
+          actualLimit
+        );
+        // re-write storage buffers are not allowed in vertex stages.
+        const maxVertexBindings =
+          type === 'storage'
+            ? 0
+            : Math.min(
+                device.limits.maxStorageBuffersInVertexStage ?? maxComputeBindings,
+                actualLimit
+              );
 
-        const kNumGroups = Math.ceil(testValue / maxBindingsPerBindGroup);
+        const totalBindings = maxComputeBindings + maxFragmentBindings + maxVertexBindings;
+        t.skipIf(
+          totalBindings < testValue,
+          `total storage buffer bindings across stages (${totalBindings}) < testValue(${testValue})`
+        );
 
-        // Not sure what to do in this case but best we get notified if it happens.
-        assert(kNumGroups <= t.device.limits.maxBindGroups);
+        // These are ordered by their stage visibility bits
+        const maxBindingsPerStage = [maxVertexBindings, maxFragmentBindings, maxComputeBindings];
 
-        const bindGroupLayouts = range(kNumGroups, i => {
-          const numInGroup = Math.min(
-            testValue - i * maxBindingsPerBindGroup,
-            maxBindingsPerBindGroup
-          );
+        // Make 3 groups using the max bindings allowed for that stage up to testValue bindings
+        let numBindingsAvailable = testValue;
+        const bindGroupLayouts = maxBindingsPerStage.map((maxBindings, visibilityBit) => {
+          const numInGroup = Math.min(numBindingsAvailable, maxBindings);
+          numBindingsAvailable -= numInGroup;
+          t.debug(`group(${visibilityBit}) numBindings: ${numInGroup}`);
+
           return device.createBindGroupLayout({
             entries: range(numInGroup, i => ({
               binding: i,
-              visibility,
+              visibility: 1 << visibilityBit,
               buffer: {
                 type,
                 hasDynamicOffset: true,

--- a/src/webgpu/api/validation/capability_checks/limits/maxDynamicStorageBuffersPerPipelineLayout.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxDynamicStorageBuffersPerPipelineLayout.spec.ts
@@ -76,7 +76,7 @@ g.test('createPipelineLayout,at_over')
           device.limits.maxStorageBuffersInFragmentStage ?? maxComputeBindings,
           actualLimit
         );
-        // re-write storage buffers are not allowed in vertex stages.
+        // read-write storage buffers are not allowed in vertex stages.
         const maxVertexBindings =
           type === 'storage'
             ? 0

--- a/src/webgpu/api/validation/capability_checks/limits/maxDynamicUniformBuffersPerPipelineLayout.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxDynamicUniformBuffersPerPipelineLayout.spec.ts
@@ -1,31 +1,26 @@
 import { range } from '../../../../../common/util/util.js';
-import { GPUConst } from '../../../../constants.js';
+import { kShaderStageCombinationsWithStage } from '../../../../capability_info.js';
 
-import { kMaximumLimitBaseParams, makeLimitTestGroup } from './limit_utils.js';
+import { kMaximumLimitBaseParams, LimitsRequest, makeLimitTestGroup } from './limit_utils.js';
+
+const kExtraLimits: LimitsRequest = {
+  maxBindingsPerBindGroup: 'adapterLimit',
+  maxBindGroups: 'adapterLimit',
+  maxUniformBuffersPerShaderStage: 'adapterLimit',
+};
 
 const limit = 'maxDynamicUniformBuffersPerPipelineLayout';
 export const { g, description } = makeLimitTestGroup(limit);
 
 g.test('createBindGroupLayout,at_over')
   .desc(`Test using createBindGroupLayout at and over ${limit} limit`)
-  .params(
-    kMaximumLimitBaseParams.combine('visibility', [
-      GPUConst.ShaderStage.VERTEX,
-      GPUConst.ShaderStage.FRAGMENT,
-      GPUConst.ShaderStage.VERTEX | GPUConst.ShaderStage.FRAGMENT,
-      GPUConst.ShaderStage.COMPUTE,
-      GPUConst.ShaderStage.COMPUTE | GPUConst.ShaderStage.VERTEX,
-      GPUConst.ShaderStage.COMPUTE | GPUConst.ShaderStage.FRAGMENT,
-      GPUConst.ShaderStage.COMPUTE | GPUConst.ShaderStage.VERTEX | GPUConst.ShaderStage.FRAGMENT,
-    ])
-  )
+  .params(kMaximumLimitBaseParams.combine('visibility', kShaderStageCombinationsWithStage))
   .fn(async t => {
     const { limitTest, testValueName, visibility } = t.params;
     await t.testDeviceWithRequestedMaximumLimits(
       limitTest,
       testValueName,
       async ({ device, testValue, shouldError }) => {
-        shouldError ||= testValue > t.device.limits.maxUniformBuffersPerShaderStage;
         await t.expectValidationError(() => {
           device.createBindGroupLayout({
             entries: range(testValue, i => ({
@@ -37,10 +32,60 @@ g.test('createBindGroupLayout,at_over')
             })),
           });
         }, shouldError);
-      }
+      },
+      kExtraLimits
     );
   });
 
 g.test('createPipelineLayout,at_over')
   .desc(`Test using at and over ${limit} limit in createPipelineLayout`)
-  .unimplemented();
+  .params(kMaximumLimitBaseParams)
+  .fn(async t => {
+    const { limitTest, testValueName } = t.params;
+
+    await t.testDeviceWithRequestedMaximumLimits(
+      limitTest,
+      testValueName,
+      async ({ device, testValue, shouldError, actualLimit }) => {
+        // We need to make the largest binding groups we can that don't exceed maxDynamicUniformBuffersPerPipelineLayout
+        // otherwise, createBindGroupLayout will fail.
+        const maxUniformBindings = Math.min(
+          device.limits.maxUniformBuffersPerShaderStage,
+          actualLimit
+        );
+
+        const totalBindings = maxUniformBindings * 3;
+        t.skipIf(
+          totalBindings < testValue,
+          `total uniform buffer bindings across stages (${totalBindings}) < testValue(${testValue})`
+        );
+
+        // These are ordered by their stage visibility bits
+        const maxBindingsPerStage = [maxUniformBindings, maxUniformBindings, maxUniformBindings];
+
+        // Make 3 groups using the max bindings allowed for that stage up to testValue bindings
+        let numBindingsAvailable = testValue;
+        const bindGroupLayouts = maxBindingsPerStage.map((maxBindings, visibilityBit) => {
+          const numInGroup = Math.min(numBindingsAvailable, maxBindings);
+          numBindingsAvailable -= numInGroup;
+          t.debug(`group(${visibilityBit}) numBindings: ${numInGroup}`);
+
+          return device.createBindGroupLayout({
+            entries: range(numInGroup, i => ({
+              binding: i,
+              visibility: 1 << visibilityBit,
+              buffer: {
+                hasDynamicOffset: true,
+              },
+            })),
+          });
+        });
+
+        await t.expectValidationError(
+          () => device.createPipelineLayout({ bindGroupLayouts }),
+          shouldError
+        );
+      },
+      kExtraLimits
+    );
+  });


### PR DESCRIPTION
The test for maxDynamicStorageBuffersPerPipelineLayout wasn't testing
what it needed to test. It needed to create bindGroups that individually
don't exceed the limit but collectively do. Fixed.
    
A similar test for maxDynamicUniformBuffersPerPipelineLayout was missing. Added.