### PR TITLE
Check packed texture formats features for 3d texture creations

### DIFF
--- a/src/webgpu/api/validation/createTexture.spec.ts
+++ b/src/webgpu/api/validation/createTexture.spec.ts
@@ -21,6 +21,7 @@ import {
   isTextureFormatPossiblyStorageReadable,
   isColorTextureFormat,
   textureFormatsAreViewCompatible,
+  textureDimensionAndFormatCompatibleForDevice,
 } from '../../format_info.js';
 import { maxMipLevelCount } from '../../util/texture/base.js';
 
@@ -100,7 +101,8 @@ g.test('zero_size_and_usage')
 
 g.test('dimension_type_and_format_compatibility')
   .desc(
-    `Test every dimension type on every format. Note that compressed formats and depth/stencil formats are not valid for 1D/3D dimension types.`
+    `Test every dimension type on every format. Note that compressed formats and depth/stencil formats are not valid
+    for 1D dimension types while it depends on the format for 3D types.`
   )
   .params(u =>
     u //
@@ -119,9 +121,12 @@ g.test('dimension_type_and_format_compatibility')
       usage: GPUTextureUsage.TEXTURE_BINDING,
     };
 
-    t.expectValidationError(() => {
-      t.createTextureTracked(descriptor);
-    }, !textureDimensionAndFormatCompatible(dimension, format));
+    t.expectValidationError(
+      () => {
+        t.createTextureTracked(descriptor);
+      },
+      !textureDimensionAndFormatCompatibleForDevice(t.device, dimension, format)
+    );
   });
 
 g.test('mipLevelCount,format')

--- a/src/webgpu/format_info.ts
+++ b/src/webgpu/format_info.ts
@@ -1875,6 +1875,26 @@ export function textureDimensionAndFormatCompatible(
 }
 
 /**
+ * Returns true iff a texture can be created with the provided GPUTextureDimension
+ * (defaulting to 2d) and GPUTextureFormat for a GPU device, by spec.
+ */
+export function textureDimensionAndFormatCompatibleForDevice(
+  device: GPUDevice,
+  dimension: undefined | GPUTextureDimension,
+  format: GPUTextureFormat
+): boolean {
+  if (
+    dimension === '3d' &&
+    ((isBCTextureFormat(format) && !device.features.has('texture-compression-bc-sliced-3d')) ||
+      (isETC2TextureFormat(format) && !device.features.has('texture-compression-etc2-sliced-3d')) ||
+      (isASTCTextureFormat(format) && !device.features.has('texture-compression-astc-sliced-3d')))
+  ) {
+    return false;
+  }
+  return textureDimensionAndFormatCompatible(dimension, format);
+}
+
+/**
  * Check if two formats are view format compatible.
  */
 export function textureFormatsAreViewCompatible(
@@ -2075,6 +2095,18 @@ export function canCopyFromAllAspectsOfTextureFormat(format: GPUTextureFormat) {
 
 export function isCompressedTextureFormat(format: GPUTextureFormat) {
   return format in kCompressedTextureFormatInfo;
+}
+
+export function isBCTextureFormat(format: GPUTextureFormat) {
+  return format in kBCTextureFormatInfo;
+}
+
+export function isETC2TextureFormat(format: GPUTextureFormat) {
+  return format in kETC2TextureFormatInfo;
+}
+
+export function isASTCTextureFormat(format: GPUTextureFormat) {
+  return format in kASTCTextureFormatInfo;
 }
 
 export function isColorTextureFormat(format: GPUTextureFormat) {

--- a/src/webgpu/format_info.ts
+++ b/src/webgpu/format_info.ts
@@ -1886,6 +1886,7 @@ export function textureDimensionAndFormatCompatibleForDevice(
   if (
     dimension === '3d' &&
     ((isBCTextureFormat(format) && !device.features.has('texture-compression-bc-sliced-3d')) ||
+      // This is not a real feature, but if it were, this is what it would be called.
       (isETC2TextureFormat(format) && !device.features.has('texture-compression-etc2-sliced-3d')) ||
       (isASTCTextureFormat(format) && !device.features.has('texture-compression-astc-sliced-3d')))
   ) {


### PR DESCRIPTION
Issues:  https://github.com/gpuweb/cts/issues/3761, https://github.com/gpuweb/cts/issues/3967

This PR is an attempt to make CTS more compliant with the WebGPU spec regarding 3D texture support for packed formats.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
