### PR TITLE
Relax tolerance of readbackFromWebGPUCanvas WPT test to 3 ULP

### DIFF
--- a/src/webgpu/web_platform/canvas/readbackFromWebGPUCanvas.spec.ts
+++ b/src/webgpu/web_platform/canvas/readbackFromWebGPUCanvas.spec.ts
@@ -69,6 +69,9 @@ const expect = {
   ]),
 };
 
+// ULP tolerance fo cross color space readback
+const kMaxDiffULPsForNormFormatWithDifferentColorSpaceCanvas = 3;
+
 /**
  * Given 4 pixels in rgba8unorm format, puts them into an ImageData
  * of the specified color space and then puts them into an srgb color space
@@ -181,7 +184,12 @@ function checkImageResultWithDifferentColorSpaceCanvas(
     destinationColorSpace
   );
 
-  readPixelsFrom2DCanvasAndCompare(t, fromWebGPUCtx, expect, 2);
+  readPixelsFrom2DCanvasAndCompare(
+    t,
+    fromWebGPUCtx,
+    expect,
+    kMaxDiffULPsForNormFormatWithDifferentColorSpaceCanvas
+  );
 }
 
 function checkImageResult(


### PR DESCRIPTION
This PR relax the cross color space error tolerance from 2 ULP to 3 ULP, making srgb testcases pass on Qualcomm devices.

Issue: #4320
<hr>

**Requirements for PR author:**

- [ ] ~All missing test coverage is tracked with "TODO" or `.unimplemented()`.~
- [ ] ~New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.~
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [ ] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
