### PR TITLE
Fix number_of_bind_group_layouts_exceeds_the_maximum_value test

### DIFF
--- a/src/webgpu/api/validation/createPipelineLayout.spec.ts
+++ b/src/webgpu/api/validation/createPipelineLayout.spec.ts
@@ -6,7 +6,7 @@ TODO: review existing tests, write descriptions, and make sure tests are complet
 
 import { AllFeaturesMaxLimitsGPUTest } from '../.././gpu_test.js';
 import { makeTestGroup } from '../../../common/framework/test_group.js';
-import { count } from '../../../common/util/util.js';
+import { count, range } from '../../../common/util/util.js';
 import {
   bufferBindingTypeInfo,
   getBindingLimitForBindingType,
@@ -104,8 +104,7 @@ g.test('number_of_bind_group_layouts_exceeds_the_maximum_value')
       entries: [],
     };
 
-    // 4 is the maximum number of bind group layouts.
-    const maxBindGroupLayouts = [1, 2, 3, 4].map(() =>
+    const maxBindGroupLayouts = range(t.device.limits.maxBindGroups, () =>
       t.device.createBindGroupLayout(bindGroupLayoutDescriptor)
     );
 


### PR DESCRIPTION
The tests changed from using the default limit to using the adapter's maximum limit but this test was still assuming the default limit. Fixed to expect the adapter's maximum limit.

* #4386



