### PR TITLE
If ASTC Sliced 3D is supported, ASTC must be supported

### DIFF
--- a/src/webgpu/api/validation/capability_checks/features/texture_formats.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/features/texture_formats.spec.ts
@@ -542,6 +542,7 @@ g.test('check_capability_guarantees')
     `check any adapter returned by requestAdapter() must provide the following guarantees:
       - "texture-compression-bc" is supported or both "texture-compression-etc2" and "texture-compression-astc" are supported
       - either "texture-compression-bc" or "texture-compression-bc-sliced-3d" is supported, both must be supported.
+      - if "texture-compression-astc-sliced-3d" is supported, then "texture-compression-astc" must be supported.
     `
   )
   .fn(async t => {
@@ -551,16 +552,24 @@ g.test('check_capability_guarantees')
     const features = adapter.features;
 
     const supportsBC = features.has('texture-compression-bc');
-    const supportsETC2ASTC =
-      features.has('texture-compression-etc2') && features.has('texture-compression-astc');
     const supportsBCSliced3D = features.has('texture-compression-bc-sliced-3d');
+    const supportsASTC = features.has('texture-compression-astc');
+    const supportsASTCSliced3D = features.has('texture-compression-astc-sliced-3d');
+    const supportsETC2 = features.has('texture-compression-etc2');
 
-    t.expect(supportsBC || supportsETC2ASTC, 'Adapter must support BC or both ETC2 and ASTC');
+    t.expect(
+      supportsBC || (supportsETC2 && supportsASTC),
+      'Adapter must support BC or both ETC2 and ASTC'
+    );
 
     if (supportsBC || supportsBCSliced3D) {
       t.expect(
         supportsBC && supportsBCSliced3D,
         'If BC or BC Sliced 3D is supported, both must be'
       );
+    }
+
+    if (supportsASTCSliced3D) {
+      t.expect(supportsASTC, 'If ASTC Sliced 3D is supported, ASTC must be supported');
     }
   });


### PR DESCRIPTION
Issue: 
- https://github.com/gpuweb/cts/issues/3967

Spec: 
- https://github.com/gpuweb/gpuweb/pull/5169

<img width="1486" alt="image" src="https://github.com/user-attachments/assets/972c6ac3-1f13-4d02-b097-7eaad5f56b7d" />

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
