### PR TITLE
Use the texture view in the texture builtin tests.

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/textureLoad.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureLoad.spec.ts
@@ -756,13 +756,14 @@ Parameters:
       .combine('format', kPossibleStorageTextureFormats)
       .beginSubcases()
       .combine('samplePoints', kSamplePointMethods)
+      .combine('baseMipLevel', [0, 1] as const)
       .combine('C', ['i32', 'u32'] as const)
   )
   .beforeAllSubcases(t =>
     t.skipIfLanguageFeatureNotSupported('readonly_and_readwrite_storage_textures')
   )
   .fn(async t => {
-    const { format, stage, samplePoints, C } = t.params;
+    const { format, stage, samplePoints, C, baseMipLevel } = t.params;
 
     t.skipIfTextureFormatNotSupported(format);
     t.skipIfTextureFormatNotUsableAsStorageTexture(format);
@@ -774,12 +775,17 @@ Parameters:
       format,
       size,
       usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
+      mipLevelCount: 3,
+    };
+    const viewDescriptor = {
+      baseMipLevel,
+      mipLevelCount: 1,
     };
     const { texels, texture } = await createTextureWithRandomDataAndGetTexels(t, descriptor);
-
+    const softwareTexture = { texels, descriptor, viewDescriptor };
     const calls: TextureCall<vec2>[] = generateTextureBuiltinInputs2D(50, {
       method: samplePoints,
-      descriptor,
+      softwareTexture,
       hashInputs: [stage, format, samplePoints, C],
     }).map(({ coords }) => {
       return {
@@ -789,7 +795,6 @@ Parameters:
       };
     });
     const textureType = `texture_storage_2d<${format}, read>`;
-    const viewDescriptor = {};
     const sampler = undefined;
     const results = await doTextureCalls(
       t,
@@ -802,7 +807,7 @@ Parameters:
     );
     const res = await checkCallResults(
       t,
-      { texels, descriptor, viewDescriptor },
+      softwareTexture,
       textureType,
       sampler,
       calls,
@@ -837,12 +842,20 @@ Parameters:
       .combine('C', ['i32', 'u32'] as const)
       .combine('A', ['i32', 'u32'] as const)
       .combine('depthOrArrayLayers', [1, 8] as const)
+      .combine('baseMipLevel', [0, 1] as const)
+      .combine('baseArrayLayer', [0, 1] as const)
+      .unless(t => t.depthOrArrayLayers === 1 && t.baseArrayLayer !== 0)
   )
-  .beforeAllSubcases(t =>
-    t.skipIfLanguageFeatureNotSupported('readonly_and_readwrite_storage_textures')
-  )
+  .beforeAllSubcases(t => {
+    t.skipIfLanguageFeatureNotSupported('readonly_and_readwrite_storage_textures');
+    t.skipIf(
+      t.isCompatibility && t.params.baseArrayLayer !== 0,
+      'compatibility mode does not support array layer sub ranges'
+    );
+  })
   .fn(async t => {
-    const { format, stage, samplePoints, C, A, depthOrArrayLayers } = t.params;
+    const { format, stage, samplePoints, C, A, depthOrArrayLayers, baseMipLevel, baseArrayLayer } =
+      t.params;
 
     t.skipIfTextureFormatNotSupported(format);
     t.skipIfTextureFormatNotUsableAsStorageTexture(format);
@@ -856,13 +869,21 @@ Parameters:
       size,
       usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.STORAGE_BINDING,
       ...(t.isCompatibility && { textureBindingViewDimension: '2d-array' }),
+      mipLevelCount: 3,
+    };
+    const viewDescriptor: GPUTextureViewDescriptor = {
+      dimension: '2d-array',
+      baseMipLevel,
+      mipLevelCount: 1,
+      baseArrayLayer,
     };
     const { texels, texture } = await createTextureWithRandomDataAndGetTexels(t, descriptor);
+    const softwareTexture = { texels, descriptor, viewDescriptor };
 
     const calls: TextureCall<vec2>[] = generateTextureBuiltinInputs2D(50, {
       method: samplePoints,
-      descriptor,
-      arrayIndex: { num: texture.depthOrArrayLayers, type: A },
+      softwareTexture,
+      arrayIndex: { num: texture.depthOrArrayLayers - baseArrayLayer, type: A },
       hashInputs: [stage, format, samplePoints, C, A],
     }).map(({ coords, arrayIndex }) => {
       return {
@@ -874,9 +895,6 @@ Parameters:
       };
     });
     const textureType = `texture_storage_2d_array<${format}, read>`;
-    const viewDescriptor: GPUTextureViewDescriptor = {
-      dimension: '2d-array',
-    };
     const sampler = undefined;
     const results = await doTextureCalls(
       t,

--- a/src/webgpu/shader/execution/expression/call/builtin/textureSample.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureSample.spec.ts
@@ -154,9 +154,10 @@ Parameters:
       .combine('offset', [false, true] as const)
       .beginSubcases()
       .combine('samplePoints', kSamplePointMethods)
+      .combine('baseMipLevel', [0, 1] as const)
   )
   .fn(async t => {
-    const { format, samplePoints, modeU, modeV, filt: minFilter, offset } = t.params;
+    const { format, samplePoints, modeU, modeV, filt: minFilter, offset, baseMipLevel } = t.params;
     skipIfTextureFormatNotSupportedOrNeedsFilteringAndIsUnfilterable(t, minFilter, format);
 
     // We want at least 4 blocks or something wide enough for 3 mip levels.
@@ -168,7 +169,11 @@ Parameters:
       usage: GPUTextureUsage.COPY_DST | GPUTextureUsage.TEXTURE_BINDING,
       mipLevelCount: 3,
     };
+    const viewDescriptor = {
+      baseMipLevel,
+    };
     const { texels, texture } = await createTextureWithRandomDataAndGetTexels(t, descriptor);
+    const softwareTexture = { texels, descriptor, viewDescriptor };
     const sampler: GPUSamplerDescriptor = {
       addressModeU: kShortAddressModeToAddressMode[modeU],
       addressModeV: kShortAddressModeToAddressMode[modeV],
@@ -180,7 +185,7 @@ Parameters:
     const calls: TextureCall<vec2>[] = generateTextureBuiltinInputs2D(50, {
       sampler,
       method: samplePoints,
-      descriptor,
+      softwareTexture,
       derivatives: true,
       offset,
       hashInputs: [format, samplePoints, modeU, modeV, minFilter, offset],
@@ -193,7 +198,6 @@ Parameters:
         offset,
       };
     });
-    const viewDescriptor = {};
     const textureType = 'texture_2d<f32>';
     const results = await doTextureCalls(
       t,


### PR DESCRIPTION
In other words, allow a GPUTextureViewDescriptor that passes in baseMipLevel, mipLevelCount, baseArrayLayer, and arrayLayerCount.

This is mostly a refactor of of the software texture sampler code to support this option.

The code that generates the parameters for the texture builtin calls needs this info to select parameters that are in range. That code takes a GPUTextureDescriptor but it also needs a GPUTextureViewDescriptor. So, made it take a either a GPUTextureDescriptor OR a SoftwareTexture. A SoftwareTexture is the combination of an array of TexelViews, a GPUTextureDescriptor and a GPUTextureViewDescriptor.

By making it be one or the other we can refactor existing tests one at a time for where we want to test sub ranges of mips levels and/or sub ranges of array layers.

SoftwareTexture used to be called just Texture which I found super confusing. I'm not sure SofwareTexture is a great name but it's better than Texture which is easily confused with GPUTexture. Further, every function that took a Texture named the parameter 'texture' which added to the confusion. So, I renamed the type to 'SoftwareTexture' and the parameter to 'softwareTexture'.

For now I only made textureLoad:storage_textures_2d, textureLoad:storage_textures_2d_array, and textureSample:sampled_2d_coords use this option.



