### PR TITLE
Fix texture tests

### DIFF
--- a/src/webgpu/api/operation/command_buffer/image_copy.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/image_copy.spec.ts
@@ -59,6 +59,7 @@ import {
   getBlockInfoForColorTextureFormat,
   canCopyToAllAspectsOfTextureFormat,
   canCopyFromAllAspectsOfTextureFormat,
+  getMaxValidTextureSizeForFormatAndDimension,
 } from '../../../format_info.js';
 import { AllFeaturesMaxLimitsGPUTest } from '../../../gpu_test.js';
 import * as ttu from '../../../texture_test_utils.js';
@@ -1245,14 +1246,16 @@ bytes in copy works for every format.
     t.skipIfTextureFormatNotSupported(format);
     t.skipIfTextureFormatAndDimensionNotCompatible(format, dimension);
     const info = getBlockInfoForTextureFormat(format);
+    const maxSize = getMaxValidTextureSizeForFormatAndDimension(t.device, format, dimension);
+
     // For CopyB2T and CopyT2B we need to have bytesPerRow 256-aligned,
     // to make this happen we align the bytesInACompleteRow value and multiply
     // bytesPerRowPadding by 256.
     const bytesPerRowAlignment =
       initMethod === 'WriteTexture' && checkMethod === 'FullCopyT2B' ? 1 : 256;
 
-    const copyWidth = copyWidthInBlocks * info.blockWidth;
-    const copyHeight = copyHeightInBlocks * info.blockHeight;
+    const copyWidth = Math.min(copyWidthInBlocks * info.blockWidth, maxSize[0]);
+    const copyHeight = Math.min(copyHeightInBlocks * info.blockHeight, maxSize[1]);
     const rowsPerImage = copyHeightInBlocks + rowsPerImagePadding;
     const bytesPerRow =
       align(bytesInACompleteRow(copyWidth, format), bytesPerRowAlignment) +

--- a/src/webgpu/api/validation/createTexture.spec.ts
+++ b/src/webgpu/api/validation/createTexture.spec.ts
@@ -22,6 +22,7 @@ import {
   isColorTextureFormat,
   textureFormatsAreViewCompatible,
   textureDimensionAndFormatCompatibleForDevice,
+  getMaxValidTextureSizeForFormatAndDimension,
 } from '../../format_info.js';
 import { maxMipLevelCount } from '../../util/texture/base.js';
 
@@ -733,11 +734,9 @@ g.test('texture_size,2d_texture,compressed_format')
     const { dimension, format, sizeVariant } = t.params;
     t.skipIfTextureFormatNotSupported(format);
     const info = getBlockInfoForTextureFormat(format);
-    const size = [
-      t.device.limits.maxTextureDimension2D,
-      t.device.limits.maxTextureDimension2D,
-      t.device.limits.maxTextureArrayLayers,
-    ].map((limit, ndx) => makeValueTestVariant(limit, sizeVariant[ndx]));
+    const size = getMaxValidTextureSizeForFormatAndDimension(t.device, format, '2d').map(
+      (limit, ndx) => makeValueTestVariant(limit, sizeVariant[ndx])
+    );
 
     const descriptor: GPUTextureDescriptor = {
       size,
@@ -967,14 +966,10 @@ g.test('texture_size,3d_texture,compressed_format')
     const { format, sizeVariant } = t.params;
     t.skipIfTextureFormatNotSupported(format);
     t.skipIfTextureFormatAndDimensionNotCompatible(format, '3d');
-    const info = getBlockInfoForTextureFormat(format);
-
     const maxTextureDimension3D = t.device.limits.maxTextureDimension3D;
-    const size = sizeVariant.map(variant => t.makeLimitVariant('maxTextureDimension3D', variant));
-
-    assert(
-      maxTextureDimension3D % info.blockWidth === 0 &&
-        maxTextureDimension3D % info.blockHeight === 0
+    const info = getBlockInfoForTextureFormat(format);
+    const size = getMaxValidTextureSizeForFormatAndDimension(t.device, format, '3d').map(
+      (limit, ndx) => makeValueTestVariant(limit, sizeVariant[ndx])
     );
 
     const descriptor: GPUTextureDescriptor = {

--- a/src/webgpu/api/validation/image_copy/layout_related.spec.ts
+++ b/src/webgpu/api/validation/image_copy/layout_related.spec.ts
@@ -12,6 +12,7 @@ import {
   isDepthOrStencilTextureFormat,
   getBlockInfoForSizedTextureFormat,
   getBlockInfoForColorTextureFormat,
+  getMaxValidTextureSizeForFormatAndDimension,
 } from '../../../format_info.js';
 import { align } from '../../../util/math.js';
 import {
@@ -195,13 +196,14 @@ Test the computation of requiredBytesInCopy by computing the minimum data size f
     t.skipIfTextureFormatNotSupported(format);
     t.skipIfTextureFormatAndDimensionNotCompatible(format, dimension);
     const info = getBlockInfoForSizedTextureFormat(format);
+    const maxSize = getMaxValidTextureSizeForFormatAndDimension(t.device, format, dimension);
 
     // In the CopyB2T and CopyT2B cases we need to have bytesPerRow 256-aligned,
     // to make this happen we align the bytesInACompleteRow value and multiply
     // bytesPerRowPadding by 256.
     const bytesPerRowAlignment = method === 'WriteTexture' ? 1 : 256;
-    const copyWidth = copyWidthInBlocks * info.blockWidth;
-    const copyHeight = copyHeightInBlocks * info.blockHeight;
+    const copyWidth = Math.min(copyWidthInBlocks * info.blockWidth, maxSize[0]);
+    const copyHeight = Math.min(copyHeightInBlocks * info.blockHeight, maxSize[1]);
     const rowsPerImage = copyHeight + rowsPerImagePaddingInBlocks * info.blockHeight;
     const bytesPerRow =
       align(bytesInACompleteRow(copyWidth, format), bytesPerRowAlignment) +

--- a/src/webgpu/format_info.ts
+++ b/src/webgpu/format_info.ts
@@ -2,7 +2,7 @@ import { isCompatibilityDevice } from '../common/framework/test_config.js';
 import { keysOf } from '../common/util/data_tables.js';
 import { assert, unreachable } from '../common/util/util.js';
 
-import { align } from './util/math.js';
+import { align, roundDown } from './util/math.js';
 import { getTextureDimensionFromView } from './util/texture/base.js';
 import { ImageCopyType } from './util/texture/layout.js';
 
@@ -2434,4 +2434,34 @@ export function computeBytesPerSampleFromFormats(formats: readonly GPUTextureFor
  */
 export function computeBytesPerSample(targets: GPUColorTargetState[]) {
   return computeBytesPerSampleFromFormats(targets.map(({ format }) => format));
+}
+
+/**
+ * Returns the maximum valid size in each dimension for a given texture format.
+ * This is useful because compressed formats must be a multiple of blocks in size
+ * so, for example, the largest valid width of a 2d texture
+ * roundDown(device.limits.maxTextureDimension2D, blockWidth)
+ */
+export function getMaxValidTextureSizeForFormatAndDimension(
+  device: GPUDevice,
+  format: GPUTextureFormat,
+  dimension: GPUTextureDimension
+): [number, number, number] {
+  const info = getBlockInfoForTextureFormat(format);
+  switch (dimension) {
+    case '1d':
+      return [device.limits.maxTextureDimension1D, 1, 1];
+    case '2d':
+      return [
+        roundDown(device.limits.maxTextureDimension2D, info.blockWidth),
+        roundDown(device.limits.maxTextureDimension2D, info.blockHeight),
+        device.limits.maxTextureArrayLayers,
+      ];
+    case '3d':
+      return [
+        roundDown(device.limits.maxTextureDimension3D, info.blockWidth),
+        roundDown(device.limits.maxTextureDimension3D, info.blockHeight),
+        device.limits.maxTextureDimension3D,
+      ];
+  }
 }


### PR DESCRIPTION
* webgpu:api,operation,command_buffer,image_copy:rowsPerImage_and_bytesPerRow
* webgpu:api,validation,createTexture:texture_size,3d_texture,compressed_format
* webgpu:api,validation,image_copy,layout_related:required_bytes_in_copy

They all had issues related to the maximum size they were allowed to test and/or the valid max dimension of a compressed texture.

Added `getMaxValidTextureSizeForFormatAndDimension` which returns the maxiumum valid size for the given format and dimension. In other words it will be the device limit rounded down by block size where appropriate.

* #4380
* #4381
* #4382

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [X] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
