### PR TITLE
Remove deprecated from gpu_test.ts/format_info.ts

### DIFF
--- a/src/webgpu/format_info.ts
+++ b/src/webgpu/format_info.ts
@@ -1,4 +1,3 @@
-// MAINTENANCE_TODO: Remove all deprecated functions once they are no longer in use.
 import { isCompatibilityDevice } from '../common/framework/test_config.js';
 import { keysOf } from '../common/util/data_tables.js';
 import { assert, unreachable } from '../common/util/util.js';
@@ -1518,13 +1517,75 @@ type TextureFormatInfo_TypeCheck = {
     )
 );
 
-// MAINTENANCE_TODO: make this private to avoid tests wrongly trying to
-// filter things on their own. Various features make this hard to do correctly
-// so we'd prefer to put filtering here, in a central place and add other functions
-// to get at this data so that they always have enough info to give the correct answer.
-/** Per-GPUTextureFormat info. */
-/** @deprecated */
-export const kTextureFormatInfo = {
+/**
+ * DO NOT EXPORT THIS - functions that need info from this table should use the appropriate
+ * method for their needs.
+ *
+ * For a list of textures formats for test parameters there are:
+ *
+ * Lists of formats that might require features to be enabled
+ * * kPossibleColorRenderableTextureFormats
+ * * kPossibleStorageTextureFormats
+ * * kPossibleReadWriteStorageTextureFormats
+ * * kPossibleMultisampledTextureFormats
+ *
+ * Lists of formats that end in -srgb
+ * * kDifferentBaseFormatTextureFormats  (includes compressed textures)
+ * * kDifferentBaseFormatRegularTextureFormats (does not include compressed textures)
+ *
+ * Formats that require a feature to use at all (mostly compressed formats)
+ * * kOptionalTextureFormats
+ *
+ * Misc
+ * * kRegularTextureFormats
+ * * kSizedDepthStencilFormats
+ * * kUnsizedDepthStencilFormats
+ * * kCompressedTextureFormats
+ * * kUncompressedTextureFormats
+ * * kColorTextureFormats - color formats including compressed and sint/uint
+ * * kEncodableTextureFormats - formats that TexelView supports.
+ * * kSizedTextureFormats - formats that have a known size (so not depth24plus ...)
+ * * kDepthStencilFormats - depth, stencil, depth-stencil
+ * * kDepthTextureFormats - depth and depth-stencil
+ * * kStencilTextureFormats - stencil and depth-stencil
+ * * kAllTextureFormats
+ *
+ * If one of the list above does not work, add a new one or to filter in beforeAllSubcases you generally want to use
+ * You will not know if you can actually use a texture for the given use case until the test runs and has a device.
+ *
+ * * isTextureFormatPossiblyUsableAsRenderAttachment
+ * * isTextureFormatPossiblyUsableAsColorRenderAttachment
+ * * isTextureFormatPossiblyMultisampled
+ * * isTextureFormatPossiblyStorageReadable
+ * * isTextureFormatPossiblyStorageReadWritable
+ * * isTextureFormatPossiblyFilterableAsTextureF32
+ *
+ * These are also usable before or during a test
+ *
+ * * isColorTextureFormat
+ * * isDepthTextureFormat
+ * * isStencilTextureFormat
+ * * isDepthOrStencilTextureFormat
+ * * isEncodableTextureFormat
+ * * isRegularTextureFormat
+ * * isCompressedFloatTextureFormat
+ * * isSintOrUintFormat
+ *
+ * To skip a test use the `skipIfXXX` tests in `GPUTest` if possible. Otherwise these functions
+ * require a device to give a correct answer.
+ *
+ * * isTextureFormatUsableAsRenderAttachment
+ * * isTextureFormatColorRenderable
+ * * isTextureFormatResolvable
+ * * isTextureFormatBlendable
+ * * isTextureFormatMultisampled
+ * * isTextureFormatUsableAsStorageFormat
+ * * isTextureFormatUsableAsReadWriteStorageTexture
+ * * isTextureFormatUsableAsStorageFormatInCreateShaderModule
+ *
+ * Per-GPUTextureFormat info.
+ */
+const kTextureFormatInfo = {
   ...kRegularTextureFormatInfo,
   ...kSizedDepthStencilFormatInfo,
   ...kUnsizedDepthStencilFormatInfo,
@@ -1801,15 +1862,6 @@ export function textureDimensionAndFormatCompatible(
   );
 }
 
-/** @deprecated */
-export function viewCompatibleDeprecated(
-  compatibilityMode: boolean,
-  a: GPUTextureFormat,
-  b: GPUTextureFormat
-): boolean {
-  return compatibilityMode ? a === b : a === b || a + '-srgb' === b || b + '-srgb' === a;
-}
-
 /**
  * Check if two formats are view format compatible.
  */
@@ -2039,11 +2091,6 @@ export function isEncodableTextureFormat(format: GPUTextureFormat) {
   return kEncodableTextureFormats.includes(format as EncodableTextureFormat);
 }
 
-/** @deprecated use isTextureFormatUsableAsRenderAttachment */
-export function canUseAsRenderTargetDeprecated(format: GPUTextureFormat) {
-  return kTextureFormatInfo[format].colorRender || isDepthOrStencilTextureFormat(format);
-}
-
 /**
  * Returns if a texture can be used as a render attachment. some color formats and all
  * depth textures and stencil textures are usable with usage RENDER_ATTACHMENT.
@@ -2177,20 +2224,6 @@ export const kCompatModeUnsupportedStorageTextureFormats: readonly GPUTextureFor
   'rg32uint',
 ] as const;
 
-/** @deprecated */
-export function isTextureFormatUsableAsStorageFormatDeprecated(
-  format: GPUTextureFormat,
-  isCompatibilityMode: boolean
-): boolean {
-  if (isCompatibilityMode) {
-    if (kCompatModeUnsupportedStorageTextureFormats.indexOf(format) >= 0) {
-      return false;
-    }
-  }
-  const info = kTextureFormatInfo[format];
-  return !!(info.color?.storage || info.depth?.storage || info.stencil?.storage);
-}
-
 /**
  * Return true if the format can be used as a storage texture.
  * Note: Some formats can be compiled in a shader but can not be used
@@ -2284,19 +2317,6 @@ export const kCompatModeUnsupportedMultisampledTextureFormats: readonly GPUTextu
   'rgba16float',
   'r32float',
 ] as const;
-
-/** @deprecated use isTextureFormatMultisampled */
-export function isMultisampledTextureFormatDeprecated(
-  format: GPUTextureFormat,
-  isCompatibilityMode: boolean
-): boolean {
-  if (isCompatibilityMode) {
-    if (kCompatModeUnsupportedMultisampledTextureFormats.indexOf(format) >= 0) {
-      return false;
-    }
-  }
-  return kAllTextureFormatInfo[format].multisample;
-}
 
 /**
  * Returns true if you can make a multisampled texture from the given format.

--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -24,7 +24,6 @@ import {
 import { kLimits, kQueryTypeInfo, WGSLLanguageFeature } from './capability_info.js';
 import { InterpolationType, InterpolationSampling } from './constants.js';
 import {
-  kTextureFormatInfo,
   kEncodableTextureFormats,
   resolvePerAspectFormat,
   SizedTextureFormat,
@@ -32,8 +31,6 @@ import {
   isCompressedTextureFormat,
   ColorTextureFormat,
   getRequiredFeatureForTextureFormat,
-  isTextureFormatUsableAsStorageFormatDeprecated,
-  isMultisampledTextureFormatDeprecated,
   isTextureFormatUsableAsStorageFormat,
   isTextureFormatUsableAsRenderAttachment,
   isTextureFormatMultisampled,
@@ -41,6 +38,10 @@ import {
   isSintOrUintFormat,
   isTextureFormatResolvable,
   isTextureFormatUsableAsReadWriteStorageTexture,
+  isDepthTextureFormat,
+  isStencilTextureFormat,
+  getBlockInfoForTextureFormat,
+  getBlockInfoForColorTextureFormat,
 } from './format_info.js';
 import { checkElementsEqual, checkElementsBetween } from './util/check_contents.js';
 import { CommandBufferMaker, EncoderType } from './util/command_buffer_maker.js';
@@ -239,8 +240,7 @@ export class GPUTestSubcaseBatchState extends SubcaseBatchState {
     const features = new Set<GPUFeatureName | undefined>();
     for (const format of formats) {
       if (format !== undefined) {
-        this.skipIfTextureFormatNotSupportedDeprecated(format);
-        features.add(kTextureFormatInfo[format].feature);
+        features.add(getRequiredFeatureForTextureFormat(format));
       }
     }
 
@@ -265,87 +265,11 @@ export class GPUTestSubcaseBatchState extends SubcaseBatchState {
     return this.mismatchedProvider;
   }
 
-  /**
-   * Some tests need a second device which is different from the first.
-   * This requests a second device so it will be available during the test. If it is not called,
-   * no second device will be available.
-   *
-   * If the request isn't supported, throws a SkipTestCase exception to skip the entire test case.
-   * @deprecated Use AllFeaturesMaxLimitsGPUTest case if possible. Otherwise, use selectDeviceOrSkipTestCase
-   * and usesMismatchedDevice. In either case, the device and mismatched device will have the same features and limits.
-   */
-  selectMismatchedDeviceOrSkipTestCase(descriptor: DeviceSelectionDescriptor): void {
-    assert(
-      this.mismatchedProvider === undefined,
-      "Can't selectMismatchedDeviceOrSkipTestCase() multiple times"
-    );
-    this.usesMismatchedDevice();
-  }
-
-  /** @deprecated use skipIfTextureFormatNotSupported on GPUTest */
-  skipIfTextureFormatNotSupportedDeprecated(...formats: (GPUTextureFormat | undefined)[]) {
-    if (this.isCompatibility) {
-      for (const format of formats) {
-        if (format === 'bgra8unorm-srgb') {
-          this.skip(`texture format '${format} is not supported in compatibility mode`);
-        }
-      }
-    }
-  }
-
-  /** @deprecated use skipIfMultisampleNotSupportedForFormat on GPUTest */
-  skipIfMultisampleNotSupportedForFormatDeprecated(...formats: (GPUTextureFormat | undefined)[]) {
-    for (const format of formats) {
-      if (format === undefined) continue;
-      if (!isMultisampledTextureFormatDeprecated(format, this.isCompatibility)) {
-        this.skip(`texture format '${format}' is not supported to be multisampled`);
-      }
-    }
-  }
-
   skipIfCopyTextureToTextureNotSupportedForFormat(...formats: (GPUTextureFormat | undefined)[]) {
     if (this.isCompatibility) {
       for (const format of formats) {
         if (format && isCompressedTextureFormat(format)) {
           this.skip(`copyTextureToTexture with ${format} is not supported in compatibility mode`);
-        }
-      }
-    }
-  }
-
-  /** @deprecated use skipIfTextureViewDimensionNotSupported on GPUTest */
-  skipIfTextureViewDimensionNotSupportedDeprecated(
-    ...dimensions: (GPUTextureViewDimension | undefined)[]
-  ) {
-    if (this.isCompatibility) {
-      for (const dimension of dimensions) {
-        if (dimension === 'cube-array') {
-          this.skip(`texture view dimension '${dimension}' is not supported`);
-        }
-      }
-    }
-  }
-
-  /** @deprecated use skipIfTextureFormatNotUsableAsStorageTexture on GPUTest */
-  skipIfTextureFormatNotUsableAsStorageTextureDeprecated(
-    ...formats: (GPUTextureFormat | undefined)[]
-  ) {
-    for (const format of formats) {
-      if (format && !isTextureFormatUsableAsStorageFormatDeprecated(format, this.isCompatibility)) {
-        this.skip(`Texture with ${format} is not usable as a storage texture`);
-      }
-    }
-  }
-
-  /** @deprecated use skipIfTextureLoadNotSupportedForTextureType on GPUTest */
-  skipIfTextureLoadNotSupportedForTextureTypeDeprecated(...types: (string | undefined | null)[]) {
-    if (this.isCompatibility) {
-      for (const type of types) {
-        switch (type) {
-          case 'texture_depth_2d':
-          case 'texture_depth_2d_array':
-          case 'texture_depth_multisampled_2d':
-            this.skip(`${type} is not supported by textureLoad in compatibility mode`);
         }
       }
     }
@@ -375,14 +299,6 @@ export class GPUTestSubcaseBatchState extends SubcaseBatchState {
         'interpolation type flat with sampling not set to either is not supported in compatibility mode'
       );
     }
-  }
-
-  /** Skips this test case if a depth texture can not be used with a non-comparison sampler. */
-  skipIfDepthTextureCanNotBeUsedWithNonComparisonSamplerDeprecated() {
-    this.skipIf(
-      this.isCompatibility,
-      'depth textures are not usable with non-comparison samplers in compatibility mode'
-    );
   }
 
   /** Skips this test case if the `langFeature` is *not* supported. */
@@ -538,17 +454,6 @@ export class GPUTestBase extends Fixture<GPUTestSubcaseBatchState> {
     };
   }
 
-  /** @deprecated */
-  skipIfTextureFormatNotSupportedDeprecated(...formats: (GPUTextureFormat | undefined)[]) {
-    if (this.isCompatibility) {
-      for (const format of formats) {
-        if (format === 'bgra8unorm-srgb') {
-          this.skip(`texture format '${format} is not supported`);
-        }
-      }
-    }
-  }
-
   /**
    * Skips test if device does not have feature.
    * Note: Try to use one of the more specific skipIf tests if possible.
@@ -606,37 +511,11 @@ export class GPUTestBase extends Fixture<GPUTestSubcaseBatchState> {
     }
   }
 
-  /** @deprecated */
-  skipIfTextureViewDimensionNotSupportedDeprecated(
-    ...dimensions: (GPUTextureViewDimension | undefined)[]
-  ) {
-    if (this.isCompatibility) {
-      for (const dimension of dimensions) {
-        if (dimension === 'cube-array') {
-          this.skip(`texture view dimension '${dimension}' is not supported`);
-        }
-      }
-    }
-  }
-
   skipIfTextureViewDimensionNotSupported(...dimensions: (GPUTextureViewDimension | undefined)[]) {
     if (isCompatibilityDevice(this.device)) {
       for (const dimension of dimensions) {
         if (dimension === 'cube-array') {
           this.skip(`texture view dimension '${dimension}' is not supported`);
-        }
-      }
-    }
-  }
-
-  /** @deprecated */
-  skipIfCopyTextureToTextureNotSupportedForFormatDeprecated(
-    ...formats: (GPUTextureFormat | undefined)[]
-  ) {
-    if (this.isCompatibility) {
-      for (const format of formats) {
-        if (format && isCompressedTextureFormat(format)) {
-          this.skip(`copyTextureToTexture with ${format} is not supported`);
         }
       }
     }
@@ -648,16 +527,6 @@ export class GPUTestBase extends Fixture<GPUTestSubcaseBatchState> {
         if (format && isCompressedTextureFormat(format)) {
           this.skip(`copyTextureToTexture with ${format} is not supported`);
         }
-      }
-    }
-  }
-
-  skipIfTextureFormatNotUsableAsStorageTextureDeprecated(
-    ...formats: (GPUTextureFormat | undefined)[]
-  ) {
-    for (const format of formats) {
-      if (format && !isTextureFormatUsableAsStorageFormatDeprecated(format, this.isCompatibility)) {
-        this.skip(`Texture with ${format} is not usable as a storage texture`);
       }
     }
   }
@@ -1441,7 +1310,7 @@ export class GPUTestBase extends Fixture<GPUTestSubcaseBatchState> {
             stencilReadOnly: fullAttachmentInfo.stencilReadOnly,
           };
           if (
-            kTextureFormatInfo[fullAttachmentInfo.depthStencilFormat].depth &&
+            isDepthTextureFormat(fullAttachmentInfo.depthStencilFormat) &&
             !fullAttachmentInfo.depthReadOnly
           ) {
             depthStencilAttachment.depthClearValue = 0;
@@ -1449,7 +1318,7 @@ export class GPUTestBase extends Fixture<GPUTestSubcaseBatchState> {
             depthStencilAttachment.depthStoreOp = 'discard';
           }
           if (
-            kTextureFormatInfo[fullAttachmentInfo.depthStencilFormat].stencil &&
+            isStencilTextureFormat(fullAttachmentInfo.depthStencilFormat) &&
             !fullAttachmentInfo.stencilReadOnly
           ) {
             depthStencilAttachment.stencilClearValue = 1;
@@ -1778,7 +1647,7 @@ export class AllFeaturesMaxLimitsGPUTestSubcaseBatchState extends GPUTestSubcase
   /**
    * Use skipIfDeviceDoesNotHaveFeature or skipIf(device.limits.maxXXX < requiredXXX) etc...
    */
-  override selectMismatchedDeviceOrSkipTestCase(descriptor: DeviceSelectionDescriptor): void {
+  selectMismatchedDeviceOrSkipTestCase(descriptor: DeviceSelectionDescriptor): void {
     unreachable('this function should not be called in AllFeaturesMaxLimitsGPUTest');
   }
 }
@@ -2309,7 +2178,9 @@ export function TextureTestMixin<F extends FixtureClass<GPUTestBase>>(
     }
 
     copyWholeTextureToNewBufferSimple(texture: GPUTexture, mipLevel: number) {
-      const { blockWidth, blockHeight, bytesPerBlock } = kTextureFormatInfo[texture.format];
+      const { blockWidth, blockHeight, bytesPerBlock } = getBlockInfoForTextureFormat(
+        texture.format
+      );
       const mipSize = physicalMipSizeFromTexture(texture, mipLevel);
       assert(bytesPerBlock !== undefined);
 
@@ -2399,7 +2270,7 @@ export function TextureTestMixin<F extends FixtureClass<GPUTestBase>>(
       origin: Required<GPUOrigin3DDict> = { x: 0, y: 0, z: 0 }
     ): number {
       const { offset, bytesPerRow, rowsPerImage } = textureDataLayout;
-      const info = kTextureFormatInfo[format];
+      const info = getBlockInfoForColorTextureFormat(format);
 
       assert(texel.x % info.blockWidth === 0);
       assert(texel.y % info.blockHeight === 0);
@@ -2412,7 +2283,7 @@ export function TextureTestMixin<F extends FixtureClass<GPUTestBase>>(
         offset +
         (texel.z + origin.z) * bytesPerImage +
         ((texel.y + origin.y) / info.blockHeight) * bytesPerRow +
-        ((texel.x + origin.x) / info.blockWidth) * info.color.bytes
+        ((texel.x + origin.x) / info.blockWidth) * info.bytesPerBlock
       );
     }
 
@@ -2424,7 +2295,7 @@ export function TextureTestMixin<F extends FixtureClass<GPUTestBase>>(
         // do not iterate anything for an empty region
         return;
       }
-      const info = kTextureFormatInfo[format];
+      const info = getBlockInfoForTextureFormat(format);
       assert(size.height % info.blockHeight === 0);
       // Note: it's important that the order is in increasing memory address order.
       for (let z = 0; z < size.depthOrArrayLayers; ++z) {

--- a/src/webgpu/shader/execution/expression/call/builtin/textureSample.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureSample.spec.ts
@@ -874,7 +874,7 @@ Parameters:
     const { format, samplePoints, A, mode } = t.params;
     t.skipIfTextureFormatNotSupported(format);
     t.skipIfDepthTextureCanNotBeUsedWithNonComparisonSampler();
-    t.skipIfTextureViewDimensionNotSupportedDeprecated('cube-array');
+    t.skipIfTextureViewDimensionNotSupported('cube-array');
 
     const viewDimension: GPUTextureViewDimension = 'cube-array';
     const size = chooseTextureSize({


### PR DESCRIPTION
And make `kTextureFormatInfo` private.

Note: I didn't remove 100% of things labeled deprecated in gpu_test.ts. I'll save the few remaining for a future PR.

#4181 
#4178 