### PR TITLE
Cleanup storage texture tests

### DIFF
--- a/src/webgpu/api/validation/createBindGroupLayout.spec.ts
+++ b/src/webgpu/api/validation/createBindGroupLayout.spec.ts
@@ -511,7 +511,6 @@ g.test('storage_texture,formats')
   .fn(t => {
     const { format, access } = t.params;
     t.skipIfTextureFormatNotSupported(format);
-    t.skipIfTextureFormatNotUsableAsStorageTexture(format);
 
     const success =
       isTextureFormatUsableAsStorageFormat(t.device, format) &&

--- a/src/webgpu/shader/validation/types/textures.spec.ts
+++ b/src/webgpu/shader/validation/types/textures.spec.ts
@@ -5,10 +5,9 @@ Validation tests for various texture types in shaders.
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import {
   getTextureFormatType,
-  isTextureFormatPossiblyStorageReadable,
   isTextureFormatUsableAsStorageFormatInCreateShaderModule,
   kAllTextureFormats,
-  kColorTextureFormats,
+  kPossibleStorageTextureFormats,
 } from '../../../format_info.js';
 import { getPlainTypeInfo } from '../../../util/shader.js';
 import { ShaderValidationTest } from '../shader_validation_test.js';
@@ -21,8 +20,7 @@ g.test('texel_formats')
   )
   .params(u =>
     u
-      .combine('format', kColorTextureFormats)
-      .filter(p => isTextureFormatPossiblyStorageReadable(p.format))
+      .combine('format', kPossibleStorageTextureFormats)
       .beginSubcases()
       .combine('shaderScalarType', ['f32', 'u32', 'i32', 'bool', 'f16'] as const)
   )


### PR DESCRIPTION
api,validation,createBindGroupLayout:storage_texture,formats was incorrectly filtering out non-storage textures.

shader,validation,types,texture:texel_formats was using kColorTextureFormats and then filtering to storage formats but for that case it should be using kPossibleStorageTextureFormats



