### PR TITLE
Minor fix to nested array tests

### DIFF
--- a/src/webgpu/shader/validation/expression/access/array.spec.ts
+++ b/src/webgpu/shader/validation/expression/access/array.spec.ts
@@ -273,7 +273,7 @@ const kOutOfBoundsCases: Record<string, OutOfBoundsCase> = {
         w : array<u32>
       }
       @group(0) @binding(0) var<storage> v : S;
-      fn foo() -> u32 {
+      fn y() -> u32 {
         let tmp : u32 = v.w[x];
         return 0;
       }`,
@@ -288,7 +288,7 @@ const kOutOfBoundsCases: Record<string, OutOfBoundsCase> = {
         w : array<u32>
       }
       @group(0) @binding(0) var<storage> v : S;
-      fn foo() -> u32 {
+      fn y() -> u32 {
         let tmp : u32 = v.w[x];
         return 0;
       }`,
@@ -303,7 +303,7 @@ const kOutOfBoundsCases: Record<string, OutOfBoundsCase> = {
         w : array<u32, 5>
       }
       @group(0) @binding(0) var<storage> v : S;
-      fn foo() -> u32 {
+      fn y() -> u32 {
         let tmp : u32 = v.w[x];
         return 0;
       }`,
@@ -321,7 +321,7 @@ const kOutOfBoundsCases: Record<string, OutOfBoundsCase> = {
         r : S
       }
       @group(0) @binding(0) var<storage> v : S2;
-      fn foo() -> u32 {
+      fn y() -> u32 {
         let tmp : u32 = v.r.w[x];
         return 0;
       }`,
@@ -339,7 +339,7 @@ const kOutOfBoundsCases: Record<string, OutOfBoundsCase> = {
         r : S
       }
       @group(0) @binding(0) var<storage> v : S2;
-      fn foo() -> u32 {
+      fn y() -> u32 {
         let tmp : u32 = v.r.w[x];
         return 0;
       }`,


### PR DESCRIPTION
The function 'foo' should be referenced and not the non existing function 'y'.
Changed all function names to y.
https://github.com/gpuweb/cts/pull/4218#issuecomment-2691797502

crbug.com/399151683
