### PR TITLE
Fix limits issues.

### DIFF
--- a/src/stress/adapter/device_allocation.spec.ts
+++ b/src/stress/adapter/device_allocation.spec.ts
@@ -8,7 +8,7 @@ import { attemptGarbageCollection } from '../../common/util/collect_garbage.js';
 import { keysOf } from '../../common/util/data_tables.js';
 import { getGPU } from '../../common/util/navigator_gpu.js';
 import { assert, iterRange } from '../../common/util/util.js';
-import { getDefaultLimitsForAdapter } from '../../webgpu/capability_info.js';
+import { getDefaultLimitsForCTS } from '../../webgpu/capability_info.js';
 
 export const g = makeTestGroup(Fixture);
 
@@ -34,7 +34,7 @@ async function createDeviceAndComputeCommands(t: Fixture, adapter: GPUAdapter) {
   // Constants are computed such that per run, this function should allocate roughly 2G
   // worth of data. This should be sufficient as we run these creation functions many
   // times. If the data backing the created objects is not recycled we should OOM.
-  const limitInfo = getDefaultLimitsForAdapter(adapter);
+  const limitInfo = getDefaultLimitsForCTS();
   const kNumPipelines = 64;
   const kNumBindgroups = 128;
   const kNumBufferElements =

--- a/src/webgpu/api/operation/adapter/requestDevice.spec.ts
+++ b/src/webgpu/api/operation/adapter/requestDevice.spec.ts
@@ -10,7 +10,7 @@ import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { getGPU } from '../../../../common/util/navigator_gpu.js';
 import { assert, assertReject, raceWithRejectOnTimeout } from '../../../../common/util/util.js';
 import {
-  getDefaultLimitsForAdapter,
+  getDefaultLimitsForCTS,
   kFeatureNames,
   kLimits,
   kLimitClasses,
@@ -54,7 +54,7 @@ g.test('default')
       );
     }
     // All limits should be defaults.
-    const limitInfo = getDefaultLimitsForAdapter(adapter);
+    const limitInfo = getDefaultLimitsForCTS();
     for (const limit of kLimits) {
       t.expect(
         device.limits[limit] === limitInfo[limit].default,
@@ -274,7 +274,7 @@ g.test('limits,supported')
     const adapter = await gpu.requestAdapter();
     assert(adapter !== null);
 
-    const limitInfo = getDefaultLimitsForAdapter(adapter);
+    const limitInfo = getDefaultLimitsForCTS();
     let value: number | undefined = -1;
     let result: number = -1;
     switch (limitValue) {
@@ -351,7 +351,7 @@ g.test('limit,better_than_supported')
     const adapter = await gpu.requestAdapter();
     assert(adapter !== null);
 
-    const limitInfo = getDefaultLimitsForAdapter(adapter);
+    const limitInfo = getDefaultLimitsForCTS();
     const value = adapter.limits[limit]! * mul + add;
     const requiredLimits = {
       [limit]: clamp(value, { min: 0, max: limitInfo[limit].maximumValue }),
@@ -397,7 +397,7 @@ g.test('limit,out_of_range')
     const gpu = getGPU(t.rec);
     const adapter = await gpu.requestAdapter();
     assert(adapter !== null);
-    const limitInfo = getDefaultLimitsForAdapter(adapter)[limit];
+    const limitInfo = getDefaultLimitsForCTS()[limit];
 
     const requiredLimits = {
       [limit]: value,
@@ -455,7 +455,7 @@ g.test('limit,worse_than_default')
     const adapter = await gpu.requestAdapter();
     assert(adapter !== null);
 
-    const limitInfo = getDefaultLimitsForAdapter(adapter);
+    const limitInfo = getDefaultLimitsForCTS();
     const value = limitInfo[limit].default * mul + add;
     const requiredLimits = {
       [limit]: clamp(value, { min: 0, max: limitInfo[limit].maximumValue }),

--- a/src/webgpu/api/validation/capability_checks/limits/limit_utils.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/limit_utils.ts
@@ -2,11 +2,7 @@ import { kUnitCaseParamsBuilder } from '../../../../../common/framework/params_b
 import { makeTestGroup } from '../../../../../common/framework/test_group.js';
 import { getGPU } from '../../../../../common/util/navigator_gpu.js';
 import { assert, range, reorder, ReorderOrder } from '../../../../../common/util/util.js';
-import {
-  getDefaultLimits,
-  getDefaultLimitsForAdapter,
-  kLimits,
-} from '../../../../capability_info.js';
+import { getDefaultLimitsForCTS, kLimits } from '../../../../capability_info.js';
 import { GPUConst } from '../../../../constants.js';
 import { GPUTestBase } from '../../../../gpu_test.js';
 
@@ -302,7 +298,7 @@ export const kMinimumLimitValueTests = [
 export type MinimumLimitValueTest = (typeof kMinimumLimitValueTests)[number];
 
 export function getDefaultLimitForAdapter(adapter: GPUAdapter, limit: GPUSupportedLimit): number {
-  const limitInfo = getDefaultLimitsForAdapter(adapter);
+  const limitInfo = getDefaultLimitsForCTS();
   return limitInfo[limit as keyof typeof limitInfo].default;
 }
 
@@ -429,7 +425,7 @@ export class LimitTestsImpl extends GPUTestBase {
   }
 
   getDefaultLimits() {
-    return getDefaultLimits(this.isCompatibility ? 'compatibility' : 'core');
+    return getDefaultLimitsForCTS();
   }
 
   getDefaultLimit(limit: (typeof kLimits)[number]) {


### PR DESCRIPTION
The new 'core-features-and-limits' way of requesting compat means that from an adapter you can not tell if that adapter supports compat on top of core or not. You can only find that out by requesting a device without `'core-features-and-limits'` and seeing if the device you got back is missing `'core-feature-and-limits'`

In code

```js
const adapter = navigator.gpu.requestAdapter({ featureLevel: 'compatibility' });
if (!adapter.features.has('core-features-and-limits')) {
  // requesting a device will give you compatibility mode
} else {
  const device = adapter.requestDevice();
  if (!device.features.has('core-features-and-limits')) {
    // the device is a compat device running on top of core
  } else {
    // the device is a core device
  }
}
```

Several parts of the tests want to know, before requesting a device, what the default limits are but they can't know what from an adapter. So, switch the tests to use the globalTestConfig.compatibility flag.


