### PR TITLE
Add some skipIfTextureFormatNotUsableAsRenderAttachment to skip rg11b…

### DIFF
--- a/src/webgpu/api/validation/createTexture.spec.ts
+++ b/src/webgpu/api/validation/createTexture.spec.ts
@@ -336,6 +336,9 @@ g.test('sampleCount,valid_sampleCount_with_other_parameter_varies')
   .fn(t => {
     const { dimension, sampleCount, format, mipLevelCount, arrayLayerCount, usage } = t.params;
     t.skipIfTextureFormatNotSupported(format);
+    if ((usage & GPUConst.TextureUsage.RENDER_ATTACHMENT) !== 0) {
+      t.skipIfTextureFormatNotUsableAsRenderAttachment(format);
+    }
     const { blockWidth, blockHeight } = getBlockInfoForTextureFormat(format);
 
     const size =

--- a/src/webgpu/api/validation/render_pipeline/fragment_state.spec.ts
+++ b/src/webgpu/api/validation/render_pipeline/fragment_state.spec.ts
@@ -258,6 +258,7 @@ g.test('targets_format_filterable')
   .fn(t => {
     const { isAsync, format, hasBlend } = t.params;
     t.skipIfTextureFormatNotSupported(format);
+    t.skipIfTextureFormatNotUsableAsRenderAttachment(format);
 
     const descriptor = t.getDescriptor({
       targets: [
@@ -379,6 +380,7 @@ g.test('pipeline_output_targets')
   .fn(t => {
     const { isAsync, format, writeMask, shaderOutput } = t.params;
     t.skipIfTextureFormatNotSupported(format);
+    t.skipIfTextureFormatNotUsableAsRenderAttachment(format);
 
     const descriptor = t.getDescriptor({
       targets: format ? [{ format, writeMask }] : [],


### PR DESCRIPTION
…10ufloat when not renderable

