### PR TITLE
Add feature tests for 3D texture with BC compressed formats

### DIFF
--- a/src/webgpu/api/validation/capability_checks/features/texture_formats.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/features/texture_formats.spec.ts
@@ -128,7 +128,7 @@ g.test('texture_view_descriptor')
     });
   });
 
-g.test('texture_compression_bc')
+g.test('texture_compression_bc_sliced_3d')
   .desc(
     `
   Tests that creating a 3D texture with BC compressed format fails if the features don't contain

--- a/src/webgpu/api/validation/capability_checks/features/texture_formats.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/features/texture_formats.spec.ts
@@ -7,6 +7,7 @@ import { getGPU } from '../../../../../common/util/navigator_gpu.js';
 import { assert } from '../../../../../common/util/util.js';
 import { kCanvasTextureFormats } from '../../../../capability_info.js';
 import {
+  kBCCompressedTextureFormats,
   getBlockInfoForTextureFormat,
   isDepthOrStencilTextureFormat,
   isTextureFormatPossiblyStorageReadable,
@@ -125,6 +126,50 @@ g.test('texture_view_descriptor')
     t.shouldThrow(enable_required_feature ? false : 'TypeError', () => {
       testTexture.createView(testViewDesc);
     });
+  });
+
+g.test('texture_compression_bc')
+  .desc(
+    `
+  Tests that creating a 3D texture with BC compressed format fails if the features don't contain
+  'texture-compression-bc' and 'texture-compression-bc-sliced-3d'.
+  `
+  )
+  .params(u =>
+    u
+      .combine('format', kBCCompressedTextureFormats)
+      .combine('supportsBC', [false, true])
+      .combine('supportsBCSliced3D', [false, true])
+  )
+  .beforeAllSubcases(t => {
+    const { supportsBC, supportsBCSliced3D } = t.params;
+
+    const requiredFeatures: GPUFeatureName[] = [];
+    if (supportsBC) {
+      requiredFeatures.push('texture-compression-bc');
+    }
+    if (supportsBCSliced3D) {
+      requiredFeatures.push('texture-compression-bc-sliced-3d');
+    }
+
+    t.selectDeviceOrSkipTestCase({ requiredFeatures });
+  })
+  .fn(t => {
+    const { format, supportsBC, supportsBCSliced3D } = t.params;
+
+    t.skipIfTextureFormatNotSupported(format);
+    const info = getBlockInfoForTextureFormat(format);
+
+    const descriptor: GPUTextureDescriptor = {
+      size: [info.blockWidth, info.blockHeight, 1],
+      dimension: '3d',
+      format,
+      usage: GPUTextureUsage.TEXTURE_BINDING,
+    };
+
+    t.expectValidationError(() => {
+      t.createTextureTracked(descriptor);
+    }, !supportsBC || !supportsBCSliced3D);
   });
 
 g.test('canvas_configuration')

--- a/src/webgpu/format_info.ts
+++ b/src/webgpu/format_info.ts
@@ -1442,6 +1442,7 @@ const kASTCTextureFormatInfo = formatTableWithDefaults({
 /* prettier-ignore */ export const   kSizedDepthStencilFormats: readonly   SizedDepthStencilFormat[] = keysOf(  kSizedDepthStencilFormatInfo);
 /* prettier-ignore */ export const kUnsizedDepthStencilFormats: readonly UnsizedDepthStencilFormat[] = keysOf(kUnsizedDepthStencilFormatInfo);
 /* prettier-ignore */ export const   kCompressedTextureFormats: readonly   CompressedTextureFormat[] = keysOf(  kCompressedTextureFormatInfo);
+/* prettier-ignore */ export const kBCCompressedTextureFormats: readonly   CompressedTextureFormat[] = keysOf(          kBCTextureFormatInfo);
 
 /* prettier-ignore */ export const        kColorTextureFormats: readonly        ColorTextureFormat[] = keysOf(       kColorTextureFormatInfo);
 /* prettier-ignore */ export const    kEncodableTextureFormats: readonly    EncodableTextureFormat[] = keysOf(   kEncodableTextureFormatInfo);
@@ -1885,12 +1886,10 @@ export function textureDimensionAndFormatCompatibleForDevice(
 ): boolean {
   if (
     dimension === '3d' &&
-    ((isBCTextureFormat(format) && !device.features.has('texture-compression-bc-sliced-3d')) ||
-      // This is not a real feature, but if it were, this is what it would be called.
-      (isETC2TextureFormat(format) && !device.features.has('texture-compression-etc2-sliced-3d')) ||
-      (isASTCTextureFormat(format) && !device.features.has('texture-compression-astc-sliced-3d')))
+    ((isBCTextureFormat(format) && device.features.has('texture-compression-bc-sliced-3d')) ||
+      (isASTCTextureFormat(format) && device.features.has('texture-compression-astc-sliced-3d')))
   ) {
-    return false;
+    return true;
   }
   return textureDimensionAndFormatCompatible(dimension, format);
 }
@@ -2100,10 +2099,6 @@ export function isCompressedTextureFormat(format: GPUTextureFormat) {
 
 export function isBCTextureFormat(format: GPUTextureFormat) {
   return format in kBCTextureFormatInfo;
-}
-
-export function isETC2TextureFormat(format: GPUTextureFormat) {
-  return format in kETC2TextureFormatInfo;
 }
 
 export function isASTCTextureFormat(format: GPUTextureFormat) {


### PR DESCRIPTION
Issue:  https://github.com/gpuweb/cts/issues/3761

This PR  adds feature tests for 3D texture with BC compressed formats and updates previous ones.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
