### PR TITLE
Add BC sliced 3D adapter capability checks

### DIFF
--- a/src/webgpu/api/validation/capability_checks/features/texture_formats.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/features/texture_formats.spec.ts
@@ -449,15 +449,28 @@ g.test('render_bundle_encoder_descriptor_depth_stencil_format')
 
 g.test('check_capability_guarantees')
   .desc(
-    `check "texture-compression-bc" is supported or both "texture-compression-etc2" and "texture-compression-astc" are supported.`
+    `check any adapter returned by requestAdapter() must provide the following guarantees:
+      - "texture-compression-bc" is supported or both "texture-compression-etc2" and "texture-compression-astc" are supported
+      - either "texture-compression-bc" or "texture-compression-bc-sliced-3d" is supported, both must be supported.
+    `
   )
   .fn(async t => {
     const adapter = await getGPU(t.rec).requestAdapter();
     assert(adapter !== null);
 
     const features = adapter.features;
-    t.expect(
-      features.has('texture-compression-bc') ||
-        (features.has('texture-compression-etc2') && features.has('texture-compression-astc'))
-    );
+
+    const supportsBC = features.has('texture-compression-bc');
+    const supportsETC2ASTC =
+      features.has('texture-compression-etc2') && features.has('texture-compression-astc');
+    const supportsBCSliced3D = features.has('texture-compression-bc-sliced-3d');
+
+    t.expect(supportsBC || supportsETC2ASTC, 'Adapter must support BC or both ETC2 and ASTC');
+
+    if (supportsBC || supportsBCSliced3D) {
+      t.expect(
+        supportsBC && supportsBCSliced3D,
+        'If BC or BC Sliced 3D is supported, both must be'
+      );
+    }
   });


### PR DESCRIPTION
Issue:  https://github.com/gpuweb/cts/issues/3761

This PR is an attempt to make CTS more compliant with the WebGPU spec regarding the BC sliced 3D feature.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
