### PR TITLE
Refactor api/validation/* with format_info.ts changes

### DIFF
--- a/src/webgpu/api/validation/image_copy/buffer_texture_copies.spec.ts
+++ b/src/webgpu/api/validation/image_copy/buffer_texture_copies.spec.ts
@@ -14,9 +14,9 @@ import {
 } from '../../../format_info.js';
 import { align } from '../../../util/math.js';
 import { kBufferCopyAlignment, kBytesPerRowAlignment } from '../../../util/texture/layout.js';
-import { ValidationTest } from '../validation_test.js';
+import { AllFeaturesMaxLimitsValidationTest } from '../validation_test.js';
 
-class ImageCopyTest extends ValidationTest {
+class ImageCopyTest extends AllFeaturesMaxLimitsValidationTest {
   testCopyBufferToTexture(
     source: GPUTexelCopyBufferInfo,
     destination: GPUTexelCopyTextureInfo,
@@ -70,12 +70,9 @@ g.test('depth_stencil_format,copy_usage_and_aspect')
       .beginSubcases()
       .combine('aspect', ['all', 'depth-only', 'stencil-only'] as const)
   )
-  .beforeAllSubcases(t => {
-    const { format } = t.params;
-    t.selectDeviceForTextureFormatOrSkipTestCase(format);
-  })
   .fn(t => {
     const { format, aspect } = t.params;
+    t.skipIfTextureFormatNotSupported(format);
 
     const textureSize = { width: 1, height: 1, depthOrArrayLayers: 1 };
     const texture = t.createTextureTracked({
@@ -135,12 +132,9 @@ g.test('depth_stencil_format,copy_buffer_size')
         { width: 4, height: 4, depthOrArrayLayers: 3 },
       ])
   )
-  .beforeAllSubcases(t => {
-    const { format } = t.params;
-    t.selectDeviceForTextureFormatOrSkipTestCase(format);
-  })
   .fn(t => {
     const { format, aspect, copyType, copySize } = t.params;
+    t.skipIfTextureFormatNotSupported(format);
 
     const texture = t.createTextureTracked({
       size: copySize,
@@ -242,12 +236,9 @@ g.test('depth_stencil_format,copy_buffer_offset')
       .beginSubcases()
       .combine('offset', [1, 2, 4, 6, 8])
   )
-  .beforeAllSubcases(t => {
-    const { format } = t.params;
-    t.selectDeviceForTextureFormatOrSkipTestCase(format);
-  })
   .fn(t => {
     const { format, aspect, copyType, offset } = t.params;
+    t.skipIfTextureFormatNotSupported(format);
 
     const textureSize = { width: 4, height: 4, depthOrArrayLayers: 1 };
 
@@ -422,9 +413,7 @@ g.test('device_mismatch')
         { bufMismatched: false, texMismatched: true },
       ] as const)
   )
-  .beforeAllSubcases(t => {
-    t.selectMismatchedDeviceOrSkipTestCase(undefined);
-  })
+  .beforeAllSubcases(t => t.usesMismatchedDevice())
   .fn(t => {
     const { copyType, bufMismatched, texMismatched } = t.params;
 

--- a/src/webgpu/api/validation/image_copy/image_copy.ts
+++ b/src/webgpu/api/validation/image_copy/image_copy.ts
@@ -6,6 +6,7 @@ import {
   getBlockInfoForTextureFormat,
   isDepthOrStencilTextureFormat,
   canCopyFromAllAspectsOfTextureFormat,
+  canCopyToAllAspectsOfTextureFormat,
 } from '../../../format_info.js';
 import { align } from '../../../util/math.js';
 import { ImageCopyType } from '../../../util/texture/layout.js';

--- a/src/webgpu/api/validation/image_copy/image_copy.ts
+++ b/src/webgpu/api/validation/image_copy/image_copy.ts
@@ -255,7 +255,7 @@ export function formatCopyableWithMethod({ format, method }: WithFormatAndMethod
   if (method === 'CopyT2B') {
     return canCopyFromAllAspectsOfTextureFormat(format);
   } else {
-    return canCopyFromAllAspectsOfTextureFormat(format);
+    return canCopyToAllAspectsOfTextureFormat(format);
   }
 }
 

--- a/src/webgpu/api/validation/image_copy/texture_related.spec.ts
+++ b/src/webgpu/api/validation/image_copy/texture_related.spec.ts
@@ -5,9 +5,12 @@ import { assert } from '../../../../common/util/util.js';
 import { kTextureDimensions, kTextureUsages } from '../../../capability_info.js';
 import { GPUConst } from '../../../constants.js';
 import {
+  getBlockInfoForColorTextureFormat,
+  getBlockInfoForSizedTextureFormat,
+  getBlockInfoForTextureFormat,
+  isDepthOrStencilTextureFormat,
   kColorTextureFormats,
   kSizedTextureFormats,
-  kTextureFormatInfo,
   textureDimensionAndFormatCompatible,
 } from '../../../format_info.js';
 import { kResourceStates } from '../../../gpu_test.js';
@@ -70,9 +73,7 @@ g.test('texture,device_mismatch')
   .paramsSubcasesOnly(u =>
     u.combine('method', kImageCopyTypes).combine('mismatched', [true, false])
   )
-  .beforeAllSubcases(t => {
-    t.selectMismatchedDeviceOrSkipTestCase(undefined);
-  })
+  .beforeAllSubcases(t => t.usesMismatchedDevice())
   .fn(t => {
     const { method, mismatched } = t.params;
     const sourceDevice = mismatched ? t.mismatchedDevice : t.device;
@@ -266,11 +267,6 @@ Test the copy must be a full subresource if the texture's format is depth/stenci
       // need to examine depth dimension via copyDepthModifier to determine whether it is a full copy for a 3D texture.
       .expand('copyDepthModifier', ({ dimension: d }) => (d === '3d' ? [0, -1] : [0]))
   )
-  .beforeAllSubcases(t => {
-    const info = kTextureFormatInfo[t.params.format];
-    t.skipIfTextureFormatNotSupportedDeprecated(t.params.format);
-    t.selectDeviceOrSkipTestCase(info.feature);
-  })
   .fn(t => {
     const {
       method,
@@ -282,8 +278,9 @@ Test the copy must be a full subresource if the texture's format is depth/stenci
       copyHeightModifier,
       copyDepthModifier,
     } = t.params;
+    t.skipIfTextureFormatNotSupported(format);
+    const info = getBlockInfoForSizedTextureFormat(format);
 
-    const info = kTextureFormatInfo[format];
     const size = { width: 32 * info.blockWidth, height: 32 * info.blockHeight, depthOrArrayLayers };
     if (dimension === '1d') {
       size.height = 1;
@@ -299,7 +296,7 @@ Test the copy must be a full subresource if the texture's format is depth/stenci
 
     let success = true;
     if (
-      (info.depth || info.stencil) &&
+      isDepthOrStencilTextureFormat(format) &&
       (copyWidthModifier !== 0 || copyHeightModifier !== 0 || copyDepthModifier !== 0)
     ) {
       success = false;
@@ -353,15 +350,11 @@ Test that the texture copy origin must be aligned to the format's block size.
       .unless(p => p.dimension === '1d' && p.coordinateToTest !== 'x')
       .expand('valueToCoordinate', texelBlockAlignmentTestExpanderForValueToCoordinate)
   )
-  .beforeAllSubcases(t => {
-    const info = kTextureFormatInfo[t.params.format];
-    t.skipIfTextureFormatNotSupportedDeprecated(t.params.format);
-    t.selectDeviceOrSkipTestCase(info.feature);
-  })
   .fn(t => {
     const { valueToCoordinate, coordinateToTest, format, method, depthOrArrayLayers, dimension } =
       t.params;
-    const info = kTextureFormatInfo[format];
+    t.skipIfTextureFormatNotSupported(format);
+    const info = getBlockInfoForTextureFormat(format);
     const size = { width: 0, height: 0, depthOrArrayLayers };
     const origin = { x: 0, y: 0, z: 0 };
     let success = true;
@@ -411,14 +404,10 @@ Test that the copy size must be aligned to the texture's format's block size.
       .unless(p => p.dimension === '1d' && p.coordinateToTest !== 'width')
       .expand('valueToCoordinate', texelBlockAlignmentTestExpanderForValueToCoordinate)
   )
-  .beforeAllSubcases(t => {
-    const info = kTextureFormatInfo[t.params.format];
-    t.skipIfTextureFormatNotSupportedDeprecated(t.params.format);
-    t.selectDeviceOrSkipTestCase(info.feature);
-  })
   .fn(t => {
     const { valueToCoordinate, coordinateToTest, dimension, format, method } = t.params;
-    const info = kTextureFormatInfo[format];
+    t.skipIfTextureFormatNotSupported(format);
+    const info = getBlockInfoForColorTextureFormat(format);
     const size = { width: 0, height: 0, depthOrArrayLayers: 0 };
     const origin = { x: 0, y: 0, z: 0 };
     let success = true;
@@ -438,7 +427,7 @@ Test that the copy size must be aligned to the texture's format's block size.
     const texture = t.createAlignedTexture(format, size, origin, dimension);
 
     const bytesPerRow = align(
-      Math.max(1, Math.ceil(size.width / info.blockWidth)) * info.color.bytes,
+      Math.max(1, Math.ceil(size.width / info.blockWidth)) * info.bytesPerBlock,
       256
     );
     const rowsPerImage = Math.ceil(size.height / info.blockHeight);
@@ -483,7 +472,7 @@ Test that the max corner of the copy rectangle (origin+copySize) must be inside 
       dimension,
     } = t.params;
     const format = 'rgba8unorm';
-    const info = kTextureFormatInfo[format];
+    const info = getBlockInfoForColorTextureFormat(format);
 
     const origin = [0, 0, 0];
     const copySize = [0, 0, 0];

--- a/src/webgpu/format_info.ts
+++ b/src/webgpu/format_info.ts
@@ -1437,12 +1437,6 @@ const kASTCTextureFormatInfo = formatTableWithDefaults({
 /* prettier-ignore */ export const kUncompressedTextureFormats: readonly UncompressedTextureFormat[] = keysOf(kUncompressedTextureFormatInfo);
 /* prettier-ignore */ export const          kAllTextureFormats: readonly          GPUTextureFormat[] = keysOf(         kAllTextureFormatInfo);
 
-// CompressedTextureFormat are unrenderable so filter from RegularTextureFormats for color targets is enough
-// @deprecated
-export const kRenderableColorTextureFormats = kRegularTextureFormats.filter(
-  v => kColorTextureFormatInfo[v].colorRender
-);
-
 // Color formats that are possibly renderable. Some may require features to be enabled.
 // MAINTENANCE_TODO: remove 'rg11b10ufloat` once colorRender is added to its info.
 // See: computeBytesPerSampleFromFormats
@@ -1853,6 +1847,23 @@ export function getBlockInfoForColorTextureFormat(format: ColorTextureFormat) {
 }
 
 /**
+ * Gets the block width, height, and bytes per block for a sized texture format.
+ * This is for sized textures only. For all texture formats @see {@link getBlockInfoForTextureFormat}
+ * The point of this function is bytesPerBlock is always defined so no need to check that it's not
+ * vs getBlockInfoForTextureFormat where it may not be defined.
+ */
+export function getBlockInfoForSizedTextureFormat(format: SizedTextureFormat) {
+  const info = kTextureFormatInfo[format];
+  const bytesPerBlock = info.color?.bytes || info.depth?.bytes || info.stencil?.bytes;
+  assert(!!bytesPerBlock);
+  return {
+    blockWidth: info.blockWidth,
+    blockHeight: info.blockHeight,
+    bytesPerBlock,
+  };
+}
+
+/**
  * Gets the block width, height, and bytes per block for an encodable texture format.
  * This is for encodable textures only. For all texture formats @see {@link getBlockInfoForTextureFormat}
  * The point of this function is bytesPerBlock is always defined so no need to check that it's not
@@ -2066,6 +2077,22 @@ export function isTextureFormatColorRenderable(
     return true;
   }
   return !!kAllTextureFormatInfo[format].colorRender;
+}
+
+/**
+ * Returns if a texture can be blended.
+ */
+export function isTextureFormatBlendable(device: GPUDevice, format: GPUTextureFormat): boolean {
+  if (!isTextureFormatColorRenderable(device, format)) {
+    return false;
+  }
+  if (format === 'rg11b10ufloat' && device.features.has('rg11b10ufloat-renderable')) {
+    return true;
+  }
+  if (is32Float(format) && device.features.has('float32-blendable')) {
+    return true;
+  }
+  return !!kAllTextureFormatInfo[format].colorRender?.blend;
 }
 
 /**


### PR DESCRIPTION
Most of these files required changed to format_info.ts so bundling them together. Otherwise I just included all changes in valdiation/image_copy/*

Issue #4178
Issue #4181

