### PR TITLE
Test onuncapturederror

### DIFF
--- a/src/webgpu/api/operation/uncapturederror.spec.ts
+++ b/src/webgpu/api/operation/uncapturederror.spec.ts
@@ -1,5 +1,5 @@
 export const description = `
-Tests for GPUDevice.onuncapturederror.
+Tests for GPUDevice.onuncapturederror / addEventListener('uncapturederror')
 `;
 
 import { makeTestGroup } from '../../../common/framework/test_group.js';
@@ -12,12 +12,14 @@ g.test('iff_uncaptured')
   .desc(
     `{validation, out-of-memory} error should fire uncapturederror iff not captured by a scope.`
   )
-  .params(u => u.combine('errorType', kGeneratableErrorScopeFilters))
+  .params(u => u
+    .combine('useOnuncapturederror', [false, true])
+    .combine('errorType', kGeneratableErrorScopeFilters))
   .fn(async t => {
-    const { errorType } = t.params;
+    const { useOnuncapturederror, errorType } = t.params;
     const uncapturedErrorEvent = await t.expectUncapturedError(() => {
       t.generateError(errorType);
-    });
+    }, useOnuncapturederror);
     t.expect(t.isInstanceOfError(errorType, uncapturedErrorEvent.error));
   });
 

--- a/src/webgpu/api/operation/uncapturederror.spec.ts
+++ b/src/webgpu/api/operation/uncapturederror.spec.ts
@@ -12,9 +12,11 @@ g.test('iff_uncaptured')
   .desc(
     `{validation, out-of-memory} error should fire uncapturederror iff not captured by a scope.`
   )
-  .params(u => u
-    .combine('useOnuncapturederror', [false, true])
-    .combine('errorType', kGeneratableErrorScopeFilters))
+  .params(u =>
+    u
+      .combine('useOnuncapturederror', [false, true])
+      .combine('errorType', kGeneratableErrorScopeFilters)
+  )
   .fn(async t => {
     const { useOnuncapturederror, errorType } = t.params;
     const uncapturedErrorEvent = await t.expectUncapturedError(() => {


### PR DESCRIPTION
New tests passing in Chrome, failing in Safari (as expected), and passing in Firefox except for OOM which already wasn't working.

Issue: fixes #4361

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
