### PR TITLE
Wait for the device pools to release

### DIFF
--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -154,9 +154,8 @@ export class GPUTestSubcaseBatchState extends SubcaseBatchState {
     ]);
 
     // If one of them rejected throw its reason. It should be an `Error`.
-    const rejected = results.find(result => result.status === 'rejected');
-    if (rejected) {
-      throw (rejected as PromiseRejectedResult).reason;
+    for (const result of results) {
+      if (result.status === 'rejected') throw result.reason;
     }
   }
 

--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -146,11 +146,18 @@ export class GPUTestSubcaseBatchState extends SubcaseBatchState {
   override async finalize(): Promise<void> {
     await super.finalize();
 
-    // Ensure devicePool.release is called for both providers even if one rejects.
-    await Promise.all([
+    // Ensure devicePool.release is called for both providers even if one rejects
+    // and wait for both of them before proceeding.
+    const results = await Promise.allSettled([
       this.provider?.then(x => devicePool.release(x)),
       this.mismatchedProvider?.then(x => mismatchedDevicePool.release(x)),
     ]);
+
+    // If one of them rejected throw its reason. It should be an `Error`.
+    const rejected = results.find(result => result.status === 'rejected');
+    if (rejected) {
+      throw (rejected as PromiseRejectedResult).reason;
+    }
   }
 
   /** @internal MAINTENANCE_TODO: Make this not visible to test code? */


### PR DESCRIPTION
When finalizing a test, wait for the device pools to release before continuing.

Issue: #4339
