### PR TITLE
Test an empty resolve pass

### DIFF
--- a/src/webgpu/api/operation/render_pass/resolve.spec.ts
+++ b/src/webgpu/api/operation/render_pass/resolve.spec.ts
@@ -1,17 +1,4 @@
-export const description = `API Operation Tests for RenderPass StoreOp.
-Tests a render pass with a resolveTarget resolves correctly for many combinations of:
-  - number of color attachments, some with and some without a resolveTarget
-  - renderPass storeOp set to {'store', 'discard'}
-  - resolveTarget mip level {0, >0} (TODO?: different mip level from colorAttachment)
-  - resolveTarget {2d array layer, TODO: 3d slice} {0, >0} with {2d, TODO: 3d} resolveTarget
-    (TODO?: different z from colorAttachment)
-  - TODO: test all renderable color formats
-  - TODO: test that any not-resolved attachments are rendered to correctly.
-  - TODO: test different loadOps
-  - TODO?: resolveTarget mip level {0, >0} (TODO?: different mip level from colorAttachment)
-  - TODO?: resolveTarget {2d array layer, TODO: 3d slice} {0, >0} with {2d, TODO: 3d} resolveTarget
-    (different z from colorAttachment)
-`;
+export const description = `API Operation Tests for multisample resolve in render passes.`;
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { AllFeaturesMaxLimitsGPUTest } from '../../../gpu_test.js';
@@ -29,8 +16,28 @@ const kFormat: GPUTextureFormat = 'rgba8unorm';
 export const g = makeTestGroup(AllFeaturesMaxLimitsGPUTest);
 
 g.test('render_pass_resolve')
+  .desc(
+    `
+Test basic render pass resolve behavior for combinations of:
+  - number of color attachments, some with and some without a resolveTarget
+  - {a single draw+resolve pass, one draw-store pass and one empty load-resolve pass}
+    (attempts to test known driver bugs with empty resolve passes)
+  - in the resolve pass, storeOp set to {'store', 'discard'}
+  - mip levels {0, 1} and array layers {0, 1}
+    TODO: cases where color attachment and resolve target don't have the same mip level
+  - resolveTarget {2d array layer, TODO: 3d slice} {0, >0} with {2d, TODO: 3d} resolveTarget
+    TODO: cases where color attachment and resolve target don't have the same z (slice or layer)
+  - TODO: test all renderable color formats
+  - TODO: test that any not-resolved attachments are rendered to correctly.
+  - TODO: test different loadOps
+  - TODO?: resolveTarget mip level {0, >0} (TODO?: different mip level from colorAttachment)
+  - TODO?: resolveTarget {2d array layer, TODO: 3d slice} {0, >0} with {2d, TODO: 3d} resolveTarget
+    (different z from colorAttachment)
+`
+  )
   .params(u =>
     u
+      .combine('separateResolvePass', [false, true])
       .combine('storeOperation', ['discard', 'store'] as const)
       .beginSubcases()
       .combine('numColorAttachments', [2, 4] as const)
@@ -93,61 +100,61 @@ g.test('render_pass_resolve')
     });
 
     const resolveTargets: GPUTexture[] = [];
-    const renderPassColorAttachments: GPURenderPassColorAttachment[] = [];
+    const drawPassAttachments: GPURenderPassColorAttachment[] = [];
+    const resolvePassAttachments: GPURenderPassColorAttachment[] = [];
 
     // The resolve target must be the same size as the color attachment. If we're resolving to mip
     // level 1, the resolve target base mip level should be 2x the color attachment size.
     const kResolveTargetSize = kSize << t.params.resolveTargetBaseMipLevel;
 
     for (let i = 0; i < t.params.numColorAttachments; i++) {
-      const colorAttachment = t.createTextureTracked({
-        format: kFormat,
-        size: { width: kSize, height: kSize, depthOrArrayLayers: 1 },
-        sampleCount: 4,
-        mipLevelCount: 1,
-        usage:
-          GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
-      });
-
-      if (t.params.slotsToResolve.includes(i)) {
-        const colorAttachment = t.createTextureTracked({
+      const colorAttachment = t
+        .createTextureTracked({
           format: kFormat,
-          size: { width: kSize, height: kSize, depthOrArrayLayers: 1 },
+          size: [kSize, kSize, 1],
           sampleCount: 4,
           mipLevelCount: 1,
           usage:
             GPUTextureUsage.COPY_DST | GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
-        });
+        })
+        .createView();
 
-        const resolveTarget = t.createTextureTracked({
+      let resolveTarget: GPUTextureView | undefined;
+      if (t.params.slotsToResolve.includes(i)) {
+        const resolveTargetTexture = t.createTextureTracked({
           format: kFormat,
-          size: {
-            width: kResolveTargetSize,
-            height: kResolveTargetSize,
-            depthOrArrayLayers: t.params.resolveTargetBaseArrayLayer + 1,
-          },
+          size: [kResolveTargetSize, kResolveTargetSize, t.params.resolveTargetBaseArrayLayer + 1],
           sampleCount: 1,
           mipLevelCount: t.params.resolveTargetBaseMipLevel + 1,
           usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
         });
+        resolveTargets.push(resolveTargetTexture);
 
-        // Clear to black for the load operation. After the draw, the top left half of the attachment
-        // will be white and the bottom right half will be black.
-        renderPassColorAttachments.push({
-          view: colorAttachment.createView(),
+        resolveTarget = resolveTargetTexture.createView({
+          baseMipLevel: t.params.resolveTargetBaseMipLevel,
+          baseArrayLayer: t.params.resolveTargetBaseArrayLayer,
+        });
+      }
+
+      // Clear to black for the load operation. After the draw, the top left half of the attachment
+      // will be white and the bottom right half will be black.
+      if (t.params.separateResolvePass) {
+        drawPassAttachments.push({
+          view: colorAttachment,
           clearValue: { r: 0.0, g: 0.0, b: 0.0, a: 0.0 },
           loadOp: 'clear',
-          storeOp: t.params.storeOperation,
-          resolveTarget: resolveTarget.createView({
-            baseMipLevel: t.params.resolveTargetBaseMipLevel,
-            baseArrayLayer: t.params.resolveTargetBaseArrayLayer,
-          }),
+          storeOp: 'store',
         });
-
-        resolveTargets.push(resolveTarget);
+        resolvePassAttachments.push({
+          view: colorAttachment,
+          resolveTarget,
+          loadOp: 'load',
+          storeOp: t.params.storeOperation,
+        });
       } else {
-        renderPassColorAttachments.push({
-          view: colorAttachment.createView(),
+        drawPassAttachments.push({
+          view: colorAttachment,
+          resolveTarget,
           clearValue: { r: 0.0, g: 0.0, b: 0.0, a: 0.0 },
           loadOp: 'clear',
           storeOp: t.params.storeOperation,
@@ -156,13 +163,14 @@ g.test('render_pass_resolve')
     }
 
     const encoder = t.device.createCommandEncoder();
-
-    const pass = encoder.beginRenderPass({
-      colorAttachments: renderPassColorAttachments,
-    });
+    const pass = encoder.beginRenderPass({ colorAttachments: drawPassAttachments });
     pass.setPipeline(pipeline);
     pass.draw(3);
     pass.end();
+    if (t.params.separateResolvePass) {
+      const pass = encoder.beginRenderPass({ colorAttachments: resolvePassAttachments });
+      pass.end();
+    }
     t.device.queue.submit([encoder.finish()]);
 
     // Verify the resolve targets contain the correct values. Note that we use z to specify the


### PR DESCRIPTION
It's been reported that empty resolve passes don't work on some drivers (Pixel 6, ARM Mali), at least when used natively in Vulkan.

There's a lot of TODOs still in this test, but at least this adds one thing. I moved those TODOs down to the test (even though they may or may not ultimately be all one test) and updated them slightly.

- [ ] TODO (probably after landing this): Run this on a device (ideally an instance of a device) that is known to have that bug and see if it fails!
  <https://gpuweb.github.io/cts/standalone/?runnow=1&q=webgpu:api,operation,render_pass,resolve:render_pass_resolve:*>

Issue: None

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
