### PR TITLE
Add feature tests for 3D texture with ASTC compressed formats

### DIFF
--- a/src/webgpu/api/validation/capability_checks/features/texture_formats.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/features/texture_formats.spec.ts
@@ -7,6 +7,7 @@ import { getGPU } from '../../../../../common/util/navigator_gpu.js';
 import { assert } from '../../../../../common/util/util.js';
 import { kCanvasTextureFormats } from '../../../../capability_info.js';
 import {
+  kASTCCompressedTextureFormats,
   kBCCompressedTextureFormats,
   getBlockInfoForTextureFormat,
   isDepthOrStencilTextureFormat,
@@ -170,6 +171,50 @@ g.test('texture_compression_bc_sliced_3d')
     t.expectValidationError(() => {
       t.createTextureTracked(descriptor);
     }, !supportsBC || !supportsBCSliced3D);
+  });
+
+g.test('texture_compression_astc_sliced_3d')
+  .desc(
+    `
+  Tests that creating a 3D texture with ASTC compressed format fails if the features don't contain
+  'texture-compression-astc' and 'texture-compression-astc-sliced-3d'.
+  `
+  )
+  .params(u =>
+    u
+      .combine('format', kASTCCompressedTextureFormats)
+      .combine('supportsASTC', [false, true])
+      .combine('supportsASTCSliced3D', [false, true])
+  )
+  .beforeAllSubcases(t => {
+    const { supportsASTC, supportsASTCSliced3D } = t.params;
+
+    const requiredFeatures: GPUFeatureName[] = [];
+    if (supportsASTC) {
+      requiredFeatures.push('texture-compression-astc');
+    }
+    if (supportsASTCSliced3D) {
+      requiredFeatures.push('texture-compression-astc-sliced-3d');
+    }
+
+    t.selectDeviceOrSkipTestCase({ requiredFeatures });
+  })
+  .fn(t => {
+    const { format, supportsASTC, supportsASTCSliced3D } = t.params;
+
+    t.skipIfTextureFormatNotSupported(format);
+    const info = getBlockInfoForTextureFormat(format);
+
+    const descriptor: GPUTextureDescriptor = {
+      size: [info.blockWidth, info.blockHeight, 1],
+      dimension: '3d',
+      format,
+      usage: GPUTextureUsage.TEXTURE_BINDING,
+    };
+
+    t.expectValidationError(() => {
+      t.createTextureTracked(descriptor);
+    }, !supportsASTC || !supportsASTCSliced3D);
   });
 
 g.test('canvas_configuration')

--- a/src/webgpu/format_info.ts
+++ b/src/webgpu/format_info.ts
@@ -1438,11 +1438,12 @@ const kASTCTextureFormatInfo = formatTableWithDefaults({
 /** An uncompressed (block size 1x1) format (regular | depth/stencil). */
 /* prettier-ignore */ export type UncompressedTextureFormat = keyof typeof kUncompressedTextureFormatInfo;
 
-/* prettier-ignore */ export const      kRegularTextureFormats: readonly      RegularTextureFormat[] = keysOf(     kRegularTextureFormatInfo);
-/* prettier-ignore */ export const   kSizedDepthStencilFormats: readonly   SizedDepthStencilFormat[] = keysOf(  kSizedDepthStencilFormatInfo);
-/* prettier-ignore */ export const kUnsizedDepthStencilFormats: readonly UnsizedDepthStencilFormat[] = keysOf(kUnsizedDepthStencilFormatInfo);
-/* prettier-ignore */ export const   kCompressedTextureFormats: readonly   CompressedTextureFormat[] = keysOf(  kCompressedTextureFormatInfo);
-/* prettier-ignore */ export const kBCCompressedTextureFormats: readonly   CompressedTextureFormat[] = keysOf(          kBCTextureFormatInfo);
+/* prettier-ignore */ export const        kRegularTextureFormats: readonly      RegularTextureFormat[] = keysOf(     kRegularTextureFormatInfo);
+/* prettier-ignore */ export const     kSizedDepthStencilFormats: readonly   SizedDepthStencilFormat[] = keysOf(  kSizedDepthStencilFormatInfo);
+/* prettier-ignore */ export const   kUnsizedDepthStencilFormats: readonly UnsizedDepthStencilFormat[] = keysOf(kUnsizedDepthStencilFormatInfo);
+/* prettier-ignore */ export const     kCompressedTextureFormats: readonly   CompressedTextureFormat[] = keysOf(  kCompressedTextureFormatInfo);
+/* prettier-ignore */ export const   kBCCompressedTextureFormats: readonly   CompressedTextureFormat[] = keysOf(          kBCTextureFormatInfo);
+/* prettier-ignore */ export const kASTCCompressedTextureFormats: readonly   CompressedTextureFormat[] = keysOf(        kASTCTextureFormatInfo);
 
 /* prettier-ignore */ export const        kColorTextureFormats: readonly        ColorTextureFormat[] = keysOf(       kColorTextureFormatInfo);
 /* prettier-ignore */ export const    kEncodableTextureFormats: readonly    EncodableTextureFormat[] = keysOf(   kEncodableTextureFormatInfo);


### PR DESCRIPTION
Issue:  https://github.com/gpuweb/cts/issues/3967

This PR  adds feature tests for 3D texture with ASTC compressed formats.

<img width="1840" alt="image" src="https://github.com/user-attachments/assets/85990bc9-ebb4-42f1-8da9-a33be124115d" />

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
