### PR TITLE
Gate use of OffscreenCanvas on it being available

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/textureDimensions.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureDimensions.spec.ts
@@ -519,8 +519,10 @@ Parameters:
   )
   .fn(t => {
     const { stage, importExternalTexture, width, height } = t.params;
-    const canvas = new OffscreenCanvas(width, height);
     const size = [width, height];
+
+    t.skipIf(typeof OffscreenCanvas === 'undefined', 'OffscreenCanvas is not supported');
+    const canvas = new OffscreenCanvas(width, height);
 
     // We have to make a context so that VideoFrame and copyExternalImageToTexture accept the canvas.
     canvas.getContext('2d');

--- a/src/webgpu/shader/execution/expression/call/builtin/textureLoad.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureLoad.spec.ts
@@ -524,7 +524,9 @@ Parameters:
       usage: GPUTextureUsage.COPY_DST,
     };
 
+    t.skipIf(typeof OffscreenCanvas === 'undefined', 'OffscreenCanvas is not supported');
     const { texels, canvas } = createCanvasWithRandomDataAndGetTexels(descriptor.size);
+
     let videoFrame: VideoFrame | undefined;
     let texture: GPUExternalTexture | GPUTexture;
     if (importExternalTexture) {

--- a/src/webgpu/shader/execution/expression/call/builtin/textureSampleBaseClampToEdge.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureSampleBaseClampToEdge.spec.ts
@@ -33,9 +33,12 @@ async function createTextureAndDataForTest(
   videoFrame?: VideoFrame;
 }> {
   if (isExternal) {
-    t.skipIf(typeof VideoFrame === 'undefined', 'VideoFrames are not supported');
+    t.skipIf(typeof OffscreenCanvas === 'undefined', 'OffscreenCanvas is not supported');
     const { texels, canvas } = createCanvasWithRandomDataAndGetTexels(descriptor.size);
+
+    t.skipIf(typeof VideoFrame === 'undefined', 'VideoFrames are not supported');
     const videoFrame = new VideoFrame(canvas, { timestamp: 0 });
+
     const texture = t.device.importExternalTexture({ source: videoFrame });
     return { texels, texture, videoFrame };
   } else {


### PR DESCRIPTION


Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [X] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
