### PR TITLE
Workgroup uniform load constructible type only 

### DIFF
--- a/src/webgpu/shader/validation/expression/call/builtin/workgroupUniformLoad.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/workgroupUniformLoad.spec.ts
@@ -134,7 +134,7 @@ ${t.params.stage} array_size = 10u;
 var<workgroup> wgvar : array<u32, array_size>;
 
 fn foo() {
-  _ = workgroupUniformLoad(&wgvar);
+  _ = workgroupUniformLoad(&wgvar)[0];
 }`;
     t.expectCompileResult(t.params.stage === 'const', code);
   });

--- a/src/webgpu/shader/validation/expression/call/builtin/workgroupUniformLoad.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/workgroupUniformLoad.spec.ts
@@ -121,6 +121,24 @@ fn foo() {
     t.expectCompileResult(t.params.type === 'bool' || t.params.call === 'bar()', code);
   });
 
+g.test('param_constructible_only')
+  .desc(
+    `
+The type of the argument passed to workgroupUniformLoad must be constructible.
+`
+  )
+  .params(u => u.combine('stage', ['const', 'override']))
+  .fn(t => {
+    const code = `
+${t.params.stage} array_size = 10u;
+var<workgroup> wgvar : array<u32, array_size>;
+
+fn foo() {
+  _ = workgroupUniformLoad(&wgvar);
+}`;
+    t.expectCompileResult(t.params.stage === 'const', code);
+  });
+
 g.test('must_use')
   .desc('Tests that the result must be used')
   .params(u => u.combine('use', [true, false] as const))


### PR DESCRIPTION
New validation based on resolution of  https://github.com/gpuweb/gpuweb/issues/5093 
(arrays must be creation-fixed-footprint)
crbug.com/402982337