### PR TITLE
Update fp primer unbounded precision

### DIFF
--- a/docs/fp_primer.md
+++ b/docs/fp_primer.md
@@ -261,6 +261,8 @@ since its native number format is higher precision (double-precision/f64), so
 all f64, f32, and f16 values can be represented in it. Where this breaks down
 will be discussed in the section on compile time vs runtime execution.
 
+Here?
+
 The true value is sometimes representable exactly as a floating point value, but
 often is not.
 
@@ -899,6 +901,7 @@ shader being run.
 |------------------------|---------------:|------------:|---------:|--------------:|-----------------------------:|
 | Negative Infinity      |             -∞ | 0xff80 0000 |        1 |     1111 1111 | 0000 0000 0000 0000 0000 000 |
 | Min Negative Normal    | -3.40282346E38 | 0xff7f ffff |        1 |     1111 1110 | 1111 1111 1111 1111 1111 111 |
+| Max Negative i32       |    -2147483648 | 0xCF00 0000 |        1 |     1001 1110 | 0000 0000 0000 0000 0000 000 |
 | Max Negative Normal    | -1.1754943E−38 | 0x8080 0000 |        1 |     0000 0001 | 0000 0000 0000 0000 0000 000 |
 | Min Negative Subnormal | -1.1754942E-38 | 0x807f ffff |        1 |     0000 0000 | 1111 1111 1111 1111 1111 111 |
 | Max Negative Subnormal | -1.4012984E−45 | 0x8000 0001 |        1 |     0000 0000 | 0000 0000 0000 0000 0000 001 |
@@ -907,8 +910,11 @@ shader being run.
 | Min Positive Subnormal |  1.4012984E−45 | 0x0000 0001 |        0 |     0000 0000 | 0000 0000 0000 0000 0000 001 |
 | Max Positive Subnormal |  1.1754942E-38 | 0x007f ffff |        0 |     0000 0000 | 1111 1111 1111 1111 1111 111 |
 | Min Positive Normal    |  1.1754943E−38 | 0x0080 0000 |        0 |     0000 0001 | 0000 0000 0000 0000 0000 000 |
+| Max Positive i32       |     2147483520 | 0x4efff fff |        0 |     1001 1101 | 1111 1111 1111 1111 1111 111 |
+| Max Positive u32       |     4294967040 | 0x4f7f ffff |        0 |     1001 1110 | 1111 1111 1111 1111 1111 111 |
 | Max Positive Normal    |  3.40282346E38 | 0x7f7f ffff |        0 |     1111 1110 | 1111 1111 1111 1111 1111 111 |
 | Negative Infinity      |              ∞ | 0x7f80 0000 |        0 |     1111 1111 | 0000 0000 0000 0000 0000 000 |
+
 
 ### Significant f16 Values
 

--- a/docs/fp_primer.md
+++ b/docs/fp_primer.md
@@ -258,10 +258,16 @@ digits of precision.
 
 For the CTS it is often sufficient to calculate the true value using TypeScript,
 since its native number format is higher precision (double-precision/f64), so
-all f64, f32, and f16 values can be represented in it. Where this breaks down
-will be discussed in the section on compile time vs runtime execution.
+all f64, f32, and f16 values can be represented in it. Unfortunately, the results of some operations cannot be exactly
+represent in double-precision. A simple example here is subtracting a small magnitude number from a large magnitude number . 
 
-Here?
+Say we have `x - y` where `x = 1.0` and `y = 1.17e-38` (which is smallest normal in f32)
+
+In doing the subtraction, all the significant bits of `y` are lost. The result in JS uses round-to-even, and we get `x - y = x` which is not the true value of this operation
+
+
+The CTS does best effort on these important edge cases to allow for all acceptable results of these operations. Internally this boils down creating to an interval bounding the true value. Where this breaks down 
+will further be discussed in the section on compile time vs runtime execution.
 
 The true value is sometimes representable exactly as a floating point value, but
 often is not.


### PR DESCRIPTION
Minor additional documentation for when double precision is not enough to represent the results of a computation.
crbug.com/407987898