### PR TITLE
Fix rg11b10ufloat filter_mode tests

### DIFF
--- a/src/webgpu/api/operation/sampling/filter_mode.spec.ts
+++ b/src/webgpu/api/operation/sampling/filter_mode.spec.ts
@@ -11,6 +11,7 @@ import { kAddressModes, kMipmapFilterModes } from '../../../capability_info.js';
 import {
   EncodableTextureFormat,
   getTextureFormatType,
+  isTextureFormatColorRenderable,
   kPossibleColorRenderableTextureFormats,
 } from '../../../format_info.js';
 import { AllFeaturesMaxLimitsGPUTest, TextureTestMixin } from '../../../gpu_test.js';
@@ -46,6 +47,12 @@ class FilterModeTest extends TextureTestMixin(AllFeaturesMaxLimitsGPUTest) {
     vertexCount: number,
     instanceCount: number
   ) {
+    let renderTargetFormat = format;
+    if (!isTextureFormatColorRenderable(this.device, format)) {
+      // If the format is not renderable, we use rgba32float as the render target format
+      // to verify the result, which is always renderable.
+      renderTargetFormat = 'rgba32float';
+    }
     const sampleTexture = this.createTextureFromTexelView(
       TexelView.fromTexelsAsColors(format, coord => {
         const id = coord.x + coord.y * kCheckerTextureSize;
@@ -57,7 +64,7 @@ class FilterModeTest extends TextureTestMixin(AllFeaturesMaxLimitsGPUTest) {
       }
     );
     const renderTexture = this.createTextureTracked({
-      format,
+      format: renderTargetFormat,
       size: renderSize,
       usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC,
     });
@@ -70,7 +77,7 @@ class FilterModeTest extends TextureTestMixin(AllFeaturesMaxLimitsGPUTest) {
       fragment: {
         module,
         entryPoint: 'fs_main',
-        targets: [{ format }],
+        targets: [{ format: renderTargetFormat }],
       },
     });
     const bindgroup = this.device.createBindGroup({
@@ -96,7 +103,7 @@ class FilterModeTest extends TextureTestMixin(AllFeaturesMaxLimitsGPUTest) {
     renderPass.draw(vertexCount, instanceCount);
     renderPass.end();
     this.device.queue.submit([commandEncoder.finish()]);
-    return renderTexture;
+    return { texture: renderTexture, format: renderTargetFormat };
   }
 }
 
@@ -548,8 +555,8 @@ g.test('magFilter,nearest')
       instanceCount
     );
     t.expectTexelViewComparisonIsOkInTexture(
-      { texture: render },
-      expectedColors(format, 'nearest', addressModeU, addressModeV),
+      { texture: render.texture },
+      expectedColors(render.format, 'nearest', addressModeU, addressModeV),
       kNearestRenderDim
     );
   });
@@ -663,8 +670,8 @@ g.test('magFilter,linear')
       instanceCount
     );
     t.expectTexelViewComparisonIsOkInTexture(
-      { texture: render },
-      expectedColors(format, 'linear', addressModeU, addressModeV),
+      { texture: render.texture },
+      expectedColors(render.format, 'linear', addressModeU, addressModeV),
       kLinearRenderDim
     );
   });
@@ -790,8 +797,8 @@ g.test('minFilter,nearest')
       instanceCount
     );
     t.expectTexelViewComparisonIsOkInTexture(
-      { texture: render },
-      expectedColors(format, 'nearest', addressModeU, addressModeV),
+      { texture: render.texture },
+      expectedColors(render.format, 'nearest', addressModeU, addressModeV),
       kNearestRenderDim
     );
   });
@@ -915,8 +922,8 @@ g.test('minFilter,linear')
       instanceCount
     );
     t.expectTexelViewComparisonIsOkInTexture(
-      { texture: render },
-      expectedColors(format, 'linear', addressModeU, addressModeV),
+      { texture: render.texture },
+      expectedColors(render.format, 'linear', addressModeU, addressModeV),
       kLinearRenderDim
     );
   });
@@ -939,6 +946,12 @@ g.test('mipmapFilter')
     const { format, filterMode } = t.params;
     t.skipIfTextureFormatNotSupported(format);
     t.skipIfTextureFormatNotFilterable(format);
+    let renderTargetFormat = format;
+    if (!isTextureFormatColorRenderable(t.device, format)) {
+      // If the format is not renderable, we use rgba32float as the render target format
+      // to verify the result, which is always renderable.
+      renderTargetFormat = 'rgba32float';
+    }
     // Takes a 8x8/4x4 mipmapped texture and renders it on multiple quads with different UVs such
     // that each instanced quad from left to right emulates moving the quad further and further from
     // the camera. Each quad is then rendered to a single pixel in a 1-dimensional texture. Since
@@ -966,7 +979,7 @@ g.test('mipmapFilter')
       }
     );
     const renderTexture = t.createTextureTracked({
-      format,
+      format: renderTargetFormat,
       size: [kRenderSize, 1],
       usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC,
     });
@@ -1016,7 +1029,7 @@ g.test('mipmapFilter')
       fragment: {
         module,
         entryPoint: 'fs_main',
-        targets: [{ format }],
+        targets: [{ format: renderTargetFormat }],
       },
     });
     const bindgroup = t.device.createBindGroup({
@@ -1050,8 +1063,8 @@ g.test('mipmapFilter')
       buffer,
       actual => {
         // Convert the buffer to texel view so we can do comparisons.
-        const layout = getTextureCopyLayout(format, '2d', [kRenderSize, 1, 1]);
-        const view = TexelView.fromTextureDataByReference(format, actual, {
+        const layout = getTextureCopyLayout(renderTargetFormat, '2d', [kRenderSize, 1, 1]);
+        const view = TexelView.fromTextureDataByReference(renderTargetFormat, actual, {
           bytesPerRow: layout.bytesPerRow,
           rowsPerImage: layout.rowsPerImage,
           subrectOrigin: [0, 0, 0],


### PR DESCRIPTION

Issue: [chromium issue 402772746](https://g-issues.chromium.org/issues/402772746)

rg11b10ufloat is not always renderable. When it's not, we cannot use it as the render target texture.

Instead, use rgba32float as the render target texture to verify the result, which is always renderable in core and compat.