### PR TITLE
Add tests for loading an atomic inside a struct

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/workgroupUniformLoad.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/workgroupUniformLoad.spec.ts
@@ -100,6 +100,17 @@ const kTypes: Record<string, TypeConfig> = {
     host_type: 'i32',
     expected: new Int32Array([-42]),
   },
+  AtomicInStruct: {
+    decls: `struct AtomicInStruct {
+      x : i32,
+      a : atomic<u32>,
+      y : u32,
+    };`,
+    host_type: 'u32',
+    store_decl: `atomicStore(&(wgvar.a), 42u);`,
+    to_host: () => `workgroupUniformLoad(&(wgvar.a))`,
+    expected: new Uint32Array([42]),
+  },
 };
 
 g.test('types')


### PR DESCRIPTION
Issue: https://github.com/gpuweb/cts/issues/4341

As requested in https://github.com/gpuweb/cts/issues/4341#issuecomment-2794413304, this PR adds tests for loading an atomic inside a struct illustrated as the following code:

```wgsl
    struct AtomicInStruct {
      x : i32,
      a : atomic<u32>,
      y : u32,
    };

    @group(0) @binding(0) var<storage, read_write> buffer : array<u32, 256>;

    var<workgroup> wgvar : AtomicInStruct;

    @compute @workgroup_size(16, 16)
    fn main(@builtin(local_invocation_index) lid: u32) {
      if (lid == 255) {
        atomicStore(&(wgvar.a), 42u);
      }
      buffer[lid] = workgroupUniformLoad(&(wgvar.a));
    }
    
```
<hr>

**Requirements for PR author:**

- [ ] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [ ] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [ ] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
