### PR TITLE
Test addEventListener works with EventListener & EventHandler

### DIFF
--- a/src/webgpu/idl/javascript.spec.ts
+++ b/src/webgpu/idl/javascript.spec.ts
@@ -676,3 +676,53 @@ Test some repercussions of the fact that GPUDevice extends EventTarget
   .fn(async t => {
     await kDispatchTests[t.params.test](t);
   });
+
+const kAddEventListenerTests = {
+  EventHandler: async (t: GPUTest) => {
+    const result = await raceWithRejectOnTimeout(
+      new Promise(resolve => {
+        t.device.addEventListener('foo', resolve, { once: true });
+        t.device.dispatchEvent(new Event('foo'));
+      }),
+      500,
+      'timeout'
+    );
+    const event = result as Event;
+    t.expect(() => event instanceof Event, 'event');
+    t.expect(() => event.type === 'foo');
+  },
+  EventListener: async (t: GPUTest) => {
+    const result = await raceWithRejectOnTimeout(
+      new Promise(resolve => {
+        t.device.addEventListener(
+          'foo',
+          {
+            handleEvent: resolve,
+          },
+          { once: true }
+        );
+        t.device.dispatchEvent(new Event('foo'));
+      }),
+      500,
+      'timeout'
+    );
+    const event = result as Event;
+    t.expect(() => event instanceof Event, 'event');
+    t.expect(() => event.type === 'foo');
+  },
+} as const;
+
+g.test('device,addEventListener')
+  .desc(
+    `
+Test that addEventListener works with both an EventListener and an EventHandler
+
+* https://dom.spec.whatwg.org/#interface-eventtarget
+* https://html.spec.whatwg.org/multipage/webappapis.html#eventhandler
+
+`
+  )
+  .params(u => u.combine('test', keysOf(kAddEventListenerTests)))
+  .fn(async t => {
+    await kAddEventListenerTests[t.params.test](t);
+  });


### PR DESCRIPTION
`addEventListener` can take both an `EventHandler` (a callback) and an `EventListener` (an object with a `handleEvent` method)

This passes on Chrome Canary, Firefox Nightly, and Safari TP