### PR TITLE
Make selectDeviceXXX unreachable on AllFeaturesMaxLimitsGPUTest

### DIFF
--- a/src/webgpu/api/validation/createBindGroup.spec.ts
+++ b/src/webgpu/api/validation/createBindGroup.spec.ts
@@ -662,7 +662,7 @@ g.test('bind_group_layout,device_mismatch')
   )
   .paramsSubcasesOnly(u => u.combine('mismatched', [true, false]))
   .beforeAllSubcases(t => {
-    t.selectMismatchedDeviceOrSkipTestCase(undefined);
+    t.usesMismatchedDevice();
   })
   .fn(t => {
     const mismatched = t.params.mismatched;
@@ -722,7 +722,7 @@ g.test('binding_resources,device_mismatch')
       .combine('visibilityMask', [kAllShaderStages, GPUConst.ShaderStage.COMPUTE] as const)
   )
   .beforeAllSubcases(t => {
-    t.selectMismatchedDeviceOrSkipTestCase(undefined);
+    t.usesMismatchedDevice();
   })
   .fn(t => {
     const { entry, resource0Mismatched, resource1Mismatched, visibilityMask } = t.params;
@@ -1132,7 +1132,7 @@ g.test('sampler,device_mismatch')
   .desc(`Tests createBindGroup cannot be called with a sampler created from another device.`)
   .paramsSubcasesOnly(u => u.combine('mismatched', [true, false]))
   .beforeAllSubcases(t => {
-    t.selectMismatchedDeviceOrSkipTestCase(undefined);
+    t.usesMismatchedDevice();
   })
   .fn(t => {
     const { mismatched } = t.params;

--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -191,6 +191,12 @@ export class GPUTestSubcaseBatchState extends SubcaseBatchState {
     this.provider.catch(() => {});
   }
 
+  usesMismatchedDevice() {
+    // MAINTENANCE_TODO: Refactor this. This should select a device with the same
+    // features and limits as the non-mismatched device for this test.
+    GPUTestSubcaseBatchState.prototype.selectMismatchedDeviceOrSkipTestCase.call(this, undefined);
+  }
+
   /**
    * Some tests or cases need particular feature flags or limits to be enabled.
    * Call this function with a descriptor or feature name (or `undefined`) to add
@@ -1728,6 +1734,38 @@ export class AllFeaturesMaxLimitsGPUTestSubcaseBatchState extends GPUTestSubcase
       initUncanonicalizedDeviceDescriptor(descriptor),
       mod
     );
+  }
+
+  /**
+   * Use skipIfDeviceDoesNotHaveFeature or similar. If you really need to test
+   * lack of a feature (for example tests under webgpu/api/validation/capability_checks)
+   * then use UniqueFeaturesAndLimitsGPUTest
+   */
+  override selectDeviceOrSkipTestCase(descriptor: DeviceSelectionDescriptor): void {
+    unreachable('this function should not be called in AllFeaturesMaxLimitsGPUTest');
+  }
+
+  /**
+   * Use skipIfDeviceDoesNotHaveFeature or similar.
+   */
+  override selectDeviceForQueryTypeOrSkipTestCase(types: GPUQueryType | GPUQueryType[]): void {
+    unreachable('this function should not be called in AllFeaturesMaxLimitsGPUTest');
+  }
+
+  /**
+   * Use skipIfDeviceDoesNotHaveFeature or skipIf(device.limits.maxXXX < requiredXXX) etc...
+   */
+  override selectDeviceForTextureFormatOrSkipTestCase(
+    formats: GPUTextureFormat | undefined | (GPUTextureFormat | undefined)[]
+  ): void {
+    unreachable('this function should not be called in AllFeaturesMaxLimitsGPUTest');
+  }
+
+  /**
+   * Use skipIfDeviceDoesNotHaveFeature or skipIf(device.limits.maxXXX < requiredXXX) etc...
+   */
+  override selectMismatchedDeviceOrSkipTestCase(descriptor: DeviceSelectionDescriptor): void {
+    unreachable('this function should not be called in AllFeaturesMaxLimitsGPUTest');
   }
 }
 

--- a/src/webgpu/web_platform/copyToTexture/canvas.spec.ts
+++ b/src/webgpu/web_platform/copyToTexture/canvas.spec.ts
@@ -623,7 +623,7 @@ g.test('copy_contents_from_gpu_context_canvas')
       .combine('height', [1, 2, 4, 15])
   )
   .beforeAllSubcases(t => {
-    t.selectMismatchedDeviceOrSkipTestCase(undefined);
+    t.usesMismatchedDevice();
   })
   .fn(t => {
     t.skipIfTextureFormatNotSupported(t.params.dstColorFormat);


### PR DESCRIPTION
Ideally I think I'd like to move these to UniqueFeaturesAndLimitsGPUTest so they just wouldn't exist on AllFeaturesMaxLimitsGPUTest and you'd get a compiler error but that's big change so for now effectively assert if they are used.

Note: a few other PRs need to land to make sure this isn't being called before this lands.




Issue: #4178 
