### PR TITLE
Add comment case to WGSL enable test.

### DIFF
--- a/src/webgpu/shader/validation/parse/enable.spec.ts
+++ b/src/webgpu/shader/validation/parse/enable.spec.ts
@@ -82,6 +82,13 @@ enable f16;`,
     enable f16;`,
     pass: true,
   },
+  in_comment_f16: {
+    code: `
+    /* enable f16; */
+    var<private> v: f16;
+    `,
+    pass: false,
+  },
 };
 
 g.test('enable')


### PR DESCRIPTION
The test is auto-skipped by expectCompileResult if shader-f16 doesn't exist. If shader-f16 does exist then this should fail because the enable appears in a comment.

I'm not sure there is a point to this test since `enable` is a language keyword and not a preprocessor directive like it was in GLSL but it can't hurt?



