### PR TITLE
Add shader tests for using texture view for externalTexture binding

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/textureSampleBaseClampToEdge.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureSampleBaseClampToEdge.spec.ts
@@ -9,7 +9,7 @@ import { TexelView } from '../../../../../util/texture/texel_view.js';
 import {
   checkCallResults,
   createTextureWithRandomDataAndGetTexels,
-  createVideoFrameWithRandomDataAndGetTexels,
+  createCanvasWithRandomDataAndGetTexels,
   doTextureCalls,
   generateTextureBuiltinInputs2D,
   kSamplePointMethods,
@@ -33,7 +33,9 @@ async function createTextureAndDataForTest(
   videoFrame?: VideoFrame;
 }> {
   if (isExternal) {
-    const { texels, videoFrame } = createVideoFrameWithRandomDataAndGetTexels(descriptor.size);
+    t.skipIf(typeof VideoFrame === 'undefined', 'VideoFrames are not supported');
+    const { texels, canvas } = createCanvasWithRandomDataAndGetTexels(descriptor.size);
+    const videoFrame = new VideoFrame(canvas, { timestamp: 0 });
     const texture = t.device.importExternalTexture({ source: videoFrame });
     return { texels, texture, videoFrame };
   } else {

--- a/src/webgpu/shader/execution/expression/call/builtin/texture_utils.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/texture_utils.ts
@@ -841,13 +841,14 @@ struct VOut {
         : GPUShaderStage.VERTEX;
 
     const entries: GPUBindGroupLayoutEntry[] = [];
-    if (texture instanceof GPUExternalTexture) {
+    if (code.includes('texture_external')) {
       entries.push({
         binding: 0,
         visibility,
         externalTexture: {},
       });
     } else if (code.includes('texture_storage')) {
+      assert(texture instanceof GPUTexture);
       entries.push({
         binding: 0,
         visibility,
@@ -862,6 +863,7 @@ struct VOut {
         },
       });
     } else {
+      assert(texture instanceof GPUTexture);
       const sampleType =
         viewDescriptor?.aspect === 'stencil-only'
           ? 'uint'
@@ -3246,9 +3248,9 @@ function valueIfAllComponentsAreEqual(
 }
 
 /**
- * Creates a VideoFrame with random data and a TexelView with the same data.
+ * Creates a Canvas with random data and a TexelView with the same data.
  */
-export function createVideoFrameWithRandomDataAndGetTexels(textureSize: GPUExtent3D) {
+export function createCanvasWithRandomDataAndGetTexels(textureSize: GPUExtent3D) {
   const size = reifyExtent3D(textureSize);
   assert(size.depthOrArrayLayers === 1);
 
@@ -3264,7 +3266,6 @@ export function createVideoFrameWithRandomDataAndGetTexels(textureSize: GPUExten
   const canvas = new OffscreenCanvas(size.width, size.height);
   const ctx = canvas.getContext('2d')!;
   ctx.putImageData(imageData, 0, 0);
-  const videoFrame = new VideoFrame(canvas, { timestamp: 0 });
 
   // Premultiply the ImageData
   for (let i = 0; i < data.length; i += 4) {
@@ -3284,7 +3285,7 @@ export function createVideoFrameWithRandomDataAndGetTexels(textureSize: GPUExten
     }),
   ];
 
-  return { videoFrame, texels };
+  return { canvas, texels };
 }
 
 const kFaceNames = ['+x', '-x', '+y', '-y', '+z', '-z'] as const;


### PR DESCRIPTION
This PR adds shader (textureLoad and textureDimensions) tests for https://github.com/gpuweb/gpuweb/pull/5079

<img width="1574" alt="image" src="https://github.com/user-attachments/assets/f9f00285-1048-4698-9881-d1e27e7c4b31" />

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
