### PR TITLE
If BC is supported, BC Sliced 3D must be supported

### DIFF
--- a/src/webgpu/api/validation/capability_checks/features/texture_formats.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/features/texture_formats.spec.ts
@@ -541,7 +541,7 @@ g.test('check_capability_guarantees')
   .desc(
     `check any adapter returned by requestAdapter() must provide the following guarantees:
       - "texture-compression-bc" is supported or both "texture-compression-etc2" and "texture-compression-astc" are supported
-      - either "texture-compression-bc" or "texture-compression-bc-sliced-3d" is supported, both must be supported.
+      - if "texture-compression-bc-sliced-3d" is supported, then "texture-compression-bc" must be supported.
       - if "texture-compression-astc-sliced-3d" is supported, then "texture-compression-astc" must be supported.
     `
   )
@@ -562,11 +562,8 @@ g.test('check_capability_guarantees')
       'Adapter must support BC or both ETC2 and ASTC'
     );
 
-    if (supportsBC || supportsBCSliced3D) {
-      t.expect(
-        supportsBC && supportsBCSliced3D,
-        'If BC or BC Sliced 3D is supported, both must be'
-      );
+    if (supportsBCSliced3D) {
+      t.expect(supportsBC, 'If BC Sliced 3D is supported, BC must be supported');
     }
 
     if (supportsASTCSliced3D) {


### PR DESCRIPTION
Spec PR: https://github.com/gpuweb/gpuweb/pull/5184

Issue: 
- https://github.com/gpuweb/cts/issues/3761

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
