### PR TITLE
Skip some requestAdapter_invalid_featureLevel tests in compat-only

### DIFF
--- a/src/webgpu/api/operation/adapter/requestAdapter.spec.ts
+++ b/src/webgpu/api/operation/adapter/requestAdapter.spec.ts
@@ -15,6 +15,7 @@ values and then checks the result to test the adapter for basic functionality.
 `;
 
 import { Fixture } from '../../../../common/framework/fixture.js';
+import { globalTestConfig } from '../../../../common/framework/test_config.js';
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { getGPU } from '../../../../common/util/navigator_gpu.js';
 import { assert, objectEquals, iterRange } from '../../../../common/util/util.js';
@@ -132,6 +133,11 @@ g.test('requestAdapter_invalid_featureLevel')
   .params(u => u.combine('featureLevel', [...validFeatureLevels, ...invalidFeatureLevels]))
   .fn(async t => {
     const { featureLevel } = t.params;
+    t.skipIf(
+      globalTestConfig.compatibility && (featureLevel === undefined || featureLevel === 'core'),
+      'core adapters are not available in compat-only'
+    );
+
     const adapter = await getGPU(t.rec).requestAdapter({ featureLevel });
 
     if (!validFeatureLevels.includes(featureLevel)) {


### PR DESCRIPTION
Issue: https://github.com/gpuweb/cts/issues/4372

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
