### PR TITLE
Remove unload handler

### DIFF
--- a/src/common/runtime/helper/test_worker.ts
+++ b/src/common/runtime/helper/test_worker.ts
@@ -23,8 +23,7 @@ function unregisterAllServiceWorkers() {
 // important, so we try our best (and don't worry about shutdown performance or disabling bfcache).
 // (We could try 'visibilitychange', but since it can happen in the middle of the page lifetime,
 // it is more likely to have unintended consequences and would need to do different stuff.)
-// - 'unload' supposedly always disables the bfcache.
-window.addEventListener('unload', runShutdownTasks);
+// - 'unload' supposedly always disables the bfcache, but is deprecated in Chrome.
 // - 'beforeunload' may disable the bfcache but may be called more reliably than 'unload'.
 window.addEventListener('beforeunload', runShutdownTasks);
 // - 'pagehide' won't disable the bfcache but may be called more reliably than the others.


### PR DESCRIPTION
Chromium has deprecated 'unload' so this is causing a bunch of console spam on our test bots.

"Permissions policy violation: unload is not allowed in this document."

Issue: https://crbug.com/332934824

<hr>

**Requirements for PR author:**

- [ ] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [ ] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [ ] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
