### PR TITLE
Update requestDevice:always_return_device

### DIFF
--- a/src/webgpu/api/operation/adapter/requestDevice.spec.ts
+++ b/src/webgpu/api/operation/adapter/requestDevice.spec.ts
@@ -518,18 +518,12 @@ g.test('always_returns_device')
       const device = await t.requestDeviceTracked(adapter);
       assert(device instanceof GPUDevice, 'requestDevice must return a device or throw');
 
-      if (featureLevel === 'core') {
+      if (featureLevel === 'core' && adapter.features.has('core-features-and-limits')) {
+        // Check if the device supports core, when featureLevel is core and adapter supports core.
         // This check is to make sure something lower-level is not forcing compatibility mode.
 
-        // MAINTENANCE_TODO: Simplify this check (and typecast) once we standardize how to do this.
-        const adapterExtensions = adapter as unknown as {
-          featureLevel?: string;
-        };
         t.expect(
-          // Old version of Compat design.
-          adapterExtensions.featureLevel === 'core' ||
-            // Current version of Compat design.
-            device.features.has('core-features-and-limits'),
+          device.features.has('core-features-and-limits'),
           'must not get a Compatibility adapter if not requested'
         );
       }


### PR DESCRIPTION
- Remove legacy adapterInfo.featureLevel
- https://g-issues.chromium.org/issues/402791063: only expect `device.features.has('core-features-and-limits')` when `featureLevel === 'core' && adapter.features.has('core-features-and-limits')`
  - So when a browser only supports compat level (e.g. `--use-webgpu-adapter=opengles` for chrome), don't expect the device to be core.