### PR TITLE
Fix cmdline runner not exiting

### DIFF
--- a/src/common/runtime/cmdline.ts
+++ b/src/common/runtime/cmdline.ts
@@ -284,6 +284,7 @@ Failed               = ${rpt(failed.length)}`);
   if (failed.length || warned.length) {
     sys.exit(1);
   }
+  sys.exit(0);
 })().catch(ex => {
   console.log(ex.stack ?? ex.toString());
   sys.exit(1);


### PR DESCRIPTION
At some point in the last few months, the cmdline runner started hanging after running the input tests. We're relying on node to shut down when there are no tasks left, so maybe we introduced something async that's not ending. In any case, it's safe to force exit after running the last test successfully.




Issue: #4325
