### PR TITLE
Refactor shader/validation/expression/call/builtin/*

### DIFF
--- a/src/webgpu/format_info.ts
+++ b/src/webgpu/format_info.ts
@@ -2048,11 +2048,21 @@ export function isTextureFormatColorRenderable(
 }
 
 /**
- * Returns the texture's type (float, unsigned-float, sint, uint, de`pth)
+ * Returns the texture's type (float, unsigned-float, sint, uint, depth)
  */
 export function getTextureFormatType(format: GPUTextureFormat) {
   const info = kTextureFormatInfo[format];
   const type = info.color?.type ?? info.depth?.type ?? info.stencil?.type;
+  assert(!!type);
+  return type;
+}
+
+/**
+ * Returns the regular texture's type (float, unsigned-float, sint, uint)
+ */
+export function getTextureFormatColorType(format: RegularTextureFormat) {
+  const info = kTextureFormatInfo[format];
+  const type = info.color?.type;
   assert(!!type);
   return type;
 }

--- a/src/webgpu/shader/validation/expression/call/builtin/abs.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/abs.spec.ts
@@ -5,11 +5,7 @@ Validation tests for the ${builtin}() builtin.
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { keysOf, objectsToRecord } from '../../../../../../common/util/data_tables.js';
-import {
-  Type,
-  kAllNumericScalarsAndVectors,
-  scalarTypeOf,
-} from '../../../../../util/conversion.js';
+import { kAllNumericScalarsAndVectors } from '../../../../../util/conversion.js';
 import { ShaderValidationTest } from '../../../shader_validation_test.js';
 
 import {
@@ -38,9 +34,6 @@ Validates that constant evaluation and override evaluation of ${builtin}() never
       .expand('value', u => fullRangeForType(kValuesTypes[u.type]))
   )
   .fn(t => {
-    if (scalarTypeOf(kValuesTypes[t.params.type]) === Type.f16) {
-      t.skipIfDeviceDoesNotHaveFeature('shader-f16');
-    }
     const expectedResult = true; // abs() should never error
     validateConstOrOverrideBuiltinEval(
       t,

--- a/src/webgpu/shader/validation/expression/call/builtin/acos.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/acos.spec.ts
@@ -9,7 +9,6 @@ import {
   Type,
   kConcreteIntegerScalarsAndVectors,
   kConvertableToFloatScalarsAndVectors,
-  scalarTypeOf,
 } from '../../../../../util/conversion.js';
 import { absBigInt } from '../../../../../util/math.js';
 import { ShaderValidationTest } from '../../../shader_validation_test.js';
@@ -47,9 +46,6 @@ Validates that constant evaluation and override evaluation of ${builtin}() rejec
       )
   )
   .fn(t => {
-    if (scalarTypeOf(kValuesTypes[t.params.type]) === Type.f16) {
-      t.skipIfDeviceDoesNotHaveFeature('shader-f16');
-    }
     const expectedResult =
       typeof t.params.value === 'bigint'
         ? absBigInt(t.params.value) <= 1n

--- a/src/webgpu/shader/validation/expression/call/builtin/acosh.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/acosh.spec.ts
@@ -47,9 +47,6 @@ Validates that constant evaluation and override evaluation of ${builtin}() rejec
       )
   )
   .fn(t => {
-    if (scalarTypeOf(kValuesTypes[t.params.type]) === Type.f16) {
-      t.skipIfDeviceDoesNotHaveFeature('shader-f16');
-    }
     const type = kValuesTypes[t.params.type];
     const expectedResult = isRepresentable(
       Math.acosh(Number(t.params.value)),

--- a/src/webgpu/shader/validation/expression/call/builtin/all.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/all.spec.ts
@@ -157,11 +157,6 @@ g.test('must_use')
 g.test('arguments')
   .desc(`Test that ${builtin} is validated correctly.`)
   .params(u => u.combine('test', keysOf(kTests)))
-  .beforeAllSubcases(t => {
-    if (t.params.test.includes('f16')) {
-      t.selectDeviceOrSkipTestCase('shader-f16');
-    }
-  })
   .fn(t => {
     const src = kTests[t.params.test].src;
     const enables = t.params.test.includes('f16') ? 'enable f16;' : '';

--- a/src/webgpu/shader/validation/expression/call/builtin/any.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/any.spec.ts
@@ -157,11 +157,6 @@ g.test('must_use')
 g.test('arguments')
   .desc(`Test that ${builtin} is validated correctly.`)
   .params(u => u.combine('test', keysOf(kTests)))
-  .beforeAllSubcases(t => {
-    if (t.params.test.includes('f16')) {
-      t.selectDeviceOrSkipTestCase('shader-f16');
-    }
-  })
   .fn(t => {
     const src = kTests[t.params.test].src;
     const enables = t.params.test.includes('f16') ? 'enable f16;' : '';

--- a/src/webgpu/shader/validation/expression/call/builtin/arrayLength.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/arrayLength.spec.ts
@@ -58,11 +58,6 @@ arrayLength accepts only runtime-sized arrays
       'array<i32>',
     ])
   )
-  .beforeAllSubcases(t => {
-    if (t.params.type.includes('f16')) {
-      t.selectDeviceOrSkipTestCase('shader-f16');
-    }
-  })
   .fn(t => {
     const code = `
 struct T {

--- a/src/webgpu/shader/validation/expression/call/builtin/asin.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/asin.spec.ts
@@ -9,7 +9,6 @@ import {
   Type,
   kConcreteIntegerScalarsAndVectors,
   kConvertableToFloatScalarsAndVectors,
-  scalarTypeOf,
 } from '../../../../../util/conversion.js';
 import { absBigInt } from '../../../../../util/math.js';
 import { ShaderValidationTest } from '../../../shader_validation_test.js';
@@ -47,9 +46,6 @@ Validates that constant evaluation and override evaluation of ${builtin}() rejec
       )
   )
   .fn(t => {
-    if (scalarTypeOf(kValuesTypes[t.params.type]) === Type.f16) {
-      t.skipIfDeviceDoesNotHaveFeature('shader-f16');
-    }
     const expectedResult =
       typeof t.params.value === 'bigint'
         ? absBigInt(t.params.value) <= 1n

--- a/src/webgpu/shader/validation/expression/call/builtin/asinh.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/asinh.spec.ts
@@ -50,9 +50,6 @@ Validates that constant evaluation and override evaluation of ${builtin}() rejec
       )
   )
   .fn(t => {
-    if (scalarTypeOf(kValuesTypes[t.params.type]) === Type.f16) {
-      t.skipIfDeviceDoesNotHaveFeature('shader-f16');
-    }
     const type = kValuesTypes[t.params.type];
     const expectedResult = isRepresentable(
       Math.asinh(Number(t.params.value)),

--- a/src/webgpu/shader/validation/expression/call/builtin/atan.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/atan.spec.ts
@@ -9,7 +9,6 @@ import {
   Type,
   kConcreteIntegerScalarsAndVectors,
   kConvertableToFloatScalarsAndVectors,
-  scalarTypeOf,
 } from '../../../../../util/conversion.js';
 import { ShaderValidationTest } from '../../../shader_validation_test.js';
 
@@ -46,9 +45,6 @@ Validates that constant evaluation and override evaluation of ${builtin}() rejec
       )
   )
   .fn(t => {
-    if (scalarTypeOf(kValuesTypes[t.params.type]) === Type.f16) {
-      t.skipIfDeviceDoesNotHaveFeature('shader-f16');
-    }
     const type = kValuesTypes[t.params.type];
     const expectedResult = true;
     validateConstOrOverrideBuiltinEval(

--- a/src/webgpu/shader/validation/expression/call/builtin/atan2.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/atan2.spec.ts
@@ -56,9 +56,6 @@ Validates that constant evaluation and override evaluation of ${builtin}() rejec
       )
   )
   .fn(t => {
-    if (scalarTypeOf(kValuesTypes[t.params.type]) === Type.f16) {
-      t.skipIfDeviceDoesNotHaveFeature('shader-f16');
-    }
     const type = kValuesTypes[t.params.type];
     const expectedResult = isRepresentable(
       Math.abs(Math.atan2(Number(t.params.x), Number(t.params.y))),
@@ -312,11 +309,6 @@ const kTests = {
 g.test('parameters')
   .desc(`Test that ${builtin} is validated correctly.`)
   .params(u => u.combine('test', keysOf(kTests)))
-  .beforeAllSubcases(t => {
-    if (kTests[t.params.test].is_f16 === true) {
-      t.selectDeviceOrSkipTestCase('shader-f16');
-    }
-  })
   .fn(t => {
     const src = kTests[t.params.test].src;
     const code = `

--- a/src/webgpu/shader/validation/expression/call/builtin/atanh.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/atanh.spec.ts
@@ -9,7 +9,6 @@ import {
   Type,
   kConcreteIntegerScalarsAndVectors,
   kConvertableToFloatScalarsAndVectors,
-  scalarTypeOf,
 } from '../../../../../util/conversion.js';
 import { absBigInt } from '../../../../../util/math.js';
 import { ShaderValidationTest } from '../../../shader_validation_test.js';
@@ -47,9 +46,6 @@ Validates that constant evaluation and override evaluation of ${builtin}() rejec
       )
   )
   .fn(t => {
-    if (scalarTypeOf(kValuesTypes[t.params.type]) === Type.f16) {
-      t.skipIfDeviceDoesNotHaveFeature('shader-f16');
-    }
     const expectedResult =
       typeof t.params.value === 'bigint'
         ? absBigInt(t.params.value) < 1n

--- a/src/webgpu/shader/validation/expression/call/builtin/bitcast.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/bitcast.spec.ts
@@ -131,7 +131,6 @@ It is a shader-creation error if any const-expression of floating-point type eva
       )
   )
   .fn(t => {
-    t.skipIfDeviceDoesNotHaveFeature('shader-f16');
     // For width = 2 generate code like:
     //  const f = bitcast<vec2<f16>>(i32(u32(0x7f800000)));
     // And for width = 4:
@@ -187,11 +186,6 @@ Test constructible types.
       ])
       .combine('direction', ['to', 'from'])
   )
-  .beforeAllSubcases(t => {
-    if (t.params.type.includes('f16')) {
-      t.selectDeviceOrSkipTestCase('shader-f16');
-    }
-  })
   .fn(t => {
     const T = t.params.type;
     const enable_directives = t.params.type.includes('f16') ? 'enable f16;\n' : '';
@@ -269,7 +263,6 @@ and no other type is that size.
       .combine('type', ['vec3<f16>', 'vec3h'])
   )
   .fn(t => {
-    t.skipIfDeviceDoesNotHaveFeature('shader-f16');
     const src_type = t.params.direction === 'to' ? t.params.type : t.params.other_type;
     const dst_type = t.params.direction === 'from' ? t.params.type : t.params.other_type;
     const code = `
@@ -316,7 +309,6 @@ and no other type is that size.
       .combine('direction', ['to', 'from'] as const)
   )
   .fn(t => {
-    t.skipIfDeviceDoesNotHaveFeature('shader-f16');
     const src_type = t.params.direction === 'to' ? 'f16' : t.params.other_type;
     const dst_type = t.params.direction === 'from' ? 'f16' : t.params.other_type;
     const code = `
@@ -339,7 +331,6 @@ g.test('valid_vec2h')
       .combine('direction', ['to', 'from'] as const)
   )
   .fn(t => {
-    t.skipIfDeviceDoesNotHaveFeature('shader-f16');
     const src_type = t.params.direction === 'to' ? t.params.type : t.params.other_type;
     const dst_type = t.params.direction === 'from' ? t.params.type : t.params.other_type;
     const code = `
@@ -369,7 +360,6 @@ g.test('valid_vec4h')
       .combine('direction', ['to', 'from'] as const)
   )
   .fn(t => {
-    t.skipIfDeviceDoesNotHaveFeature('shader-f16');
     const src_type = t.params.direction === 'to' ? t.params.type : t.params.other_type;
     const dst_type = t.params.direction === 'from' ? t.params.type : t.params.other_type;
     const code = `

--- a/src/webgpu/shader/validation/expression/call/builtin/ceil.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/ceil.spec.ts
@@ -9,7 +9,6 @@ import {
   Type,
   kConcreteIntegerScalarsAndVectors,
   kConvertableToFloatScalarsAndVectors,
-  scalarTypeOf,
 } from '../../../../../util/conversion.js';
 import { ShaderValidationTest } from '../../../shader_validation_test.js';
 
@@ -39,9 +38,6 @@ Validates that constant evaluation and override evaluation of ${builtin}() never
       .expand('value', u => fullRangeForType(kValuesTypes[u.type]))
   )
   .fn(t => {
-    if (scalarTypeOf(kValuesTypes[t.params.type]) === Type.f16) {
-      t.skipIfDeviceDoesNotHaveFeature('shader-f16');
-    }
     const expectedResult = true; // ceil() should never error
     validateConstOrOverrideBuiltinEval(
       t,

--- a/src/webgpu/shader/validation/expression/call/builtin/clamp.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/clamp.spec.ts
@@ -45,9 +45,6 @@ Validates that constant evaluation and override evaluation of ${builtin}() rejec
       .expand('high', u => fullRangeForType(kValuesTypes[u.type], 4))
   )
   .fn(t => {
-    if (scalarTypeOf(kValuesTypes[t.params.type]) === Type.f16) {
-      t.skipIfDeviceDoesNotHaveFeature('shader-f16');
-    }
     const type = kValuesTypes[t.params.type];
     const expectedResult = t.params.low <= t.params.high;
     validateConstOrOverrideBuiltinEval(
@@ -72,18 +69,10 @@ Validates that even with valid types, if types do not match, ${builtin}() errors
       .combine('low', keysOf(kValuesTypes))
       .combine('high', keysOf(kValuesTypes))
   )
-  .beforeAllSubcases(t => {
-    if (scalarTypeOf(kValuesTypes[t.params.e]) === Type.f16) {
-      t.selectDeviceOrSkipTestCase('shader-f16');
-    }
-  })
   .fn(t => {
     const e = kValuesTypes[t.params.e];
     const low = kValuesTypes[t.params.low];
     const high = kValuesTypes[t.params.high];
-
-    // Skip if shader-16 isn't available.
-    t.skipIf(scalarTypeOf(low) === Type.f16 || scalarTypeOf(high) === Type.f16);
 
     // If there exists 1 type of the 3 args that the other 2 can be converted into, then the args
     // are valid.
@@ -128,12 +117,6 @@ Validates that low <= high.
       // in_shader: Is the function call statically accessed by the entry point?
       .combine('in_shader', [false, true] as const)
   )
-  .beforeAllSubcases(t => {
-    const ty = kValuesTypes[t.params.type];
-    if (ty.requiresF16()) {
-      t.selectDeviceOrSkipTestCase('shader-f16');
-    }
-  })
   .fn(t => {
     const ty = kValuesTypes[t.params.type];
     const scalar = scalarTypeOf(ty);

--- a/src/webgpu/shader/validation/expression/call/builtin/cos.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/cos.spec.ts
@@ -9,7 +9,6 @@ import {
   Type,
   kConcreteIntegerScalarsAndVectors,
   kConvertableToFloatScalarsAndVectors,
-  scalarTypeOf,
 } from '../../../../../util/conversion.js';
 import { ShaderValidationTest } from '../../../shader_validation_test.js';
 
@@ -46,9 +45,6 @@ Validates that constant evaluation and override evaluation of ${builtin}() rejec
       )
   )
   .fn(t => {
-    if (scalarTypeOf(kValuesTypes[t.params.type]) === Type.f16) {
-      t.skipIfDeviceDoesNotHaveFeature('shader-f16');
-    }
     validateConstOrOverrideBuiltinEval(
       t,
       builtin,

--- a/src/webgpu/shader/validation/expression/call/builtin/cosh.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/cosh.spec.ts
@@ -39,9 +39,6 @@ Validates that constant evaluation and override evaluation of ${builtin}() rejec
       .expand('value', u => fullRangeForType(kValuesTypes[u.type]))
   )
   .fn(t => {
-    if (scalarTypeOf(kValuesTypes[t.params.type]) === Type.f16) {
-      t.skipIfDeviceDoesNotHaveFeature('shader-f16');
-    }
     const type = kValuesTypes[t.params.type];
     const expectedResult = isRepresentable(
       Math.cosh(Number(t.params.value)),

--- a/src/webgpu/shader/validation/expression/call/builtin/cross.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/cross.spec.ts
@@ -51,17 +51,11 @@ Validates that constant evaluation and override evaluation of ${builtin}() never
       .expand('a', u => fullRangeForType(kValidArgumentTypes[u.type], 5))
       .expand('b', u => fullRangeForType(kValidArgumentTypes[u.type], 5))
   )
-  .beforeAllSubcases(t => {
-    if (scalarTypeOf(kValidArgumentTypes[t.params.type]) === Type.f16) {
-      t.selectDeviceOrSkipTestCase('shader-f16');
-    }
-  })
   .fn(t => {
     let expectedResult = true;
 
     const scalarType = scalarTypeOf(kValidArgumentTypes[t.params.type]);
     const quantizeFn = quantizeFunctionForScalarType(scalarType);
-
     // Should be invalid if the cross product calculations result in intermediate
     // values that exceed the maximum representable float value for the given type.
     const a = Number(t.params.a);

--- a/src/webgpu/shader/validation/expression/call/builtin/degrees.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/degrees.spec.ts
@@ -40,9 +40,6 @@ Validates that constant evaluation and override evaluation of ${builtin}() input
       .expand('value', u => fullRangeForType(kValuesTypes[u.type]))
   )
   .fn(t => {
-    if (scalarTypeOf(kValuesTypes[t.params.type]) === Type.f16) {
-      t.skipIfDeviceDoesNotHaveFeature('shader-f16');
-    }
     const type = kValuesTypes[t.params.type];
     const expectedResult = isRepresentable(
       (Number(t.params.value) * 180) / Math.PI,

--- a/src/webgpu/shader/validation/expression/call/builtin/derivatives.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/derivatives.spec.ts
@@ -112,11 +112,6 @@ Derivative builtins only accept f32 scalar and vector types.
   .params(u =>
     u.combine('type', keysOf(kArgumentTypes)).combine('call', ['', ...kDerivativeBuiltins])
   )
-  .beforeAllSubcases(t => {
-    if (scalarTypeOf(kArgumentTypes[t.params.type]) === Type.f16) {
-      t.selectDeviceOrSkipTestCase('shader-f16');
-    }
-  })
   .fn(t => {
     const type = kArgumentTypes[t.params.type];
     const code = `

--- a/src/webgpu/shader/validation/expression/call/builtin/determinant.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/determinant.spec.ts
@@ -46,9 +46,6 @@ g.test('matrix_args')
       .combine('type', ['abstract-int', 'abstract-float', 'f32', 'f16'] as const)
   )
   .fn(t => {
-    if (t.params.type === 'f16') {
-      t.skipIfDeviceDoesNotHaveFeature('shader-f16');
-    }
     const cols = t.params.cols;
     const rows = t.params.rows;
     const type = t.params.type;

--- a/src/webgpu/shader/validation/expression/call/builtin/distance.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/distance.spec.ts
@@ -6,7 +6,6 @@ Validation tests for the ${builtin}() builtin.
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { keysOf, objectsToRecord } from '../../../../../../common/util/data_tables.js';
 import {
-  Type,
   kConvertableToFloatScalarsAndVectors,
   scalarTypeOf,
 } from '../../../../../util/conversion.js';
@@ -39,11 +38,6 @@ Validates that constant evaluation and override evaluation of ${builtin}() never
       .expand('a', u => fullRangeForType(kValidArgumentTypes[u.type], 5))
       .expand('b', u => fullRangeForType(kValidArgumentTypes[u.type], 5))
   )
-  .beforeAllSubcases(t => {
-    if (scalarTypeOf(kValidArgumentTypes[t.params.type]) === Type.f16) {
-      t.selectDeviceOrSkipTestCase('shader-f16');
-    }
-  })
   .fn(t => {
     const scalarType = scalarTypeOf(kValidArgumentTypes[t.params.type]);
     const vCheck = new ConstantOrOverrideValueChecker(t, scalarType);

--- a/src/webgpu/shader/validation/expression/call/builtin/dot.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/dot.spec.ts
@@ -35,11 +35,6 @@ Validates that constant evaluation and override evaluation of ${builtin}() never
       .expand('a', u => fullRangeForType(kValidArgumentTypes[u.type], 5))
       .expand('b', u => fullRangeForType(kValidArgumentTypes[u.type], 5))
   )
-  .beforeAllSubcases(t => {
-    if (scalarTypeOf(kValidArgumentTypes[t.params.type]) === Type.f16) {
-      t.selectDeviceOrSkipTestCase('shader-f16');
-    }
-  })
   .fn(t => {
     const scalarType = scalarTypeOf(kValidArgumentTypes[t.params.type]);
     const vCheck = new ConstantOrOverrideValueChecker(t, scalarType);

--- a/src/webgpu/shader/validation/expression/call/builtin/exp.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/exp.spec.ts
@@ -69,9 +69,6 @@ Validates that constant evaluation and override evaluation of ${builtin}() rejec
       .expand('value', u => valueForType(kValuesTypes[u.type]))
   )
   .fn(t => {
-    if (scalarTypeOf(kValuesTypes[t.params.type]) === Type.f16) {
-      t.skipIfDeviceDoesNotHaveFeature('shader-f16');
-    }
     const type = kValuesTypes[t.params.type];
     const expectedResult = isRepresentable(
       Math.exp(Number(t.params.value)),

--- a/src/webgpu/shader/validation/expression/call/builtin/exp2.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/exp2.spec.ts
@@ -69,9 +69,6 @@ Validates that constant evaluation and override evaluation of ${builtin}() rejec
       .expand('value', u => valueForType(kValuesTypes[u.type]))
   )
   .fn(t => {
-    if (scalarTypeOf(kValuesTypes[t.params.type]) === Type.f16) {
-      t.skipIfDeviceDoesNotHaveFeature('shader-f16');
-    }
     const type = kValuesTypes[t.params.type];
     const expectedResult = isRepresentable(
       Math.pow(2, Number(t.params.value)),

--- a/src/webgpu/shader/validation/expression/call/builtin/faceForward.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/faceForward.spec.ts
@@ -52,17 +52,11 @@ Validates that constant evaluation and override evaluation of ${builtin}() never
       .expand('b', u => fullRangeForType(kValidArgumentTypes[u.type], 5))
       .expand('c', u => fullRangeForType(kValidArgumentTypes[u.type], 5))
   )
-  .beforeAllSubcases(t => {
-    if (scalarTypeOf(kValidArgumentTypes[t.params.type]) === Type.f16) {
-      t.selectDeviceOrSkipTestCase('shader-f16');
-    }
-  })
   .fn(t => {
     let expectedResult = true;
 
     const scalarType = scalarTypeOf(kValidArgumentTypes[t.params.type]);
     const quantizeFn = quantizeFunctionForScalarType(scalarType);
-
     // Face Forward equation: dot(b, c) < 0 ? -a : a
     // Should be invalid if the calculations result in intermediate values that
     // exceed the maximum representable float value for the given type.

--- a/src/webgpu/shader/validation/expression/call/builtin/floor.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/floor.spec.ts
@@ -9,7 +9,6 @@ import {
   Type,
   kConcreteIntegerScalarsAndVectors,
   kConvertableToFloatScalarsAndVectors,
-  scalarTypeOf,
 } from '../../../../../util/conversion.js';
 import { ShaderValidationTest } from '../../../shader_validation_test.js';
 
@@ -39,9 +38,6 @@ Validates that constant evaluation and override evaluation of ${builtin}() never
       .expand('value', u => fullRangeForType(kValuesTypes[u.type]))
   )
   .fn(t => {
-    if (scalarTypeOf(kValuesTypes[t.params.type]) === Type.f16) {
-      t.skipIfDeviceDoesNotHaveFeature('shader-f16');
-    }
     const expectedResult = true; // floor() should never error
     validateConstOrOverrideBuiltinEval(
       t,

--- a/src/webgpu/shader/validation/expression/call/builtin/fma.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/fma.spec.ts
@@ -5,7 +5,7 @@ Validation tests for the ${builtin}() builtin.
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { keysOf, objectsToRecord } from '../../../../../../common/util/data_tables.js';
-import { Type, kConvertableToFloatVectors, scalarTypeOf } from '../../../../../util/conversion.js';
+import { kConvertableToFloatVectors, scalarTypeOf } from '../../../../../util/conversion.js';
 import { ShaderValidationTest } from '../../../shader_validation_test.js';
 
 import {
@@ -37,11 +37,6 @@ where the algorithm produces OOB results.
       .expand('b', u => fullRangeForType(kValidArgumentTypes[u.type], 5))
       .expand('c', u => fullRangeForType(kValidArgumentTypes[u.type], 5))
   )
-  .beforeAllSubcases(t => {
-    if (scalarTypeOf(kValidArgumentTypes[t.params.type]) === Type.f16) {
-      t.selectDeviceOrSkipTestCase('shader-f16');
-    }
-  })
   .fn(t => {
     const scalarType = scalarTypeOf(kValidArgumentTypes[t.params.type]);
     const vCheck = new ConstantOrOverrideValueChecker(t, scalarType);

--- a/src/webgpu/shader/validation/expression/call/builtin/fract.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/fract.spec.ts
@@ -5,11 +5,7 @@ Validation tests for the ${builtin}() builtin.
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { keysOf, objectsToRecord } from '../../../../../../common/util/data_tables.js';
-import {
-  Type,
-  kConvertableToFloatScalarsAndVectors,
-  scalarTypeOf,
-} from '../../../../../util/conversion.js';
+import { kConvertableToFloatScalarsAndVectors } from '../../../../../util/conversion.js';
 import { ShaderValidationTest } from '../../../shader_validation_test.js';
 
 import {
@@ -37,11 +33,6 @@ Validates that constant evaluation and override evaluation of ${builtin}() error
       .beginSubcases()
       .expand('value', u => fullRangeForType(kValidArgumentTypes[u.type]))
   )
-  .beforeAllSubcases(t => {
-    if (scalarTypeOf(kValidArgumentTypes[t.params.type]) === Type.f16) {
-      t.selectDeviceOrSkipTestCase('shader-f16');
-    }
-  })
   .fn(t => {
     const expectedResult = true;
 

--- a/src/webgpu/shader/validation/expression/call/builtin/frexp.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/frexp.spec.ts
@@ -5,11 +5,7 @@ Validation tests for the ${builtin}() builtin.
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { keysOf, objectsToRecord } from '../../../../../../common/util/data_tables.js';
-import {
-  Type,
-  kConvertableToFloatScalarsAndVectors,
-  scalarTypeOf,
-} from '../../../../../util/conversion.js';
+import { kConvertableToFloatScalarsAndVectors } from '../../../../../util/conversion.js';
 import { ShaderValidationTest } from '../../../shader_validation_test.js';
 
 import {
@@ -37,11 +33,6 @@ Validates that constant evaluation and override evaluation of ${builtin}() error
       .beginSubcases()
       .expand('value', u => fullRangeForType(kValidArgumentTypes[u.type]))
   )
-  .beforeAllSubcases(t => {
-    if (scalarTypeOf(kValidArgumentTypes[t.params.type]) === Type.f16) {
-      t.selectDeviceOrSkipTestCase('shader-f16');
-    }
-  })
   .fn(t => {
     const expectedResult = true;
 

--- a/src/webgpu/shader/validation/expression/call/builtin/inverseSqrt.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/inverseSqrt.spec.ts
@@ -46,9 +46,6 @@ Validates that constant evaluation and override evaluation of ${builtin}() input
       )
   )
   .fn(t => {
-    if (scalarTypeOf(kValuesTypes[t.params.type]) === Type.f16) {
-      t.skipIfDeviceDoesNotHaveFeature('shader-f16');
-    }
     const type = kValuesTypes[t.params.type];
     const expectedResult =
       t.params.value > 0 &&

--- a/src/webgpu/shader/validation/expression/call/builtin/ldexp.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/ldexp.spec.ts
@@ -84,11 +84,6 @@ Validates that constant evaluation and override evaluation of ${builtin}() never
       .expand('a', u => fullRangeForType(kValidArgumentTypesA[u.typeA], 5))
       .expand('b', u => biasRange(kValidArgumentTypesA[u.typeA]))
   )
-  .beforeAllSubcases(t => {
-    if (scalarTypeOf(kValidArgumentTypesA[t.params.typeA]) === Type.f16) {
-      t.selectDeviceOrSkipTestCase('shader-f16');
-    }
-  })
   .fn(t => {
     const typeA = kValidArgumentTypesA[t.params.typeA];
     const bias = biasForType(scalarTypeOf(typeA));
@@ -146,12 +141,6 @@ g.test('partial_values')
       // in_shader: Is the functino call statically accessed by the entry point?
       .combine('in_shader', [false, true] as const)
   )
-  .beforeAllSubcases(t => {
-    const ty = kValidArgumentTypesA[t.params.typeA];
-    if (ty.requiresF16()) {
-      t.selectDeviceOrSkipTestCase('shader-f16');
-    }
-  })
   .fn(t => {
     const tyA = kValidArgumentTypesA[t.params.typeA];
     const tyB = kValidArgumentTypesB[t.params.typeB];

--- a/src/webgpu/shader/validation/expression/call/builtin/length.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/length.spec.ts
@@ -83,11 +83,6 @@ the input scalar value always compiles without error
       .beginSubcases()
       .expand('value', u => fullRangeForType(kScalarTypes[u.type]))
   )
-  .beforeAllSubcases(t => {
-    if (scalarTypeOf(kScalarTypes[t.params.type]) === Type.f16) {
-      t.selectDeviceOrSkipTestCase('shader-f16');
-    }
-  })
   .fn(t => {
     // We only validate with numbers known to be representable by the type
     const expectedResult = true;
@@ -119,11 +114,6 @@ Validates that constant evaluation and override evaluation of ${builtin}() with 
       .expand('_result', u => [calculate([u.x, u.y], scalarTypeOf(kVec2Types[u.type]))])
       .filter(u => u._result.isResultRepresentable === u._result.isIntermediateRepresentable)
   )
-  .beforeAllSubcases(t => {
-    if (scalarTypeOf(kVec2Types[t.params.type]) === Type.f16) {
-      t.selectDeviceOrSkipTestCase('shader-f16');
-    }
-  })
   .fn(t => {
     const expectedResult = t.params._result.isResultRepresentable;
     validateConstOrOverrideBuiltinEval(
@@ -155,11 +145,6 @@ Validates that constant evaluation and override evaluation of ${builtin}() with 
       .expand('_result', u => [calculate([u.x, u.y, u.z], scalarTypeOf(kVec3Types[u.type]))])
       .filter(u => u._result.isResultRepresentable === u._result.isIntermediateRepresentable)
   )
-  .beforeAllSubcases(t => {
-    if (scalarTypeOf(kVec3Types[t.params.type]) === Type.f16) {
-      t.selectDeviceOrSkipTestCase('shader-f16');
-    }
-  })
   .fn(t => {
     const expectedResult = t.params._result.isResultRepresentable;
     validateConstOrOverrideBuiltinEval(
@@ -192,11 +177,6 @@ Validates that constant evaluation and override evaluation of ${builtin}() with 
       .expand('_result', u => [calculate([u.x, u.y, u.z, u.w], scalarTypeOf(kVec4Types[u.type]))])
       .filter(u => u._result.isResultRepresentable === u._result.isIntermediateRepresentable)
   )
-  .beforeAllSubcases(t => {
-    if (scalarTypeOf(kVec4Types[t.params.type]) === Type.f16) {
-      t.selectDeviceOrSkipTestCase('shader-f16');
-    }
-  })
   .fn(t => {
     const expectedResult = t.params._result.isResultRepresentable;
     validateConstOrOverrideBuiltinEval(

--- a/src/webgpu/shader/validation/expression/call/builtin/log.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/log.spec.ts
@@ -9,7 +9,6 @@ import {
   Type,
   kConcreteIntegerScalarsAndVectors,
   kConvertableToFloatScalarsAndVectors,
-  scalarTypeOf,
 } from '../../../../../util/conversion.js';
 import { ShaderValidationTest } from '../../../shader_validation_test.js';
 
@@ -39,9 +38,6 @@ Validates that constant evaluation and override evaluation of ${builtin}() input
       .expand('value', u => fullRangeForType(kValuesTypes[u.type]))
   )
   .fn(t => {
-    if (scalarTypeOf(kValuesTypes[t.params.type]) === Type.f16) {
-      t.skipIfDeviceDoesNotHaveFeature('shader-f16');
-    }
     const expectedResult = t.params.value > 0;
     validateConstOrOverrideBuiltinEval(
       t,

--- a/src/webgpu/shader/validation/expression/call/builtin/log2.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/log2.spec.ts
@@ -9,7 +9,6 @@ import {
   Type,
   kConcreteIntegerScalarsAndVectors,
   kConvertableToFloatScalarsAndVectors,
-  scalarTypeOf,
 } from '../../../../../util/conversion.js';
 import { ShaderValidationTest } from '../../../shader_validation_test.js';
 
@@ -39,9 +38,6 @@ Validates that constant evaluation and override evaluation of ${builtin}() input
       .expand('value', u => fullRangeForType(kValuesTypes[u.type]))
   )
   .fn(t => {
-    if (scalarTypeOf(kValuesTypes[t.params.type]) === Type.f16) {
-      t.skipIfDeviceDoesNotHaveFeature('shader-f16');
-    }
     const expectedResult = t.params.value > 0;
     validateConstOrOverrideBuiltinEval(
       t,

--- a/src/webgpu/shader/validation/expression/call/builtin/max.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/max.spec.ts
@@ -5,11 +5,7 @@ Validation tests for the ${builtin}() builtin.
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { keysOf, objectsToRecord } from '../../../../../../common/util/data_tables.js';
-import {
-  Type,
-  kAllNumericScalarsAndVectors,
-  scalarTypeOf,
-} from '../../../../../util/conversion.js';
+import { kAllNumericScalarsAndVectors } from '../../../../../util/conversion.js';
 import { ShaderValidationTest } from '../../../shader_validation_test.js';
 
 import {
@@ -39,9 +35,6 @@ Validates that constant evaluation and override evaluation of ${builtin}() never
       .expand('b', u => fullRangeForType(kValuesTypes[u.type], 5))
   )
   .fn(t => {
-    if (scalarTypeOf(kValuesTypes[t.params.type]) === Type.f16) {
-      t.skipIfDeviceDoesNotHaveFeature('shader-f16');
-    }
     const type = kValuesTypes[t.params.type];
     const expectedResult = true; // should never error
     validateConstOrOverrideBuiltinEval(

--- a/src/webgpu/shader/validation/expression/call/builtin/min.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/min.spec.ts
@@ -5,11 +5,7 @@ Validation tests for the ${builtin}() builtin.
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { keysOf, objectsToRecord } from '../../../../../../common/util/data_tables.js';
-import {
-  Type,
-  kAllNumericScalarsAndVectors,
-  scalarTypeOf,
-} from '../../../../../util/conversion.js';
+import { kAllNumericScalarsAndVectors } from '../../../../../util/conversion.js';
 import { ShaderValidationTest } from '../../../shader_validation_test.js';
 
 import {
@@ -39,9 +35,6 @@ Validates that constant evaluation and override evaluation of ${builtin}() never
       .expand('b', u => fullRangeForType(kValuesTypes[u.type], 5))
   )
   .fn(t => {
-    if (scalarTypeOf(kValuesTypes[t.params.type]) === Type.f16) {
-      t.skipIfDeviceDoesNotHaveFeature('shader-f16');
-    }
     const type = kValuesTypes[t.params.type];
     const expectedResult = true; // should never error
     validateConstOrOverrideBuiltinEval(

--- a/src/webgpu/shader/validation/expression/call/builtin/mix.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/mix.spec.ts
@@ -5,7 +5,7 @@ Validation tests for the ${builtin}() builtin.
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { keysOf, objectsToRecord } from '../../../../../../common/util/data_tables.js';
-import { Type, kConvertableToFloatVectors, scalarTypeOf } from '../../../../../util/conversion.js';
+import { kConvertableToFloatVectors, scalarTypeOf } from '../../../../../util/conversion.js';
 import { ShaderValidationTest } from '../../../shader_validation_test.js';
 
 import {
@@ -36,11 +36,6 @@ Validates that constant evaluation and override evaluation of ${builtin}() never
       .expand('b', u => fullRangeForType(kValidArgumentTypes[u.type], 5))
       .expand('c', u => fullRangeForType(kValidArgumentTypes[u.type], 5))
   )
-  .beforeAllSubcases(t => {
-    if (scalarTypeOf(kValidArgumentTypes[t.params.type]) === Type.f16) {
-      t.selectDeviceOrSkipTestCase('shader-f16');
-    }
-  })
   .fn(t => {
     const scalarType = scalarTypeOf(kValidArgumentTypes[t.params.type]);
     const vCheck = new ConstantOrOverrideValueChecker(t, scalarType);

--- a/src/webgpu/shader/validation/expression/call/builtin/modf.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/modf.spec.ts
@@ -9,7 +9,6 @@ import {
   Type,
   kConcreteIntegerScalarsAndVectors,
   kConvertableToFloatScalarsAndVectors,
-  scalarTypeOf,
 } from '../../../../../util/conversion.js';
 import { ShaderValidationTest } from '../../../shader_validation_test.js';
 
@@ -39,9 +38,6 @@ Validates that constant evaluation and override evaluation of ${builtin}() rejec
       .expand('value', u => fullRangeForType(kValuesTypes[u.type]))
   )
   .fn(t => {
-    if (scalarTypeOf(kValuesTypes[t.params.type]) === Type.f16) {
-      t.skipIfDeviceDoesNotHaveFeature('shader-f16');
-    }
     const expectedResult = true; // Result should always be representable by the type
     validateConstOrOverrideBuiltinEval(
       t,

--- a/src/webgpu/shader/validation/expression/call/builtin/normalize.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/normalize.spec.ts
@@ -68,17 +68,11 @@ Validates that constant evaluation and override evaluation of ${builtin}() rejec
       .beginSubcases()
       .expand('value', u => fullRangeForType(kValidArgumentTypes[u.type]))
   )
-  .beforeAllSubcases(t => {
-    if (scalarTypeOf(kValidArgumentTypes[t.params.type]) === Type.f16) {
-      t.selectDeviceOrSkipTestCase('shader-f16');
-    }
-  })
   .fn(t => {
     let expectedResult = true;
 
     const scalarType = scalarTypeOf(kValidArgumentTypes[t.params.type]);
     const quantizeFn = quantizeFunctionForScalarType(scalarType);
-
     // Should be invalid if the normalization calculations result in intermediate
     // values that exceed the maximum representable float value for the given type,
     // or if the length is smaller than the smallest representable float value.
@@ -122,11 +116,6 @@ Validates that all scalar arguments and vector integer or boolean arguments are 
 `
   )
   .params(u => u.combine('type', keysOf(kInvalidArgumentTypes)))
-  .beforeAllSubcases(t => {
-    if (kInvalidArgumentTypes[t.params.type] === Type.f16) {
-      t.selectDeviceOrSkipTestCase('shader-f16');
-    }
-  })
   .fn(t => {
     const expectedResult = false; // should always error with invalid argument types
     validateConstOrOverrideBuiltinEval(

--- a/src/webgpu/shader/validation/expression/call/builtin/pow.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/pow.spec.ts
@@ -55,11 +55,6 @@ it needs to be clarified in the spec if this is the desired behavior.
       .expand('a', u => fullRangeForType(kValidArgumentTypes[u.type], 5))
       .expand('b', u => fullRangeForType(kValidArgumentTypes[u.type], 5))
   )
-  .beforeAllSubcases(t => {
-    if (scalarTypeOf(kValidArgumentTypes[t.params.type]) === Type.f16) {
-      t.selectDeviceOrSkipTestCase('shader-f16');
-    }
-  })
   .fn(t => {
     let expectedResult = true;
 
@@ -106,11 +101,6 @@ Validates that all integer or boolean scalar and vector arguments are rejected b
 `
   )
   .params(u => u.combine('type', keysOf(kInvalidArgumentTypes)))
-  .beforeAllSubcases(t => {
-    if (kInvalidArgumentTypes[t.params.type] === Type.f16) {
-      t.selectDeviceOrSkipTestCase('shader-f16');
-    }
-  })
   .fn(t => {
     const expectedResult = false; // should always error with invalid argument types
     const type = kInvalidArgumentTypes[t.params.type];

--- a/src/webgpu/shader/validation/expression/call/builtin/quadBroadcast.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/quadBroadcast.spec.ts
@@ -17,9 +17,6 @@ export const g = makeTestGroup(ShaderValidationTest);
 g.test('requires_subgroups')
   .desc('Validates that the subgroups feature is required')
   .params(u => u.combine('enable', [false, true] as const))
-  .beforeAllSubcases(t => {
-    t.selectDeviceOrSkipTestCase('subgroups' as GPUFeatureName);
-  })
   .fn(t => {
     const wgsl = `
 ${t.params.enable ? 'enable subgroups;' : ''}
@@ -53,9 +50,6 @@ fn main() {
 g.test('early_eval')
   .desc('Ensures the builtin is not able to be compile time evaluated')
   .params(u => u.combine('stage', keysOf(kStages)))
-  .beforeAllSubcases(t => {
-    t.selectDeviceOrSkipTestCase('subgroups' as GPUFeatureName);
-  })
   .fn(t => {
     const code = kStages[t.params.stage];
     t.expectCompileResult(t.params.stage === 'runtime', code);
@@ -64,9 +58,6 @@ g.test('early_eval')
 g.test('must_use')
   .desc('Tests that the builtin has the @must_use attribute')
   .params(u => u.combine('must_use', [true, false] as const))
-  .beforeAllSubcases(t => {
-    t.selectDeviceOrSkipTestCase('subgroups' as GPUFeatureName);
-  })
   .fn(t => {
     const wgsl = `
 enable subgroups;
@@ -81,14 +72,6 @@ fn main() {
 g.test('data_type')
   .desc('Validates data parameter type')
   .params(u => u.combine('type', keysOf(kArgumentTypes)))
-  .beforeAllSubcases(t => {
-    const features = ['subgroups' as GPUFeatureName];
-    const type = kArgumentTypes[t.params.type];
-    if (type.requiresF16()) {
-      features.push('shader-f16');
-    }
-    t.selectDeviceOrSkipTestCase(features);
-  })
   .fn(t => {
     const type = kArgumentTypes[t.params.type];
     let enables = `enable subgroups;\n`;
@@ -124,15 +107,6 @@ g.test('return_type')
         );
       })
   )
-  .beforeAllSubcases(t => {
-    const features = ['subgroups' as GPUFeatureName];
-    const dataType = kArgumentTypes[t.params.dataType];
-    const retType = kArgumentTypes[t.params.retType];
-    if (dataType.requiresF16() || retType.requiresF16()) {
-      features.push('shader-f16');
-    }
-    t.selectDeviceOrSkipTestCase(features);
-  })
   .fn(t => {
     const dataType = kArgumentTypes[t.params.dataType];
     const retType = kArgumentTypes[t.params.retType];
@@ -154,9 +128,6 @@ fn main() {
 g.test('id_type')
   .desc('Validates id parameter type')
   .params(u => u.combine('type', keysOf(kArgumentTypes)))
-  .beforeAllSubcases(t => {
-    t.selectDeviceOrSkipTestCase('subgroups' as GPUFeatureName);
-  })
   .fn(t => {
     const type = kArgumentTypes[t.params.type];
     const wgsl = `
@@ -204,9 +175,6 @@ const kIdCases = {
 g.test('id_constness')
   .desc('Validates that id must be a const-expression')
   .params(u => u.combine('value', keysOf(kIdCases)))
-  .beforeAllSubcases(t => {
-    t.selectDeviceOrSkipTestCase('subgroups' as GPUFeatureName);
-  })
   .fn(t => {
     const wgsl = `
 enable subgroups;
@@ -230,9 +198,6 @@ g.test('id_values')
       .beginSubcases()
       .combine('type', ['literal', 'const', 'expr'] as const)
   )
-  .beforeAllSubcases(t => {
-    t.selectDeviceOrSkipTestCase('subgroups' as GPUFeatureName);
-  })
   .fn(t => {
     let arg = `${t.params.value}`;
     if (t.params.type === 'const') {
@@ -257,9 +222,6 @@ fn foo() {
 g.test('stage')
   .desc('Validates it is only usable in correct stage')
   .params(u => u.combine('stage', ['compute', 'fragment', 'vertex'] as const))
-  .beforeAllSubcases(t => {
-    t.selectDeviceOrSkipTestCase('subgroups' as GPUFeatureName);
-  })
   .fn(t => {
     const compute = `
 @compute @workgroup_size(1)

--- a/src/webgpu/shader/validation/expression/call/builtin/quadSwap.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/quadSwap.spec.ts
@@ -19,9 +19,6 @@ const kOps = ['quadSwapX', 'quadSwapY', 'quadSwapDiagonal'] as const;
 g.test('requires_subgroups')
   .desc('Validates that the subgroups feature is required')
   .params(u => u.combine('enable', [false, true] as const).combine('op', kOps))
-  .beforeAllSubcases(t => {
-    t.selectDeviceOrSkipTestCase('subgroups' as GPUFeatureName);
-  })
   .fn(t => {
     const wgsl = `
 ${t.params.enable ? 'enable subgroups;' : ''}
@@ -59,9 +56,6 @@ fn main() {
 g.test('early_eval')
   .desc('Ensures the builtin is not able to be compile time evaluated')
   .params(u => u.combine('stage', keysOf(kStages)).combine('op', kOps))
-  .beforeAllSubcases(t => {
-    t.selectDeviceOrSkipTestCase('subgroups' as GPUFeatureName);
-  })
   .fn(t => {
     const code = kStages[t.params.stage](t.params.op);
     t.expectCompileResult(t.params.stage === 'runtime', code);
@@ -70,9 +64,6 @@ g.test('early_eval')
 g.test('must_use')
   .desc('Tests that the builtin has the @must_use attribute')
   .params(u => u.combine('must_use', [true, false] as const).combine('op', kOps))
-  .beforeAllSubcases(t => {
-    t.selectDeviceOrSkipTestCase('subgroups' as GPUFeatureName);
-  })
   .fn(t => {
     const wgsl = `
 enable subgroups;
@@ -89,14 +80,6 @@ const kTypes = objectsToRecord(kAllScalarsAndVectors);
 g.test('data_type')
   .desc('Validates data parameter type')
   .params(u => u.combine('type', keysOf(kTypes)).combine('op', kOps))
-  .beforeAllSubcases(t => {
-    const features = ['subgroups' as GPUFeatureName];
-    const type = kTypes[t.params.type];
-    if (type.requiresF16()) {
-      features.push('shader-f16');
-    }
-    t.selectDeviceOrSkipTestCase(features);
-  })
   .fn(t => {
     const type = kTypes[t.params.type];
     let enables = `enable subgroups;\n`;
@@ -127,15 +110,6 @@ g.test('return_type')
       .combine('op', kOps)
       .combine('paramType', keysOf(kTypes))
   )
-  .beforeAllSubcases(t => {
-    const features = ['subgroups' as GPUFeatureName];
-    const retType = kTypes[t.params.retType];
-    const paramType = kTypes[t.params.paramType];
-    if (retType.requiresF16() || paramType.requiresF16()) {
-      features.push('shader-f16');
-    }
-    t.selectDeviceOrSkipTestCase(features);
-  })
   .fn(t => {
     const retType = kTypes[t.params.retType];
     const paramType = kTypes[t.params.paramType];
@@ -166,9 +140,6 @@ fn main() {
 g.test('stage')
   .desc('validates builtin is only usable in the correct stages')
   .params(u => u.combine('stage', ['compute', 'fragment', 'vertex'] as const).combine('op', kOps))
-  .beforeAllSubcases(t => {
-    t.selectDeviceOrSkipTestCase('subgroups' as GPUFeatureName);
-  })
   .fn(t => {
     const compute = `
 @compute @workgroup_size(1)

--- a/src/webgpu/shader/validation/expression/call/builtin/quantizeToF16.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/quantizeToF16.spec.ts
@@ -92,11 +92,6 @@ const kArgCases = {
 g.test('args')
   .desc(`Test compilation failure of ${builtin} with variously shaped and typed arguments`)
   .params(u => u.combine('arg', keysOf(kArgCases)))
-  .beforeAllSubcases(t => {
-    if (t.params.arg in kArgCasesF16) {
-      t.selectDeviceOrSkipTestCase('shader-f16');
-    }
-  })
   .fn(t => {
     t.expectCompileResult(
       t.params.arg === 'good',

--- a/src/webgpu/shader/validation/expression/call/builtin/radians.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/radians.spec.ts
@@ -9,7 +9,6 @@ import {
   Type,
   kConcreteIntegerScalarsAndVectors,
   kConvertableToFloatScalarsAndVectors,
-  scalarTypeOf,
 } from '../../../../../util/conversion.js';
 import { ShaderValidationTest } from '../../../shader_validation_test.js';
 
@@ -39,9 +38,6 @@ Validates that constant evaluation and override evaluation of ${builtin}() input
       .expand('value', u => fullRangeForType(kValuesTypes[u.type]))
   )
   .fn(t => {
-    if (scalarTypeOf(kValuesTypes[t.params.type]) === Type.f16) {
-      t.skipIfDeviceDoesNotHaveFeature('shader-f16');
-    }
     const expectedResult = true; // The result is always smaller than the input, so can't go OOB.
     validateConstOrOverrideBuiltinEval(
       t,

--- a/src/webgpu/shader/validation/expression/call/builtin/reflect.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/reflect.spec.ts
@@ -51,17 +51,11 @@ Validates that constant evaluation and override evaluation of ${builtin}() never
       .expand('a', u => fullRangeForType(kValidArgumentTypes[u.type], 5))
       .expand('b', u => fullRangeForType(kValidArgumentTypes[u.type], 5))
   )
-  .beforeAllSubcases(t => {
-    if (scalarTypeOf(kValidArgumentTypes[t.params.type]) === Type.f16) {
-      t.selectDeviceOrSkipTestCase('shader-f16');
-    }
-  })
   .fn(t => {
     let expectedResult = true;
 
     const scalarType = scalarTypeOf(kValidArgumentTypes[t.params.type]);
     const quantizeFn = quantizeFunctionForScalarType(scalarType);
-
     // Reflect equation: a - 2 * dot(b, a) * b
     // Should be invalid if the reflect calculations result in intermediate
     // values that exceed the maximum representable float value for the given type.

--- a/src/webgpu/shader/validation/expression/call/builtin/refract.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/refract.spec.ts
@@ -70,11 +70,6 @@ where a the calculations result in a non-representable value for the given type.
       .expand('b', u => fullRangeForType(kValidArgumentTypes[u.type], 5))
       .expand('c', u => fullRangeForType(kValidArgumentTypes[u.type], 5))
   )
-  .beforeAllSubcases(t => {
-    if (scalarTypeOf(kValidArgumentTypes[t.params.type]) === Type.f16) {
-      t.selectDeviceOrSkipTestCase('shader-f16');
-    }
-  })
   .fn(t => {
     const type = kValidArgumentTypes[t.params.type];
     const scalarType = scalarTypeOf(kValidArgumentTypes[t.params.type]);

--- a/src/webgpu/shader/validation/expression/call/builtin/round.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/round.spec.ts
@@ -51,9 +51,6 @@ Validates that constant evaluation and override evaluation of ${builtin}() input
       })
   )
   .fn(t => {
-    if (scalarTypeOf(kValuesTypes[t.params.type]) === Type.f16) {
-      t.skipIfDeviceDoesNotHaveFeature('shader-f16');
-    }
     const expectedResult = true; // Result should always be representable by the type
     validateConstOrOverrideBuiltinEval(
       t,

--- a/src/webgpu/shader/validation/expression/call/builtin/saturate.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/saturate.spec.ts
@@ -9,7 +9,6 @@ import {
   Type,
   kConcreteIntegerScalarsAndVectors,
   kConvertableToFloatScalarsAndVectors,
-  scalarTypeOf,
 } from '../../../../../util/conversion.js';
 import { ShaderValidationTest } from '../../../shader_validation_test.js';
 
@@ -39,9 +38,6 @@ Validates that constant evaluation and override evaluation of ${builtin}() input
       .expand('value', u => fullRangeForType(kValuesTypes[u.type]))
   )
   .fn(t => {
-    if (scalarTypeOf(kValuesTypes[t.params.type]) === Type.f16) {
-      t.skipIfDeviceDoesNotHaveFeature('shader-f16');
-    }
     const expectedResult = true; // Result should always be representable by the type
     validateConstOrOverrideBuiltinEval(
       t,

--- a/src/webgpu/shader/validation/expression/call/builtin/select.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/select.spec.ts
@@ -10,7 +10,6 @@ import {
   concreteTypeOf,
   isConvertible,
   kAllScalarsAndVectors,
-  scalarTypeOf,
 } from '../../../../../util/conversion.js';
 import { ShaderValidationTest } from '../../../shader_validation_test.js';
 
@@ -27,14 +26,6 @@ Validates that scalar and vector arguments are not rejected by ${builtin}() for 
 `
   )
   .params(u => u.combine('type1', keysOf(kArgumentTypes)).combine('type2', keysOf(kArgumentTypes)))
-  .beforeAllSubcases(t => {
-    if (
-      scalarTypeOf(kArgumentTypes[t.params.type1]) === Type.f16 ||
-      scalarTypeOf(kArgumentTypes[t.params.type2]) === Type.f16
-    ) {
-      t.selectDeviceOrSkipTestCase('shader-f16');
-    }
-  })
   .fn(t => {
     const type1 = kArgumentTypes[t.params.type1];
     const type2 = kArgumentTypes[t.params.type2];
@@ -62,11 +53,6 @@ Validates that third argument must be bool for ${builtin}()
 `
   )
   .params(u => u.combine('type', keysOf(kArgumentTypes)))
-  .beforeAllSubcases(t => {
-    if (scalarTypeOf(kArgumentTypes[t.params.type]) === Type.f16) {
-      t.selectDeviceOrSkipTestCase('shader-f16');
-    }
-  })
   .fn(t => {
     const type = kArgumentTypes[t.params.type];
     validateConstOrOverrideBuiltinEval(
@@ -215,11 +201,6 @@ g.test('must_use')
 g.test('arguments')
   .desc(`Test that ${builtin} is validated correctly.`)
   .params(u => u.combine('test', keysOf(kTests)))
-  .beforeAllSubcases(t => {
-    if (t.params.test.includes('f16')) {
-      t.selectDeviceOrSkipTestCase('shader-f16');
-    }
-  })
   .fn(t => {
     const src = kTests[t.params.test].src;
     const enables = t.params.test.includes('f16') ? 'enable f16;' : '';

--- a/src/webgpu/shader/validation/expression/call/builtin/sign.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/sign.spec.ts
@@ -6,10 +6,8 @@ Validation tests for the ${builtin}() builtin.
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { keysOf, objectsToRecord } from '../../../../../../common/util/data_tables.js';
 import {
-  Type,
   kFloatScalarsAndVectors,
   kConcreteSignedIntegerScalarsAndVectors,
-  scalarTypeOf,
 } from '../../../../../util/conversion.js';
 import { ShaderValidationTest } from '../../../shader_validation_test.js';
 
@@ -42,9 +40,6 @@ Validates that constant evaluation and override evaluation of ${builtin}() input
       .expand('value', u => fullRangeForType(kValuesTypes[u.type]))
   )
   .fn(t => {
-    if (scalarTypeOf(kValuesTypes[t.params.type]) === Type.f16) {
-      t.skipIfDeviceDoesNotHaveFeature('shader-f16');
-    }
     const expectedResult = true; // Result should always be representable by the type
     validateConstOrOverrideBuiltinEval(
       t,

--- a/src/webgpu/shader/validation/expression/call/builtin/sin.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/sin.spec.ts
@@ -9,7 +9,6 @@ import {
   Type,
   kConcreteIntegerScalarsAndVectors,
   kConvertableToFloatScalarsAndVectors,
-  scalarTypeOf,
 } from '../../../../../util/conversion.js';
 import { ShaderValidationTest } from '../../../shader_validation_test.js';
 
@@ -46,9 +45,6 @@ Validates that constant evaluation and override evaluation of ${builtin}() rejec
       )
   )
   .fn(t => {
-    if (scalarTypeOf(kValuesTypes[t.params.type]) === Type.f16) {
-      t.skipIfDeviceDoesNotHaveFeature('shader-f16');
-    }
     validateConstOrOverrideBuiltinEval(
       t,
       builtin,

--- a/src/webgpu/shader/validation/expression/call/builtin/sinh.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/sinh.spec.ts
@@ -39,9 +39,6 @@ Validates that constant evaluation and override evaluation of ${builtin}() rejec
       .expand('value', u => fullRangeForType(kValuesTypes[u.type]))
   )
   .fn(t => {
-    if (scalarTypeOf(kValuesTypes[t.params.type]) === Type.f16) {
-      t.skipIfDeviceDoesNotHaveFeature('shader-f16');
-    }
     const type = kValuesTypes[t.params.type];
     const expectedResult = isRepresentable(
       Math.sinh(Number(t.params.value)),

--- a/src/webgpu/shader/validation/expression/call/builtin/smoothstep.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/smoothstep.spec.ts
@@ -44,9 +44,6 @@ Validates that constant evaluation and override evaluation of ${builtin}() rejec
       .expand('value2', u => [-1000, -10, 0, 10, 1000])
   )
   .fn(t => {
-    if (scalarTypeOf(kValuesTypes[t.params.type]) === Type.f16) {
-      t.skipIfDeviceDoesNotHaveFeature('shader-f16');
-    }
     const type = kValuesTypes[t.params.type];
 
     // We expect to fail if low == high.
@@ -82,9 +79,6 @@ g.test('partial_eval_errors')
       .combine('in_shader', [false, true] as const)
   )
   .fn(t => {
-    if (scalarTypeOf(kValuesTypes[t.params.type]) === Type.f16) {
-      t.skipIfDeviceDoesNotHaveFeature('shader-f16');
-    }
     const type = kValuesTypes[t.params.type];
     const scalarTy = scalarTypeOf(type);
     const enable = `${type.requiresF16() ? 'enable f16;' : ''}`;
@@ -153,11 +147,6 @@ Validates that scalar and vector arguments are rejected by ${builtin}() if not f
 `
   )
   .params(u => u.combine('type', keysOf(kArgumentTypes)))
-  .beforeAllSubcases(t => {
-    if (scalarTypeOf(kArgumentTypes[t.params.type]) === Type.f16) {
-      t.selectDeviceOrSkipTestCase('shader-f16');
-    }
-  })
   .fn(t => {
     const type = kArgumentTypes[t.params.type];
     const expectedResult = isConvertibleToFloatType(elementTypeOf(type));
@@ -296,11 +285,6 @@ const kTests = {
 g.test('arguments')
   .desc(`Test that ${builtin} is validated correctly when called with different arguments.`)
   .params(u => u.combine('test', keysOf(kTests)))
-  .beforeAllSubcases(t => {
-    if (t.params.test.includes('f16')) {
-      t.selectDeviceOrSkipTestCase('shader-f16');
-    }
-  })
   .fn(t => {
     const src = kTests[t.params.test].src;
     const enables = t.params.test.includes('f16') ? 'enable f16;' : '';

--- a/src/webgpu/shader/validation/expression/call/builtin/sqrt.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/sqrt.spec.ts
@@ -47,9 +47,6 @@ Validates that constant evaluation and override evaluation of ${builtin}() input
       )
   )
   .fn(t => {
-    if (scalarTypeOf(kValuesTypes[t.params.type]) === Type.f16) {
-      t.skipIfDeviceDoesNotHaveFeature('shader-f16');
-    }
     const type = kValuesTypes[t.params.type];
     const expectedResult =
       t.params.value >= 0 &&

--- a/src/webgpu/shader/validation/expression/call/builtin/step.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/step.spec.ts
@@ -5,11 +5,7 @@ Validation tests for the ${builtin}() builtin.
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { keysOf, objectsToRecord } from '../../../../../../common/util/data_tables.js';
-import {
-  Type,
-  kConvertableToFloatScalarsAndVectors,
-  scalarTypeOf,
-} from '../../../../../util/conversion.js';
+import { kConvertableToFloatScalarsAndVectors } from '../../../../../util/conversion.js';
 import { ShaderValidationTest } from '../../../shader_validation_test.js';
 
 import {
@@ -38,11 +34,6 @@ Validates that constant evaluation and override evaluation of ${builtin}() error
       .expand('a', u => fullRangeForType(kValidArgumentTypes[u.type], 5))
       .expand('b', u => fullRangeForType(kValidArgumentTypes[u.type], 5))
   )
-  .beforeAllSubcases(t => {
-    if (scalarTypeOf(kValidArgumentTypes[t.params.type]) === Type.f16) {
-      t.selectDeviceOrSkipTestCase('shader-f16');
-    }
-  })
   .fn(t => {
     const expectedResult = true;
 

--- a/src/webgpu/shader/validation/expression/call/builtin/subgroupAdd.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/subgroupAdd.spec.ts
@@ -38,9 +38,6 @@ fn main() {
 g.test('early_eval')
   .desc('Ensures the builtin is not able to be compile time evaluated')
   .params(u => u.combine('stage', keysOf(kStages)).beginSubcases().combine('builtin', kBuiltins))
-  .beforeAllSubcases(t => {
-    t.selectDeviceOrSkipTestCase('subgroups' as GPUFeatureName);
-  })
   .fn(t => {
     const code = kStages[t.params.stage](t.params.builtin);
     t.expectCompileResult(t.params.stage === 'runtime', code);
@@ -54,9 +51,6 @@ g.test('must_use')
       .beginSubcases()
       .combine('builtin', kBuiltins)
   )
-  .beforeAllSubcases(t => {
-    t.selectDeviceOrSkipTestCase('subgroups' as GPUFeatureName);
-  })
   .fn(t => {
     const wgsl = `
 enable subgroups;
@@ -75,14 +69,6 @@ g.test('data_type')
   .params(u =>
     u.combine('type', keysOf(kArgumentTypes)).beginSubcases().combine('builtin', kBuiltins)
   )
-  .beforeAllSubcases(t => {
-    const features = ['subgroups' as GPUFeatureName];
-    const type = kArgumentTypes[t.params.type];
-    if (type.requiresF16()) {
-      features.push('shader-f16');
-    }
-    t.selectDeviceOrSkipTestCase(features);
-  })
   .fn(t => {
     const type = kArgumentTypes[t.params.type];
     let enables = `enable subgroups;\n`;
@@ -120,15 +106,6 @@ g.test('return_type')
       .beginSubcases()
       .combine('builtin', kBuiltins)
   )
-  .beforeAllSubcases(t => {
-    const features = ['subgroups' as GPUFeatureName];
-    const dataType = kArgumentTypes[t.params.dataType];
-    const retType = kArgumentTypes[t.params.retType];
-    if (dataType.requiresF16() || retType.requiresF16()) {
-      features.push('shader-f16');
-    }
-    t.selectDeviceOrSkipTestCase(features);
-  })
   .fn(t => {
     const dataType = kArgumentTypes[t.params.dataType];
     const retType = kArgumentTypes[t.params.retType];
@@ -155,9 +132,6 @@ g.test('stage')
       .beginSubcases()
       .combine('builtin', kBuiltins)
   )
-  .beforeAllSubcases(t => {
-    t.selectDeviceOrSkipTestCase('subgroups' as GPUFeatureName);
-  })
   .fn(t => {
     const compute = `
 @compute @workgroup_size(1)
@@ -206,9 +180,6 @@ g.test('invalid_types')
   .params(u =>
     u.combine('case', keysOf(kInvalidTypeCases)).beginSubcases().combine('builtin', kBuiltins)
   )
-  .beforeAllSubcases(t => {
-    t.selectDeviceOrSkipTestCase('subgroups' as GPUFeatureName);
-  })
   .fn(t => {
     const val = kInvalidTypeCases[t.params.case];
     const wgsl = `

--- a/src/webgpu/shader/validation/expression/call/builtin/subgroupAnyAll.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/subgroupAnyAll.spec.ts
@@ -14,9 +14,6 @@ const kOps = ['subgroupAny', 'subgroupAll'] as const;
 g.test('requires_subgroups')
   .desc('Validates that the subgroups feature is required')
   .params(u => u.combine('enable', [false, true] as const).combine('op', kOps))
-  .beforeAllSubcases(t => {
-    t.selectDeviceOrSkipTestCase('subgroups' as GPUFeatureName);
-  })
   .fn(t => {
     const wgsl = `
 ${t.params.enable ? 'enable subgroups;' : ''}
@@ -54,9 +51,6 @@ fn main() {
 g.test('early_eval')
   .desc('Ensures the builtin is not able to be compile time evaluated')
   .params(u => u.combine('stage', keysOf(kStages)).combine('op', kOps))
-  .beforeAllSubcases(t => {
-    t.selectDeviceOrSkipTestCase('subgroups' as GPUFeatureName);
-  })
   .fn(t => {
     const code = kStages[t.params.stage](t.params.op);
     t.expectCompileResult(t.params.stage === 'runtime', code);
@@ -65,9 +59,6 @@ g.test('early_eval')
 g.test('must_use')
   .desc('Tests that the builtin has the @must_use attribute')
   .params(u => u.combine('must_use', [true, false] as const).combine('op', kOps))
-  .beforeAllSubcases(t => {
-    t.selectDeviceOrSkipTestCase('subgroups' as GPUFeatureName);
-  })
   .fn(t => {
     const wgsl = `
 enable subgroups;
@@ -84,14 +75,6 @@ const kTypes = objectsToRecord(kAllScalarsAndVectors);
 g.test('data_type')
   .desc('Validates data parameter type')
   .params(u => u.combine('type', keysOf(kTypes)).combine('op', kOps))
-  .beforeAllSubcases(t => {
-    const features = ['subgroups' as GPUFeatureName];
-    const type = kTypes[t.params.type];
-    if (type.requiresF16()) {
-      features.push('shader-f16');
-    }
-    t.selectDeviceOrSkipTestCase(features);
-  })
   .fn(t => {
     const type = kTypes[t.params.type];
     let enables = `enable subgroups;\n`;
@@ -120,14 +103,6 @@ g.test('return_type')
       })
       .combine('op', kOps)
   )
-  .beforeAllSubcases(t => {
-    const features = ['subgroups' as GPUFeatureName];
-    const type = kTypes[t.params.type];
-    if (type.requiresF16()) {
-      features.push('shader-f16');
-    }
-    t.selectDeviceOrSkipTestCase(features);
-  })
   .fn(t => {
     const type = kTypes[t.params.type];
     let enables = `enable subgroups;\n`;
@@ -147,9 +122,6 @@ fn main() {
 g.test('stage')
   .desc('validates builtin is only usable in the correct stages')
   .params(u => u.combine('stage', ['compute', 'fragment', 'vertex'] as const).combine('op', kOps))
-  .beforeAllSubcases(t => {
-    t.selectDeviceOrSkipTestCase('subgroups' as GPUFeatureName);
-  })
   .fn(t => {
     const compute = `
 @compute @workgroup_size(1)

--- a/src/webgpu/shader/validation/expression/call/builtin/subgroupBallot.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/subgroupBallot.spec.ts
@@ -12,9 +12,6 @@ export const g = makeTestGroup(ShaderValidationTest);
 g.test('requires_subgroups')
   .desc('Validates that the subgroups feature is required')
   .params(u => u.combine('enable', [false, true] as const))
-  .beforeAllSubcases(t => {
-    t.selectDeviceOrSkipTestCase('subgroups' as GPUFeatureName);
-  })
   .fn(t => {
     const wgsl = `
 ${t.params.enable ? 'enable subgroups;' : ''}
@@ -46,9 +43,6 @@ fn main() {
 g.test('early_eval')
   .desc('Ensures the builtin is not able to be compile time evaluated')
   .params(u => u.combine('stage', keysOf(kStages)))
-  .beforeAllSubcases(t => {
-    t.selectDeviceOrSkipTestCase('subgroups' as GPUFeatureName);
-  })
   .fn(t => {
     const code = kStages[t.params.stage];
     t.expectCompileResult(t.params.stage === 'runtime', code);
@@ -57,9 +51,6 @@ g.test('early_eval')
 g.test('must_use')
   .desc('Tests that the builtin has the @must_use attribute')
   .params(u => u.combine('must_use', [true, false] as const))
-  .beforeAllSubcases(t => {
-    t.selectDeviceOrSkipTestCase('subgroups' as GPUFeatureName);
-  })
   .fn(t => {
     const wgsl = `
 enable subgroups;
@@ -76,14 +67,6 @@ const kArgumentTypes = objectsToRecord(kAllScalarsAndVectors);
 g.test('data_type')
   .desc('Validates data parameter type')
   .params(u => u.combine('type', keysOf(kArgumentTypes)))
-  .beforeAllSubcases(t => {
-    const features = ['subgroups' as GPUFeatureName];
-    const type = kArgumentTypes[t.params.type];
-    if (type.requiresF16()) {
-      features.push('shader-f16');
-    }
-    t.selectDeviceOrSkipTestCase(features);
-  })
   .fn(t => {
     const type = kArgumentTypes[t.params.type];
     let enables = `enable subgroups;\n`;
@@ -109,14 +92,6 @@ g.test('return_type')
       return eleType !== Type.abstractInt && eleType !== Type.abstractFloat;
     })
   )
-  .beforeAllSubcases(t => {
-    const features = ['subgroups' as GPUFeatureName];
-    const type = kArgumentTypes[t.params.type];
-    if (type.requiresF16()) {
-      features.push('shader-f16');
-    }
-    t.selectDeviceOrSkipTestCase(features);
-  })
   .fn(t => {
     const type = kArgumentTypes[t.params.type];
     let enables = `enable subgroups;\n`;
@@ -136,9 +111,6 @@ fn main() {
 g.test('stage')
   .desc('Validates it is only usable in correct stage')
   .params(u => u.combine('stage', ['compute', 'fragment', 'vertex'] as const))
-  .beforeAllSubcases(t => {
-    t.selectDeviceOrSkipTestCase('subgroups' as GPUFeatureName);
-  })
   .fn(t => {
     const compute = `
 @compute @workgroup_size(1)

--- a/src/webgpu/shader/validation/expression/call/builtin/subgroupBitwise.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/subgroupBitwise.spec.ts
@@ -19,9 +19,6 @@ const kOps = ['subgroupAnd', 'subgroupOr', 'subgroupXor'] as const;
 g.test('requires_subgroups')
   .desc('Validates that the subgroups feature is required')
   .params(u => u.combine('enable', [false, true] as const).combine('op', kOps))
-  .beforeAllSubcases(t => {
-    t.selectDeviceOrSkipTestCase('subgroups' as GPUFeatureName);
-  })
   .fn(t => {
     const wgsl = `
 ${t.params.enable ? 'enable subgroups;' : ''}
@@ -59,9 +56,6 @@ fn main() {
 g.test('early_eval')
   .desc('Ensures the builtin is not able to be compile time evaluated')
   .params(u => u.combine('stage', keysOf(kStages)).combine('op', kOps))
-  .beforeAllSubcases(t => {
-    t.selectDeviceOrSkipTestCase('subgroups' as GPUFeatureName);
-  })
   .fn(t => {
     const code = kStages[t.params.stage](t.params.op);
     t.expectCompileResult(t.params.stage === 'runtime', code);
@@ -70,9 +64,6 @@ g.test('early_eval')
 g.test('must_use')
   .desc('Tests that the builtin has the @must_use attribute')
   .params(u => u.combine('must_use', [true, false] as const).combine('op', kOps))
-  .beforeAllSubcases(t => {
-    t.selectDeviceOrSkipTestCase('subgroups' as GPUFeatureName);
-  })
   .fn(t => {
     const wgsl = `
 enable subgroups;
@@ -89,14 +80,6 @@ const kTypes = objectsToRecord(kAllScalarsAndVectors);
 g.test('data_type')
   .desc('Validates data parameter type')
   .params(u => u.combine('type', keysOf(kTypes)).combine('op', kOps))
-  .beforeAllSubcases(t => {
-    const features = ['subgroups' as GPUFeatureName];
-    const type = kTypes[t.params.type];
-    if (type.requiresF16()) {
-      features.push('shader-f16');
-    }
-    t.selectDeviceOrSkipTestCase(features);
-  })
   .fn(t => {
     const type = kTypes[t.params.type];
     let enables = `enable subgroups;\n`;
@@ -128,15 +111,6 @@ g.test('return_type')
       .combine('op', kOps)
       .combine('paramType', keysOf(kTypes))
   )
-  .beforeAllSubcases(t => {
-    const features = ['subgroups' as GPUFeatureName];
-    const retType = kTypes[t.params.retType];
-    const paramType = kTypes[t.params.paramType];
-    if (retType.requiresF16() || paramType.requiresF16()) {
-      features.push('shader-f16');
-    }
-    t.selectDeviceOrSkipTestCase(features);
-  })
   .fn(t => {
     const retType = kTypes[t.params.retType];
     const paramType = kTypes[t.params.paramType];
@@ -165,9 +139,6 @@ fn main() {
 g.test('stage')
   .desc('validates builtin is only usable in the correct stages')
   .params(u => u.combine('stage', ['compute', 'fragment', 'vertex'] as const).combine('op', kOps))
-  .beforeAllSubcases(t => {
-    t.selectDeviceOrSkipTestCase('subgroups' as GPUFeatureName);
-  })
   .fn(t => {
     const compute = `
 @compute @workgroup_size(1)

--- a/src/webgpu/shader/validation/expression/call/builtin/subgroupBroadcast.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/subgroupBroadcast.spec.ts
@@ -17,9 +17,6 @@ export const g = makeTestGroup(ShaderValidationTest);
 g.test('requires_subgroups')
   .desc('Validates that the subgroups feature is required')
   .params(u => u.combine('enable', [false, true] as const))
-  .beforeAllSubcases(t => {
-    t.selectDeviceOrSkipTestCase('subgroups' as GPUFeatureName);
-  })
   .fn(t => {
     const wgsl = `
 ${t.params.enable ? 'enable subgroups;' : ''}
@@ -53,9 +50,6 @@ fn main() {
 g.test('early_eval')
   .desc('Ensures the builtin is not able to be compile time evaluated')
   .params(u => u.combine('stage', keysOf(kStages)))
-  .beforeAllSubcases(t => {
-    t.selectDeviceOrSkipTestCase('subgroups' as GPUFeatureName);
-  })
   .fn(t => {
     const code = kStages[t.params.stage];
     t.expectCompileResult(t.params.stage === 'runtime', code);
@@ -64,9 +58,6 @@ g.test('early_eval')
 g.test('must_use')
   .desc('Tests that the builtin has the @must_use attribute')
   .params(u => u.combine('must_use', [true, false] as const))
-  .beforeAllSubcases(t => {
-    t.selectDeviceOrSkipTestCase('subgroups' as GPUFeatureName);
-  })
   .fn(t => {
     const wgsl = `
 enable subgroups;
@@ -81,14 +72,6 @@ fn main() {
 g.test('data_type')
   .desc('Validates data parameter type')
   .params(u => u.combine('type', keysOf(kArgumentTypes)))
-  .beforeAllSubcases(t => {
-    const features = ['subgroups' as GPUFeatureName];
-    const type = kArgumentTypes[t.params.type];
-    if (type.requiresF16()) {
-      features.push('shader-f16');
-    }
-    t.selectDeviceOrSkipTestCase(features);
-  })
   .fn(t => {
     const type = kArgumentTypes[t.params.type];
     let enables = `enable subgroups;\n`;
@@ -124,15 +107,6 @@ g.test('return_type')
         );
       })
   )
-  .beforeAllSubcases(t => {
-    const features = ['subgroups' as GPUFeatureName];
-    const dataType = kArgumentTypes[t.params.dataType];
-    const retType = kArgumentTypes[t.params.retType];
-    if (dataType.requiresF16() || retType.requiresF16()) {
-      features.push('shader-f16');
-    }
-    t.selectDeviceOrSkipTestCase(features);
-  })
   .fn(t => {
     const dataType = kArgumentTypes[t.params.dataType];
     const retType = kArgumentTypes[t.params.retType];
@@ -154,9 +128,6 @@ fn main() {
 g.test('id_type')
   .desc('Validates id parameter type')
   .params(u => u.combine('type', keysOf(kArgumentTypes)))
-  .beforeAllSubcases(t => {
-    t.selectDeviceOrSkipTestCase('subgroups' as GPUFeatureName);
-  })
   .fn(t => {
     const type = kArgumentTypes[t.params.type];
     const wgsl = `
@@ -204,9 +175,6 @@ const kIdCases = {
 g.test('id_constness')
   .desc('Validates that id must be a const-expression')
   .params(u => u.combine('value', keysOf(kIdCases)))
-  .beforeAllSubcases(t => {
-    t.selectDeviceOrSkipTestCase('subgroups' as GPUFeatureName);
-  })
   .fn(t => {
     const wgsl = `
 enable subgroups;
@@ -230,9 +198,6 @@ g.test('id_values')
       .beginSubcases()
       .combine('type', ['literal', 'const', 'expr'] as const)
   )
-  .beforeAllSubcases(t => {
-    t.selectDeviceOrSkipTestCase('subgroups' as GPUFeatureName);
-  })
   .fn(t => {
     let arg = `${t.params.value}`;
     if (t.params.type === 'const') {
@@ -257,9 +222,6 @@ fn foo() {
 g.test('stage')
   .desc('Validates it is only usable in correct stage')
   .params(u => u.combine('stage', ['compute', 'fragment', 'vertex'] as const))
-  .beforeAllSubcases(t => {
-    t.selectDeviceOrSkipTestCase('subgroups' as GPUFeatureName);
-  })
   .fn(t => {
     const compute = `
 @compute @workgroup_size(1)

--- a/src/webgpu/shader/validation/expression/call/builtin/subgroupBroadcastFirst.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/subgroupBroadcastFirst.spec.ts
@@ -12,9 +12,6 @@ export const g = makeTestGroup(ShaderValidationTest);
 g.test('requires_subgroups')
   .desc('Validates that the subgroups feature is required')
   .params(u => u.combine('enable', [false, true] as const))
-  .beforeAllSubcases(t => {
-    t.selectDeviceOrSkipTestCase('subgroups' as GPUFeatureName);
-  })
   .fn(t => {
     const wgsl = `
 ${t.params.enable ? 'enable subgroups;' : ''}
@@ -48,9 +45,6 @@ fn main() {
 g.test('early_eval')
   .desc('Ensures the builtin is not able to be compile time evaluated')
   .params(u => u.combine('stage', keysOf(kStages)))
-  .beforeAllSubcases(t => {
-    t.selectDeviceOrSkipTestCase('subgroups' as GPUFeatureName);
-  })
   .fn(t => {
     const code = kStages[t.params.stage];
     t.expectCompileResult(t.params.stage === 'runtime', code);
@@ -59,9 +53,6 @@ g.test('early_eval')
 g.test('must_use')
   .desc('Tests that the builtin has the @must_use attribute')
   .params(u => u.combine('must_use', [true, false] as const))
-  .beforeAllSubcases(t => {
-    t.selectDeviceOrSkipTestCase('subgroups' as GPUFeatureName);
-  })
   .fn(t => {
     const wgsl = `
 enable subgroups;
@@ -76,14 +67,6 @@ fn main() {
 g.test('data_type')
   .desc('Validates data parameter type')
   .params(u => u.combine('type', keysOf(kArgumentTypes)))
-  .beforeAllSubcases(t => {
-    const features = ['subgroups' as GPUFeatureName];
-    const type = kArgumentTypes[t.params.type];
-    if (type.requiresF16()) {
-      features.push('shader-f16');
-    }
-    t.selectDeviceOrSkipTestCase(features);
-  })
   .fn(t => {
     const type = kArgumentTypes[t.params.type];
     let enables = `enable subgroups;\n`;
@@ -119,15 +102,6 @@ g.test('return_type')
         );
       })
   )
-  .beforeAllSubcases(t => {
-    const features = ['subgroups' as GPUFeatureName];
-    const dataType = kArgumentTypes[t.params.dataType];
-    const retType = kArgumentTypes[t.params.retType];
-    if (dataType.requiresF16() || retType.requiresF16()) {
-      features.push('shader-f16');
-    }
-    t.selectDeviceOrSkipTestCase(features);
-  })
   .fn(t => {
     const dataType = kArgumentTypes[t.params.dataType];
     const retType = kArgumentTypes[t.params.retType];
@@ -149,9 +123,6 @@ fn main() {
 g.test('stage')
   .desc('Validates it is only usable in correct stage')
   .params(u => u.combine('stage', ['compute', 'fragment', 'vertex'] as const))
-  .beforeAllSubcases(t => {
-    t.selectDeviceOrSkipTestCase('subgroups' as GPUFeatureName);
-  })
   .fn(t => {
     const compute = `
 @compute @workgroup_size(1)

--- a/src/webgpu/shader/validation/expression/call/builtin/subgroupElect.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/subgroupElect.spec.ts
@@ -12,9 +12,6 @@ export const g = makeTestGroup(ShaderValidationTest);
 g.test('requires_subgroups')
   .desc('Validates that the subgroups feature is required')
   .params(u => u.combine('enable', [false, true] as const))
-  .beforeAllSubcases(t => {
-    t.selectDeviceOrSkipTestCase('subgroups' as GPUFeatureName);
-  })
   .fn(t => {
     const wgsl = `
 ${t.params.enable ? 'enable subgroups;' : ''}
@@ -46,9 +43,6 @@ fn main() {
 g.test('early_eval')
   .desc('Ensures the builtin is not able to be compile time evaluated')
   .params(u => u.combine('stage', keysOf(kStages)))
-  .beforeAllSubcases(t => {
-    t.selectDeviceOrSkipTestCase('subgroups' as GPUFeatureName);
-  })
   .fn(t => {
     const code = kStages[t.params.stage];
     t.expectCompileResult(t.params.stage === 'runtime', code);
@@ -57,9 +51,6 @@ g.test('early_eval')
 g.test('must_use')
   .desc('Tests that the builtin has the @must_use attribute')
   .params(u => u.combine('must_use', [true, false] as const))
-  .beforeAllSubcases(t => {
-    t.selectDeviceOrSkipTestCase('subgroups' as GPUFeatureName);
-  })
   .fn(t => {
     const wgsl = `
 enable subgroups;
@@ -76,14 +67,6 @@ const kTypes = objectsToRecord(kAllScalarsAndVectors);
 g.test('data_type')
   .desc('Validates there are no valid data parameters')
   .params(u => u.combine('type', keysOf(kTypes)))
-  .beforeAllSubcases(t => {
-    const features = ['subgroups' as GPUFeatureName];
-    const type = kTypes[t.params.type];
-    if (type.requiresF16()) {
-      features.push('shader-f16');
-    }
-    t.selectDeviceOrSkipTestCase(features);
-  })
   .fn(t => {
     const type = kTypes[t.params.type];
     let enables = `enable subgroups;\n`;
@@ -109,14 +92,6 @@ g.test('return_type')
       return eleType !== Type.abstractInt && eleType !== Type.abstractFloat;
     })
   )
-  .beforeAllSubcases(t => {
-    const features = ['subgroups' as GPUFeatureName];
-    const type = kTypes[t.params.type];
-    if (type.requiresF16()) {
-      features.push('shader-f16');
-    }
-    t.selectDeviceOrSkipTestCase(features);
-  })
   .fn(t => {
     const type = kTypes[t.params.type];
     let enables = `enable subgroups;\n`;
@@ -136,9 +111,6 @@ fn main() {
 g.test('stage')
   .desc('validates builtin is only usable in the correct stages')
   .params(u => u.combine('stage', ['compute', 'fragment', 'vertex'] as const))
-  .beforeAllSubcases(t => {
-    t.selectDeviceOrSkipTestCase('subgroups' as GPUFeatureName);
-  })
   .fn(t => {
     const compute = `
 @compute @workgroup_size(1)

--- a/src/webgpu/shader/validation/expression/call/builtin/subgroupMinMax.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/subgroupMinMax.spec.ts
@@ -19,9 +19,6 @@ const kOps = ['subgroupMin', 'subgroupMax'] as const;
 g.test('requires_subgroups')
   .desc('Validates that the subgroups feature is required')
   .params(u => u.combine('enable', [false, true] as const).combine('op', kOps))
-  .beforeAllSubcases(t => {
-    t.selectDeviceOrSkipTestCase('subgroups' as GPUFeatureName);
-  })
   .fn(t => {
     const wgsl = `
 ${t.params.enable ? 'enable subgroups;' : ''}
@@ -59,9 +56,6 @@ fn main() {
 g.test('early_eval')
   .desc('Ensures the builtin is not able to be compile time evaluated')
   .params(u => u.combine('stage', keysOf(kStages)).combine('op', kOps))
-  .beforeAllSubcases(t => {
-    t.selectDeviceOrSkipTestCase('subgroups' as GPUFeatureName);
-  })
   .fn(t => {
     const code = kStages[t.params.stage](t.params.op);
     t.expectCompileResult(t.params.stage === 'runtime', code);
@@ -70,9 +64,6 @@ g.test('early_eval')
 g.test('must_use')
   .desc('Tests that the builtin has the @must_use attribute')
   .params(u => u.combine('must_use', [true, false] as const).combine('op', kOps))
-  .beforeAllSubcases(t => {
-    t.selectDeviceOrSkipTestCase('subgroups' as GPUFeatureName);
-  })
   .fn(t => {
     const wgsl = `
 enable subgroups;
@@ -89,14 +80,6 @@ const kTypes = objectsToRecord(kAllScalarsAndVectors);
 g.test('data_type')
   .desc('Validates data parameter type')
   .params(u => u.combine('type', keysOf(kTypes)).combine('op', kOps))
-  .beforeAllSubcases(t => {
-    const features = ['subgroups' as GPUFeatureName];
-    const type = kTypes[t.params.type];
-    if (type.requiresF16()) {
-      features.push('shader-f16');
-    }
-    t.selectDeviceOrSkipTestCase(features);
-  })
   .fn(t => {
     const type = kTypes[t.params.type];
     let enables = `enable subgroups;\n`;
@@ -127,15 +110,6 @@ g.test('return_type')
       .combine('op', kOps)
       .combine('paramType', keysOf(kTypes))
   )
-  .beforeAllSubcases(t => {
-    const features = ['subgroups' as GPUFeatureName];
-    const retType = kTypes[t.params.retType];
-    const paramType = kTypes[t.params.paramType];
-    if (retType.requiresF16() || paramType.requiresF16()) {
-      features.push('shader-f16');
-    }
-    t.selectDeviceOrSkipTestCase(features);
-  })
   .fn(t => {
     const retType = kTypes[t.params.retType];
     const paramType = kTypes[t.params.paramType];
@@ -166,9 +140,6 @@ fn main() {
 g.test('stage')
   .desc('validates builtin is only usable in the correct stages')
   .params(u => u.combine('stage', ['compute', 'fragment', 'vertex'] as const).combine('op', kOps))
-  .beforeAllSubcases(t => {
-    t.selectDeviceOrSkipTestCase('subgroups' as GPUFeatureName);
-  })
   .fn(t => {
     const compute = `
 @compute @workgroup_size(1)

--- a/src/webgpu/shader/validation/expression/call/builtin/subgroupMul.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/subgroupMul.spec.ts
@@ -38,9 +38,6 @@ fn main() {
 g.test('early_eval')
   .desc('Ensures the builtin is not able to be compile time evaluated')
   .params(u => u.combine('stage', keysOf(kStages)).beginSubcases().combine('builtin', kBuiltins))
-  .beforeAllSubcases(t => {
-    t.selectDeviceOrSkipTestCase('subgroups' as GPUFeatureName);
-  })
   .fn(t => {
     const code = kStages[t.params.stage](t.params.builtin);
     t.expectCompileResult(t.params.stage === 'runtime', code);
@@ -54,9 +51,6 @@ g.test('must_use')
       .beginSubcases()
       .combine('builtin', kBuiltins)
   )
-  .beforeAllSubcases(t => {
-    t.selectDeviceOrSkipTestCase('subgroups' as GPUFeatureName);
-  })
   .fn(t => {
     const wgsl = `
 enable subgroups;
@@ -75,14 +69,6 @@ g.test('data_type')
   .params(u =>
     u.combine('type', keysOf(kArgumentTypes)).beginSubcases().combine('builtin', kBuiltins)
   )
-  .beforeAllSubcases(t => {
-    const features = ['subgroups' as GPUFeatureName];
-    const type = kArgumentTypes[t.params.type];
-    if (type.requiresF16()) {
-      features.push('shader-f16');
-    }
-    t.selectDeviceOrSkipTestCase(features);
-  })
   .fn(t => {
     const type = kArgumentTypes[t.params.type];
     let enables = `enable subgroups;\n`;
@@ -120,15 +106,6 @@ g.test('return_type')
       .beginSubcases()
       .combine('builtin', kBuiltins)
   )
-  .beforeAllSubcases(t => {
-    const features = ['subgroups' as GPUFeatureName];
-    const dataType = kArgumentTypes[t.params.dataType];
-    const retType = kArgumentTypes[t.params.retType];
-    if (dataType.requiresF16() || retType.requiresF16()) {
-      features.push('shader-f16');
-    }
-    t.selectDeviceOrSkipTestCase(features);
-  })
   .fn(t => {
     const dataType = kArgumentTypes[t.params.dataType];
     const retType = kArgumentTypes[t.params.retType];
@@ -155,9 +132,6 @@ g.test('stage')
       .beginSubcases()
       .combine('builtin', kBuiltins)
   )
-  .beforeAllSubcases(t => {
-    t.selectDeviceOrSkipTestCase('subgroups' as GPUFeatureName);
-  })
   .fn(t => {
     const compute = `
 @compute @workgroup_size(1)
@@ -206,9 +180,6 @@ g.test('invalid_types')
   .params(u =>
     u.combine('case', keysOf(kInvalidTypeCases)).beginSubcases().combine('builtin', kBuiltins)
   )
-  .beforeAllSubcases(t => {
-    t.selectDeviceOrSkipTestCase('subgroups' as GPUFeatureName);
-  })
   .fn(t => {
     const val = kInvalidTypeCases[t.params.case];
     const wgsl = `

--- a/src/webgpu/shader/validation/expression/call/builtin/subgroupShuffle.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/subgroupShuffle.spec.ts
@@ -24,9 +24,6 @@ const kOps = [
 g.test('requires_subgroups')
   .desc('Validates that the subgroups feature is required')
   .params(u => u.combine('enable', [false, true] as const).combine('op', kOps))
-  .beforeAllSubcases(t => {
-    t.selectDeviceOrSkipTestCase('subgroups' as GPUFeatureName);
-  })
   .fn(t => {
     const wgsl = `
 ${t.params.enable ? 'enable subgroups;' : ''}
@@ -64,9 +61,6 @@ fn main() {
 g.test('early_eval')
   .desc('Ensures the builtin is not able to be compile time evaluated')
   .params(u => u.combine('stage', keysOf(kStages)).combine('op', kOps))
-  .beforeAllSubcases(t => {
-    t.selectDeviceOrSkipTestCase('subgroups' as GPUFeatureName);
-  })
   .fn(t => {
     const code = kStages[t.params.stage](t.params.op);
     t.expectCompileResult(t.params.stage === 'runtime', code);
@@ -85,9 +79,6 @@ g.test('param2_early_eval')
       .beginSubcases()
       .combine('stage', ['constant', 'override', 'runtime'] as const)
   )
-  .beforeAllSubcases(t => {
-    t.selectDeviceOrSkipTestCase('subgroups' as GPUFeatureName);
-  })
   .fn(t => {
     let arg = `const_param`;
     if (t.params.stage === 'override') {
@@ -129,9 +120,6 @@ fn foo() {
 g.test('must_use')
   .desc('Tests that the builtin has the @must_use attribute')
   .params(u => u.combine('must_use', [true, false] as const).combine('op', kOps))
-  .beforeAllSubcases(t => {
-    t.selectDeviceOrSkipTestCase('subgroups' as GPUFeatureName);
-  })
   .fn(t => {
     const wgsl = `
 enable subgroups;
@@ -148,14 +136,6 @@ const kTypes = objectsToRecord(kAllScalarsAndVectors);
 g.test('data_type')
   .desc('Validates data parameter type')
   .params(u => u.combine('type', keysOf(kTypes)).combine('op', kOps))
-  .beforeAllSubcases(t => {
-    const features = ['subgroups' as GPUFeatureName];
-    const type = kTypes[t.params.type];
-    if (type.requiresF16()) {
-      features.push('shader-f16');
-    }
-    t.selectDeviceOrSkipTestCase(features);
-  })
   .fn(t => {
     const type = kTypes[t.params.type];
     let enables = `enable subgroups;\n`;
@@ -186,15 +166,6 @@ g.test('return_type')
       .combine('op', kOps)
       .combine('paramType', keysOf(kTypes))
   )
-  .beforeAllSubcases(t => {
-    const features = ['subgroups' as GPUFeatureName];
-    const retType = kTypes[t.params.retType];
-    const paramType = kTypes[t.params.paramType];
-    if (retType.requiresF16() || paramType.requiresF16()) {
-      features.push('shader-f16');
-    }
-    t.selectDeviceOrSkipTestCase(features);
-  })
   .fn(t => {
     const retType = kTypes[t.params.retType];
     const paramType = kTypes[t.params.paramType];
@@ -225,14 +196,6 @@ fn main() {
 g.test('param2_type')
   .desc('Validates shuffle parameter type')
   .params(u => u.combine('type', keysOf(kTypes)).combine('op', kOps))
-  .beforeAllSubcases(t => {
-    const features = ['subgroups' as GPUFeatureName];
-    const type = kTypes[t.params.type];
-    if (type.requiresF16()) {
-      features.push('shader-f16');
-    }
-    t.selectDeviceOrSkipTestCase(features);
-  })
   .fn(t => {
     const type = kTypes[t.params.type];
     let enables = `enable subgroups;\n`;
@@ -254,9 +217,6 @@ fn main() {
 g.test('stage')
   .desc('validates builtin is only usable in the correct stages')
   .params(u => u.combine('stage', ['compute', 'fragment', 'vertex'] as const).combine('op', kOps))
-  .beforeAllSubcases(t => {
-    t.selectDeviceOrSkipTestCase('subgroups' as GPUFeatureName);
-  })
   .fn(t => {
     const compute = `
 @compute @workgroup_size(1)

--- a/src/webgpu/shader/validation/expression/call/builtin/tan.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/tan.spec.ts
@@ -46,9 +46,6 @@ Validates that constant evaluation and override evaluation of ${builtin}() rejec
       )
   )
   .fn(t => {
-    if (scalarTypeOf(kValuesTypes[t.params.type]) === Type.f16) {
-      t.skipIfDeviceDoesNotHaveFeature('shader-f16');
-    }
     const type = kValuesTypes[t.params.type];
     const fp = fpTraitsFor(
       // AbstractInt is converted to AbstractFloat before calling into the builtin

--- a/src/webgpu/shader/validation/expression/call/builtin/tanh.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/tanh.spec.ts
@@ -39,9 +39,6 @@ Validates that constant evaluation and override evaluation of ${builtin}() rejec
       .expand('value', u => fullRangeForType(kValuesTypes[u.type]))
   )
   .fn(t => {
-    if (scalarTypeOf(kValuesTypes[t.params.type]) === Type.f16) {
-      t.skipIfDeviceDoesNotHaveFeature('shader-f16');
-    }
     const type = kValuesTypes[t.params.type];
     const expectedResult = isRepresentable(
       Math.tanh(Number(t.params.value)),

--- a/src/webgpu/shader/validation/expression/call/builtin/textureDimensions.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/textureDimensions.spec.ts
@@ -9,7 +9,7 @@ Validation tests for the ${builtin}() builtin.
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { keysOf, objectsToRecord } from '../../../../../../common/util/data_tables.js';
-import { kAllTextureFormats, kTextureFormatInfo } from '../../../../../format_info.js';
+import { kPossibleStorageTextureFormats } from '../../../../../format_info.js';
 import {
   Type,
   kAllScalarsAndVectors,
@@ -156,13 +156,11 @@ Validates the return type of ${builtin} is the expected type.
       .combine('returnType', keysOf(kValuesTypes))
       .combine('textureType', kStorageTextureTypes)
       .beginSubcases()
-      .combine('format', kAllTextureFormats)
-      // filter to only storage texture formats.
-      .filter(t => !!kTextureFormatInfo[t.format].color?.storage)
+      .combine('format', kPossibleStorageTextureFormats)
   )
   .fn(t => {
     const { returnType, textureType, format } = t.params;
-    t.skipIfTextureFormatNotUsableAsStorageTextureDeprecated(format);
+    t.skipIfTextureFormatNotUsableAsStorageTexture(format);
 
     const returnVarType = kValuesTypes[returnType];
     const { returnType: returnRequiredType, hasLevelArg } =

--- a/src/webgpu/shader/validation/expression/call/builtin/textureLoad.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/textureLoad.spec.ts
@@ -13,7 +13,7 @@ Validation tests for the ${builtin}() builtin.
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { keysOf, objectsToRecord } from '../../../../../../common/util/data_tables.js';
 import { assert } from '../../../../../../common/util/util.js';
-import { kAllTextureFormats, kTextureFormatInfo } from '../../../../../format_info.js';
+import { kAllTextureFormats, kPossibleStorageTextureFormats } from '../../../../../format_info.js';
 import {
   Type,
   kAllScalarsAndVectors,
@@ -114,10 +114,9 @@ Validates the return type of ${builtin} is the expected type.
         kNonStorageTextureTypeInfo[t.textureType].texelTypes.map(v => v.toString())
       )
   )
-  .beforeAllSubcases(t =>
-    t.skipIfTextureLoadNotSupportedForTextureTypeDeprecated(t.params.textureType)
-  )
   .fn(t => {
+    t.skipIfTextureLoadNotSupportedForTextureType(t.params.textureType);
+
     const { returnType, textureType, texelType } = t.params;
     const returnVarType = kValuesTypes[returnType];
     const { coordsArgTypes, hasArrayIndexArg, hasLevelArg, hasSampleIndexArg } =
@@ -161,10 +160,9 @@ Validates that only incorrect coords arguments are rejected by ${builtin}
       // filter out unsigned types with negative values
       .filter(t => !isUnsignedType(kValuesTypes[t.coordType]) || t.value >= 0)
   )
-  .beforeAllSubcases(t =>
-    t.skipIfTextureLoadNotSupportedForTextureTypeDeprecated(t.params.textureType)
-  )
   .fn(t => {
+    t.skipIfTextureLoadNotSupportedForTextureType(t.params.textureType);
+
     const { textureType, coordType, texelType, value } = t.params;
     const coordArgType = kValuesTypes[coordType];
     const { coordsArgTypes, hasArrayIndexArg, hasLevelArg, hasSampleIndexArg } =
@@ -202,9 +200,7 @@ Validates that only incorrect coords arguments are rejected by ${builtin}
       .combine('textureType', kStorageTextureTypes)
       .combine('coordType', keysOf(kValuesTypes))
       .beginSubcases()
-      .combine('format', kAllTextureFormats)
-      // filter to only storage texture formats.
-      .filter(t => !!kTextureFormatInfo[t.format].color?.storage)
+      .combine('format', kPossibleStorageTextureFormats)
       .combine('value', [-1, 0, 1] as const)
       // filter out unsigned types with negative values
       .filter(t => !isUnsignedType(kValuesTypes[t.coordType]) || t.value >= 0)
@@ -214,7 +210,7 @@ Validates that only incorrect coords arguments are rejected by ${builtin}
   )
   .fn(t => {
     const { textureType, coordType, format, value } = t.params;
-    t.skipIfTextureFormatNotUsableAsStorageTextureDeprecated(format);
+    t.skipIfTextureFormatNotUsableAsStorageTexture(format);
 
     const coordArgType = kValuesTypes[coordType];
     const { coordsArgTypes, hasArrayIndexArg } =
@@ -259,10 +255,9 @@ Validates that only incorrect array_index arguments are rejected by ${builtin}
       // filter out unsigned types with negative values
       .filter(t => !isUnsignedType(kValuesTypes[t.arrayIndexType]) || t.value >= 0)
   )
-  .beforeAllSubcases(t =>
-    t.skipIfTextureLoadNotSupportedForTextureTypeDeprecated(t.params.textureType)
-  )
   .fn(t => {
+    t.skipIfTextureLoadNotSupportedForTextureType(t.params.textureType);
+
     const { textureType, arrayIndexType, texelType, value } = t.params;
     const arrayIndexArgType = kValuesTypes[arrayIndexType];
     const args = [arrayIndexArgType.create(value)];
@@ -303,9 +298,7 @@ Validates that only incorrect array_index arguments are rejected by ${builtin}
       )
       .combine('arrayIndexType', keysOf(kValuesTypes))
       .beginSubcases()
-      .combine('format', kAllTextureFormats)
-      // filter to only storage texture formats.
-      .filter(t => !!kTextureFormatInfo[t.format].color?.storage)
+      .combine('format', kPossibleStorageTextureFormats)
       .combine('value', [-1, 0, 1])
       // filter out unsigned types with negative values
       .filter(t => !isUnsignedType(kValuesTypes[t.arrayIndexType]) || t.value >= 0)
@@ -315,7 +308,7 @@ Validates that only incorrect array_index arguments are rejected by ${builtin}
   )
   .fn(t => {
     const { textureType, arrayIndexType, format, value } = t.params;
-    t.skipIfTextureFormatNotUsableAsStorageTextureDeprecated(format);
+    t.skipIfTextureFormatNotUsableAsStorageTexture(format);
 
     const arrayIndexArgType = kValuesTypes[arrayIndexType];
     const args = [arrayIndexArgType.create(value)];
@@ -361,10 +354,9 @@ Validates that only incorrect level arguments are rejected by ${builtin}
       // filter out unsigned types with negative values
       .filter(t => !isUnsignedType(kValuesTypes[t.levelType]) || t.value >= 0)
   )
-  .beforeAllSubcases(t =>
-    t.skipIfTextureLoadNotSupportedForTextureTypeDeprecated(t.params.textureType)
-  )
   .fn(t => {
+    t.skipIfTextureLoadNotSupportedForTextureType(t.params.textureType);
+
     const { textureType, levelType, texelType, value } = t.params;
     const levelArgType = kValuesTypes[levelType];
     const { coordsArgTypes, hasArrayIndexArg } =
@@ -411,10 +403,9 @@ Validates that only incorrect sample_index arguments are rejected by ${builtin}
       // filter out unsigned types with negative values
       .filter(t => !isUnsignedType(kValuesTypes[t.sampleIndexType]) || t.value >= 0)
   )
-  .beforeAllSubcases(t =>
-    t.skipIfTextureLoadNotSupportedForTextureTypeDeprecated(t.params.textureType)
-  )
   .fn(t => {
+    t.skipIfTextureLoadNotSupportedForTextureType(t.params.textureType);
+
     const { textureType, sampleIndexType, texelType, value } = t.params;
     const sampleIndexArgType = kValuesTypes[sampleIndexType];
     const { coordsArgTypes, hasArrayIndexArg, hasLevelArg } =
@@ -452,11 +443,9 @@ Validates that incompatible texture types don't work with ${builtin}
       .beginSubcases()
       .combine('textureType', kNonStorageTextureTypes)
   )
-  .beforeAllSubcases(t =>
-    t.skipIfTextureLoadNotSupportedForTextureTypeDeprecated(t.params.testTextureType)
-  )
   .fn(t => {
     const { testTextureType, textureType } = t.params;
+    t.skipIfTextureLoadNotSupportedForTextureType(textureType);
     const { coordsArgTypes, hasArrayIndexArg, hasLevelArg, hasSampleIndexArg } =
       kValidTextureLoadParameterTypesForNonStorageTextures[textureType];
 
@@ -509,11 +498,9 @@ Validates that incompatible texture types don't work with ${builtin}
       .combine('textureType', kStorageTextureTypes)
       .combine('format', kAllTextureFormats)
   )
-  .beforeAllSubcases(t =>
-    t.skipIfTextureLoadNotSupportedForTextureTypeDeprecated(t.params.testTextureType)
-  )
   .fn(t => {
     const { testTextureType, textureType } = t.params;
+    t.skipIfTextureLoadNotSupportedForTextureType(textureType);
     const { coordsArgTypes, hasArrayIndexArg, hasLevelArg, hasSampleIndexArg } =
       kValidTextureLoadParameterTypesForStorageTextures[textureType];
 

--- a/src/webgpu/shader/validation/expression/call/builtin/textureNumLayers.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/textureNumLayers.spec.ts
@@ -8,7 +8,7 @@ Validation tests for the ${builtin}() builtin.
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { keysOf, objectsToRecord } from '../../../../../../common/util/data_tables.js';
-import { kAllTextureFormats, kTextureFormatInfo } from '../../../../../format_info.js';
+import { kPossibleStorageTextureFormats } from '../../../../../format_info.js';
 import {
   Type,
   kAllScalarsAndVectors,
@@ -83,13 +83,11 @@ Validates the return type of ${builtin} is the expected type.
       .combine('returnType', keysOf(kValuesTypes))
       .combine('textureType', kTextureNumLayersTextureTypesForStorageTextures)
       .beginSubcases()
-      .combine('format', kAllTextureFormats)
-      // filter to only storage texture formats.
-      .filter(t => !!kTextureFormatInfo[t.format].color?.storage)
+      .combine('format', kPossibleStorageTextureFormats)
   )
   .fn(t => {
     const { returnType, textureType, format } = t.params;
-    t.skipIfTextureFormatNotUsableAsStorageTextureDeprecated(format);
+    t.skipIfTextureFormatNotUsableAsStorageTexture(format);
 
     const returnVarType = kValuesTypes[returnType];
 

--- a/src/webgpu/shader/validation/expression/call/builtin/textureStore.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/textureStore.spec.ts
@@ -10,7 +10,10 @@ Validation tests for the ${builtin}() builtin.
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { keysOf, objectsToRecord } from '../../../../../../common/util/data_tables.js';
-import { kAllTextureFormats, kTextureFormatInfo } from '../../../../../format_info.js';
+import {
+  getTextureFormatColorType,
+  kPossibleStorageTextureFormats,
+} from '../../../../../format_info.js';
 import {
   Type,
   kAllScalarsAndVectors,
@@ -145,14 +148,12 @@ Validates that only incorrect value arguments are rejected by ${builtin}
       .combine('textureType', kTextureTypes)
       .combine('valueType', keysOf(kValuesTypes))
       .beginSubcases()
-      .combine('format', kAllTextureFormats)
-      // filter to only storage texture formats.
-      .filter(t => !!kTextureFormatInfo[t.format].color?.storage)
+      .combine('format', kPossibleStorageTextureFormats)
       .combine('value', [0, 1, 2])
   )
   .fn(t => {
     const { textureType, valueType, format, value } = t.params;
-    t.skipIfTextureFormatNotUsableAsStorageTextureDeprecated(format);
+    t.skipIfTextureFormatNotUsableAsStorageTexture(format);
 
     const valueArgType = kValuesTypes[valueType];
     const args = [valueArgType.create(value)];
@@ -169,8 +170,8 @@ Validates that only incorrect value arguments are rejected by ${builtin}
   return vec4f(0);
 }
 `;
-    const colorType = kTextureFormatInfo[format].color?.type;
-    const requiredValueType = kTextureColorTypeToType[colorType!];
+    const colorType = getTextureFormatColorType(format);
+    const requiredValueType = kTextureColorTypeToType[colorType];
     const expectSuccess = isConvertible(valueArgType, requiredValueType);
     t.expectCompileResult(expectSuccess, code);
   });
@@ -187,9 +188,7 @@ Validates that incompatible texture types don't work with ${builtin}
       .combine('testTextureType', kTestTextureTypes)
       .beginSubcases()
       .combine('textureType', keysOf(kValidTextureStoreParameterTypes))
-      .combine('format', kAllTextureFormats)
-      // filter to only storage texture formats.
-      .filter(t => !!kTextureFormatInfo[t.format].color?.storage)
+      .combine('format', kPossibleStorageTextureFormats)
   )
   .fn(t => {
     const { testTextureType, textureType, format } = t.params;
@@ -197,8 +196,8 @@ Validates that incompatible texture types don't work with ${builtin}
 
     const coordWGSL = coordsArgTypes[0].create(0).wgsl();
     const arrayWGSL = hasArrayIndexArg ? ', 0' : '';
-    const colorType = kTextureFormatInfo[format].color?.type;
-    const valueType = kTextureColorTypeToType[colorType!];
+    const colorType = getTextureFormatColorType(format);
+    const valueType = kTextureColorTypeToType[colorType];
     const valueWGSL = valueType.create(0).wgsl();
 
     const code = `

--- a/src/webgpu/shader/validation/expression/call/builtin/transpose.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/transpose.spec.ts
@@ -6,12 +6,10 @@ Validation tests for the ${builtin}() builtin.
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { keysOf, objectsToRecord } from '../../../../../../common/util/data_tables.js';
 import {
-  Type,
   isConvertible,
   kAllMatrices,
   kConcreteFloatScalars,
   kFloatScalars,
-  scalarTypeOf,
 } from '../../../../../util/conversion.js';
 import { ShaderValidationTest } from '../../../shader_validation_test.js';
 
@@ -38,11 +36,6 @@ Validates that constant evaluation and override evaluation of ${builtin}() accep
       .beginSubcases()
       .expand('value', u => fullRangeForType(kValidArgumentTypes[u.type]))
   )
-  .beforeAllSubcases(t => {
-    if (scalarTypeOf(kValidArgumentTypes[t.params.type]) === Type.f16) {
-      t.selectDeviceOrSkipTestCase('shader-f16');
-    }
-  })
   .fn(t => {
     const expectedResult = true;
 
@@ -100,11 +93,6 @@ g.test('return')
       .combine('output_rows', [2, 3, 4] as const)
       .combine('output_cols', [2, 3, 4] as const)
   )
-  .beforeAllSubcases(t => {
-    if (t.params.input_type === 'f16' || t.params.output_type === 'f16') {
-      t.selectDeviceOrSkipTestCase('shader-f16');
-    }
-  })
   .fn(t => {
     const input_type = t.params.input_type;
     const input_cols = t.params.input_cols;

--- a/src/webgpu/shader/validation/expression/call/builtin/trunc.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/trunc.spec.ts
@@ -5,11 +5,7 @@ Validation tests for the ${builtin}() builtin.
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { keysOf, objectsToRecord } from '../../../../../../common/util/data_tables.js';
-import {
-  Type,
-  kConvertableToFloatScalarsAndVectors,
-  scalarTypeOf,
-} from '../../../../../util/conversion.js';
+import { kConvertableToFloatScalarsAndVectors } from '../../../../../util/conversion.js';
 import { ShaderValidationTest } from '../../../shader_validation_test.js';
 
 import {
@@ -37,11 +33,6 @@ Validates that constant evaluation and override evaluation of ${builtin}() error
       .beginSubcases()
       .expand('value', u => fullRangeForType(kValidArgumentTypes[u.type]))
   )
-  .beforeAllSubcases(t => {
-    if (scalarTypeOf(kValidArgumentTypes[t.params.type]) === Type.f16) {
-      t.selectDeviceOrSkipTestCase('shader-f16');
-    }
-  })
   .fn(t => {
     const expectedResult = true;
 

--- a/src/webgpu/shader/validation/expression/call/builtin/unpack2x16float.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/unpack2x16float.spec.ts
@@ -100,11 +100,6 @@ g.test('arguments')
       .beginSubcases()
       .expand('returnType', u => (u.args.includes('good') ? keysOf(kAllValueTypes) : [kReturnType]))
   )
-  .beforeAllSubcases(t => {
-    if (t.params.args.includes('f16') || t.params.returnType?.toString().includes('f16')) {
-      t.selectDeviceOrSkipTestCase('shader-f16');
-    }
-  })
   .fn(t => {
     const expectedResult = t.params.args.includes('good') && t.params.returnType === kReturnType;
     validateConstOrOverrideBuiltinEval(

--- a/src/webgpu/shader/validation/expression/call/builtin/unpack2x16snorm.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/unpack2x16snorm.spec.ts
@@ -81,11 +81,6 @@ g.test('arguments')
       .beginSubcases()
       .expand('returnType', u => (u.args.includes('good') ? keysOf(kAllValueTypes) : [kReturnType]))
   )
-  .beforeAllSubcases(t => {
-    if (t.params.args.includes('f16') || t.params.returnType?.toString().includes('f16')) {
-      t.selectDeviceOrSkipTestCase('shader-f16');
-    }
-  })
   .fn(t => {
     const expectedResult = t.params.args.includes('good') && t.params.returnType === kReturnType;
     validateConstOrOverrideBuiltinEval(

--- a/src/webgpu/shader/validation/expression/call/builtin/unpack2x16unorm.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/unpack2x16unorm.spec.ts
@@ -81,11 +81,6 @@ g.test('arguments')
       .beginSubcases()
       .expand('returnType', u => (u.args.includes('good') ? keysOf(kAllValueTypes) : [kReturnType]))
   )
-  .beforeAllSubcases(t => {
-    if (t.params.args.includes('f16') || t.params.returnType?.toString().includes('f16')) {
-      t.selectDeviceOrSkipTestCase('shader-f16');
-    }
-  })
   .fn(t => {
     const expectedResult = t.params.args.includes('good') && t.params.returnType === kReturnType;
     validateConstOrOverrideBuiltinEval(

--- a/src/webgpu/shader/validation/expression/call/builtin/unpack4x8snorm.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/unpack4x8snorm.spec.ts
@@ -81,11 +81,6 @@ g.test('arguments')
       .beginSubcases()
       .expand('returnType', u => (u.args.includes('good') ? keysOf(kAllValueTypes) : [kReturnType]))
   )
-  .beforeAllSubcases(t => {
-    if (t.params.args.includes('f16') || t.params.returnType?.toString().includes('f16')) {
-      t.selectDeviceOrSkipTestCase('shader-f16');
-    }
-  })
   .fn(t => {
     const expectedResult = t.params.args.includes('good') && t.params.returnType === kReturnType;
     validateConstOrOverrideBuiltinEval(

--- a/src/webgpu/shader/validation/expression/call/builtin/unpack4x8unorm.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/unpack4x8unorm.spec.ts
@@ -81,11 +81,6 @@ g.test('arguments')
       .beginSubcases()
       .expand('returnType', u => (u.args.includes('good') ? keysOf(kAllValueTypes) : [kReturnType]))
   )
-  .beforeAllSubcases(t => {
-    if (t.params.args.includes('f16') || t.params.returnType?.toString().includes('f16')) {
-      t.selectDeviceOrSkipTestCase('shader-f16');
-    }
-  })
   .fn(t => {
     const expectedResult = t.params.args.includes('good') && t.params.returnType === kReturnType;
     validateConstOrOverrideBuiltinEval(

--- a/src/webgpu/shader/validation/expression/call/builtin/unpack4xI8.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/unpack4xI8.spec.ts
@@ -102,11 +102,6 @@ g.test('arguments')
       .beginSubcases()
       .expand('returnType', u => (u.args.includes('good') ? keysOf(kAllValueTypes) : [kReturnType]))
   )
-  .beforeAllSubcases(t => {
-    if (t.params.args.includes('f16') || t.params.returnType?.toString().includes('f16')) {
-      t.selectDeviceOrSkipTestCase('shader-f16');
-    }
-  })
   .fn(t => {
     const expectedResult = t.params.args.includes('good') && t.params.returnType === kReturnType;
     validateConstOrOverrideBuiltinEval(

--- a/src/webgpu/shader/validation/expression/call/builtin/unpack4xU8.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/unpack4xU8.spec.ts
@@ -102,11 +102,6 @@ g.test('arguments')
       .beginSubcases()
       .expand('returnType', u => (u.args.includes('good') ? keysOf(kAllValueTypes) : [kReturnType]))
   )
-  .beforeAllSubcases(t => {
-    if (t.params.args.includes('f16') || t.params.returnType?.toString().includes('f16')) {
-      t.selectDeviceOrSkipTestCase('shader-f16');
-    }
-  })
   .fn(t => {
     const expectedResult = t.params.args.includes('good') && t.params.returnType === kReturnType;
     validateConstOrOverrideBuiltinEval(

--- a/src/webgpu/shader/validation/expression/call/builtin/value_constructor.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/value_constructor.spec.ts
@@ -24,9 +24,6 @@ g.test('scalar_zero_value')
   .desc('Tests zero value scalar constructors')
   .params(u => u.combine('type', kScalarTypes))
   .fn(t => {
-    if (t.params.type === 'f16') {
-      t.skipIfDeviceDoesNotHaveFeature('shader-f16');
-    }
     const enable = t.params.type === 'f16' ? 'enable f16;' : '';
     const code = `${enable}
     const x : ${t.params.type} = ${t.params.type}();
@@ -41,11 +38,6 @@ g.test('scalar_value')
       .combine('type', kScalarTypes)
       .combine('value_type', [...kScalarTypes, 'vec2u', 'S', 'array<u32, 2>'])
   )
-  .beforeAllSubcases(t => {
-    if (t.params.type === 'f16' || t.params.value_type === 'f16') {
-      t.selectDeviceOrSkipTestCase('shader-f16');
-    }
-  })
   .fn(t => {
     const enable = t.params.type === 'f16' || t.params.value_type === 'f16' ? 'enable f16;' : '';
     const code = `${enable}
@@ -62,9 +54,6 @@ g.test('vector_zero_value')
       .combine('size', [2, 3, 4] as const)
   )
   .fn(t => {
-    if (t.params.type === 'f16') {
-      t.skipIfDeviceDoesNotHaveFeature('shader-f16');
-    }
     const abstract = t.params.type === 'abstract-int' || t.params.type === 'abstract-float';
     const param = abstract ? '' : `<${t.params.type}>`;
     const decl = `vec${t.params.size}${param}`;
@@ -107,13 +96,6 @@ g.test('vector_splat')
       .beginSubcases()
       .combine('size', [2, 3, 4] as const)
   )
-  .beforeAllSubcases(t => {
-    const ty = Type[t.params.type];
-    const eleTy = Type[t.params.ele_type];
-    if (ty.requiresF16() || eleTy.requiresF16()) {
-      t.selectDeviceOrSkipTestCase('shader-f16');
-    }
-  })
   .fn(t => {
     const eleTy = Type[t.params.ele_type];
     const abstract = t.params.type === 'abstract-int' || t.params.type === 'abstract-float';
@@ -157,13 +139,6 @@ g.test('vector_copy')
       .combine('decl_size', [2, 3, 4] as const)
       .combine('value_size', [2, 3, 4] as const)
   )
-  .beforeAllSubcases(t => {
-    const ty = Type[t.params.decl_type];
-    const eleTy = Type[t.params.value_type];
-    if (ty.requiresF16() || eleTy.requiresF16()) {
-      t.selectDeviceOrSkipTestCase('shader-f16');
-    }
-  })
   .fn(t => {
     const declTy = Type[t.params.decl_type];
     const valueTy = Type[t.params.value_type];
@@ -212,13 +187,6 @@ g.test('vector_elementwise')
       .combine('num_eles', [2, 3, 4, 5] as const)
       .combine('full_type', [true, false] as const)
   )
-  .beforeAllSubcases(t => {
-    const ty = Type[t.params.type];
-    const eleTy = Type[t.params.ele_type];
-    if (ty.requiresF16() || eleTy.requiresF16()) {
-      t.selectDeviceOrSkipTestCase('shader-f16');
-    }
-  })
   .fn(t => {
     const eleTy = Type[t.params.ele_type];
     const abstract = t.params.type === 'abstract-int' || t.params.type === 'abstract-float';
@@ -276,13 +244,6 @@ g.test('vector_mixed')
       .combine('num_eles', [3, 4, 5] as const)
       .combine('full_type', [true, false] as const)
   )
-  .beforeAllSubcases(t => {
-    const ty = Type[t.params.type];
-    const eleTy = Type[t.params.ele_type];
-    if (ty.requiresF16() || eleTy.requiresF16()) {
-      t.selectDeviceOrSkipTestCase('shader-f16');
-    }
-  })
   .fn(t => {
     const eleTy = Type[t.params.ele_type];
     const abstract = t.params.type === 'abstract-int' || t.params.type === 'abstract-float';
@@ -346,9 +307,6 @@ g.test('matrix_zero_value')
       .combine('cols', [2, 3, 4] as const)
   )
   .fn(t => {
-    if (t.params.type === 'f16') {
-      t.skipIfDeviceDoesNotHaveFeature('shader-f16');
-    }
     const decl = `mat${t.params.cols}x${t.params.rows}<${t.params.type}>`;
     const enable = t.params.type === 'f16' ? 'enable f16;' : '';
     let code = `${enable}
@@ -373,13 +331,6 @@ g.test('matrix_copy')
       .combine('c2', [2, 3, 4] as const)
       .combine('r2', [2, 3, 4] as const)
   )
-  .beforeAllSubcases(t => {
-    const t1 = Type[t.params.type1];
-    const t2 = Type[t.params.type2];
-    if (t1.requiresF16() || t2.requiresF16()) {
-      t.selectDeviceOrSkipTestCase('shader-f16');
-    }
-  })
   .fn(t => {
     const t1 = Type[t.params.type1];
     const t2 = Type[t.params.type2];
@@ -406,13 +357,6 @@ g.test('matrix_column')
       .combine('c2', [2, 3, 4] as const)
       .combine('r2', [2, 3, 4] as const)
   )
-  .beforeAllSubcases(t => {
-    const t1 = Type[t.params.type1];
-    const t2 = Type[t.params.type2];
-    if (t1.requiresF16() || t2.requiresF16()) {
-      t.selectDeviceOrSkipTestCase('shader-f16');
-    }
-  })
   .fn(t => {
     const t1 = Type[t.params.type1];
     const t2 = Type[t.params.type2];
@@ -448,13 +392,6 @@ g.test('matrix_elementwise')
       .combine('c2', [2, 3, 4] as const)
       .combine('r2', [2, 3, 4] as const)
   )
-  .beforeAllSubcases(t => {
-    const t1 = Type[t.params.type1];
-    const t2 = Type[t.params.type2];
-    if (t1.requiresF16() || t2.requiresF16()) {
-      t.selectDeviceOrSkipTestCase('shader-f16');
-    }
-  })
   .fn(t => {
     const t1 = Type[t.params.type1];
     const t2 = Type[t.params.type2];
@@ -702,11 +639,6 @@ const kConstructors = {
 g.test('must_use')
   .desc('Tests that value constructors must be used')
   .params(u => u.combine('ctor', keysOf(kConstructors)).combine('use', [true, false] as const))
-  .beforeAllSubcases(t => {
-    if (t.params.ctor.includes('f16')) {
-      t.selectDeviceOrSkipTestCase('shader-f16');
-    }
-  })
   .fn(t => {
     const code = `
     ${t.params.ctor.includes('f16') ? 'enable f16;' : ''}


### PR DESCRIPTION
Sorry this is so many files. The only real changes are in 

* `textureDimensions.spec.ts`
* `textureLoad.spec.ts`
* `textureNumLayers.spec.ts`
* `textureStorage.spec.ts`
* `format_info.ts`
* `shader_validation_test.ts`

The rest are all just deletions of code that checked if f16 is used and selected a device for `shader-16` or checked if subgroups are needed and selected a device for subgroups. That's no longer needed.

Issue: #4178
Issue: #4181 
