### PR TITLE
Fix shader/execution/expression/call/builtin/textureSampleBias

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/textureSampleBias.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureSampleBias.spec.ts
@@ -417,6 +417,7 @@ Parameters:
   )
   .fn(async t => {
     const { format, samplePoints, A, mode, filt: minFilter } = t.params;
+    t.skipIfTextureViewDimensionNotSupported('cube-array');
     skipIfTextureFormatNotSupportedOrNeedsFilteringAndIsUnfilterable(t, minFilter, format);
 
     const viewDimension: GPUTextureViewDimension = 'cube-array';


### PR DESCRIPTION
I lost a check and somehow missed that it was failing in compat. Added the check back.




Issue: #4181
