### PR TITLE
Test 3D compressed formats in copyTextureToTexture

### DIFF
--- a/src/webgpu/api/operation/command_buffer/copyTextureToTexture.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/copyTextureToTexture.spec.ts
@@ -25,6 +25,7 @@ import {
   textureFormatsAreViewCompatible,
 } from '../../../format_info.js';
 import { AllFeaturesMaxLimitsGPUTest } from '../../../gpu_test.js';
+import { skipIfTextureAndFormatNotCompatibleForDevice } from '../../../shader/execution/expression/call/builtin/texture_utils.js';
 import * as ttu from '../../../texture_test_utils.js';
 import { checkElementsEqual } from '../../../util/check_contents.js';
 import { align } from '../../../util/math.js';
@@ -895,11 +896,6 @@ g.test('color_textures,compressed,non_array')
         );
       })
       .combine('dimension', kTextureDimensions)
-      .filter(
-        ({ dimension, srcFormat, dstFormat }) =>
-          textureDimensionAndFormatCompatible(dimension, srcFormat) &&
-          textureDimensionAndFormatCompatible(dimension, dstFormat)
-      )
       .beginSubcases()
       .combine('textureSizeInBlocks', [
         // The heights and widths in blocks are all power of 2
@@ -931,6 +927,8 @@ g.test('color_textures,compressed,non_array')
       srcCopyLevel,
       dstCopyLevel,
     } = t.params;
+    skipIfTextureAndFormatNotCompatibleForDevice(t, dimension, srcFormat);
+    skipIfTextureAndFormatNotCompatibleForDevice(t, dimension, dstFormat);
     t.skipIfCopyTextureToTextureNotSupportedForFormat(srcFormat, dstFormat);
     const { blockWidth: srcBlockWidth, blockHeight: srcBlockHeight } =
       getBlockInfoForColorTextureFormat(srcFormat);
@@ -1053,11 +1051,6 @@ g.test('color_textures,compressed,array')
         );
       })
       .combine('dimension', ['2d', '3d'] as const)
-      .filter(
-        ({ dimension, srcFormat, dstFormat }) =>
-          textureDimensionAndFormatCompatible(dimension, srcFormat) &&
-          textureDimensionAndFormatCompatible(dimension, dstFormat)
-      )
       .beginSubcases()
       .combine('textureSizeInBlocks', [
         // The heights and widths in blocks are all power of 2
@@ -1081,6 +1074,8 @@ g.test('color_textures,compressed,array')
     } = t.params;
     t.skipIfTextureFormatNotSupported(srcFormat, dstFormat);
     t.skipIfCopyTextureToTextureNotSupportedForFormat(srcFormat, dstFormat);
+    skipIfTextureAndFormatNotCompatibleForDevice(t, dimension, srcFormat);
+    skipIfTextureAndFormatNotCompatibleForDevice(t, dimension, dstFormat);
 
     const { blockWidth: srcBlockWidth, blockHeight: srcBlockHeight } =
       getBlockInfoForColorTextureFormat(srcFormat);

--- a/src/webgpu/shader/execution/expression/call/builtin/texture_utils.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/texture_utils.ts
@@ -17,6 +17,7 @@ import {
   isSintOrUintFormat,
   isStencilTextureFormat,
   kEncodableTextureFormats,
+  textureDimensionAndFormatCompatibleForDevice,
   textureViewDimensionAndFormatCompatibleForDevice,
 } from '../../../../../format_info.js';
 import { GPUTest } from '../../../../../gpu_test.js';
@@ -88,6 +89,17 @@ export function skipIfTextureViewAndFormatNotCompatibleForDevice(
   t.skipIf(
     !textureViewDimensionAndFormatCompatibleForDevice(t.device, viewDimension, format),
     `format: ${format} does not support viewDimension: ${viewDimension}`
+  );
+}
+
+export function skipIfTextureAndFormatNotCompatibleForDevice(
+  t: GPUTest,
+  dimension: GPUTextureDimension,
+  format: GPUTextureFormat
+) {
+  t.skipIf(
+    !textureDimensionAndFormatCompatibleForDevice(t.device, dimension, format),
+    `format: ${format} does not support dimension: ${dimension}`
   );
 }
 


### PR DESCRIPTION
Following https://github.com/gpuweb/cts/pull/4359, this CL adds tests for 3D compressed texture formats in `copyTextureToTexture`  when possible

Issues:
* #3967
* #3761

<img width="1726" alt="image" src="https://github.com/user-attachments/assets/b8222fa6-1da5-4164-8cc0-6b2759e3f81e" /> Now (left) Before (right)
<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
