### PR TITLE
Remove WGSLTextureSampleTest and WGSLTextureQueryTest

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/textureDimensions.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureDimensions.spec.ts
@@ -20,12 +20,16 @@ import {
   sampleTypeForFormatAndAspect,
   textureDimensionAndFormatCompatible,
 } from '../../../../../format_info.js';
+import { AllFeaturesMaxLimitsGPUTest, GPUTest } from '../../../../../gpu_test.js';
 import { align } from '../../../../../util/math.js';
 import { kShaderStages, ShaderStage } from '../../../../validation/decl/util.js';
 
-import { WGSLTextureQueryTest } from './texture_utils.js';
+import {
+  executeTextureQueryAndExpectResult,
+  skipIfNoStorageTexturesInStage,
+} from './texture_utils.js';
 
-export const g = makeTestGroup(WGSLTextureQueryTest);
+export const g = makeTestGroup(AllFeaturesMaxLimitsGPUTest);
 
 /// The maximum number of texture mipmap levels to test.
 /// Keep this small to reduce memory and test permutations.
@@ -223,7 +227,7 @@ function testValues(params: {
  * `values.expected`.
  */
 function run(
-  t: WGSLTextureQueryTest,
+  t: GPUTest,
   stage: ShaderStage,
   texture: GPUTexture | GPUExternalTexture,
   viewDescriptor: GPUTextureViewDescriptor | undefined,
@@ -243,7 +247,7 @@ fn getValue() -> ${outputType} {
   };
 }
 `;
-  t.executeAndExpectResult(stage, wgsl, texture, viewDescriptor, values.expected);
+  executeTextureQueryAndExpectResult(t, stage, wgsl, texture, viewDescriptor, values.expected);
 }
 
 /** @returns true if the GPUTextureViewDimension is valid for a storage texture */
@@ -472,7 +476,7 @@ Parameters:
       .expand('baseMipLevel', baseMipLevel)
   )
   .fn(t => {
-    t.skipIfNoStorageTexturesInStage(t.params.stage);
+    skipIfNoStorageTexturesInStage(t, t.params.stage);
     t.skipIfTextureFormatNotSupported(t.params.format);
     t.skipIfTextureFormatNotUsableAsStorageTexture(t.params.format);
 

--- a/src/webgpu/shader/execution/expression/call/builtin/textureGather.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureGather.spec.ts
@@ -31,6 +31,7 @@ import {
   kDepthStencilFormats,
   kAllTextureFormats,
 } from '../../../../../format_info.js';
+import { AllFeaturesMaxLimitsGPUTest } from '../../../../../gpu_test.js';
 
 import {
   appendComponentTypeForFormatToTextureType,
@@ -50,10 +51,9 @@ import {
   TextureCall,
   vec2,
   vec3,
-  WGSLTextureSampleTest,
 } from './texture_utils.js';
 
-export const g = makeTestGroup(WGSLTextureSampleTest);
+export const g = makeTestGroup(AllFeaturesMaxLimitsGPUTest);
 
 g.test('sampled_2d_coords')
   .specURL('https://www.w3.org/TR/WGSL/#texturegather')

--- a/src/webgpu/shader/execution/expression/call/builtin/textureGatherCompare.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureGatherCompare.spec.ts
@@ -19,6 +19,7 @@ A texture gather compare operation performs a depth comparison on four texels in
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { kCompareFunctions } from '../../../../../capability_info.js';
 import { isDepthTextureFormat, kDepthStencilFormats } from '../../../../../format_info.js';
+import { AllFeaturesMaxLimitsGPUTest } from '../../../../../gpu_test.js';
 
 import {
   checkCallResults,
@@ -36,10 +37,9 @@ import {
   TextureCall,
   vec2,
   vec3,
-  WGSLTextureSampleTest,
 } from './texture_utils.js';
 
-export const g = makeTestGroup(WGSLTextureSampleTest);
+export const g = makeTestGroup(AllFeaturesMaxLimitsGPUTest);
 
 g.test('array_2d_coords')
   .specURL('https://www.w3.org/TR/WGSL/#texturegathercompare')

--- a/src/webgpu/shader/execution/expression/call/builtin/textureNumLayers.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureNumLayers.spec.ts
@@ -9,9 +9,14 @@ import {
   isTextureFormatPossiblyStorageReadWritable,
   kPossibleStorageTextureFormats,
 } from '../../../../../format_info.js';
+import { AllFeaturesMaxLimitsGPUTest } from '../../../../../gpu_test.js';
 import { kShaderStages } from '../../../../validation/decl/util.js';
 
-import { kSampleTypeInfo, WGSLTextureQueryTest } from './texture_utils.js';
+import {
+  executeTextureQueryAndExpectResult,
+  kSampleTypeInfo,
+  skipIfNoStorageTexturesInStage,
+} from './texture_utils.js';
 
 const kNumLayers = 36;
 
@@ -36,7 +41,7 @@ function getLayerSettingsAndExpected({
       };
 }
 
-export const g = makeTestGroup(WGSLTextureQueryTest);
+export const g = makeTestGroup(AllFeaturesMaxLimitsGPUTest);
 
 g.test('sampled')
   .specURL('https://www.w3.org/TR/WGSL/#texturenumlayers')
@@ -96,7 +101,7 @@ fn getValue() -> u32 {
       arrayLayerCount,
     };
 
-    t.executeAndExpectResult(stage, code, texture, viewDescription, expected);
+    executeTextureQueryAndExpectResult(t, stage, code, texture, viewDescription, expected);
   });
 
 g.test('arrayed')
@@ -154,7 +159,7 @@ fn getValue() -> u32 {
       arrayLayerCount,
     };
 
-    t.executeAndExpectResult(stage, code, texture, viewDescription, expected);
+    executeTextureQueryAndExpectResult(t, stage, code, texture, viewDescription, expected);
   });
 
 g.test('storage')
@@ -206,7 +211,7 @@ Parameters
   })
   .fn(t => {
     const { stage, format, access_mode, view_type } = t.params;
-    t.skipIfNoStorageTexturesInStage(stage);
+    skipIfNoStorageTexturesInStage(t, stage);
     t.skipIfTextureFormatNotUsableAsStorageTexture(format);
     if (access_mode === 'read_write') {
       t.skipIfTextureFormatNotUsableAsReadWriteStorageTexture(format);
@@ -235,5 +240,5 @@ fn getValue() -> u32 {
       arrayLayerCount,
     };
 
-    t.executeAndExpectResult(stage, code, texture, viewDescription, expected);
+    executeTextureQueryAndExpectResult(t, stage, code, texture, viewDescription, expected);
   });

--- a/src/webgpu/shader/execution/expression/call/builtin/textureNumLevels.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureNumLevels.spec.ts
@@ -5,10 +5,11 @@ Returns the number of mip levels of a texture.
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
+import { AllFeaturesMaxLimitsGPUTest } from '../../../../../gpu_test.js';
 import { getTextureDimensionFromView } from '../../../../../util/texture/base.js';
 import { kShaderStages } from '../../../../validation/decl/util.js';
 
-import { kSampleTypeInfo, WGSLTextureQueryTest } from './texture_utils.js';
+import { executeTextureQueryAndExpectResult, kSampleTypeInfo } from './texture_utils.js';
 
 function getLevelSettingsAndExpected(viewType: 'full' | 'partial', mipLevelCount: number) {
   return viewType === 'partial'
@@ -37,7 +38,7 @@ const kTextureTypeToViewDimension = {
   texture_depth_cube_array: 'cube-array',
 } as const;
 
-export const g = makeTestGroup(WGSLTextureQueryTest);
+export const g = makeTestGroup(AllFeaturesMaxLimitsGPUTest);
 
 g.test('sampled')
   .specURL('https://www.w3.org/TR/WGSL/#texturenumlevels')
@@ -116,7 +117,7 @@ fn getValue() -> u32 {
       mipLevelCount,
     };
 
-    t.executeAndExpectResult(stage, code, texture, viewDescription, expected);
+    executeTextureQueryAndExpectResult(t, stage, code, texture, viewDescription, expected);
   });
 
 g.test('depth')
@@ -186,5 +187,5 @@ fn getValue() -> u32 {
       mipLevelCount,
     };
 
-    t.executeAndExpectResult(stage, code, texture, viewDescription, expected);
+    executeTextureQueryAndExpectResult(t, stage, code, texture, viewDescription, expected);
   });

--- a/src/webgpu/shader/execution/expression/call/builtin/textureNumSamples.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureNumSamples.spec.ts
@@ -5,11 +5,12 @@ Returns the number samples per texel in a multisampled texture.
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
+import { AllFeaturesMaxLimitsGPUTest } from '../../../../../gpu_test.js';
 import { kShaderStages } from '../../../../validation/decl/util.js';
 
-import { kSampleTypeInfo, WGSLTextureQueryTest } from './texture_utils.js';
+import { executeTextureQueryAndExpectResult, kSampleTypeInfo } from './texture_utils.js';
 
-export const g = makeTestGroup(WGSLTextureQueryTest);
+export const g = makeTestGroup(AllFeaturesMaxLimitsGPUTest);
 
 g.test('sampled')
   .specURL('https://www.w3.org/TR/WGSL/#texturenumsamples')
@@ -52,7 +53,7 @@ fn getValue() -> u32 {
     `;
 
     const expected = [sampleCount];
-    t.executeAndExpectResult(stage, code, texture, {}, expected);
+    executeTextureQueryAndExpectResult(t, stage, code, texture, {}, expected);
   });
 
 g.test('depth')
@@ -85,5 +86,5 @@ fn getValue() -> u32 {
     `;
 
     const expected = [sampleCount];
-    t.executeAndExpectResult(stage, code, texture, {}, expected);
+    executeTextureQueryAndExpectResult(t, stage, code, texture, {}, expected);
   });

--- a/src/webgpu/shader/execution/expression/call/builtin/textureSample.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureSample.spec.ts
@@ -15,6 +15,7 @@ import {
   textureDimensionAndFormatCompatible,
   isTextureFormatPossiblyFilterableAsTextureF32,
 } from '../../../../../format_info.js';
+import { AllFeaturesMaxLimitsGPUTest } from '../../../../../gpu_test.js';
 
 import {
   vec2,
@@ -35,13 +36,12 @@ import {
   isPotentiallyFilterableAndFillable,
   skipIfTextureFormatNotSupportedOrNeedsFilteringAndIsUnfilterable,
   getTextureTypeForTextureViewDimension,
-  WGSLTextureSampleTest,
   isSupportedViewFormatCombo,
   vec1,
   generateTextureBuiltinInputs1D,
 } from './texture_utils.js';
 
-export const g = makeTestGroup(WGSLTextureSampleTest);
+export const g = makeTestGroup(AllFeaturesMaxLimitsGPUTest);
 
 g.test('sampled_1d_coords')
   .specURL('https://www.w3.org/TR/WGSL/#texturesample')

--- a/src/webgpu/shader/execution/expression/call/builtin/textureSampleBaseClampToEdge.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureSampleBaseClampToEdge.spec.ts
@@ -3,7 +3,7 @@ Execution tests for textureSampleBaseClampToEdge
 `;
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
-import { GPUTest } from '../../../../../gpu_test.js';
+import { AllFeaturesMaxLimitsGPUTest, GPUTest } from '../../../../../gpu_test.js';
 import { TexelView } from '../../../../../util/texture/texel_view.js';
 
 import {
@@ -18,10 +18,9 @@ import {
   kShortShaderStages,
   TextureCall,
   vec2,
-  WGSLTextureSampleTest,
 } from './texture_utils.js';
 
-export const g = makeTestGroup(WGSLTextureSampleTest);
+export const g = makeTestGroup(AllFeaturesMaxLimitsGPUTest);
 
 async function createTextureAndDataForTest(
   t: GPUTest,

--- a/src/webgpu/shader/execution/expression/call/builtin/textureSampleBias.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureSampleBias.spec.ts
@@ -12,6 +12,7 @@ import {
   isTextureFormatPossiblyFilterableAsTextureF32,
   kAllTextureFormats,
 } from '../../../../../format_info.js';
+import { AllFeaturesMaxLimitsGPUTest } from '../../../../../gpu_test.js';
 
 import {
   vec2,
@@ -31,12 +32,11 @@ import {
   chooseTextureSize,
   isPotentiallyFilterableAndFillable,
   getTextureTypeForTextureViewDimension,
-  WGSLTextureSampleTest,
   isSupportedViewFormatCombo,
   skipIfTextureFormatNotSupportedOrNeedsFilteringAndIsUnfilterable,
 } from './texture_utils.js';
 
-export const g = makeTestGroup(WGSLTextureSampleTest);
+export const g = makeTestGroup(AllFeaturesMaxLimitsGPUTest);
 
 // See comment "Issues with textureSampleBias" in texture_utils.ts
 // 3 was chosen because it shows errors on M1 Mac

--- a/src/webgpu/shader/execution/expression/call/builtin/textureSampleCompare.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureSampleCompare.spec.ts
@@ -8,6 +8,7 @@ Samples a depth texture and compares the sampled depth values against a referenc
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { kCompareFunctions } from '../../../../../capability_info.js';
 import { isDepthTextureFormat, kDepthStencilFormats } from '../../../../../format_info.js';
+import { AllFeaturesMaxLimitsGPUTest } from '../../../../../gpu_test.js';
 
 import {
   checkCallResults,
@@ -24,10 +25,9 @@ import {
   TextureCall,
   vec2,
   vec3,
-  WGSLTextureSampleTest,
 } from './texture_utils.js';
 
-export const g = makeTestGroup(WGSLTextureSampleTest);
+export const g = makeTestGroup(AllFeaturesMaxLimitsGPUTest);
 
 g.test('2d_coords')
   .specURL('https://www.w3.org/TR/WGSL/#texturesamplecompare')

--- a/src/webgpu/shader/execution/expression/call/builtin/textureSampleCompareLevel.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureSampleCompareLevel.spec.ts
@@ -14,6 +14,7 @@ The textureSampleCompareLevel function is the same as textureSampleCompare, exce
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { kCompareFunctions } from '../../../../../capability_info.js';
 import { isDepthTextureFormat, kDepthStencilFormats } from '../../../../../format_info.js';
+import { AllFeaturesMaxLimitsGPUTest } from '../../../../../gpu_test.js';
 
 import {
   checkCallResults,
@@ -31,10 +32,9 @@ import {
   TextureCall,
   vec2,
   vec3,
-  WGSLTextureSampleTest,
 } from './texture_utils.js';
 
-export const g = makeTestGroup(WGSLTextureSampleTest);
+export const g = makeTestGroup(AllFeaturesMaxLimitsGPUTest);
 
 g.test('2d_coords')
   .specURL('https://www.w3.org/TR/WGSL/#texturesamplecomparelevel')

--- a/src/webgpu/shader/execution/expression/call/builtin/textureSampleGrad.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureSampleGrad.spec.ts
@@ -10,6 +10,7 @@ import {
   isTextureFormatPossiblyFilterableAsTextureF32,
   kAllTextureFormats,
 } from '../../../../../format_info.js';
+import { AllFeaturesMaxLimitsGPUTest } from '../../../../../gpu_test.js';
 
 import {
   appendComponentTypeForFormatToTextureType,
@@ -33,10 +34,9 @@ import {
   TextureCall,
   vec2,
   vec3,
-  WGSLTextureSampleTest,
 } from './texture_utils.js';
 
-export const g = makeTestGroup(WGSLTextureSampleTest);
+export const g = makeTestGroup(AllFeaturesMaxLimitsGPUTest);
 
 g.test('sampled_2d_coords')
   .specURL('https://www.w3.org/TR/WGSL/#texturesamplegrad')

--- a/src/webgpu/shader/execution/expression/call/builtin/textureSampleLevel.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureSampleLevel.spec.ts
@@ -11,6 +11,7 @@ import {
   kAllTextureFormats,
   kDepthStencilFormats,
 } from '../../../../../format_info.js';
+import { AllFeaturesMaxLimitsGPUTest } from '../../../../../gpu_test.js';
 
 import {
   appendComponentTypeForFormatToTextureType,
@@ -35,10 +36,9 @@ import {
   TextureCall,
   vec2,
   vec3,
-  WGSLTextureSampleTest,
 } from './texture_utils.js';
 
-export const g = makeTestGroup(WGSLTextureSampleTest);
+export const g = makeTestGroup(AllFeaturesMaxLimitsGPUTest);
 
 g.test('sampled_2d_coords')
   .specURL('https://www.w3.org/TR/WGSL/#texturesamplelevel')

--- a/src/webgpu/shader/execution/expression/call/builtin/texture_utils.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/texture_utils.ts
@@ -18,7 +18,7 @@ import {
   isStencilTextureFormat,
   kEncodableTextureFormats,
 } from '../../../../../format_info.js';
-import { AllFeaturesMaxLimitsGPUTest, GPUTest } from '../../../../../gpu_test.js';
+import { GPUTest } from '../../../../../gpu_test.js';
 import {
   align,
   clamp,
@@ -754,36 +754,40 @@ function getWeightForMipLevel(
 }
 
 /**
- * Used for textureNumSamples, textureNumLevels, textureNumLayers, textureDimension
+ * Skip a test if the specific stage doesn't support storage textures.
  */
-export class WGSLTextureQueryTest extends AllFeaturesMaxLimitsGPUTest {
-  skipIfNoStorageTexturesInStage(stage: ShaderStage) {
-    if (this.isCompatibility) {
-      this.skipIf(
-        stage === 'fragment' && !(this.device.limits.maxStorageTexturesInFragmentStage! > 0),
-        'device does not support storage textures in fragment shaders'
-      );
-      this.skipIf(
-        stage === 'vertex' && !(this.device.limits.maxStorageTexturesInVertexStage! > 0),
-        'device does not support storage textures in vertex shaders'
-      );
-    }
+export function skipIfNoStorageTexturesInStage(t: GPUTest, stage: ShaderStage) {
+  if (t.isCompatibility) {
+    t.skipIf(
+      stage === 'fragment' && !(t.device.limits.maxStorageTexturesInFragmentStage! > 0),
+      'device does not support storage textures in fragment shaders'
+    );
+    t.skipIf(
+      stage === 'vertex' && !(t.device.limits.maxStorageTexturesInVertexStage! > 0),
+      'device does not support storage textures in vertex shaders'
+    );
   }
+}
 
-  executeAndExpectResult(
-    stage: ShaderStage,
-    code: string,
-    texture: GPUTexture | GPUExternalTexture,
-    viewDescriptor: GPUTextureViewDescriptor | undefined,
-    expected: number[]
-  ) {
-    const { device } = this;
+/**
+ * Runs a texture query like textureDimensions, textureNumLevels and expects
+ * a particular result.
+ */
+export function executeTextureQueryAndExpectResult(
+  t: GPUTest,
+  stage: ShaderStage,
+  code: string,
+  texture: GPUTexture | GPUExternalTexture,
+  viewDescriptor: GPUTextureViewDescriptor | undefined,
+  expected: number[]
+) {
+  const { device } = t;
 
-    const returnType = `vec4<u32>`;
-    const castWGSL = `${returnType}(getValue()${range(4 - expected.length, () => ', 0').join('')})`;
-    const stageWGSL =
-      stage === 'vertex'
-        ? `
+  const returnType = `vec4<u32>`;
+  const castWGSL = `${returnType}(getValue()${range(4 - expected.length, () => ', 0').join('')})`;
+  const stageWGSL =
+    stage === 'vertex'
+      ? `
 // --------------------------- vertex stage shaders --------------------------------
 @vertex fn vsVertex(
     @builtin(vertex_index) vertex_index : u32,
@@ -798,8 +802,8 @@ export class WGSLTextureQueryTest extends AllFeaturesMaxLimitsGPUTest {
   return bitcast<vec4u>(v.result);
 }
 `
-        : stage === 'fragment'
-        ? `
+      : stage === 'fragment'
+      ? `
 // --------------------------- fragment stage shaders --------------------------------
 @vertex fn vsFragment(
     @builtin(vertex_index) vertex_index : u32,
@@ -812,7 +816,7 @@ export class WGSLTextureQueryTest extends AllFeaturesMaxLimitsGPUTest {
   return bitcast<vec4u>(${castWGSL});
 }
 `
-        : `
+      : `
 // --------------------------- compute stage shaders --------------------------------
 @group(1) @binding(0) var<storage, read_write> results: array<${returnType}>;
 
@@ -820,8 +824,8 @@ export class WGSLTextureQueryTest extends AllFeaturesMaxLimitsGPUTest {
   results[id.x] = ${castWGSL};
 }
 `;
-    const wgsl = `
-      ${code}
+  const wgsl = `
+    ${code}
 
 struct VOut {
   @builtin(position) pos: vec4f,
@@ -829,197 +833,187 @@ struct VOut {
   @location(1) @interpolate(flat, either) result: ${returnType},
 };
 
-      ${stageWGSL}
-    `;
-    const module = device.createShaderModule({ code: wgsl });
+    ${stageWGSL}
+  `;
+  const module = device.createShaderModule({ code: wgsl });
 
-    const visibility =
-      stage === 'compute'
-        ? GPUShaderStage.COMPUTE
-        : stage === 'fragment'
-        ? GPUShaderStage.FRAGMENT
-        : GPUShaderStage.VERTEX;
+  const visibility =
+    stage === 'compute'
+      ? GPUShaderStage.COMPUTE
+      : stage === 'fragment'
+      ? GPUShaderStage.FRAGMENT
+      : GPUShaderStage.VERTEX;
 
-    const entries: GPUBindGroupLayoutEntry[] = [];
-    if (code.includes('texture_external')) {
-      entries.push({
-        binding: 0,
-        visibility,
-        externalTexture: {},
-      });
-    } else if (code.includes('texture_storage')) {
-      assert(texture instanceof GPUTexture);
-      entries.push({
-        binding: 0,
-        visibility,
-        storageTexture: {
-          access: code.includes(', read>')
-            ? 'read-only'
-            : code.includes(', write>')
-            ? 'write-only'
-            : 'read-write',
-          viewDimension: viewDescriptor?.dimension ?? '2d',
-          format: texture.format,
-        },
-      });
-    } else {
-      assert(texture instanceof GPUTexture);
-      const sampleType =
-        viewDescriptor?.aspect === 'stencil-only'
-          ? 'uint'
-          : code.includes('texture_depth')
-          ? 'depth'
-          : isDepthTextureFormat(texture.format)
-          ? 'unfilterable-float'
-          : isStencilTextureFormat(texture.format)
-          ? 'uint'
-          : texture.sampleCount > 1 && getTextureFormatType(texture.format) === 'float'
-          ? 'unfilterable-float'
-          : getTextureFormatType(texture.format) ?? 'unfilterable-float';
-      entries.push({
-        binding: 0,
-        visibility,
-        texture: {
-          sampleType,
-          viewDimension: viewDescriptor?.dimension ?? '2d',
-          multisampled: texture.sampleCount > 1,
-        },
-      });
-    }
+  const entries: GPUBindGroupLayoutEntry[] = [];
+  if (code.includes('texture_external')) {
+    entries.push({
+      binding: 0,
+      visibility,
+      externalTexture: {},
+    });
+  } else if (code.includes('texture_storage')) {
+    assert(texture instanceof GPUTexture);
+    entries.push({
+      binding: 0,
+      visibility,
+      storageTexture: {
+        access: code.includes(', read>')
+          ? 'read-only'
+          : code.includes(', write>')
+          ? 'write-only'
+          : 'read-write',
+        viewDimension: viewDescriptor?.dimension ?? '2d',
+        format: texture.format,
+      },
+    });
+  } else {
+    assert(texture instanceof GPUTexture);
+    const sampleType =
+      viewDescriptor?.aspect === 'stencil-only'
+        ? 'uint'
+        : code.includes('texture_depth')
+        ? 'depth'
+        : isDepthTextureFormat(texture.format)
+        ? 'unfilterable-float'
+        : isStencilTextureFormat(texture.format)
+        ? 'uint'
+        : texture.sampleCount > 1 && getTextureFormatType(texture.format) === 'float'
+        ? 'unfilterable-float'
+        : getTextureFormatType(texture.format) ?? 'unfilterable-float';
+    entries.push({
+      binding: 0,
+      visibility,
+      texture: {
+        sampleType,
+        viewDimension: viewDescriptor?.dimension ?? '2d',
+        multisampled: texture.sampleCount > 1,
+      },
+    });
+  }
 
-    const bindGroupLayouts: GPUBindGroupLayout[] = [device.createBindGroupLayout({ entries })];
+  const bindGroupLayouts: GPUBindGroupLayout[] = [device.createBindGroupLayout({ entries })];
 
-    if (stage === 'compute') {
-      bindGroupLayouts.push(
-        device.createBindGroupLayout({
-          entries: [
-            {
-              binding: 0,
-              visibility: GPUShaderStage.COMPUTE,
-              buffer: {
-                type: 'storage',
-                hasDynamicOffset: false,
-                minBindingSize: 16,
-              },
+  if (stage === 'compute') {
+    bindGroupLayouts.push(
+      device.createBindGroupLayout({
+        entries: [
+          {
+            binding: 0,
+            visibility: GPUShaderStage.COMPUTE,
+            buffer: {
+              type: 'storage',
+              hasDynamicOffset: false,
+              minBindingSize: 16,
             },
-          ],
-        })
-      );
-    }
+          },
+        ],
+      })
+    );
+  }
 
-    const layout = device.createPipelineLayout({
-      bindGroupLayouts,
+  const layout = device.createPipelineLayout({
+    bindGroupLayouts,
+  });
+
+  let pipeline: GPUComputePipeline | GPURenderPipeline;
+
+  switch (stage) {
+    case 'compute':
+      pipeline = device.createComputePipeline({
+        layout,
+        compute: { module },
+      });
+      break;
+    case 'fragment':
+    case 'vertex':
+      pipeline = device.createRenderPipeline({
+        layout,
+        vertex: { module },
+        fragment: {
+          module,
+          targets: [{ format: 'rgba32uint' }],
+        },
+      });
+      break;
+  }
+
+  const bindGroup0 = device.createBindGroup({
+    layout: pipeline.getBindGroupLayout(0),
+    entries: [
+      {
+        binding: 0,
+        resource:
+          texture instanceof GPUExternalTexture ? texture : texture.createView(viewDescriptor),
+      },
+    ],
+  });
+
+  const renderTarget = t.createTextureTracked({
+    format: 'rgba32uint',
+    size: [expected.length, 1],
+    usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
+  });
+
+  const resultBuffer = t.createBufferTracked({
+    label: 'executeAndExpectResult:resultBuffer',
+    size: align(expected.length * 4, 256),
+    usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC,
+  });
+
+  let storageBuffer: GPUBuffer | undefined;
+  const encoder = device.createCommandEncoder({ label: 'executeAndExpectResult' });
+
+  if (stage === 'compute') {
+    storageBuffer = t.createBufferTracked({
+      label: 'executeAndExpectResult:storageBuffer',
+      size: resultBuffer.size,
+      usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC,
     });
 
-    let pipeline: GPUComputePipeline | GPURenderPipeline;
+    const bindGroup1 = device.createBindGroup({
+      layout: pipeline!.getBindGroupLayout(1),
+      entries: [{ binding: 0, resource: { buffer: storageBuffer } }],
+    });
 
-    switch (stage) {
-      case 'compute':
-        pipeline = device.createComputePipeline({
-          layout,
-          compute: { module },
-        });
-        break;
-      case 'fragment':
-      case 'vertex':
-        pipeline = device.createRenderPipeline({
-          layout,
-          vertex: { module },
-          fragment: {
-            module,
-            targets: [{ format: 'rgba32uint' }],
-          },
-        });
-        break;
-    }
-
-    const bindGroup0 = device.createBindGroup({
-      layout: pipeline.getBindGroupLayout(0),
-      entries: [
+    const pass = encoder.beginComputePass();
+    pass.setPipeline(pipeline! as GPUComputePipeline);
+    pass.setBindGroup(0, bindGroup0);
+    pass.setBindGroup(1, bindGroup1);
+    pass.dispatchWorkgroups(expected.length);
+    pass.end();
+    encoder.copyBufferToBuffer(storageBuffer, 0, resultBuffer, 0, storageBuffer.size);
+  } else {
+    const pass = encoder.beginRenderPass({
+      colorAttachments: [
         {
-          binding: 0,
-          resource:
-            texture instanceof GPUExternalTexture ? texture : texture.createView(viewDescriptor),
+          view: renderTarget.createView(),
+          loadOp: 'clear',
+          storeOp: 'store',
         },
       ],
     });
 
-    const renderTarget = this.createTextureTracked({
-      format: 'rgba32uint',
-      size: [expected.length, 1],
-      usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
-    });
-
-    const resultBuffer = this.createBufferTracked({
-      label: 'executeAndExpectResult:resultBuffer',
-      size: align(expected.length * 4, 256),
-      usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC,
-    });
-
-    let storageBuffer: GPUBuffer | undefined;
-    const encoder = device.createCommandEncoder({ label: 'executeAndExpectResult' });
-
-    if (stage === 'compute') {
-      storageBuffer = this.createBufferTracked({
-        label: 'executeAndExpectResult:storageBuffer',
-        size: resultBuffer.size,
-        usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC,
-      });
-
-      const bindGroup1 = device.createBindGroup({
-        layout: pipeline!.getBindGroupLayout(1),
-        entries: [{ binding: 0, resource: { buffer: storageBuffer } }],
-      });
-
-      const pass = encoder.beginComputePass();
-      pass.setPipeline(pipeline! as GPUComputePipeline);
-      pass.setBindGroup(0, bindGroup0);
-      pass.setBindGroup(1, bindGroup1);
-      pass.dispatchWorkgroups(expected.length);
-      pass.end();
-      encoder.copyBufferToBuffer(storageBuffer, 0, resultBuffer, 0, storageBuffer.size);
-    } else {
-      const pass = encoder.beginRenderPass({
-        colorAttachments: [
-          {
-            view: renderTarget.createView(),
-            loadOp: 'clear',
-            storeOp: 'store',
-          },
-        ],
-      });
-
-      pass.setPipeline(pipeline! as GPURenderPipeline);
-      pass.setBindGroup(0, bindGroup0);
-      for (let i = 0; i < expected.length; ++i) {
-        pass.setViewport(i, 0, 1, 1, 0, 1);
-        pass.draw(3, 1, 0, i);
-      }
-      pass.end();
-      encoder.copyTextureToBuffer(
-        { texture: renderTarget },
-        {
-          buffer: resultBuffer,
-          bytesPerRow: resultBuffer.size,
-        },
-        [renderTarget.width, 1]
-      );
+    pass.setPipeline(pipeline! as GPURenderPipeline);
+    pass.setBindGroup(0, bindGroup0);
+    for (let i = 0; i < expected.length; ++i) {
+      pass.setViewport(i, 0, 1, 1, 0, 1);
+      pass.draw(3, 1, 0, i);
     }
-    this.device.queue.submit([encoder.finish()]);
-
-    const e = new Uint32Array(4);
-    e.set(expected);
-    this.expectGPUBufferValuesEqual(resultBuffer, e);
+    pass.end();
+    encoder.copyTextureToBuffer(
+      { texture: renderTarget },
+      {
+        buffer: resultBuffer,
+        bytesPerRow: resultBuffer.size,
+      },
+      [renderTarget.width, 1]
+    );
   }
-}
+  t.device.queue.submit([encoder.finish()]);
 
-/**
- * Used for textureSampleXXX
- */
-export class WGSLTextureSampleTest extends AllFeaturesMaxLimitsGPUTest {
-  override async init(): Promise<void> {
-    await super.init();
-  }
+  const e = new Uint32Array(4);
+  e.set(expected);
+  t.expectGPUBufferValuesEqual(resultBuffer, e);
 }
 
 /**


### PR DESCRIPTION
The first is left over from when the texture tests always queried GPU weights. Those weights are not queries on demand and so the class has no point.

The second is just arguably a bad pattern and so refactored since it's not needed.


