### PR TITLE
web_platform,canvas,configure:viewFormats: call getCurrentTexture() twice.

### DIFF
--- a/src/webgpu/web_platform/canvas/configure.spec.ts
+++ b/src/webgpu/web_platform/canvas/configure.spec.ts
@@ -94,6 +94,11 @@ g.test('device')
       ctx.getCurrentTexture();
     });
 
+    // Should throw on the second call to getCurrentTexture also.
+    t.shouldThrow('InvalidStateError', () => {
+      ctx.getCurrentTexture();
+    });
+
     // Calling configure with a device should succeed.
     ctx.configure({
       device: t.device,


### PR DESCRIPTION
Verify that the second call to getCurrentTexture() on an invalid texture also throws an error.




Issue: #4337

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [X] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
