### PR TITLE
Fix for running under deno

### DIFF
--- a/src/common/runtime/cmdline.ts
+++ b/src/common/runtime/cmdline.ts
@@ -1,7 +1,5 @@
 /* eslint-disable no-console, n/no-restricted-import */
 
-import * as fs from 'fs';
-
 import { dataCache } from '../framework/data_cache.js';
 import { getResourcePath, setBaseResourcePath } from '../framework/resources.js';
 import { globalTestConfig } from '../framework/test_config.js';
@@ -152,13 +150,16 @@ Did you remember to build with code coverage instrumentation enabled?`
 dataCache.setStore({
   load: (path: string) => {
     return new Promise<Uint8Array>((resolve, reject) => {
-      fs.readFile(getResourcePath(`cache/${path}`), (err, data) => {
-        if (err !== null) {
-          reject(err.message);
-        } else {
-          resolve(data);
+      sys.readFile(
+        getResourcePath(`cache/${path}`),
+        (err: { message: string }, data: Uint8Array) => {
+          if (err !== null) {
+            reject(err.message);
+          } else {
+            resolve(data);
+          }
         }
-      });
+      );
     });
   },
 });

--- a/src/common/runtime/helper/sys.ts
+++ b/src/common/runtime/helper/sys.ts
@@ -3,10 +3,11 @@
 
 function node() {
   /* eslint-disable-next-line n/no-restricted-require */
-  const { existsSync } = require('fs');
+  const { readFile, existsSync } = require('fs');
 
   return {
     type: 'node',
+    readFile,
     existsSync,
     args: process.argv.slice(2),
     cwd: () => process.cwd(),
@@ -16,6 +17,10 @@ function node() {
 
 declare global {
   namespace Deno {
+    function readFile(
+      path: string,
+      callback?: (error: unknown, data: string) => void
+    ): Promise<Uint8Array>;
     function readFileSync(path: string): Uint8Array;
     const args: string[];
     const cwd: () => string;
@@ -36,6 +41,7 @@ function deno() {
   return {
     type: 'deno',
     existsSync,
+    readFile: Deno.readFile,
     args: Deno.args,
     cwd: Deno.cwd,
     exit: Deno.exit,


### PR DESCRIPTION
Issue: #4123 

<hr>

**Requirements for PR author:**

- [ ] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [ ] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [ ] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
