### PR TITLE
Bump tsconfig.json lib to es2023

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "./node_modules/gts/tsconfig-google.json",
   "compilerOptions": {
-    "lib": ["dom", "es2020"],
+    "lib": ["dom", "ES2023"],
     "module": "esnext",
     // Use types only from these packages (not everything in package.json, which is the default).
     // Note that TypeScript's `/// <reference />` is the same as adding an entry here - it's global


### PR DESCRIPTION
Currently it's on ES2020 which does not define `WeakRef`. Given no other browser has shipped yet maybe it's ok to set it to ES2023?

