### PR TITLE
Pipeline error for out of bounds array with dynamic and offset

### DIFF
--- a/src/webgpu/shader/validation/expression/access/array.spec.ts
+++ b/src/webgpu/shader/validation/expression/access/array.spec.ts
@@ -378,7 +378,7 @@ const kOutOfBoundsCases: Record<string, OutOfBoundsCase> = {
     pipeline: true,
     value: 1,
   },
-  override_array_dynamic_tested_oob_pos: {
+  override_array_dynamic_type_checked_oob_pos: {
     code: `@group(0) @binding(0) var<storage> v : array<array<array<u32, 3>, 4>, 5>;
     override x : i32;
     override w = 0u;
@@ -391,7 +391,7 @@ const kOutOfBoundsCases: Record<string, OutOfBoundsCase> = {
     pipeline: true,
     value: 3,
   },
-  override_array_dynamic_tested_oob_neg: {
+  override_array_dynamic_type_checked_oob_neg: {
     code: `@group(0) @binding(0) var<storage> v : array<array<array<u32, 3>, 4>, 5>;
     override x : i32;
     override w = 0u;
@@ -404,7 +404,7 @@ const kOutOfBoundsCases: Record<string, OutOfBoundsCase> = {
     pipeline: true,
     value: -1,
   },
-  override_array_dynamic_tested: {
+  override_array_dynamic_type_checked_bounds: {
     code: `@group(0) @binding(0) var<storage> v : array<array<array<u32, 3>, 4>, 5>;
     override x : i32;
     override w = 0u;

--- a/src/webgpu/shader/validation/expression/access/array.spec.ts
+++ b/src/webgpu/shader/validation/expression/access/array.spec.ts
@@ -378,6 +378,45 @@ const kOutOfBoundsCases: Record<string, OutOfBoundsCase> = {
     pipeline: true,
     value: 1,
   },
+  override_array_dynamic_tested_oob_pos: {
+    code: `@group(0) @binding(0) var<storage> v : array<array<array<u32, 3>, 4>, 5>;
+    override x : i32;
+    override w = 0u;
+    fn y() -> u32 {
+      var u = 0;
+      let tmp = v[w][u][x];
+      return 0;
+    }`,
+    result: false,
+    pipeline: true,
+    value: 3,
+  },
+  override_array_dynamic_tested_oob_neg: {
+    code: `@group(0) @binding(0) var<storage> v : array<array<array<u32, 3>, 4>, 5>;
+    override x : i32;
+    override w = 0u;
+    fn y() -> u32 {
+      var u = 0;
+      let tmp = v[w][u][x];
+      return 0;
+    }`,
+    result: false,
+    pipeline: true,
+    value: -1,
+  },
+  override_array_dynamic_tested: {
+    code: `@group(0) @binding(0) var<storage> v : array<array<array<u32, 3>, 4>, 5>;
+    override x : i32;
+    override w = 0u;
+    fn y() -> u32 {
+      var u = 0;
+      let tmp = v[w][u][x];
+      return 0;
+    }`,
+    result: true,
+    pipeline: true,
+    value: 1,
+  },
 };
 
 g.test('early_eval_errors')


### PR DESCRIPTION
Const indices are validated against array types for bounds checking even if there is a dynamic index dependency on the array expression.

For example 
```
const q = array(array(14,2,3),array(1,7,3));

const o = 17;
fn compute() -> f32 {
  var a = 20;
  return f32(q[a][o]);
}
```
Will generate an out of bounds error (compile)
whereas currently we expect (but do not get) a pipeline error for 
```

const q = array(array(14,2,3),array(1,7,3));

const o = 17;
fn compute() -> f32 {
  var a = 20;
  return f32(q[a][o]);
}
```

crbug.com/415298444