### PR TITLE
Fix subgroupMul execution tests for subgroup size > 32

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/subgroupMul.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/subgroupMul.spec.ts
@@ -283,7 +283,8 @@ function checkPredicatedMultiplication(
   for (let i = 0; i < output.length; i++) {
     const size = metadata[i];
     const id = metadata[output.length + i];
-    let expected = 1;
+    const u32Boundary = Math.pow(2, 32);
+    let expectedU32 = 1;
     if (filter(id, size)) {
       // This function replicates the behavior in the shader.
       const valueModFun = function (id: number) {
@@ -293,15 +294,16 @@ function checkPredicatedMultiplication(
         operation === 'subgroupInclusiveMul' ? id + 1 : operation === 'subgroupMul' ? size : id;
       for (let j = 0; j < bound; j++) {
         if (filter(j, size)) {
-          expected *= valueModFun(j);
+          // Result may overflow u32, compute it by modulo u32Boundary (2^32) after every multiplication.
+          expectedU32 = (expectedU32 * valueModFun(j)) % u32Boundary;
         }
       }
     } else {
-      expected = kDataSentinel;
+      expectedU32 = kDataSentinel;
     }
-    if (expected !== output[i]) {
+    if (expectedU32 !== output[i]) {
       return new Error(`Invocation ${i}: incorrect result
-- expected: ${expected}
+- expected: ${expectedU32}
 -      got: ${output[i]}`);
     }
   }
@@ -481,14 +483,16 @@ function checkFragment(
       const v =
         expected.get(subgroup_id) ?? new Uint32Array([...iterRange(kMaxSize, x => kIdentity)]);
       const bound = op === 'subgroupMul' ? kMaxSize : op === 'subgroupInclusiveMul' ? id + 1 : id;
-      let expect = kIdentity;
+      const u32Boundary = Math.pow(2, 32);
+      let expectU32 = kIdentity;
       for (let i = 0; i < bound; i++) {
-        expect *= v[i];
+        // Result may overflow u32, compute it by modulo u32Boundary (2^32) after every multiplication.
+        expectU32 = (expectU32 * v[i]) % u32Boundary;
       }
 
-      if (res !== expect) {
+      if (res !== expectU32) {
         return new Error(`Row ${row}, col ${col}: incorrect results
-- expected: ${expect}
+- expected: ${expectU32}
 -      got: ${res}`);
       }
     }


### PR DESCRIPTION
This PR fix the subgroupMul execution tests' expectation overflowing u32 for subgroup size > 32, which caused Qualcomm (min subgroup size = 64) always fail these tests. With this PR Qualcomm can pass these tests.

Issue: #4318

<hr>

**Requirements for PR author:**

- [ ] ~All missing test coverage is tracked with "TODO" or `.unimplemented()`.~
- [ ] ~New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.~
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [ ] ~Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)~

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
