### PR TITLE
Return mismatched device holder to the mismatched device pool

### DIFF
--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -153,7 +153,7 @@ export class GPUTestSubcaseBatchState extends SubcaseBatchState {
     // Ensure devicePool.release is called for both providers even if one rejects.
     await Promise.all([
       this.provider?.then(x => devicePool.release(x)),
-      this.mismatchedProvider?.then(x => devicePool.release(x)),
+      this.mismatchedProvider?.then(x => mismatchedDevicePool.release(x)),
     ]);
   }
 


### PR DESCRIPTION
I didn't dig into why this was working but coming changes broke without this.

Issue: #4178 
