### PR TITLE
Fix usages of textureDimensionAndFormatCompatible

### DIFF
--- a/src/webgpu/api/operation/command_buffer/copyTextureToTexture.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/copyTextureToTexture.spec.ts
@@ -21,7 +21,7 @@ import {
   kDepthStencilFormats,
   kRegularTextureFormats,
   RegularTextureFormat,
-  textureDimensionAndFormatCompatible,
+  textureFormatAndDimensionPossiblyCompatible,
   textureFormatsAreViewCompatible,
 } from '../../../format_info.js';
 import { AllFeaturesMaxLimitsGPUTest } from '../../../gpu_test.js';
@@ -82,6 +82,9 @@ class F extends AllFeaturesMaxLimitsGPUTest {
     dstCopyLevel: number
   ): void {
     this.skipIfTextureFormatNotSupported(srcFormat, dstFormat);
+    this.skipIfCopyTextureToTextureNotSupportedForFormat(srcFormat, dstFormat);
+    this.skipIfTextureFormatAndDimensionNotCompatible(srcFormat, dimension);
+    this.skipIfTextureFormatAndDimensionNotCompatible(dstFormat, dimension);
 
     // If we're in compatibility mode and it's a compressed texture
     // then we need to render the texture to test the results of the copy.
@@ -802,8 +805,8 @@ g.test('color_textures,non_compressed,non_array')
       .combine('dimension', kTextureDimensions)
       .filter(
         ({ dimension, srcFormat, dstFormat }) =>
-          textureDimensionAndFormatCompatible(dimension, srcFormat) &&
-          textureDimensionAndFormatCompatible(dimension, dstFormat)
+          textureFormatAndDimensionPossiblyCompatible(dimension, srcFormat) &&
+          textureFormatAndDimensionPossiblyCompatible(dimension, dstFormat)
       )
       .beginSubcases()
       .expandWithParams(p => {
@@ -979,8 +982,8 @@ g.test('color_textures,non_compressed,array')
       .combine('dimension', ['2d', '3d'] as const)
       .filter(
         ({ dimension, srcFormat, dstFormat }) =>
-          textureDimensionAndFormatCompatible(dimension, srcFormat) &&
-          textureDimensionAndFormatCompatible(dimension, dstFormat)
+          textureFormatAndDimensionPossiblyCompatible(dimension, srcFormat) &&
+          textureFormatAndDimensionPossiblyCompatible(dimension, dstFormat)
       )
       .beginSubcases()
       .combine('textureSize', [
@@ -1071,11 +1074,6 @@ g.test('color_textures,compressed,array')
       srcCopyLevel,
       dstCopyLevel,
     } = t.params;
-    t.skipIfTextureFormatNotSupported(srcFormat, dstFormat);
-    t.skipIfCopyTextureToTextureNotSupportedForFormat(srcFormat, dstFormat);
-    t.skipIfTextureFormatAndDimensionNotCompatible(srcFormat, dimension);
-    t.skipIfTextureFormatAndDimensionNotCompatible(dstFormat, dimension);
-
     const { blockWidth: srcBlockWidth, blockHeight: srcBlockHeight } =
       getBlockInfoForColorTextureFormat(srcFormat);
     const { blockWidth: dstBlockWidth, blockHeight: dstBlockHeight } =

--- a/src/webgpu/api/operation/command_buffer/copyTextureToTexture.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/copyTextureToTexture.spec.ts
@@ -25,7 +25,6 @@ import {
   textureFormatsAreViewCompatible,
 } from '../../../format_info.js';
 import { AllFeaturesMaxLimitsGPUTest } from '../../../gpu_test.js';
-import { skipIfTextureAndFormatNotCompatibleForDevice } from '../../../shader/execution/expression/call/builtin/texture_utils.js';
 import * as ttu from '../../../texture_test_utils.js';
 import { checkElementsEqual } from '../../../util/check_contents.js';
 import { align } from '../../../util/math.js';
@@ -927,8 +926,8 @@ g.test('color_textures,compressed,non_array')
       srcCopyLevel,
       dstCopyLevel,
     } = t.params;
-    skipIfTextureAndFormatNotCompatibleForDevice(t, dimension, srcFormat);
-    skipIfTextureAndFormatNotCompatibleForDevice(t, dimension, dstFormat);
+    t.skipIfTextureFormatAndDimensionNotCompatible(srcFormat, dimension);
+    t.skipIfTextureFormatAndDimensionNotCompatible(dstFormat, dimension);
     t.skipIfCopyTextureToTextureNotSupportedForFormat(srcFormat, dstFormat);
     const { blockWidth: srcBlockWidth, blockHeight: srcBlockHeight } =
       getBlockInfoForColorTextureFormat(srcFormat);
@@ -1074,8 +1073,8 @@ g.test('color_textures,compressed,array')
     } = t.params;
     t.skipIfTextureFormatNotSupported(srcFormat, dstFormat);
     t.skipIfCopyTextureToTextureNotSupportedForFormat(srcFormat, dstFormat);
-    skipIfTextureAndFormatNotCompatibleForDevice(t, dimension, srcFormat);
-    skipIfTextureAndFormatNotCompatibleForDevice(t, dimension, dstFormat);
+    t.skipIfTextureFormatAndDimensionNotCompatible(srcFormat, dimension);
+    t.skipIfTextureFormatAndDimensionNotCompatible(dstFormat, dimension);
 
     const { blockWidth: srcBlockWidth, blockHeight: srcBlockHeight } =
       getBlockInfoForColorTextureFormat(srcFormat);

--- a/src/webgpu/api/operation/command_buffer/image_copy.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/image_copy.spec.ts
@@ -47,7 +47,7 @@ import {
   kDepthStencilFormats,
   kColorTextureFormats,
   depthStencilBufferTextureCopySupported,
-  textureDimensionAndFormatCompatible,
+  textureFormatAndDimensionPossiblyCompatible,
   depthStencilFormatAspectSize,
   DepthStencilFormat,
   ColorTextureFormat,
@@ -1218,7 +1218,9 @@ bytes in copy works for every format.
       .combine('format', kColorTextureFormats)
       .filter(formatCanBeTested)
       .combine('dimension', kTextureDimensions)
-      .filter(({ dimension, format }) => textureDimensionAndFormatCompatible(dimension, format))
+      .filter(({ dimension, format }) =>
+        textureFormatAndDimensionPossiblyCompatible(dimension, format)
+      )
       .beginSubcases()
       .combineWithParams(kRowsPerImageAndBytesPerRowParams.paddings)
       .expandWithParams(p => {
@@ -1240,7 +1242,8 @@ bytes in copy works for every format.
       initMethod,
       checkMethod,
     } = t.params;
-    t.skipIfTextureFormatNotSupported(t.params.format);
+    t.skipIfTextureFormatNotSupported(format);
+    t.skipIfTextureFormatAndDimensionNotCompatible(format, dimension);
     const info = getBlockInfoForTextureFormat(format);
     // For CopyB2T and CopyT2B we need to have bytesPerRow 256-aligned,
     // to make this happen we align the bytesInACompleteRow value and multiply
@@ -1321,7 +1324,9 @@ works for every format with 2d and 2d-array textures.
       .combine('format', kColorTextureFormats)
       .filter(formatCanBeTested)
       .combine('dimension', kTextureDimensions)
-      .filter(({ dimension, format }) => textureDimensionAndFormatCompatible(dimension, format))
+      .filter(({ dimension, format }) =>
+        textureFormatAndDimensionPossiblyCompatible(dimension, format)
+      )
       .beginSubcases()
       .combineWithParams(kOffsetsAndSizesParams.offsetsAndPaddings)
       .combine('copyDepth', kOffsetsAndSizesParams.copyDepth) // 2d and 2d-array textures
@@ -1352,6 +1357,7 @@ works for every format with 2d and 2d-array textures.
       rowsPerImageEqualsCopyHeight,
     } = t.params;
     t.skipIfTextureFormatNotSupported(format);
+    t.skipIfTextureFormatAndDimensionNotCompatible(format, dimension);
 
     // Skip test cases designed for special cases coverage on compatibility mode to save run time.
     if (!(t.isCompatibility && (format === 'r8snorm' || format === 'rg8snorm'))) {
@@ -1420,7 +1426,9 @@ for all formats. We pass origin and copyExtent as [number, number, number].`
       .combine('format', kColorTextureFormats)
       .filter(formatCanBeTested)
       .combine('dimension', kTextureDimensions)
-      .filter(({ dimension, format }) => textureDimensionAndFormatCompatible(dimension, format))
+      .filter(({ dimension, format }) =>
+        textureFormatAndDimensionPossiblyCompatible(dimension, format)
+      )
       .beginSubcases()
       .combine('originValueInBlocks', [0, 7, 8])
       .combine('copySizeValueInBlocks', [0, 7, 8])
@@ -1444,6 +1452,7 @@ for all formats. We pass origin and copyExtent as [number, number, number].`
       checkMethod,
     } = t.params;
     t.skipIfTextureFormatNotSupported(format);
+    t.skipIfTextureFormatAndDimensionNotCompatible(format, dimension);
     const info = getBlockInfoForColorTextureFormat(format);
 
     let originBlocks = [1, 1, 1];
@@ -1581,7 +1590,9 @@ TODO: Make a variant for depth-stencil formats.
       .combine('format', kColorTextureFormats)
       .filter(formatCanBeTested)
       .combine('dimension', ['2d', '3d'] as const)
-      .filter(({ dimension, format }) => textureDimensionAndFormatCompatible(dimension, format))
+      .filter(({ dimension, format }) =>
+        textureFormatAndDimensionPossiblyCompatible(dimension, format)
+      )
       .beginSubcases()
       .combineWithParams([
         // origin + copySize = texturePhysicalSizeAtMipLevel for all coordinates, 2d texture */
@@ -1641,6 +1652,8 @@ TODO: Make a variant for depth-stencil formats.
       checkMethod,
     } = t.params;
     t.skipIfTextureFormatNotSupported(format);
+    t.skipIfTextureFormatAndDimensionNotCompatible(format, dimension);
+
     const info = getBlockInfoForColorTextureFormat(format);
 
     const origin = {

--- a/src/webgpu/api/operation/resource_init/check_texture/texture_zero_init_test.ts
+++ b/src/webgpu/api/operation/resource_init/check_texture/texture_zero_init_test.ts
@@ -8,7 +8,7 @@ import { kTextureAspects, kTextureDimensions } from '../../../../capability_info
 import { GPUConst } from '../../../../constants.js';
 import {
   kUncompressedTextureFormats,
-  textureDimensionAndFormatCompatible,
+  textureFormatAndDimensionPossiblyCompatible,
   UncompressedTextureFormat,
   EncodableTextureFormat,
   isColorTextureFormat,
@@ -480,7 +480,7 @@ export const kTestParams = kUnitCaseParamsBuilder
   ])
   // [3] compressed formats
   .combine('format', kUncompressedTextureFormats)
-  .filter(({ dimension, format }) => textureDimensionAndFormatCompatible(dimension, format))
+  .filter(({ dimension, format }) => textureFormatAndDimensionPossiblyCompatible(dimension, format))
   .beginSubcases()
   .combine('aspect', kTextureAspects)
   .unless(({ readMethod, format, aspect }) => {

--- a/src/webgpu/api/operation/resource_init/texture_zero.spec.ts
+++ b/src/webgpu/api/operation/resource_init/texture_zero.spec.ts
@@ -42,6 +42,7 @@ g.test('uninitialized_texture_is_zero')
   .params(kTestParams)
   .fn(t => {
     t.skipIfTextureFormatNotSupportedForTest(t.params);
+    t.skipIfTextureFormatAndDimensionNotCompatible(t.params.format, t.params.dimension);
 
     const usage = getRequiredTextureUsage(
       t.params.format,

--- a/src/webgpu/api/validation/createTexture.spec.ts
+++ b/src/webgpu/api/validation/createTexture.spec.ts
@@ -12,7 +12,7 @@ import {
   kRegularTextureFormats,
   kFeaturesForFormats,
   filterFormatsByFeature,
-  textureDimensionAndFormatCompatible,
+  textureFormatAndDimensionPossiblyCompatible,
   getBlockInfoForTextureFormat,
   isTextureFormatMultisampled,
   isTextureFormatColorRenderable,
@@ -53,11 +53,15 @@ g.test('zero_size_and_usage')
         'usage',
       ] as const)
       // Filter out incompatible dimension type and format combinations.
-      .filter(({ dimension, format }) => textureDimensionAndFormatCompatible(dimension, format))
+      .filter(({ dimension, format }) =>
+        textureFormatAndDimensionPossiblyCompatible(dimension, format)
+      )
   )
   .fn(t => {
     const { dimension, zeroArgument, format } = t.params;
     t.skipIfTextureFormatNotSupported(format);
+    t.skipIfTextureFormatAndDimensionNotCompatible(format, dimension);
+
     const info = getBlockInfoForTextureFormat(format);
 
     const size = [info.blockWidth, info.blockHeight, 1];
@@ -141,13 +145,16 @@ g.test('mipLevelCount,format')
       .beginSubcases()
       .combine('mipLevelCount', [1, 2, 3, 6, 7])
       // Filter out incompatible dimension type and format combinations.
-      .filter(({ dimension, format }) => textureDimensionAndFormatCompatible(dimension, format))
+      .filter(({ dimension, format }) =>
+        textureFormatAndDimensionPossiblyCompatible(dimension, format)
+      )
       .combine('largestDimension', [0, 1, 2])
       .unless(({ dimension, largestDimension }) => dimension === '1d' && largestDimension > 0)
   )
   .fn(t => {
     const { dimension, format, mipLevelCount, largestDimension } = t.params;
     t.skipIfTextureFormatNotSupported(format);
+    t.skipIfTextureFormatAndDimensionNotCompatible(format, dimension);
     const info = getBlockInfoForTextureFormat(format);
 
     // Compute dimensions such that the dimensions are in range [17, 32] and aligned with the
@@ -325,7 +332,9 @@ g.test('sampleCount,valid_sampleCount_with_other_parameter_varies')
         return usageSet;
       })
       // Filter out incompatible dimension type and format combinations.
-      .filter(({ dimension, format }) => textureDimensionAndFormatCompatible(dimension, format))
+      .filter(({ dimension, format }) =>
+        textureFormatAndDimensionPossiblyCompatible(dimension, format)
+      )
       .unless(({ usage, format, mipLevelCount, dimension }) => {
         return (
           ((usage & GPUConst.TextureUsage.RENDER_ATTACHMENT) !== 0 &&
@@ -340,6 +349,7 @@ g.test('sampleCount,valid_sampleCount_with_other_parameter_varies')
   .fn(t => {
     const { dimension, sampleCount, format, mipLevelCount, arrayLayerCount, usage } = t.params;
     t.skipIfTextureFormatNotSupported(format);
+    t.skipIfTextureFormatAndDimensionNotCompatible(format, dimension);
     if ((usage & GPUConst.TextureUsage.RENDER_ATTACHMENT) !== 0) {
       t.skipIfTextureFormatNotUsableAsRenderAttachment(format);
     }
@@ -416,11 +426,14 @@ g.test('texture_size,default_value_and_smallest_size,uncompressed_format')
       .beginSubcases()
       .combine('size', [[1], [1, 1], [1, 1, 1]])
       // Filter out incompatible dimension type and format combinations.
-      .filter(({ dimension, format }) => textureDimensionAndFormatCompatible(dimension, format))
+      .filter(({ dimension, format }) =>
+        textureFormatAndDimensionPossiblyCompatible(dimension, format)
+      )
   )
   .fn(t => {
     const { dimension, format, size } = t.params;
     t.skipIfTextureFormatNotSupported(format);
+    t.skipIfTextureFormatAndDimensionNotCompatible(format, dimension);
 
     const descriptor: GPUTextureDescriptor = {
       size,
@@ -439,9 +452,12 @@ g.test('texture_size,default_value_and_smallest_size,compressed_format')
   )
   .params(u =>
     u
-      // Compressed formats are invalid for 1D and 3D.
-      .combine('dimension', [undefined, '2d'] as const)
+      // Compressed formats are invalid for 1D.
+      .combine('dimension', [undefined, '2d', '3d'] as const)
       .combine('format', kCompressedTextureFormats)
+      .filter(({ dimension, format }) =>
+        textureFormatAndDimensionPossiblyCompatible(dimension, format)
+      )
       .beginSubcases()
       .expandWithParams(p => {
         const { blockWidth, blockHeight } = getBlockInfoForTextureFormat(p.format);
@@ -458,6 +474,7 @@ g.test('texture_size,default_value_and_smallest_size,compressed_format')
   .fn(t => {
     const { dimension, format, size, _success } = t.params;
     t.skipIfTextureFormatNotSupported(format);
+    t.skipIfTextureFormatAndDimensionNotCompatible(format, dimension);
 
     const descriptor: GPUTextureDescriptor = {
       size,
@@ -770,6 +787,7 @@ g.test('texture_size,3d_texture,uncompressed_format')
   .fn(t => {
     const { format, sizeVariant } = t.params;
     t.skipIfTextureFormatNotSupported(format);
+    t.skipIfTextureFormatAndDimensionNotCompatible(format, '3d');
     const maxTextureDimension3D = t.device.limits.maxTextureDimension3D;
     const size = sizeVariant.map(variant => t.makeLimitVariant('maxTextureDimension3D', variant));
 
@@ -945,13 +963,10 @@ g.test('texture_size,3d_texture,compressed_format')
         ];
       })
   )
-  .beforeAllSubcases(t => {
-    // Compressed formats are not supported in 3D in WebGPU v1 because they are complicated but not very useful for now.
-    t.skip('Compressed 3D texture is not supported');
-  })
   .fn(t => {
     const { format, sizeVariant } = t.params;
     t.skipIfTextureFormatNotSupported(format);
+    t.skipIfTextureFormatAndDimensionNotCompatible(format, '3d');
     const info = getBlockInfoForTextureFormat(format);
 
     const maxTextureDimension3D = t.device.limits.maxTextureDimension3D;
@@ -974,7 +989,8 @@ g.test('texture_size,3d_texture,compressed_format')
       size[1] % info.blockHeight === 0 &&
       size[0] <= maxTextureDimension3D &&
       size[1] <= maxTextureDimension3D &&
-      size[2] <= maxTextureDimension3D;
+      size[2] <= maxTextureDimension3D &&
+      textureDimensionAndFormatCompatibleForDevice(t.device, '3d', format);
 
     t.expectValidationError(() => {
       t.createTextureTracked(descriptor);
@@ -994,11 +1010,14 @@ g.test('texture_usage')
       .combine('usage0', kTextureUsages)
       .combine('usage1', kTextureUsages)
       // Filter out incompatible dimension type and format combinations.
-      .filter(({ dimension, format }) => textureDimensionAndFormatCompatible(dimension, format))
+      .filter(({ dimension, format }) =>
+        textureFormatAndDimensionPossiblyCompatible(dimension, format)
+      )
   )
   .fn(t => {
     const { dimension, format, usage0, usage1 } = t.params;
     t.skipIfTextureFormatNotSupported(format);
+    t.skipIfTextureFormatAndDimensionNotCompatible(format, dimension);
     const info = getBlockInfoForTextureFormat(format);
 
     const size = [info.blockWidth, info.blockHeight, 1];

--- a/src/webgpu/api/validation/image_copy/buffer_related.spec.ts
+++ b/src/webgpu/api/validation/image_copy/buffer_related.spec.ts
@@ -7,7 +7,7 @@ import {
   getBlockInfoForSizedTextureFormat,
   isDepthOrStencilTextureFormat,
   kSizedTextureFormats,
-  textureDimensionAndFormatCompatible,
+  textureFormatAndDimensionPossiblyCompatible,
 } from '../../../format_info.js';
 import { kResourceStates } from '../../../gpu_test.js';
 import { kImageCopyTypes } from '../../../util/texture/layout.js';
@@ -160,7 +160,9 @@ Test that bytesPerRow must be a multiple of 256 for CopyB2T and CopyT2B if it is
       .combine('format', kSizedTextureFormats)
       .filter(formatCopyableWithMethod)
       .combine('dimension', kTextureDimensions)
-      .filter(({ dimension, format }) => textureDimensionAndFormatCompatible(dimension, format))
+      .filter(({ dimension, format }) =>
+        textureFormatAndDimensionPossiblyCompatible(dimension, format)
+      )
       .beginSubcases()
       .combine('bytesPerRow', [undefined, 0, 1, 255, 256, 257, 512])
       .combine('copyHeightInBlocks', [0, 1, 2, 3])
@@ -188,6 +190,7 @@ Test that bytesPerRow must be a multiple of 256 for CopyB2T and CopyT2B if it is
     const { method, dimension, format, bytesPerRow, copyHeightInBlocks, _textureHeightInBlocks } =
       t.params;
     t.skipIfTextureFormatNotSupported(format);
+    t.skipIfTextureFormatAndDimensionNotCompatible(format, dimension);
 
     const info = getBlockInfoForSizedTextureFormat(format);
 

--- a/src/webgpu/api/validation/image_copy/layout_related.spec.ts
+++ b/src/webgpu/api/validation/image_copy/layout_related.spec.ts
@@ -7,7 +7,7 @@ import { assert } from '../../../../common/util/util.js';
 import { kTextureDimensions } from '../../../capability_info.js';
 import {
   kSizedTextureFormats,
-  textureDimensionAndFormatCompatible,
+  textureFormatAndDimensionPossiblyCompatible,
   getBlockInfoForTextureFormat,
   isDepthOrStencilTextureFormat,
   getBlockInfoForSizedTextureFormat,
@@ -141,7 +141,9 @@ Test the computation of requiredBytesInCopy by computing the minimum data size f
       .combine('format', kSizedTextureFormats)
       .filter(formatCopyableWithMethod)
       .combine('dimension', kTextureDimensions)
-      .filter(({ dimension, format }) => textureDimensionAndFormatCompatible(dimension, format))
+      .filter(({ dimension, format }) =>
+        textureFormatAndDimensionPossiblyCompatible(dimension, format)
+      )
       .beginSubcases()
       .combineWithParams([
         { bytesPerRowPadding: 0, rowsPerImagePaddingInBlocks: 0 }, // no padding
@@ -191,6 +193,7 @@ Test the computation of requiredBytesInCopy by computing the minimum data size f
       method,
     } = t.params;
     t.skipIfTextureFormatNotSupported(format);
+    t.skipIfTextureFormatAndDimensionNotCompatible(format, dimension);
     const info = getBlockInfoForSizedTextureFormat(format);
 
     // In the CopyB2T and CopyT2B cases we need to have bytesPerRow 256-aligned,
@@ -241,7 +244,9 @@ Test that rowsPerImage has no alignment constraints.
       .combine('format', kSizedTextureFormats)
       .filter(formatCopyableWithMethod)
       .combine('dimension', kTextureDimensions)
-      .filter(({ dimension, format }) => textureDimensionAndFormatCompatible(dimension, format))
+      .filter(({ dimension, format }) =>
+        textureFormatAndDimensionPossiblyCompatible(dimension, format)
+      )
       .beginSubcases()
       .expand('rowsPerImage', texelBlockAlignmentTestExpanderForRowsPerImage)
       // Copy height is info.blockHeight, so rowsPerImage must be equal or greater than it.
@@ -251,14 +256,16 @@ Test that rowsPerImage has no alignment constraints.
       )
   )
   .fn(t => {
-    const { rowsPerImage, format, method } = t.params;
+    const { rowsPerImage, format, dimension, method } = t.params;
     t.skipIfTextureFormatNotSupported(format);
+    t.skipIfTextureFormatAndDimensionNotCompatible(format, dimension);
     const info = getBlockInfoForSizedTextureFormat(format);
 
     const size = { width: info.blockWidth, height: info.blockHeight, depthOrArrayLayers: 1 };
     const texture = t.createTextureTracked({
       size,
       format,
+      dimension,
       usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.COPY_DST,
     });
 
@@ -285,19 +292,23 @@ Test the alignment requirement on the linear data offset (block size, or 4 for d
       .combine('format', kSizedTextureFormats)
       .filter(formatCopyableWithMethod)
       .combine('dimension', kTextureDimensions)
-      .filter(({ dimension, format }) => textureDimensionAndFormatCompatible(dimension, format))
+      .filter(({ dimension, format }) =>
+        textureFormatAndDimensionPossiblyCompatible(dimension, format)
+      )
       .beginSubcases()
       .expand('offset', texelBlockAlignmentTestExpanderForOffset)
   )
   .fn(t => {
-    const { format, offset, method } = t.params;
+    const { format, dimension, offset, method } = t.params;
     t.skipIfTextureFormatNotSupported(format);
+    t.skipIfTextureFormatAndDimensionNotCompatible(format, dimension);
     const info = getBlockInfoForSizedTextureFormat(format);
 
     const size = { width: info.blockWidth, height: info.blockHeight, depthOrArrayLayers: 1 };
     const texture = t.createTextureTracked({
       size,
       format,
+      dimension,
       usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.COPY_DST,
     });
 
@@ -334,7 +345,9 @@ Test that bytesPerRow, if specified must be big enough for a full copy row.
       .combine('format', kSizedTextureFormats)
       .filter(formatCopyableWithMethod)
       .combine('dimension', kTextureDimensions)
-      .filter(({ dimension, format }) => textureDimensionAndFormatCompatible(dimension, format))
+      .filter(({ dimension, format }) =>
+        textureFormatAndDimensionPossiblyCompatible(dimension, format)
+      )
       .beginSubcases()
       .combine('copyHeightInBlocks', [1, 2])
       .combine('copyDepth', [1, 2])
@@ -394,6 +407,7 @@ Test that bytesPerRow, if specified must be big enough for a full copy row.
     const {
       method,
       format,
+      dimension,
       bytesPerRow,
       widthInBlocks,
       copyWidthInBlocks,
@@ -402,15 +416,21 @@ Test that bytesPerRow, if specified must be big enough for a full copy row.
       _success,
     } = t.params;
     t.skipIfTextureFormatNotSupported(format);
+    t.skipIfTextureFormatAndDimensionNotCompatible(format, dimension);
     const info = getBlockInfoForSizedTextureFormat(format);
 
     // We create an aligned texture using the widthInBlocks which may be different from the
     // copyWidthInBlocks. This allows us to test scenarios where the two may be different.
-    const texture = t.createAlignedTexture(format, {
-      width: widthInBlocks * info.blockWidth,
-      height: copyHeightInBlocks * info.blockHeight,
-      depthOrArrayLayers: copyDepth,
-    });
+    const texture = t.createAlignedTexture(
+      format,
+      {
+        width: widthInBlocks * info.blockWidth,
+        height: copyHeightInBlocks * info.blockHeight,
+        depthOrArrayLayers: copyDepth,
+      },
+      { x: 0, y: 0, z: 0 },
+      dimension
+    );
 
     const layout = { bytesPerRow, rowsPerImage: copyHeightInBlocks };
     const copySize = {

--- a/src/webgpu/api/validation/image_copy/texture_related.spec.ts
+++ b/src/webgpu/api/validation/image_copy/texture_related.spec.ts
@@ -11,7 +11,7 @@ import {
   isDepthOrStencilTextureFormat,
   kColorTextureFormats,
   kSizedTextureFormats,
-  textureDimensionAndFormatCompatible,
+  textureFormatAndDimensionPossiblyCompatible,
 } from '../../../format_info.js';
 import { kResourceStates } from '../../../gpu_test.js';
 import { align } from '../../../util/math.js';
@@ -254,7 +254,9 @@ Test the copy must be a full subresource if the texture's format is depth/stenci
         { depthOrArrayLayers: 32, dimension: '3d' },
       ] as const)
       .combine('format', kSizedTextureFormats)
-      .filter(({ dimension, format }) => textureDimensionAndFormatCompatible(dimension, format))
+      .filter(({ dimension, format }) =>
+        textureFormatAndDimensionPossiblyCompatible(dimension, format)
+      )
       .filter(formatCopyableWithMethod)
       .beginSubcases()
       .combine('mipLevel', [0, 2])
@@ -280,6 +282,7 @@ Test the copy must be a full subresource if the texture's format is depth/stenci
       copyDepthModifier,
     } = t.params;
     t.skipIfTextureFormatNotSupported(format);
+    t.skipIfTextureFormatAndDimensionNotCompatible(format, dimension);
     const info = getBlockInfoForSizedTextureFormat(format);
 
     const size = { width: 32 * info.blockWidth, height: 32 * info.blockHeight, depthOrArrayLayers };
@@ -345,7 +348,9 @@ Test that the texture copy origin must be aligned to the format's block size.
         { depthOrArrayLayers: 3, dimension: '2d' },
         { depthOrArrayLayers: 3, dimension: '3d' },
       ] as const)
-      .filter(({ dimension, format }) => textureDimensionAndFormatCompatible(dimension, format))
+      .filter(({ dimension, format }) =>
+        textureFormatAndDimensionPossiblyCompatible(dimension, format)
+      )
       .beginSubcases()
       .combine('coordinateToTest', ['x', 'y', 'z'] as const)
       .unless(p => p.dimension === '1d' && p.coordinateToTest !== 'x')
@@ -355,6 +360,7 @@ Test that the texture copy origin must be aligned to the format's block size.
     const { valueToCoordinate, coordinateToTest, format, method, depthOrArrayLayers, dimension } =
       t.params;
     t.skipIfTextureFormatNotSupported(format);
+    t.skipIfTextureFormatAndDimensionNotCompatible(format, dimension);
     const info = getBlockInfoForTextureFormat(format);
     const size = { width: 0, height: 0, depthOrArrayLayers };
     const origin = { x: 0, y: 0, z: 0 };
@@ -399,7 +405,9 @@ Test that the copy size must be aligned to the texture's format's block size.
       .combine('format', kColorTextureFormats)
       .filter(formatCopyableWithMethod)
       .combine('dimension', kTextureDimensions)
-      .filter(({ dimension, format }) => textureDimensionAndFormatCompatible(dimension, format))
+      .filter(({ dimension, format }) =>
+        textureFormatAndDimensionPossiblyCompatible(dimension, format)
+      )
       .beginSubcases()
       .combine('coordinateToTest', ['width', 'height', 'depthOrArrayLayers'] as const)
       .unless(p => p.dimension === '1d' && p.coordinateToTest !== 'width')
@@ -408,6 +416,7 @@ Test that the copy size must be aligned to the texture's format's block size.
   .fn(t => {
     const { valueToCoordinate, coordinateToTest, dimension, format, method } = t.params;
     t.skipIfTextureFormatNotSupported(format);
+    t.skipIfTextureFormatAndDimensionNotCompatible(format, dimension);
     const info = getBlockInfoForColorTextureFormat(format);
     const size = { width: 0, height: 0, depthOrArrayLayers: 0 };
     const origin = { x: 0, y: 0, z: 0 };

--- a/src/webgpu/format_info.ts
+++ b/src/webgpu/format_info.ts
@@ -1866,10 +1866,13 @@ export function depthStencilFormatAspectSize(
  * Returns true iff a texture can be created with the provided GPUTextureDimension
  * (defaulting to 2d) and GPUTextureFormat, by spec.
  */
-export function textureDimensionAndFormatCompatible(
+export function textureFormatAndDimensionPossiblyCompatible(
   dimension: undefined | GPUTextureDimension,
   format: GPUTextureFormat
 ): boolean {
+  if (dimension === '3d' && (isBCTextureFormat(format) || isASTCTextureFormat(format))) {
+    return true;
+  }
   const info = kAllTextureFormatInfo[format];
   return !(
     (dimension === '1d' || dimension === '3d') &&
@@ -1893,7 +1896,11 @@ export function textureDimensionAndFormatCompatibleForDevice(
   ) {
     return true;
   }
-  return textureDimensionAndFormatCompatible(dimension, format);
+  const info = kAllTextureFormatInfo[format];
+  return !(
+    (dimension === '1d' || dimension === '3d') &&
+    (info.blockWidth > 1 || info.depth || info.stencil)
+  );
 }
 
 /**

--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -38,6 +38,8 @@ import {
   isTextureFormatUsableAsReadWriteStorageTexture,
   isDepthTextureFormat,
   isStencilTextureFormat,
+  textureViewDimensionAndFormatCompatibleForDevice,
+  textureDimensionAndFormatCompatibleForDevice,
 } from './format_info.js';
 import { checkElementsEqual, checkElementsBetween } from './util/check_contents.js';
 import { CommandBufferMaker, EncoderType } from './util/command_buffer_maker.js';
@@ -499,6 +501,26 @@ export class GPUTestBase extends Fixture<GPUTestSubcaseBatchState> {
         `texture format '${format}' requires feature: '${feature}`
       );
     }
+  }
+
+  skipIfTextureFormatAndViewDimensionNotCompatible(
+    format: GPUTextureFormat,
+    viewDimension: GPUTextureViewDimension
+  ) {
+    this.skipIf(
+      !textureViewDimensionAndFormatCompatibleForDevice(this.device, viewDimension, format),
+      `format: ${format} does not support viewDimension: ${viewDimension}`
+    );
+  }
+
+  skipIfTextureFormatAndDimensionNotCompatible(
+    format: GPUTextureFormat,
+    dimension: GPUTextureDimension
+  ) {
+    this.skipIf(
+      !textureDimensionAndFormatCompatibleForDevice(this.device, dimension, format),
+      `format: ${format} does not support dimension: ${dimension}`
+    );
   }
 
   skipIfTextureFormatNotResolvable(...formats: (GPUTextureFormat | undefined)[]) {

--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -515,7 +515,7 @@ export class GPUTestBase extends Fixture<GPUTestSubcaseBatchState> {
 
   skipIfTextureFormatAndDimensionNotCompatible(
     format: GPUTextureFormat,
-    dimension: GPUTextureDimension
+    dimension: GPUTextureDimension | undefined
   ) {
     this.skipIf(
       !textureDimensionAndFormatCompatibleForDevice(this.device, dimension, format),

--- a/src/webgpu/shader/execution/expression/call/builtin/textureDimensions.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureDimensions.spec.ts
@@ -18,7 +18,7 @@ import {
   kDepthTextureFormats,
   kPossibleStorageTextureFormats,
   sampleTypeForFormatAndAspect,
-  textureDimensionAndFormatCompatible,
+  textureFormatAndDimensionPossiblyCompatible,
 } from '../../../../../format_info.js';
 import { AllFeaturesMaxLimitsGPUTest, GPUTest } from '../../../../../gpu_test.js';
 import { align } from '../../../../../util/math.js';
@@ -126,7 +126,10 @@ function viewDimensions(params: {
   }
 
   return kAllViewDimensions.filter(dim =>
-    textureDimensionAndFormatCompatible(textureDimensionsForViewDimensions(dim), params.format)
+    textureFormatAndDimensionPossiblyCompatible(
+      textureDimensionsForViewDimensions(dim),
+      params.format
+    )
   );
 }
 
@@ -305,6 +308,10 @@ Parameters:
   .fn(t => {
     t.skipIfTextureFormatNotSupported(t.params.format);
     t.skipIfTextureViewDimensionNotSupported(t.params.dimensions);
+    t.skipIfTextureFormatAndDimensionNotCompatible(
+      t.params.format,
+      textureDimensionsForViewDimensions(t.params.dimensions)
+    );
     if (t.params.samples > 1) {
       t.skipIfTextureFormatNotMultisampled(t.params.format);
     }

--- a/src/webgpu/shader/execution/expression/call/builtin/textureLoad.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureLoad.spec.ts
@@ -22,7 +22,7 @@ import {
   isCompressedFloatTextureFormat,
   isDepthTextureFormat,
   kAllTextureFormats,
-  textureDimensionAndFormatCompatible,
+  textureFormatAndDimensionPossiblyCompatible,
   isCompressedTextureFormat,
   kPossibleMultisampledTextureFormats,
   kDepthTextureFormats,
@@ -98,7 +98,7 @@ Parameters:
     u
       .combine('stage', kShortShaderStages)
       .combine('format', kAllTextureFormats)
-      .filter(t => textureDimensionAndFormatCompatible('1d', t.format))
+      .filter(t => textureFormatAndDimensionPossiblyCompatible('1d', t.format))
       // 1d textures can't have a height !== 1
       .filter(t => !isCompressedTextureFormat(t.format))
       .beginSubcases()
@@ -109,6 +109,7 @@ Parameters:
   .fn(async t => {
     const { format, stage, C, L, samplePoints } = t.params;
     t.skipIfTextureFormatNotSupported(format);
+    t.skipIfTextureFormatAndDimensionNotCompatible(format, '1d');
 
     // We want at least 4 blocks or something wide enough for 3 mip levels.
     const [width] = chooseTextureSize({ minSize: 8, minBlocks: 4, format });
@@ -260,7 +261,8 @@ Parameters:
     u
       .combine('stage', kShortShaderStages)
       .combine('format', kAllTextureFormats)
-      .filter(t => textureDimensionAndFormatCompatible('3d', t.format))
+      .filter(t => textureFormatAndDimensionPossiblyCompatible('3d', t.format))
+      .filter(t => !isCompressedFloatTextureFormat(t.format))
       .beginSubcases()
       .combine('samplePoints', kSamplePointMethods)
       .combine('C', ['i32', 'u32'] as const)
@@ -269,6 +271,7 @@ Parameters:
   .fn(async t => {
     const { format, stage, samplePoints, C, L } = t.params;
     t.skipIfTextureFormatNotSupported(format);
+    t.skipIfTextureFormatAndDimensionNotCompatible(format, '3d');
 
     // We want at least 4 blocks or something wide enough for 3 mip levels.
     const size = chooseTextureSize({ minSize: 8, minBlocks: 4, format, viewDimension: '3d' });

--- a/src/webgpu/shader/execution/expression/call/builtin/textureSample.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureSample.spec.ts
@@ -38,7 +38,7 @@ import {
   getTextureTypeForTextureViewDimension,
   vec1,
   generateTextureBuiltinInputs1D,
-  skipIfTextureViewAndFormatNotCompatibleForDevice,
+  skipIfTextureViewAndFormatNotCompatibleForDeviceFoo,
 } from './texture_utils.js';
 
 export const g = makeTestGroup(AllFeaturesMaxLimitsGPUTest);
@@ -362,7 +362,7 @@ Parameters:
       offset,
     } = t.params;
     skipIfTextureFormatNotSupportedOrNeedsFilteringAndIsUnfilterable(t, minFilter, format);
-    skipIfTextureViewAndFormatNotCompatibleForDevice(t, format, viewDimension);
+    t.skipIfTextureFormatAndViewDimensionNotCompatible(format, viewDimension);
 
     const size = chooseTextureSize({ minSize: 8, minBlocks: 2, format, viewDimension });
     const descriptor: GPUTextureDescriptor = {

--- a/src/webgpu/shader/execution/expression/call/builtin/textureSample.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureSample.spec.ts
@@ -12,7 +12,7 @@ import {
   isDepthTextureFormat,
   kDepthStencilFormats,
   kAllTextureFormats,
-  textureDimensionAndFormatCompatible,
+  textureFormatAndDimensionPossiblyCompatible,
   isTextureFormatPossiblyFilterableAsTextureF32,
 } from '../../../../../format_info.js';
 import { AllFeaturesMaxLimitsGPUTest } from '../../../../../gpu_test.js';
@@ -38,7 +38,6 @@ import {
   getTextureTypeForTextureViewDimension,
   vec1,
   generateTextureBuiltinInputs1D,
-  skipIfTextureViewAndFormatNotCompatibleForDeviceFoo,
 } from './texture_utils.js';
 
 export const g = makeTestGroup(AllFeaturesMaxLimitsGPUTest);
@@ -58,7 +57,7 @@ Parameters:
   .params(u =>
     u
       .combine('format', kAllTextureFormats)
-      .filter(t => textureDimensionAndFormatCompatible('1d', t.format))
+      .filter(t => textureFormatAndDimensionPossiblyCompatible('1d', t.format))
       .filter(t => isPotentiallyFilterableAndFillable(t.format))
       .combine('filt', ['nearest', 'linear'] as const)
       .combine('modeU', kShortAddressModes)
@@ -67,6 +66,7 @@ Parameters:
   )
   .fn(async t => {
     const { format, samplePoints, modeU, filt: minFilter } = t.params;
+    t.skipIfTextureFormatAndDimensionNotCompatible(format, '1d');
     skipIfTextureFormatNotSupportedOrNeedsFilteringAndIsUnfilterable(t, minFilter, format);
 
     // We want at least 4 blocks or something wide enough for 3 mip levels.

--- a/src/webgpu/shader/execution/expression/call/builtin/textureSampleBias.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureSampleBias.spec.ts
@@ -33,7 +33,7 @@ import {
   isPotentiallyFilterableAndFillable,
   getTextureTypeForTextureViewDimension,
   skipIfTextureFormatNotSupportedOrNeedsFilteringAndIsUnfilterable,
-  skipIfTextureViewAndFormatNotCompatibleForDevice,
+  skipIfTextureViewAndFormatNotCompatibleForDeviceFoo,
 } from './texture_utils.js';
 
 export const g = makeTestGroup(AllFeaturesMaxLimitsGPUTest);
@@ -190,7 +190,7 @@ Parameters:
       offset,
     } = t.params;
     skipIfTextureFormatNotSupportedOrNeedsFilteringAndIsUnfilterable(t, minFilter, format);
-    skipIfTextureViewAndFormatNotCompatibleForDevice(t, format, viewDimension);
+    t.skipIfTextureFormatAndViewDimensionNotCompatible(format, viewDimension);
 
     const size = chooseTextureSize({ minSize: 8, minBlocks: 2, format, viewDimension });
     const descriptor: GPUTextureDescriptor = {

--- a/src/webgpu/shader/execution/expression/call/builtin/textureSampleBias.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureSampleBias.spec.ts
@@ -33,7 +33,6 @@ import {
   isPotentiallyFilterableAndFillable,
   getTextureTypeForTextureViewDimension,
   skipIfTextureFormatNotSupportedOrNeedsFilteringAndIsUnfilterable,
-  skipIfTextureViewAndFormatNotCompatibleForDeviceFoo,
 } from './texture_utils.js';
 
 export const g = makeTestGroup(AllFeaturesMaxLimitsGPUTest);

--- a/src/webgpu/shader/execution/expression/call/builtin/textureSampleGrad.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureSampleGrad.spec.ts
@@ -30,7 +30,7 @@ import {
   kShortShaderStages,
   SamplePointMethods,
   skipIfTextureFormatNotSupportedOrNeedsFilteringAndIsUnfilterable,
-  skipIfTextureViewAndFormatNotCompatibleForDevice,
+  skipIfTextureViewAndFormatNotCompatibleForDeviceFoo,
   TextureCall,
   vec2,
   vec3,
@@ -186,7 +186,7 @@ Parameters:
       offset,
     } = t.params;
     skipIfTextureFormatNotSupportedOrNeedsFilteringAndIsUnfilterable(t, minFilter, format);
-    skipIfTextureViewAndFormatNotCompatibleForDevice(t, format, viewDimension);
+    t.skipIfTextureFormatAndViewDimensionNotCompatible(format, viewDimension);
 
     const size = chooseTextureSize({ minSize: 8, minBlocks: 2, format, viewDimension });
     const descriptor: GPUTextureDescriptor = {

--- a/src/webgpu/shader/execution/expression/call/builtin/textureSampleGrad.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureSampleGrad.spec.ts
@@ -30,7 +30,6 @@ import {
   kShortShaderStages,
   SamplePointMethods,
   skipIfTextureFormatNotSupportedOrNeedsFilteringAndIsUnfilterable,
-  skipIfTextureViewAndFormatNotCompatibleForDeviceFoo,
   TextureCall,
   vec2,
   vec3,

--- a/src/webgpu/shader/execution/expression/call/builtin/textureSampleLevel.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureSampleLevel.spec.ts
@@ -32,7 +32,7 @@ import {
   kShortShaderStages,
   SamplePointMethods,
   skipIfTextureFormatNotSupportedOrNeedsFilteringAndIsUnfilterable,
-  skipIfTextureViewAndFormatNotCompatibleForDevice,
+  skipIfTextureViewAndFormatNotCompatibleForDeviceFoo,
   TextureCall,
   vec2,
   vec3,
@@ -405,7 +405,7 @@ Parameters:
       offset,
     } = t.params;
     skipIfTextureFormatNotSupportedOrNeedsFilteringAndIsUnfilterable(t, minFilter, format);
-    skipIfTextureViewAndFormatNotCompatibleForDevice(t, format, viewDimension);
+    t.skipIfTextureFormatAndViewDimensionNotCompatible(format, viewDimension);
 
     const [width, height] = chooseTextureSize({ minSize: 32, minBlocks: 2, format, viewDimension });
     const depthOrArrayLayers = getDepthOrArrayLayersForViewDimension(viewDimension);
@@ -521,7 +521,7 @@ baseMipLevel, lodMinClamp, and lodMaxClamp, with an dwithout filtering.
       lodMinClamp,
     } = t.params;
     skipIfTextureFormatNotSupportedOrNeedsFilteringAndIsUnfilterable(t, minFilter, format);
-    skipIfTextureViewAndFormatNotCompatibleForDevice(t, format, viewDimension);
+    t.skipIfTextureFormatAndViewDimensionNotCompatible(format, viewDimension);
 
     const [width, height] = chooseTextureSize({ minSize: 32, minBlocks: 2, format, viewDimension });
     const depthOrArrayLayers = getDepthOrArrayLayersForViewDimension(viewDimension);

--- a/src/webgpu/shader/execution/expression/call/builtin/textureSampleLevel.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureSampleLevel.spec.ts
@@ -32,7 +32,6 @@ import {
   kShortShaderStages,
   SamplePointMethods,
   skipIfTextureFormatNotSupportedOrNeedsFilteringAndIsUnfilterable,
-  skipIfTextureViewAndFormatNotCompatibleForDeviceFoo,
   TextureCall,
   vec2,
   vec3,

--- a/src/webgpu/shader/execution/expression/call/builtin/texture_utils.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/texture_utils.spec.ts
@@ -25,7 +25,6 @@ import {
   makeRandomDepthComparisonTexelGenerator,
   queryMipLevelMixWeightsForDevice,
   readTextureToTexelViews,
-  skipIfTextureViewAndFormatNotCompatibleForDevice,
   texelsApproximatelyEqual,
 } from './texture_utils.js';
 
@@ -52,7 +51,7 @@ g.test('createTextureWithRandomDataAndGetTexels_with_generator')
     const { format, viewDimension } = t.params;
     t.skipIfTextureFormatNotSupported(format);
     t.skipIfTextureViewDimensionNotSupported(viewDimension);
-    skipIfTextureViewAndFormatNotCompatibleForDevice(t, format, viewDimension);
+    t.skipIfTextureFormatAndViewDimensionNotCompatible(format, viewDimension);
     // choose an odd size (9) so we're more likely to test alignment issue.
     const size = chooseTextureSize({ minSize: 9, minBlocks: 4, format, viewDimension });
     t.debug(`size: ${size.map(v => v.toString()).join(', ')}`);
@@ -96,7 +95,7 @@ g.test('readTextureToTexelViews')
   .fn(async t => {
     const { srcFormat, texelViewFormat, viewDimension, sampleCount } = t.params;
     t.skipIfTextureViewDimensionNotSupported(viewDimension);
-    skipIfTextureViewAndFormatNotCompatibleForDevice(t, srcFormat, viewDimension);
+    t.skipIfTextureFormatAndViewDimensionNotCompatible(srcFormat, viewDimension);
     if (sampleCount > 1) {
       t.skipIfTextureFormatNotMultisampled(srcFormat);
     }

--- a/src/webgpu/shader/execution/expression/call/builtin/texture_utils.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/texture_utils.ts
@@ -17,8 +17,6 @@ import {
   isSintOrUintFormat,
   isStencilTextureFormat,
   kEncodableTextureFormats,
-  textureDimensionAndFormatCompatibleForDevice,
-  textureViewDimensionAndFormatCompatibleForDevice,
 } from '../../../../../format_info.js';
 import { GPUTest } from '../../../../../gpu_test.js';
 import {
@@ -80,28 +78,6 @@ export const kSampleTypeInfo = {
     format: 'rgba8uint',
   },
 } as const;
-
-export function skipIfTextureViewAndFormatNotCompatibleForDevice(
-  t: GPUTest,
-  format: GPUTextureFormat,
-  viewDimension: GPUTextureViewDimension
-) {
-  t.skipIf(
-    !textureViewDimensionAndFormatCompatibleForDevice(t.device, viewDimension, format),
-    `format: ${format} does not support viewDimension: ${viewDimension}`
-  );
-}
-
-export function skipIfTextureAndFormatNotCompatibleForDevice(
-  t: GPUTest,
-  dimension: GPUTextureDimension,
-  format: GPUTextureFormat
-) {
-  t.skipIf(
-    !textureDimensionAndFormatCompatibleForDevice(t.device, dimension, format),
-    `format: ${format} does not support dimension: ${dimension}`
-  );
-}
 
 /**
  * Return the texture type for a given view dimension


### PR DESCRIPTION
Sorry this is so big. Most of it is relatively search and replace

Fix usages of `textureDimensionAndFormatCompatible`.

All of these usages were wrong as they need the device to
know if a dimension and format are compatible since
extensions enable 3d dimension with compressed textures.

So, rename `textureDimensionAndFormatCompatible` to
`textureFormatAndDimensionAndPossiblyCompatible` to
let a test filter out formats that can't possibly
be used with certain dimensions. Then, for each test,
call `t.skipIfTextureFormatAndDimensionNotCompatible`
which checks the extensions.

Further, a few tests needed fixing.

copyTextureToTexture validation tests needed to handle
3d compress texture size limits correctly.

createTexture needed to not skip 3d compressed textures

layout_related needed to pass dimension to createAlignedTexture
and also, several tests had dimension as a test parameter but
didn't seem to be using it anywhere so added it into at least
texture creation on those tests.

expectTextureToMatchByRendering needed to handle 3d textures

texture_zero tests were mostly indirectly affected by
changes to texture_zero_init_test.ts. Nothing interesting
changed in this PR but the params there are extremely
convoluted and I didn't bother to decode exactly what
is going on in detail. I did glance over them and I think
they aren't skipping compressed textures.