### PR TITLE
Add some JavaScript inheritance tests.

### DIFF
--- a/src/webgpu/idl/javascript.spec.ts
+++ b/src/webgpu/idl/javascript.spec.ts
@@ -538,3 +538,27 @@ g.test('sameObject')
       assert(origValue2.foo === undefined);
     }
   });
+
+const kClassInheritanceTests: { [key: string]: () => boolean } = {
+  GPUDevice: () => GPUDevice.prototype instanceof EventTarget,
+  GPUPipelineError: () => GPUPipelineError.prototype instanceof DOMException,
+  GPUValidationError: () => GPUValidationError.prototype instanceof GPUError,
+  GPUOutOfMemoryError: () => GPUOutOfMemoryError.prototype instanceof GPUError,
+  GPUInternalError: () => GPUInternalError.prototype instanceof GPUError,
+  GPUUncapturedErrorEvent: () => GPUUncapturedErrorEvent.prototype instanceof Event,
+} as const;
+
+g.test('inheritance')
+  .desc(
+    `
+Test that objects inherit from the correct base class
+
+This is important because apps might patch the base class
+and expect instances of these classes to respond correctly.
+`
+  )
+  .params(u => u.combine('type', keysOf(kClassInheritanceTests)))
+  .fn(t => {
+    const fn = kClassInheritanceTests[t.params.type];
+    t.expect(fn(), fn.toString());
+  });


### PR DESCRIPTION
This is mostly for non-browser implementations to pass. dawn.node passes none of these. Working on getting it pass all of them. This is related to it correctly handling events.



