### PR TITLE
Fix block/enforce/compat option interaction

### DIFF
--- a/src/common/util/navigator_gpu.ts
+++ b/src/common/util/navigator_gpu.ts
@@ -197,22 +197,26 @@ export function getGPU(recorder: TestCaseRecorder | null): GPU {
 
   if (defaultRequestAdapterOptions) {
     // eslint-disable-next-line @typescript-eslint/unbound-method
-    const oldFn = impl.requestAdapter;
-    impl.requestAdapter = function (
-      options?: GPURequestAdapterOptions
-    ): Promise<GPUAdapter | null> {
-      const promise = oldFn.call(this, { ...defaultRequestAdapterOptions, ...options });
-      if (recorder) {
-        void promise.then(adapter => {
+    const origRequestAdapterFn = impl.requestAdapter;
+
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    Object.defineProperty(impl, 'requestAdapter', {
+      configurable: true,
+      async value(options?: GPURequestAdapterOptions) {
+        const adapter = await origRequestAdapterFn.call(this, {
+          ...defaultRequestAdapterOptions,
+          ...options,
+        });
+        if (recorder && adapter) {
           if (adapter) {
             const adapterInfo = adapter.info;
             const infoString = `Adapter: ${adapterInfo.vendor} / ${adapterInfo.architecture} / ${adapterInfo.device}`;
             recorder.debug(new ErrorWithExtra(infoString, () => ({ adapterInfo })));
           }
-        });
-      }
-      return promise;
-    };
+        }
+        return adapter;
+      },
+    });
   }
 
   return impl;

--- a/src/common/util/navigator_gpu.ts
+++ b/src/common/util/navigator_gpu.ts
@@ -208,11 +208,9 @@ export function getGPU(recorder: TestCaseRecorder | null): GPU {
           ...options,
         });
         if (recorder && adapter) {
-          if (adapter) {
-            const adapterInfo = adapter.info;
-            const infoString = `Adapter: ${adapterInfo.vendor} / ${adapterInfo.architecture} / ${adapterInfo.device}`;
-            recorder.debug(new ErrorWithExtra(infoString, () => ({ adapterInfo })));
-          }
+          const adapterInfo = adapter.info;
+          const infoString = `Adapter: ${adapterInfo.vendor} / ${adapterInfo.architecture} / ${adapterInfo.device}`;
+          recorder.debug(new ErrorWithExtra(infoString, () => ({ adapterInfo })));
         }
         return adapter;
       },


### PR DESCRIPTION
If you turned on either blockAllFeatures or enforceDefaultLimits and then you also turned on compatibility mode you'd get an error that `impl.requestAdapter` is read-only.

This is the fix.

