### PR TITLE
cameraCapture: Simplify codepaths, try to wait for a real frame

### DIFF
--- a/src/webgpu/web_platform/external_texture/video.spec.ts
+++ b/src/webgpu/web_platform/external_texture/video.spec.ts
@@ -10,7 +10,7 @@ TODO(#4364): Test camera capture with copyExternalImageToTexture (not necessaril
 `;
 
 import { makeTestGroup } from '../../../common/framework/test_group.js';
-import { resolveOnTimeout, unreachable } from '../../../common/util/util.js';
+import { unreachable } from '../../../common/util/util.js';
 import { GPUTest } from '../../gpu_test.js';
 import * as ttu from '../../texture_test_utils.js';
 import { TextureUploadingUtils } from '../../util/copy_to_texture.js';
@@ -657,16 +657,7 @@ compared with 2d canvas rendering result.
     let frameWidth: number, frameHeight: number;
     switch (path) {
       case 'HTMLVideoElement': {
-        const video = await getVideoElementFromCamera(t, constraints);
-        // Pause the video so we get consistent readbacks.
-        const paused = new Promise(resolve => {
-          video.onpause = resolve;
-        });
-        video.pause();
-        // FIXME: This doesn't work, still need the timeout
-        await paused;
-        //await resolveOnTimeout(10);
-
+        const video = await getVideoElementFromCamera(t, constraints, true);
         frameWidth = video.videoWidth;
         frameHeight = video.videoHeight;
         source = video;

--- a/src/webgpu/web_platform/util.ts
+++ b/src/webgpu/web_platform/util.ts
@@ -661,15 +661,12 @@ export async function getVideoElementFromCamera(
   }
   assert(foundNonBlankFrame, 'Failed to get a non-blank video frame');
 
-  // Pause the video so we get consistent readbacks.
   if (paused) {
-    const onpause = new Promise(resolve => {
+    // Pause the video so we get consistent readbacks.
+    await new Promise(resolve => {
       video.onpause = resolve;
+      video.pause();
     });
-    video.pause();
-    // FIXME: This doesn't work, still need the timeout
-    await onpause;
-    await resolveOnTimeout(10);
   }
 
   return video;


### PR DESCRIPTION
- Don't use fallback paths in camera capture; instead, have the test pick the exact path it's using, and parameterize over it. Test two paths: VideoFrame from MediaStreamTrackProcessor, and the old-fashioned HTMLVideoElement.
- Work around an issue where Chrome (at least on Mac) shows blank frames for a while after initializing the camera.
- I happened to notice that requesting different width/height from the camera is broken in Chrome in several ways, so added cases for that.
- Added a TODO for copyExternalImageToTexture from camera

These tests only worked in Chrome, and even then they were buggy (usually running the test on a blank first frame). Now, the HTMLVideoElement tests work in Safari.

Test failures are as follows, on an M1 Mac:
- Chrome: https://crbug.com/411656657
  - HTMLVideoElement passes some cases, but fails when a requested size is passed to getUserMedia().
  - VideoFrame fails due to incorrect color management (regardless of dstColorSpace).
- Safari:
  - HTMLVideoElement fails due to incorrect color management (regardless of dstColorSpace).
  - VideoFrame is skipped.
- Firefox: doesn't yet implement importExternalTexture.

Issue: fixes #4363, cc #4364

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
