### PR TITLE
Make ShaderValidationTest auto skip if required features missing.

### DIFF
--- a/src/webgpu/shader/validation/shader_validation_test.ts
+++ b/src/webgpu/shader/validation/shader_validation_test.ts
@@ -1,6 +1,45 @@
 import { keysOf } from '../../../common/util/data_tables.js';
 import { ErrorWithExtra } from '../../../common/util/util.js';
-import { AllFeaturesMaxLimitsGPUTest, UniqueFeaturesOrLimitsGPUTest } from '../../gpu_test.js';
+import {
+  AllFeaturesMaxLimitsGPUTest,
+  GPUTest,
+  UniqueFeaturesOrLimitsGPUTest,
+} from '../../gpu_test.js';
+
+const kEnables: Record<string, GPUFeatureName> = {
+  f16: 'shader-f16',
+  subgroups: 'subgroups' as GPUFeatureName,
+  clip_distances: 'clip-distances' as GPUFeatureName,
+};
+
+/**
+ * Note: These regular expressions are not meant to be perfect. This is not production code expecting
+ * to work with any WGSL passed by a user. It's only test code for working with WGSL written
+ * in the CTS. A CTS test for which these regular expressions don't work should use a different set of
+ * testing functions or options that don't use these regular expressions.
+ */
+const kEnableREs = Object.entries(kEnables).map(([enableName, feature]) => {
+  return {
+    re: new RegExp(
+      `^\\s*enable\\s+(?:\\s*\\w+\\s*,)*\\s*${enableName}\\s*(?:,\\s*\\w+)*\\s*;\\s*$`
+    ),
+    feature,
+  };
+});
+
+/**
+ * Note: This function is not meant to be perfect. This is not production code expecting
+ * to work with any WGSL passed by a user. It's only test code for working with WGSL written
+ * in the CTS. A CTS test for which this check doesn't work can choose a different set of
+ * testing functions or options that don't take this path.
+ */
+function skipIfCodeNeedsFeatureAndDeviceDoesNotHaveFeature(t: GPUTest, code: string) {
+  for (const { re, feature } of kEnableREs) {
+    if (re.test(code)) {
+      t.skipIfDeviceDoesNotHaveFeature(feature);
+    }
+  }
+}
 
 /**
  * Base fixture for WGSL shader validation tests.
@@ -8,6 +47,8 @@ import { AllFeaturesMaxLimitsGPUTest, UniqueFeaturesOrLimitsGPUTest } from '../.
 export class ShaderValidationTest extends AllFeaturesMaxLimitsGPUTest {
   /**
    * Add a test expectation for whether a createShaderModule call succeeds or not.
+   * Note: skips test if 'enable X' exists in code and X's corresponding feature does not exist on device
+   * unless you pass in autoSkipIfFeatureNotAvailable: false.
    *
    * @example
    * ```ts
@@ -15,7 +56,14 @@ export class ShaderValidationTest extends AllFeaturesMaxLimitsGPUTest {
    * t.expectCompileResult(false, `wgsl code`); // Expect validation error with any error string
    * ```
    */
-  expectCompileResult(expectedResult: boolean, code: string) {
+  expectCompileResult(
+    expectedResult: boolean,
+    code: string,
+    options?: { autoSkipIfFeatureNotAvailable?: boolean } // defaults to true
+  ) {
+    if (options?.autoSkipIfFeatureNotAvailable !== false) {
+      skipIfCodeNeedsFeatureAndDeviceDoesNotHaveFeature(this, code);
+    }
     let shaderModule: GPUShaderModule;
     this.expectGPUError(
       'validation',
@@ -109,6 +157,8 @@ export class ShaderValidationTest extends AllFeaturesMaxLimitsGPUTest {
 
   /**
    * Add a test expectation for whether a createComputePipeline call succeeds or not.
+   * Note: skips test if 'enable X' exists in code and X's corresponding feature does not exist on device
+   * unless you pass in autoSkipIfFeatureNotAvailable: false
    */
   expectPipelineResult(args: {
     // True if the pipeline should build without error
@@ -121,6 +171,8 @@ export class ShaderValidationTest extends AllFeaturesMaxLimitsGPUTest {
     reference?: string[];
     // List of additional statements to insert in the entry point.
     statements?: string[];
+    // Skip tests when WGSL code has 'enable X' and feature for 'X' is not available on device
+    autoSkipIfFeatureNotAvailable?: boolean; // defaults to true. You must set to false to turn this off.
   }) {
     const phonies: Array<string> = [];
 
@@ -141,6 +193,10 @@ export class ShaderValidationTest extends AllFeaturesMaxLimitsGPUTest {
 fn main() {
   ${phonies.join('\n')}
 }`;
+
+    if (args.autoSkipIfFeatureNotAvailable !== false) {
+      skipIfCodeNeedsFeatureAndDeviceDoesNotHaveFeature(this, code);
+    }
 
     let shaderModule: GPUShaderModule;
     this.expectGPUError(


### PR DESCRIPTION
With this change, if the WGSL passed to testing functions in ShaderValidationTest uses 'enable X' the test is skipped if the corresponding feature for 'X' does not exist on the device.

Tests that want to check that you can not use 'enable X' when feature 'X' does not exist should use different functions or these functions can be modified to take a 'do not auto skip' option.




Issue: #4178 
