### PR TITLE
Fix texture_intra_invocation_coherence.spec.ts

### DIFF
--- a/src/webgpu/format_info.ts
+++ b/src/webgpu/format_info.ts
@@ -1569,6 +1569,12 @@ export const kPossibleStorageTextureFormats = [
   'bgra8unorm',
 ] as const;
 
+// Texture formats that may possibly be used as a storage texture.
+// Some may require certain features to be enabled.
+export const kPossibleReadWriteStorageTextureFormats = [
+  ...kPossibleStorageTextureFormats.filter(f => kTextureFormatInfo[f].color?.readWriteStorage),
+] as const;
+
 // Texture formats that may possibly be multisampled.
 // Some may require certain features to be enabled.
 export const kPossibleMultisampledTextureFormats = [

--- a/src/webgpu/shader/execution/memory_model/texture_intra_invocation_coherence.spec.ts
+++ b/src/webgpu/shader/execution/memory_model/texture_intra_invocation_coherence.spec.ts
@@ -13,13 +13,16 @@ WebGPU implementations emit correct fence calls.`;
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { unreachable, iterRange } from '../../../../common/util/util.js';
-import { AllFeaturesMaxLimitsGPUTest } from '../../../gpu_test.js';
+import { kPossibleReadWriteStorageTextureFormats } from '../../../format_info.js';
+import { UniqueFeaturesOrLimitsGPUTest } from '../../../gpu_test.js';
 import { PRNG } from '../../../util/prng.js';
 
-const kRWStorageFormats: GPUTextureFormat[] = ['r32uint', 'r32sint', 'r32float'];
 const kDimensions: GPUTextureViewDimension[] = ['1d', '2d', '2d-array', '3d'];
 
-export const g = makeTestGroup(AllFeaturesMaxLimitsGPUTest);
+// MAINTENANCE_TODO: Switch this to AllFeaturesMaxLimitsGPUTest
+// Currently the test breaks if switch as it asks for a texture larger
+// than the max size.
+export const g = makeTestGroup(UniqueFeaturesOrLimitsGPUTest);
 
 function indexToCoord(dim: GPUTextureViewDimension): string {
   switch (dim) {
@@ -139,10 +142,16 @@ function getTextureSize(numTexels: number, dim: GPUTextureViewDimension): GPUExt
 
 g.test('texture_intra_invocation_coherence')
   .desc(`Tests writes from an invocation are visible to reads from the same invocation`)
-  .params(u => u.combine('format', kRWStorageFormats).combine('dim', kDimensions))
+  .params(u =>
+    u.combine('format', kPossibleReadWriteStorageTextureFormats).combine('dim', kDimensions)
+  )
+  .beforeAllSubcases(t => {
+    t.selectDeviceForTextureFormatOrSkipTestCase(t.params.format);
+  })
   .fn(t => {
     t.skipIfLanguageFeatureNotSupported('readonly_and_readwrite_storage_textures');
     t.skipIfTextureFormatNotSupported(t.params.format);
+    t.skipIfTextureFormatNotUsableAsReadWriteStorageTexture(t.params.format);
 
     const wgx = 16;
     const wgy = t.device.limits.maxComputeInvocationsPerWorkgroup / wgx;
@@ -202,7 +211,8 @@ fn main(@builtin(global_invocation_id) gid : vec3u) {
     // To get a variety of testing, seed the random number generator based on which case this is.
     // This means subcases will not execute the same code.
     const seed =
-      kRWStorageFormats.indexOf(t.params.format) * kRWStorageFormats.length +
+      kPossibleReadWriteStorageTextureFormats.indexOf(t.params.format) *
+        kPossibleReadWriteStorageTextureFormats.length +
       kDimensions.indexOf(t.params.dim);
     const prng = new PRNG(seed);
 
@@ -244,10 +254,10 @@ fn main(@builtin(global_invocation_id) gid : vec3u) {
       write_masks,
       GPUBufferUsage.COPY_SRC | GPUBufferUsage.STORAGE
     );
-    const output_buffer = t.makeBufferWithContents(
-      new Uint32Array([...iterRange(invocations, x => 0)]),
-      GPUBufferUsage.COPY_SRC | GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE
-    );
+    const output_buffer = t.createBufferTracked({
+      size: invocations * 4,
+      usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE,
+    });
 
     // Texture
     const texture_size = getTextureSize(invocations * num_writes_per_invocation, t.params.dim);


### PR DESCRIPTION
This test needs to be refactored to use `AllFeaturesMaxLimitsGPUTest`. As it is, if the limits are maxxed then it chooses a texture size that is too large for 3d textures and fails.

Issue: #4178
