### PR TITLE
Refactor src/webpgu/api/validation/encoding and a few extra

### DIFF
--- a/src/webgpu/api/validation/encoding/beginRenderPass.spec.ts
+++ b/src/webgpu/api/validation/encoding/beginRenderPass.spec.ts
@@ -22,9 +22,9 @@ Notes:
 `;
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
-import { ValidationTest } from '../validation_test.js';
+import { AllFeaturesMaxLimitsValidationTest } from '../validation_test.js';
 
-export const g = makeTestGroup(ValidationTest);
+export const g = makeTestGroup(AllFeaturesMaxLimitsValidationTest);
 
 g.test('color_attachments,device_mismatch')
   .desc(
@@ -62,9 +62,7 @@ g.test('color_attachments,device_mismatch')
       target1Mismatched: true,
     },
   ])
-  .beforeAllSubcases(t => {
-    t.selectMismatchedDeviceOrSkipTestCase(undefined);
-  })
+  .beforeAllSubcases(t => t.usesMismatchedDevice())
   .fn(t => {
     const { view0Mismatched, target0Mismatched, view1Mismatched, target1Mismatched } = t.params;
     const mismatched = view0Mismatched || target0Mismatched || view1Mismatched || target1Mismatched;
@@ -111,9 +109,7 @@ g.test('depth_stencil_attachment,device_mismatch')
     'Tests beginRenderPass cannot be called with a depth stencil attachment whose texture view is created from another device'
   )
   .paramsSubcasesOnly(u => u.combine('mismatched', [true, false]))
-  .beforeAllSubcases(t => {
-    t.selectMismatchedDeviceOrSkipTestCase(undefined);
-  })
+  .beforeAllSubcases(t => t.usesMismatchedDevice())
   .fn(t => {
     const { mismatched } = t.params;
 
@@ -150,9 +146,7 @@ g.test('occlusion_query_set,device_mismatch')
     'Tests beginRenderPass cannot be called with an occlusion query set created from another device'
   )
   .paramsSubcasesOnly(u => u.combine('mismatched', [true, false]))
-  .beforeAllSubcases(t => {
-    t.selectMismatchedDeviceOrSkipTestCase(undefined);
-  })
+  .beforeAllSubcases(t => t.usesMismatchedDevice())
   .fn(t => {
     const { mismatched } = t.params;
     const sourceDevice = mismatched ? t.mismatchedDevice : t.device;
@@ -175,11 +169,9 @@ g.test('timestamp_query_set,device_mismatch')
   `
   )
   .paramsSubcasesOnly(u => u.combine('mismatched', [true, false]))
-  .beforeAllSubcases(t => {
-    t.selectDeviceOrSkipTestCase(['timestamp-query']);
-    t.selectMismatchedDeviceOrSkipTestCase('timestamp-query');
-  })
+  .beforeAllSubcases(t => t.usesMismatchedDevice())
   .fn(t => {
+    t.skipIfDeviceDoesNotSupportQueryType('timestamp');
     const { mismatched } = t.params;
     const sourceDevice = mismatched ? t.mismatchedDevice : t.device;
 

--- a/src/webgpu/api/validation/encoding/cmds/clearBuffer.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/clearBuffer.spec.ts
@@ -6,9 +6,9 @@ import { makeTestGroup } from '../../../../../common/framework/test_group.js';
 import { kBufferUsages } from '../../../../capability_info.js';
 import { kResourceStates } from '../../../../gpu_test.js';
 import { kMaxSafeMultipleOf8 } from '../../../../util/math.js';
-import { ValidationTest } from '../../validation_test.js';
+import { AllFeaturesMaxLimitsValidationTest } from '../../validation_test.js';
 
-class F extends ValidationTest {
+class F extends AllFeaturesMaxLimitsValidationTest {
   TestClearBuffer(options: {
     buffer: GPUBuffer;
     offset: number | undefined;
@@ -57,9 +57,7 @@ g.test('buffer_state')
 g.test('buffer,device_mismatch')
   .desc(`Tests clearBuffer cannot be called with buffer created from another device.`)
   .paramsSubcasesOnly(u => u.combine('mismatched', [true, false]))
-  .beforeAllSubcases(t => {
-    t.selectMismatchedDeviceOrSkipTestCase(undefined);
-  })
+  .beforeAllSubcases(t => t.usesMismatchedDevice())
   .fn(t => {
     const { mismatched } = t.params;
     const sourceDevice = mismatched ? t.mismatchedDevice : t.device;

--- a/src/webgpu/api/validation/encoding/cmds/compute_pass.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/compute_pass.spec.ts
@@ -9,9 +9,9 @@ import { makeValueTestVariant } from '../../../../../common/util/util.js';
 import { kBufferUsages } from '../../../../capability_info.js';
 import { GPUConst } from '../../../../constants.js';
 import { kResourceStates, ResourceState } from '../../../../gpu_test.js';
-import { ValidationTest } from '../../validation_test.js';
+import { AllFeaturesMaxLimitsValidationTest } from '../../validation_test.js';
 
-class F extends ValidationTest {
+class F extends AllFeaturesMaxLimitsValidationTest {
   createComputePipeline(state: 'valid' | 'invalid'): GPUComputePipeline {
     if (state === 'valid') {
       return this.createNoOpComputePipeline();
@@ -67,9 +67,7 @@ setPipeline should generate an error iff using an 'invalid' pipeline.
 g.test('pipeline,device_mismatch')
   .desc('Tests setPipeline cannot be called with a compute pipeline created from another device')
   .paramsSubcasesOnly(u => u.combine('mismatched', [true, false]))
-  .beforeAllSubcases(t => {
-    t.selectMismatchedDeviceOrSkipTestCase(undefined);
-  })
+  .beforeAllSubcases(t => t.usesMismatchedDevice())
   .fn(t => {
     const { mismatched } = t.params;
     const sourceDevice = mismatched ? t.mismatchedDevice : t.device;
@@ -193,9 +191,7 @@ g.test('indirect_dispatch_buffer,device_mismatch')
     `Tests dispatchWorkgroupsIndirect cannot be called with an indirect buffer created from another device`
   )
   .paramsSubcasesOnly(u => u.combine('mismatched', [true, false]))
-  .beforeAllSubcases(t => {
-    t.selectMismatchedDeviceOrSkipTestCase(undefined);
-  })
+  .beforeAllSubcases(t => t.usesMismatchedDevice())
   .fn(t => {
     const { mismatched } = t.params;
 

--- a/src/webgpu/api/validation/encoding/cmds/copyBufferToBuffer.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/copyBufferToBuffer.spec.ts
@@ -27,9 +27,9 @@ import { makeTestGroup } from '../../../../../common/framework/test_group.js';
 import { kBufferUsages } from '../../../../capability_info.js';
 import { kResourceStates } from '../../../../gpu_test.js';
 import { kMaxSafeMultipleOf8 } from '../../../../util/math.js';
-import { ValidationTest } from '../../validation_test.js';
+import { AllFeaturesMaxLimitsValidationTest } from '../../validation_test.js';
 
-class F extends ValidationTest {
+class F extends AllFeaturesMaxLimitsValidationTest {
   TestCopyBufferToBuffer(options: {
     srcBuffer: GPUBuffer;
     srcOffset: number;
@@ -102,9 +102,7 @@ g.test('buffer,device_mismatch')
     { srcMismatched: true, dstMismatched: false },
     { srcMismatched: false, dstMismatched: true },
   ] as const)
-  .beforeAllSubcases(t => {
-    t.selectMismatchedDeviceOrSkipTestCase(undefined);
-  })
+  .beforeAllSubcases(t => t.usesMismatchedDevice())
   .fn(t => {
     const { srcMismatched, dstMismatched } = t.params;
 

--- a/src/webgpu/api/validation/encoding/cmds/debug.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/debug.spec.ts
@@ -15,9 +15,9 @@ Test Coverage:
 
 import { makeTestGroup } from '../../../../../common/framework/test_group.js';
 import { kEncoderTypes } from '../../../../util/command_buffer_maker.js';
-import { ValidationTest } from '../../validation_test.js';
+import { AllFeaturesMaxLimitsValidationTest } from '../../validation_test.js';
 
-export const g = makeTestGroup(ValidationTest);
+export const g = makeTestGroup(AllFeaturesMaxLimitsValidationTest);
 
 g.test('debug_group_balanced')
   .params(u =>

--- a/src/webgpu/api/validation/encoding/cmds/index_access.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/index_access.spec.ts
@@ -3,9 +3,9 @@ Validation tests for indexed draws accessing the index buffer.
 `;
 
 import { makeTestGroup } from '../../../../../common/framework/test_group.js';
-import { ValidationTest } from '../../validation_test.js';
+import { AllFeaturesMaxLimitsValidationTest } from '../../validation_test.js';
 
-class F extends ValidationTest {
+class F extends AllFeaturesMaxLimitsValidationTest {
   createIndexBuffer(indexData: Iterable<number>): GPUBuffer {
     return this.makeBufferWithContents(new Uint32Array(indexData), GPUBufferUsage.INDEX);
   }

--- a/src/webgpu/api/validation/encoding/cmds/render/draw.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/render/draw.spec.ts
@@ -7,7 +7,7 @@ and parameters as expect.
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { kVertexFormatInfo } from '../../../../../capability_info.js';
 import { GPUTest } from '../../../../../gpu_test.js';
-import { ValidationTest } from '../../../validation_test.js';
+import { AllFeaturesMaxLimitsValidationTest } from '../../../validation_test.js';
 
 type VertexAttrib<A> = A & { shaderLocation: number };
 type VertexBuffer<V, A> = V & {
@@ -98,7 +98,7 @@ function callDraw(
 }
 
 function makeTestPipeline(
-  test: ValidationTest,
+  test: AllFeaturesMaxLimitsValidationTest,
   buffers: VertexState<
     { stepMode: GPUVertexStepMode; arrayStride: number },
     {
@@ -133,7 +133,7 @@ function makeTestPipeline(
 }
 
 function makeTestPipelineWithVertexAndInstanceBuffer(
-  test: ValidationTest,
+  test: AllFeaturesMaxLimitsValidationTest,
   arrayStride: number,
   attributeFormat: GPUVertexFormat,
   attributeOffset: number = 0
@@ -190,7 +190,7 @@ const kDefaultParameterForIndexedDraw = {
   indexBufferSize: 2 * 200, // exact required bound size for index buffer
 };
 
-export const g = makeTestGroup(ValidationTest);
+export const g = makeTestGroup(AllFeaturesMaxLimitsValidationTest);
 
 g.test(`unused_buffer_bound`)
   .desc(

--- a/src/webgpu/api/validation/encoding/cmds/render/dynamic_state.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/render/dynamic_state.spec.ts
@@ -23,9 +23,8 @@ TODO: ensure existing tests cover these notes. Note many of these may be operati
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
-import { MaxLimitsTestMixin } from '../../../../../gpu_test.js';
 import { nextAfterF32 } from '../../../../../util/math.js';
-import { ValidationTest } from '../../../validation_test.js';
+import { AllFeaturesMaxLimitsValidationTest } from '../../../validation_test.js';
 
 interface ViewportCall {
   x: number;
@@ -43,7 +42,7 @@ interface ScissorCall {
   h: number;
 }
 
-class F extends ValidationTest {
+class F extends AllFeaturesMaxLimitsValidationTest {
   testViewportCall(
     success: boolean,
     v: ViewportCall,
@@ -130,7 +129,7 @@ class F extends ValidationTest {
   }
 }
 
-export const g = makeTestGroup(MaxLimitsTestMixin(F));
+export const g = makeTestGroup(F);
 
 g.test('setViewport,width_height_nonnegative')
   .desc(

--- a/src/webgpu/api/validation/encoding/cmds/render/indirect_draw.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/render/indirect_draw.spec.ts
@@ -5,13 +5,13 @@ Validation tests for drawIndirect/drawIndexedIndirect on render pass and render 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUConst } from '../../../../../constants.js';
 import { kResourceStates } from '../../../../../gpu_test.js';
-import { ValidationTest } from '../../../validation_test.js';
+import { AllFeaturesMaxLimitsValidationTest } from '../../../validation_test.js';
 
 import { kRenderEncodeTypeParams } from './render.js';
 
 const kIndirectDrawTestParams = kRenderEncodeTypeParams.combine('indexed', [true, false] as const);
 
-class F extends ValidationTest {
+class F extends AllFeaturesMaxLimitsValidationTest {
   makeIndexBuffer(): GPUBuffer {
     return this.createBufferTracked({
       size: 16,
@@ -55,9 +55,7 @@ g.test('indirect_buffer,device_mismatch')
     'Tests draw(Indexed)Indirect cannot be called with an indirect buffer created from another device'
   )
   .paramsSubcasesOnly(kIndirectDrawTestParams.combine('mismatched', [true, false]))
-  .beforeAllSubcases(t => {
-    t.selectMismatchedDeviceOrSkipTestCase(undefined);
-  })
+  .beforeAllSubcases(t => t.usesMismatchedDevice())
   .fn(t => {
     const { encoderType, indexed, mismatched } = t.params;
 

--- a/src/webgpu/api/validation/encoding/cmds/render/indirect_multi_draw.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/render/indirect_multi_draw.spec.ts
@@ -10,13 +10,13 @@ import {
   kMaxUnsignedLongLongValue,
 } from '../../../../../constants.js';
 import { kResourceStates } from '../../../../../gpu_test.js';
-import { ValidationTest } from '../../../validation_test.js';
+import { AllFeaturesMaxLimitsValidationTest } from '../../../validation_test.js';
 
 const kIndirectMultiDrawTestParams = kUnitCaseParamsBuilder
   .combine('indexed', [true, false] as const)
   .combine('useDrawCountBuffer', [true, false] as const);
 
-class F extends ValidationTest {
+class F extends AllFeaturesMaxLimitsValidationTest {
   makeIndexBuffer(): GPUBuffer {
     return this.createBufferTracked({
       size: 16,
@@ -33,10 +33,6 @@ g.test('buffers_state')
 Tests indirect and draw count buffers must be valid.
   `
   )
-  .beforeAllSubcases(t => {
-    t.selectDeviceOrSkipTestCase('chromium-experimental-multi-draw-indirect' as GPUFeatureName);
-  })
-
   .paramsSubcasesOnly(
     kIndirectMultiDrawTestParams
       .combine('indirectState', kResourceStates)
@@ -52,6 +48,7 @@ Tests indirect and draw count buffers must be valid.
       )
   )
   .fn(t => {
+    t.skipIfDeviceDoesNotHaveFeature('chromium-experimental-multi-draw-indirect' as GPUFeatureName);
     const { indexed, indirectState, useDrawCountBuffer, drawCountState } = t.params;
     const indirectBuffer = t.createBufferWithState(indirectState, {
       size: 256,
@@ -96,11 +93,9 @@ g.test('buffers,device_mismatch')
       // drawCountMismatched only matters if useDrawCountBuffer=true
       .filter(p => p.useDrawCountBuffer || !p.drawCountMismatched)
   )
-  .beforeAllSubcases(t => {
-    t.selectDeviceOrSkipTestCase('chromium-experimental-multi-draw-indirect' as GPUFeatureName);
-    t.selectMismatchedDeviceOrSkipTestCase(undefined);
-  })
+  .beforeAllSubcases(t => t.usesMismatchedDevice())
   .fn(t => {
+    t.skipIfDeviceDoesNotHaveFeature('chromium-experimental-multi-draw-indirect' as GPUFeatureName);
     const { indexed, useDrawCountBuffer, indirectMismatched, drawCountMismatched } = t.params;
 
     const indirectDevice = indirectMismatched ? t.mismatchedDevice : t.device;
@@ -140,9 +135,6 @@ g.test('indirect_buffer_usage')
 Tests indirect and draw count buffers must have 'Indirect' usage.
   `
   )
-  .beforeAllSubcases(t => {
-    t.selectDeviceOrSkipTestCase('chromium-experimental-multi-draw-indirect' as GPUFeatureName);
-  })
   .paramsSubcasesOnly(
     kIndirectMultiDrawTestParams
       .combine('indirectUsage', [
@@ -157,6 +149,7 @@ Tests indirect and draw count buffers must have 'Indirect' usage.
       ] as const)
   )
   .fn(t => {
+    t.skipIfDeviceDoesNotHaveFeature('chromium-experimental-multi-draw-indirect' as GPUFeatureName);
     const { indexed, indirectUsage, useDrawCountBuffer, drawCountUsage } = t.params;
 
     const indirectBuffer = t.createBufferTracked({
@@ -192,9 +185,6 @@ g.test('offsets_alignment')
 Tests indirect and draw count offsets must be a multiple of 4.
   `
   )
-  .beforeAllSubcases(t => {
-    t.selectDeviceOrSkipTestCase('chromium-experimental-multi-draw-indirect' as GPUFeatureName);
-  })
   .paramsSubcasesOnly(
     kIndirectMultiDrawTestParams.combineWithParams([
       // Valid
@@ -209,6 +199,7 @@ Tests indirect and draw count offsets must be a multiple of 4.
     ] as const)
   )
   .fn(t => {
+    t.skipIfDeviceDoesNotHaveFeature('chromium-experimental-multi-draw-indirect' as GPUFeatureName);
     const { indexed, indirectOffset, useDrawCountBuffer, drawCountOffset } = t.params;
 
     const indirectBuffer = t.createBufferTracked({
@@ -287,10 +278,8 @@ Tests multi indirect draw calls with various indirect offsets and buffer sizes w
         yield { offset: 0, maxDrawCount: kMaxUnsignedLongValue, bufferSize: 1024 };
       })
   )
-  .beforeAllSubcases(t => {
-    t.selectDeviceOrSkipTestCase('chromium-experimental-multi-draw-indirect' as GPUFeatureName);
-  })
   .fn(t => {
+    t.skipIfDeviceDoesNotHaveFeature('chromium-experimental-multi-draw-indirect' as GPUFeatureName);
     const { indexed, offset, maxDrawCount, bufferSize } = t.params;
 
     const indirectBuffer = t.createBufferTracked({
@@ -336,10 +325,8 @@ Tests multi indirect draw calls with various draw count offsets, and draw count 
         { offset: kMaxUnsignedLongLongValue, bufferSize: 1024 },
       ])
   )
-  .beforeAllSubcases(t => {
-    t.selectDeviceOrSkipTestCase('chromium-experimental-multi-draw-indirect' as GPUFeatureName);
-  })
   .fn(t => {
+    t.skipIfDeviceDoesNotHaveFeature('chromium-experimental-multi-draw-indirect' as GPUFeatureName);
     const { indexed, bufferSize, offset } = t.params;
 
     const indirectBuffer = t.createBufferTracked({

--- a/src/webgpu/api/validation/encoding/cmds/render/setIndexBuffer.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/render/setIndexBuffer.spec.ts
@@ -5,11 +5,11 @@ Validation tests for setIndexBuffer on render pass and render bundle.
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { GPUConst } from '../../../../../constants.js';
 import { kResourceStates } from '../../../../../gpu_test.js';
-import { ValidationTest } from '../../../validation_test.js';
+import { AllFeaturesMaxLimitsValidationTest } from '../../../validation_test.js';
 
 import { kRenderEncodeTypeParams, buildBufferOffsetAndSizeOOBTestParams } from './render.js';
 
-export const g = makeTestGroup(ValidationTest);
+export const g = makeTestGroup(AllFeaturesMaxLimitsValidationTest);
 
 g.test('index_buffer_state')
   .desc(
@@ -33,9 +33,7 @@ Tests index buffer must be valid.
 g.test('index_buffer,device_mismatch')
   .desc('Tests setIndexBuffer cannot be called with an index buffer created from another device')
   .paramsSubcasesOnly(kRenderEncodeTypeParams.combine('mismatched', [true, false]))
-  .beforeAllSubcases(t => {
-    t.selectMismatchedDeviceOrSkipTestCase(undefined);
-  })
+  .beforeAllSubcases(t => t.usesMismatchedDevice())
   .fn(t => {
     const { encoderType, mismatched } = t.params;
     const sourceDevice = mismatched ? t.mismatchedDevice : t.device;

--- a/src/webgpu/api/validation/encoding/cmds/render/setPipeline.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/render/setPipeline.spec.ts
@@ -4,11 +4,11 @@ Validation tests for setPipeline on render pass and render bundle.
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { kRenderEncodeTypes } from '../../../../../util/command_buffer_maker.js';
-import { ValidationTest } from '../../../validation_test.js';
+import { AllFeaturesMaxLimitsValidationTest } from '../../../validation_test.js';
 
 import { kRenderEncodeTypeParams } from './render.js';
 
-export const g = makeTestGroup(ValidationTest);
+export const g = makeTestGroup(AllFeaturesMaxLimitsValidationTest);
 
 g.test('invalid_pipeline')
   .desc(
@@ -31,9 +31,7 @@ Tests setPipeline should generate an error iff using an 'invalid' pipeline.
 g.test('pipeline,device_mismatch')
   .desc('Tests setPipeline cannot be called with a render pipeline created from another device')
   .paramsSubcasesOnly(kRenderEncodeTypeParams.combine('mismatched', [true, false]))
-  .beforeAllSubcases(t => {
-    t.selectMismatchedDeviceOrSkipTestCase(undefined);
-  })
+  .beforeAllSubcases(t => t.usesMismatchedDevice())
   .fn(t => {
     const { encoderType, mismatched } = t.params;
     const sourceDevice = mismatched ? t.mismatchedDevice : t.device;

--- a/src/webgpu/api/validation/encoding/cmds/render/setVertexBuffer.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/render/setVertexBuffer.spec.ts
@@ -6,11 +6,11 @@ import { makeTestGroup } from '../../../../../../common/framework/test_group.js'
 import { makeValueTestVariant } from '../../../../../../common/util/util.js';
 import { GPUConst } from '../../../../../constants.js';
 import { kResourceStates } from '../../../../../gpu_test.js';
-import { ValidationTest } from '../../../validation_test.js';
+import { AllFeaturesMaxLimitsValidationTest } from '../../../validation_test.js';
 
 import { kRenderEncodeTypeParams, buildBufferOffsetAndSizeOOBTestParams } from './render.js';
 
-export const g = makeTestGroup(ValidationTest);
+export const g = makeTestGroup(AllFeaturesMaxLimitsValidationTest);
 
 g.test('slot')
   .desc(
@@ -62,9 +62,7 @@ Tests vertex buffer must be valid.
 g.test('vertex_buffer,device_mismatch')
   .desc('Tests setVertexBuffer cannot be called with a vertex buffer created from another device')
   .paramsSubcasesOnly(kRenderEncodeTypeParams.combine('mismatched', [true, false]))
-  .beforeAllSubcases(t => {
-    t.selectMismatchedDeviceOrSkipTestCase(undefined);
-  })
+  .beforeAllSubcases(t => t.usesMismatchedDevice())
   .fn(t => {
     const { encoderType, mismatched } = t.params;
     const sourceDevice = mismatched ? t.mismatchedDevice : t.device;

--- a/src/webgpu/api/validation/encoding/cmds/render/state_tracking.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/render/state_tracking.spec.ts
@@ -4,9 +4,9 @@ Validation tests for setVertexBuffer/setIndexBuffer state (not validation). See 
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { range } from '../../../../../../common/util/util.js';
-import { ValidationTest } from '../../../validation_test.js';
+import { AllFeaturesMaxLimitsValidationTest } from '../../../validation_test.js';
 
-class F extends ValidationTest {
+class F extends AllFeaturesMaxLimitsValidationTest {
   getVertexBuffer(): GPUBuffer {
     return this.createBufferTracked({
       size: 256,

--- a/src/webgpu/api/validation/encoding/cmds/render_pass.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/render_pass.spec.ts
@@ -9,6 +9,6 @@ TODO:
 `;
 
 import { makeTestGroup } from '../../../../../common/framework/test_group.js';
-import { ValidationTest } from '../../validation_test.js';
+import { AllFeaturesMaxLimitsValidationTest } from '../../validation_test.js';
 
-export const g = makeTestGroup(ValidationTest);
+export const g = makeTestGroup(AllFeaturesMaxLimitsValidationTest);

--- a/src/webgpu/api/validation/encoding/cmds/setBindGroup.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/setBindGroup.spec.ts
@@ -17,14 +17,14 @@ import {
   kMinDynamicBufferOffsetAlignment,
 } from '../../../../capability_info.js';
 import { GPUConst } from '../../../../constants.js';
-import { kResourceStates, MaxLimitsTestMixin, ResourceState } from '../../../../gpu_test.js';
+import { kResourceStates, ResourceState } from '../../../../gpu_test.js';
 import {
   kProgrammableEncoderTypes,
   ProgrammableEncoderType,
 } from '../../../../util/command_buffer_maker.js';
-import { ValidationTest } from '../../validation_test.js';
+import { AllFeaturesMaxLimitsValidationTest } from '../../validation_test.js';
 
-class F extends ValidationTest {
+class F extends AllFeaturesMaxLimitsValidationTest {
   encoderTypeToStageFlag(encoderType: ProgrammableEncoderType): GPUShaderStageFlags {
     switch (encoderType) {
       case 'compute pass':
@@ -102,7 +102,7 @@ class F extends ValidationTest {
   }
 }
 
-export const g = makeTestGroup(MaxLimitsTestMixin(F));
+export const g = makeTestGroup(F);
 
 g.test('state_and_binding_index')
   .desc('Tests that setBindGroup correctly handles {valid, invalid, destroyed} bindGroups.')
@@ -144,9 +144,7 @@ g.test('bind_group,device_mismatch')
       .combine('useU32Array', [true, false])
       .combine('mismatched', [true, false])
   )
-  .beforeAllSubcases(t => {
-    t.selectMismatchedDeviceOrSkipTestCase(undefined);
-  })
+  .beforeAllSubcases(t => t.usesMismatchedDevice())
   .fn(t => {
     const { encoderType, useU32Array, mismatched } = t.params;
     const sourceDevice = mismatched ? t.mismatchedDevice : t.device;

--- a/src/webgpu/api/validation/encoding/createRenderBundleEncoder.spec.ts
+++ b/src/webgpu/api/validation/encoding/createRenderBundleEncoder.spec.ts
@@ -9,19 +9,20 @@ import { range } from '../../../../common/util/util.js';
 import { getDefaultLimits } from '../../../capability_info.js';
 import {
   computeBytesPerSampleFromFormats,
+  getColorRenderByteCost,
+  isDepthOrStencilTextureFormat,
+  isTextureFormatColorRenderable,
   kAllTextureFormats,
   kDepthStencilFormats,
-  kTextureFormatInfo,
   kRenderableColorTextureFormats,
 } from '../../../format_info.js';
-import { MaxLimitsTestMixin } from '../../../gpu_test.js';
-import { ValidationTest } from '../validation_test.js';
+import { AllFeaturesMaxLimitsValidationTest } from '../validation_test.js';
 
 // MAINTENANCE_TODO: This should be changed to kMaxColorAttachmentsToTest
 // when this is made a MaxLimitTest (see above).
 const kMaxColorAttachments = getDefaultLimits('core').maxColorAttachments.default;
 
-export const g = makeTestGroup(MaxLimitsTestMixin(ValidationTest));
+export const g = makeTestGroup(AllFeaturesMaxLimitsValidationTest);
 
 g.test('attachment_state,limits,maxColorAttachments')
   .desc(`Tests that attachment state must have <= device.limits.maxColorAttachments.`)
@@ -62,20 +63,17 @@ g.test('attachment_state,limits,maxColorAttachmentBytesPerSample,aligned')
         range(kMaxColorAttachments, i => i + 1)
       )
   )
-  .beforeAllSubcases(t => {
-    t.skipIfTextureFormatNotSupportedDeprecated(t.params.format);
-  })
   .fn(t => {
     const { format, colorFormatCount } = t.params;
+    t.skipIfTextureFormatNotSupported(format);
     const maxColorAttachments = t.device.limits.maxColorAttachments;
     t.skipIf(
       colorFormatCount > maxColorAttachments,
       `${colorFormatCount} > maxColorAttachments: ${maxColorAttachments}`
     );
-    const info = kTextureFormatInfo[format];
     const shouldError =
-      !info.colorRender ||
-      info.colorRender.byteCost * colorFormatCount >
+      !isTextureFormatColorRenderable(t.device, format) ||
+      getColorRenderByteCost(format) * colorFormatCount >
         t.device.limits.maxColorAttachmentBytesPerSample;
 
     t.expectValidationError(() => {
@@ -166,16 +164,12 @@ g.test('valid_texture_formats')
       .beginSubcases()
       .combine('attachment', ['color', 'depthStencil'])
   )
-  .beforeAllSubcases(t => {
-    const { format } = t.params;
-    t.selectDeviceForTextureFormatOrSkipTestCase(format);
-  })
   .fn(t => {
     const { format, attachment } = t.params;
+    t.skipIfTextureFormatNotSupported(format);
 
-    const colorRenderable = kTextureFormatInfo[format].colorRender;
-
-    const depthStencil = kTextureFormatInfo[format].depth || kTextureFormatInfo[format].stencil;
+    const colorRenderable = isTextureFormatColorRenderable(t.device, format);
+    const depthStencil = isDepthOrStencilTextureFormat(format);
 
     switch (attachment) {
       case 'color': {
@@ -213,12 +207,9 @@ g.test('depth_stencil_readonly')
       .combine('depthReadOnly', [false, true])
       .combine('stencilReadOnly', [false, true])
   )
-  .beforeAllSubcases(t => {
-    const { depthStencilFormat } = t.params;
-    t.selectDeviceForTextureFormatOrSkipTestCase(depthStencilFormat);
-  })
   .fn(t => {
     const { depthStencilFormat, depthReadOnly, stencilReadOnly } = t.params;
+    t.skipIfTextureFormatNotSupported(depthStencilFormat);
     t.device.createRenderBundleEncoder({
       colorFormats: [],
       depthStencilFormat,

--- a/src/webgpu/api/validation/encoding/encoder_open_state.spec.ts
+++ b/src/webgpu/api/validation/encoding/encoder_open_state.spec.ts
@@ -6,11 +6,11 @@ GPURenderPassEncoder when the encoder is not finished.
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { keysOf } from '../../../../common/util/data_tables.js';
 import { unreachable } from '../../../../common/util/util.js';
-import { ValidationTest } from '../validation_test.js';
+import { AllFeaturesMaxLimitsValidationTest } from '../validation_test.js';
 
 import { beginRenderPassWithQuerySet } from './queries/common.js';
 
-class F extends ValidationTest {
+class F extends AllFeaturesMaxLimitsValidationTest {
   createRenderPipelineForTest(): GPURenderPipeline {
     return this.device.createRenderPipeline({
       layout: 'auto',
@@ -165,15 +165,11 @@ g.test('non_pass_commands')
       .beginSubcases()
       .combine('finishBeforeCommand', [false, true])
   )
-  .beforeAllSubcases(t => {
-    switch (t.params.command) {
-      case 'writeTimestamp':
-        t.selectDeviceOrSkipTestCase('timestamp-query');
-        break;
-    }
-  })
   .fn(t => {
     const { command, finishBeforeCommand } = t.params;
+    if (command === 'writeTimestamp') {
+      t.skipIfDeviceDoesNotSupportQueryType('timestamp');
+    }
 
     const srcBuffer = t.createBufferTracked({
       size: 16,
@@ -304,14 +300,13 @@ g.test('render_pass_commands')
       .beginSubcases()
       .combine('finishBeforeCommand', [false, true])
   )
-  .beforeAllSubcases(t => {
-    const { command } = t.params;
-    if (command === 'multiDrawIndirect' || command === 'multiDrawIndexedIndirect') {
-      t.selectDeviceOrSkipTestCase('chromium-experimental-multi-draw-indirect' as GPUFeatureName);
-    }
-  })
   .fn(t => {
     const { command, finishBeforeCommand } = t.params;
+    if (command === 'multiDrawIndirect' || command === 'multiDrawIndexedIndirect') {
+      t.skipIfDeviceDoesNotHaveFeature(
+        'chromium-experimental-multi-draw-indirect' as GPUFeatureName
+      );
+    }
 
     const querySet = t.createQuerySetTracked({ type: 'occlusion', count: 1 });
     const encoder = t.device.createCommandEncoder();

--- a/src/webgpu/api/validation/encoding/encoder_state.spec.ts
+++ b/src/webgpu/api/validation/encoding/encoder_state.spec.ts
@@ -18,9 +18,9 @@ TODO:
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { objectEquals } from '../../../../common/util/util.js';
-import { ValidationTest } from '../validation_test.js';
+import { AllFeaturesMaxLimitsValidationTest } from '../validation_test.js';
 
-class F extends ValidationTest {
+class F extends AllFeaturesMaxLimitsValidationTest {
   beginRenderPass(commandEncoder: GPUCommandEncoder, view: GPUTextureView): GPURenderPassEncoder {
     return commandEncoder.beginRenderPass({
       colorAttachments: [

--- a/src/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.ts
+++ b/src/webgpu/api/validation/encoding/programmable/pipeline_bind_group_compat.spec.ts
@@ -21,12 +21,11 @@ import {
   ValidBindableResource,
 } from '../../../../capability_info.js';
 import { GPUConst } from '../../../../constants.js';
-import { MaxLimitsTestMixin } from '../../../../gpu_test.js';
 import {
   ProgrammableEncoderType,
   kProgrammableEncoderTypes,
 } from '../../../../util/command_buffer_maker.js';
-import { ValidationTest } from '../../validation_test.js';
+import { AllFeaturesMaxLimitsValidationTest } from '../../validation_test.js';
 
 const kComputeCmds = ['dispatch', 'dispatchIndirect'] as const;
 type ComputeCmd = (typeof kComputeCmds)[number];
@@ -72,7 +71,7 @@ const kCompatTestParams = kUnitCaseParamsBuilder
   .expand('call', p => getTestCmds(p.encoderType))
   .combine('callWithZero', [true, false]);
 
-class F extends ValidationTest {
+class F extends AllFeaturesMaxLimitsValidationTest {
   getIndexBuffer(): GPUBuffer {
     return this.createBufferTracked({
       size: 8 * Uint32Array.BYTES_PER_ELEMENT,
@@ -425,7 +424,7 @@ class F extends ValidationTest {
   }
 }
 
-export const g = makeTestGroup(MaxLimitsTestMixin(F));
+export const g = makeTestGroup(F);
 
 g.test('bind_groups_and_pipeline_layout_mismatch')
   .desc(

--- a/src/webgpu/api/validation/encoding/queries/begin_end.spec.ts
+++ b/src/webgpu/api/validation/encoding/queries/begin_end.spec.ts
@@ -3,11 +3,11 @@ Validation for encoding begin/endable queries.
 `;
 
 import { makeTestGroup } from '../../../../../common/framework/test_group.js';
-import { ValidationTest } from '../../validation_test.js';
+import { AllFeaturesMaxLimitsValidationTest } from '../../validation_test.js';
 
 import { beginRenderPassWithQuerySet, createQuerySetWithType } from './common.js';
 
-export const g = makeTestGroup(ValidationTest);
+export const g = makeTestGroup(AllFeaturesMaxLimitsValidationTest);
 
 g.test('occlusion_query,begin_end_balance')
   .desc(

--- a/src/webgpu/api/validation/encoding/queries/general.spec.ts
+++ b/src/webgpu/api/validation/encoding/queries/general.spec.ts
@@ -4,11 +4,11 @@ Validation for encoding queries.
 
 import { makeTestGroup } from '../../../../../common/framework/test_group.js';
 import { kQueryTypes } from '../../../../capability_info.js';
-import { ValidationTest } from '../../validation_test.js';
+import { AllFeaturesMaxLimitsValidationTest } from '../../validation_test.js';
 
 import { createQuerySetWithType } from './common.js';
 
-export const g = makeTestGroup(ValidationTest);
+export const g = makeTestGroup(AllFeaturesMaxLimitsValidationTest);
 
 g.test('occlusion_query,query_type')
   .desc(
@@ -19,14 +19,11 @@ Tests that set occlusion query set with all types in render pass descriptor:
   `
   )
   .params(u => u.combine('type', [undefined, ...kQueryTypes]))
-  .beforeAllSubcases(t => {
-    const { type } = t.params;
-    if (type) {
-      t.selectDeviceForQueryTypeOrSkipTestCase(type);
-    }
-  })
   .fn(t => {
     const type = t.params.type;
+    if (type) {
+      t.skipIfDeviceDoesNotSupportQueryType(type);
+    }
     const querySet = type === undefined ? undefined : createQuerySetWithType(t, type, 1);
 
     const encoder = t.createEncoder('render pass', { occlusionQuerySet: querySet });
@@ -85,19 +82,10 @@ TODO: writeTimestamp is removed from the spec so it's skipped if it TypeErrors.
       .beginSubcases()
       .expand('queryIndex', p => (p.type === 'timestamp' ? [0, 2] : [0]))
   )
-  .beforeAllSubcases(t => {
-    const { type } = t.params;
-
-    // writeTimestamp is only available for devices that enable the 'timestamp-query' feature.
-    const queryTypes: GPUQueryType[] = ['timestamp'];
-    if (type !== 'timestamp') {
-      queryTypes.push(type);
-    }
-
-    t.selectDeviceForQueryTypeOrSkipTestCase(queryTypes);
-  })
   .fn(t => {
     const { type, queryIndex } = t.params;
+    t.skipIfDeviceDoesNotSupportQueryType('timestamp');
+    t.skipIfDeviceDoesNotSupportQueryType(type);
 
     const count = 2;
     const querySet = createQuerySetWithType(t, type, count);
@@ -122,10 +110,8 @@ TODO: writeTimestamp is removed from the spec so it's skipped if it TypeErrors.
 `
   )
   .paramsSubcasesOnly(u => u.combine('querySetState', ['valid', 'invalid'] as const))
-  .beforeAllSubcases(t => {
-    t.selectDeviceForQueryTypeOrSkipTestCase('timestamp');
-  })
   .fn(t => {
+    t.skipIfDeviceDoesNotSupportQueryType('timestamp');
     const { querySetState } = t.params;
 
     const querySet = t.createQuerySetWithState(querySetState, {
@@ -151,11 +137,9 @@ g.test('writeTimestamp,device_mismatch')
   `
   )
   .paramsSubcasesOnly(u => u.combine('mismatched', [true, false]))
-  .beforeAllSubcases(t => {
-    t.selectDeviceForQueryTypeOrSkipTestCase('timestamp');
-    t.selectMismatchedDeviceOrSkipTestCase('timestamp-query');
-  })
+  .beforeAllSubcases(t => t.usesMismatchedDevice())
   .fn(t => {
+    t.skipIfDeviceDoesNotSupportQueryType('timestamp');
     const { mismatched } = t.params;
     const sourceDevice = mismatched ? t.mismatchedDevice : t.device;
 

--- a/src/webgpu/api/validation/encoding/queries/resolveQuerySet.spec.ts
+++ b/src/webgpu/api/validation/encoding/queries/resolveQuerySet.spec.ts
@@ -4,9 +4,9 @@ Validation tests for resolveQuerySet.
 import { makeTestGroup } from '../../../../../common/framework/test_group.js';
 import { GPUConst } from '../../../../constants.js';
 import { kResourceStates } from '../../../../gpu_test.js';
-import { ValidationTest } from '../../validation_test.js';
+import { AllFeaturesMaxLimitsValidationTest } from '../../validation_test.js';
 
-export const g = makeTestGroup(ValidationTest);
+export const g = makeTestGroup(AllFeaturesMaxLimitsValidationTest);
 
 export const kQueryCount = 2;
 
@@ -153,9 +153,7 @@ g.test('query_set_buffer,device_mismatch')
     { querySetMismatched: true, bufferMismatched: false },
     { querySetMismatched: false, bufferMismatched: true },
   ] as const)
-  .beforeAllSubcases(t => {
-    t.selectMismatchedDeviceOrSkipTestCase(undefined);
-  })
+  .beforeAllSubcases(t => t.usesMismatchedDevice())
   .fn(t => {
     const { querySetMismatched, bufferMismatched } = t.params;
 

--- a/src/webgpu/api/validation/encoding/render_bundle.spec.ts
+++ b/src/webgpu/api/validation/encoding/render_bundle.spec.ts
@@ -4,9 +4,9 @@ Tests execution of render bundles.
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { kDepthStencilFormats } from '../../../format_info.js';
-import { ValidationTest } from '../validation_test.js';
+import { AllFeaturesMaxLimitsValidationTest } from '../validation_test.js';
 
-export const g = makeTestGroup(ValidationTest);
+export const g = makeTestGroup(AllFeaturesMaxLimitsValidationTest);
 
 g.test('empty_bundle_list')
   .desc(
@@ -34,9 +34,7 @@ g.test('device_mismatch')
     { bundle0Mismatched: true, bundle1Mismatched: false },
     { bundle0Mismatched: false, bundle1Mismatched: true },
   ])
-  .beforeAllSubcases(t => {
-    t.selectMismatchedDeviceOrSkipTestCase(undefined);
-  })
+  .beforeAllSubcases(t => t.usesMismatchedDevice())
   .fn(t => {
     const { bundle0Mismatched, bundle1Mismatched } = t.params;
 
@@ -130,12 +128,9 @@ g.test('depth_stencil_formats_mismatch')
       { bundleFormat: 'stencil8', passFormat: 'depth24plus-stencil8' },
     ] as const)
   )
-  .beforeAllSubcases(t => {
-    const { bundleFormat, passFormat } = t.params;
-    t.selectDeviceForTextureFormatOrSkipTestCase([bundleFormat, passFormat]);
-  })
   .fn(t => {
     const { bundleFormat, passFormat } = t.params;
+    t.skipIfTextureFormatNotSupported(bundleFormat, passFormat);
     const compatible = bundleFormat === passFormat;
 
     const bundleEncoder = t.device.createRenderBundleEncoder({
@@ -171,9 +166,6 @@ g.test('depth_stencil_readonly_mismatch')
       .combine('passDepthReadOnly', [false, true])
       .combine('passStencilReadOnly', [false, true])
   )
-  .beforeAllSubcases(t => {
-    t.selectDeviceForTextureFormatOrSkipTestCase(t.params.depthStencilFormat);
-  })
   .fn(t => {
     const {
       depthStencilFormat,
@@ -182,6 +174,7 @@ g.test('depth_stencil_readonly_mismatch')
       passDepthReadOnly,
       passStencilReadOnly,
     } = t.params;
+    t.skipIfTextureFormatNotSupported(depthStencilFormat);
 
     const compatible =
       (!passDepthReadOnly || bundleDepthReadOnly === passDepthReadOnly) &&

--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -141,6 +141,8 @@ export class GPUTestSubcaseBatchState extends SubcaseBatchState {
     requiredLimits: {},
     defaultQueue: {},
   };
+  /** Whether or not to provide a mismatched device */
+  private useMismatchedDevice = false;
 
   override async postInit(): Promise<void> {
     // Skip all subcases if there's no device.
@@ -163,6 +165,7 @@ export class GPUTestSubcaseBatchState extends SubcaseBatchState {
       this.requestDeviceWithRequiredParametersOrSkip(this.skipIfRequirements);
     }
     assert(this.provider !== undefined);
+    assert(!this.useMismatchedDevice || this.mismatchedProvider !== undefined);
     return this.provider;
   }
 
@@ -189,12 +192,27 @@ export class GPUTestSubcaseBatchState extends SubcaseBatchState {
     );
     // Suppress uncaught promise rejection (we'll catch it later).
     this.provider.catch(() => {});
+
+    if (this.useMismatchedDevice) {
+      this.mismatchedProvider = mismatchedDevicePool.acquire(
+        this.recorder,
+        initUncanonicalizedDeviceDescriptor(descriptor),
+        descriptorModifier
+      );
+      // Suppress uncaught promise rejection (we'll catch it later).
+      this.mismatchedProvider.catch(() => {});
+    }
   }
 
+  /**
+   * Some tests need a second device which is different from the first.
+   * This requests a second device so it will be available during the test. If it is not called,
+   * no second device will be available. The second device will be created with the
+   * same features and limits as the first device.
+   */
   usesMismatchedDevice() {
-    // MAINTENANCE_TODO: Refactor this. This should select a device with the same
-    // features and limits as the non-mismatched device for this test.
-    GPUTestSubcaseBatchState.prototype.selectMismatchedDeviceOrSkipTestCase.call(this, undefined);
+    assert(this.provider === undefined, 'Can not call usedMismatchedDevice after device creation');
+    this.useMismatchedDevice = true;
   }
 
   /**
@@ -253,20 +271,15 @@ export class GPUTestSubcaseBatchState extends SubcaseBatchState {
    * no second device will be available.
    *
    * If the request isn't supported, throws a SkipTestCase exception to skip the entire test case.
+   * @deprecated Use AllFeaturesMaxLimitsGPUTest case if possible. Otherwise, use selectDeviceOrSkipTestCase
+   * and usesMismatchedDevice. In either case, the device and mismatched device will have the same features and limits.
    */
   selectMismatchedDeviceOrSkipTestCase(descriptor: DeviceSelectionDescriptor): void {
     assert(
       this.mismatchedProvider === undefined,
       "Can't selectMismatchedDeviceOrSkipTestCase() multiple times"
     );
-
-    this.mismatchedProvider = mismatchedDevicePool.acquire(
-      this.recorder,
-      initUncanonicalizedDeviceDescriptor(descriptor),
-      undefined
-    );
-    // Suppress uncaught promise rejection (we'll catch it later).
-    this.mismatchedProvider.catch(() => {});
+    this.usesMismatchedDevice();
   }
 
   /** @deprecated use skipIfTextureFormatNotSupported on GPUTest */
@@ -1507,7 +1520,7 @@ export class GPUTest extends GPUTestBase {
   get mismatchedDevice(): GPUDevice {
     assert(
       this.mismatchedProvider !== undefined,
-      'selectMismatchedDeviceOrSkipTestCase was not called in beforeAllSubcases'
+      'usesMismatchedDevice or selectMismatchedDeviceOrSkipTestCase was not called in beforeAllSubcases'
     );
     return this.mismatchedProvider.device;
   }
@@ -1693,6 +1706,7 @@ export function RequiredLimitsTestMixin<F extends FixtureClass<GPUTestBase>>(
 
 /**
  * Requests all the max limits from the adapter.
+ * @deprecated Use AllFeaturesMaxLimitsGPUTest or related.
  */
 export function MaxLimitsTestMixin<F extends FixtureClass<GPUTestBase>>(Base: F) {
   return RequiredLimitsTestMixin(Base, {


### PR DESCRIPTION
Issue #4181
Issue #4178

Note: For copyTextureToTexture:texture_format_compatibility it was not at all clear to me why it was choosing textures with features. AFAICT that was testing almost nothing. Refactored it.
