### PR TITLE
Unreserve the `binding_array` keyword.

### DIFF
--- a/src/webgpu/shader/validation/parse/identifiers.spec.ts
+++ b/src/webgpu/shader/validation/parse/identifiers.spec.ts
@@ -133,7 +133,6 @@ const kInvalidIdentifiers = new Set([
   'auto',
   'await',
   'become',
-  'binding_array',
   'cast',
   'catch',
   'class',


### PR DESCRIPTION
See https://github.com/gpuweb/gpuweb/pull/5091




Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [X] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
