### PR TITLE
wgsl: test declaring a name 'binding_array'

### DIFF
--- a/src/webgpu/shader/validation/parse/identifiers.spec.ts
+++ b/src/webgpu/shader/validation/parse/identifiers.spec.ts
@@ -27,6 +27,7 @@ const kValidIdentifiers = new Set([
   'array',
   'atomic',
   'bool',
+  'binding_array',
   'bf16',
   'bitcast',
   'f32',
@@ -75,6 +76,7 @@ const kValidIdentifiers = new Set([
   'vec3',
   'vec4',
 ]);
+
 const kInvalidIdentifiers = new Set([
   '_', // Single underscore is a syntactic token for phony assignment.
   '__', // Leading double underscore is reserved.


### PR DESCRIPTION
Fixed: #4256


<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
