### PR TITLE
Add tests for workgroupUniformLoad overload

### DIFF
--- a/src/webgpu/shader/validation/expression/call/builtin/workgroupUniformLoad.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/workgroupUniformLoad.spec.ts
@@ -86,8 +86,6 @@ fn foo() {
 // A list of types that contains atomics, with a single control case.
 const kAtomicTypes: string[] = [
   'bool', // control case
-  'atomic<i32>',
-  'atomic<u32>',
   'array<atomic<i32>, 4>',
   'AtomicStruct',
 ];


### PR DESCRIPTION
This PR adds shader tests for workgroupUniformLoad overload as approved by https://github.com/gpuweb/gpuweb/pull/5141

<img width="1531" alt="image" src="https://github.com/user-attachments/assets/71db33a1-742c-4527-83a3-cf20b00bf4f6" />

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.) See https://dawn-review.googlesource.com/c/dawn/+/234354
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
