### PR TITLE
Follow common JavaScript style

### DIFF
--- a/src/webgpu/api/operation/command_buffer/copyTextureToTexture.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/copyTextureToTexture.spec.ts
@@ -37,7 +37,7 @@ import { findFailedPixels } from '../../../util/texture/texture_ok.js';
 const dataGenerator = new DataArrayGenerator();
 
 class F extends AllFeaturesMaxLimitsGPUTest {
-  GetInitialDataPerMipLevel(
+  getInitialDataPerMipLevel(
     dimension: GPUTextureDimension,
     textureSize: Required<GPUExtent3DDict>,
     format: ColorTextureFormat,
@@ -52,7 +52,7 @@ class F extends AllFeaturesMaxLimitsGPUTest {
     return dataGenerator.generateView(byteSize);
   }
 
-  GetInitialStencilDataPerMipLevel(
+  getInitialStencilDataPerMipLevel(
     textureSize: Required<GPUExtent3DDict>,
     format: DepthStencilFormat,
     mipLevel: number
@@ -67,7 +67,7 @@ class F extends AllFeaturesMaxLimitsGPUTest {
     return dataGenerator.generateView(byteSize);
   }
 
-  DoCopyTextureToTextureTest(
+  doCopyTextureToTextureTest(
     dimension: GPUTextureDimension,
     srcTextureSize: Required<GPUExtent3DDict>,
     dstTextureSize: Required<GPUExtent3DDict>,
@@ -113,7 +113,7 @@ class F extends AllFeaturesMaxLimitsGPUTest {
     const dstTexture = this.createTextureTracked(dstTextureDesc);
 
     // Fill the whole subresource of srcTexture at srcCopyLevel with initialSrcData.
-    const initialSrcData = this.GetInitialDataPerMipLevel(
+    const initialSrcData = this.getInitialDataPerMipLevel(
       dimension,
       srcTextureSize,
       srcFormat,
@@ -397,7 +397,7 @@ class F extends AllFeaturesMaxLimitsGPUTest {
     });
   }
 
-  InitializeStencilAspect(
+  initializeStencilAspect(
     sourceTexture: GPUTexture,
     initialStencilData: Uint8Array,
     srcCopyLevel: number,
@@ -417,7 +417,7 @@ class F extends AllFeaturesMaxLimitsGPUTest {
     );
   }
 
-  VerifyStencilAspect(
+  verifyStencilAspect(
     destinationTexture: GPUTexture,
     initialStencilData: Uint8Array,
     dstCopyLevel: number,
@@ -468,7 +468,7 @@ class F extends AllFeaturesMaxLimitsGPUTest {
     this.expectGPUBufferValuesEqual(outputBuffer, expectedStencilData);
   }
 
-  GetRenderPipelineForT2TCopyWithDepthTests(
+  getRenderPipelineForT2TCopyWithDepthTests(
     bindGroupLayout: GPUBindGroupLayout,
     hasColorAttachment: boolean,
     depthStencil: GPUDepthStencilState
@@ -515,7 +515,7 @@ class F extends AllFeaturesMaxLimitsGPUTest {
     return this.device.createRenderPipeline(renderPipelineDescriptor);
   }
 
-  GetBindGroupLayoutForT2TCopyWithDepthTests(): GPUBindGroupLayout {
+  getBindGroupLayoutForT2TCopyWithDepthTests(): GPUBindGroupLayout {
     return this.device.createBindGroupLayout({
       entries: [
         {
@@ -531,7 +531,7 @@ class F extends AllFeaturesMaxLimitsGPUTest {
     });
   }
 
-  GetBindGroupForT2TCopyWithDepthTests(
+  getBindGroupForT2TCopyWithDepthTests(
     bindGroupLayout: GPUBindGroupLayout,
     totalCopyArrayLayers: number
   ): GPUBindGroup {
@@ -562,7 +562,7 @@ class F extends AllFeaturesMaxLimitsGPUTest {
   }
 
   /** Initialize the depth aspect of sourceTexture with draw calls */
-  InitializeDepthAspect(
+  initializeDepthAspect(
     sourceTexture: GPUTexture,
     depthFormat: GPUTextureFormat,
     srcCopyLevel: number,
@@ -571,13 +571,13 @@ class F extends AllFeaturesMaxLimitsGPUTest {
   ): void {
     // Prepare a renderPipeline with depthCompareFunction == 'always' and depthWriteEnabled == true
     // for the initializations of the depth attachment.
-    const bindGroupLayout = this.GetBindGroupLayoutForT2TCopyWithDepthTests();
-    const renderPipeline = this.GetRenderPipelineForT2TCopyWithDepthTests(bindGroupLayout, false, {
+    const bindGroupLayout = this.getBindGroupLayoutForT2TCopyWithDepthTests();
+    const renderPipeline = this.getRenderPipelineForT2TCopyWithDepthTests(bindGroupLayout, false, {
       format: depthFormat,
       depthWriteEnabled: true,
       depthCompare: 'always',
     });
-    const bindGroup = this.GetBindGroupForT2TCopyWithDepthTests(bindGroupLayout, copySize[2]);
+    const bindGroup = this.getBindGroupForT2TCopyWithDepthTests(bindGroupLayout, copySize[2]);
 
     const hasStencil = isStencilTextureFormat(sourceTexture.format);
     const encoder = this.device.createCommandEncoder();
@@ -606,7 +606,7 @@ class F extends AllFeaturesMaxLimitsGPUTest {
     this.queue.submit([encoder.finish()]);
   }
 
-  VerifyDepthAspect(
+  verifyDepthAspect(
     destinationTexture: GPUTexture,
     depthFormat: GPUTextureFormat,
     dstCopyLevel: number,
@@ -615,13 +615,13 @@ class F extends AllFeaturesMaxLimitsGPUTest {
   ): void {
     // Prepare a renderPipeline with depthCompareFunction == 'equal' and depthWriteEnabled == false
     // for the comparison of the depth attachment.
-    const bindGroupLayout = this.GetBindGroupLayoutForT2TCopyWithDepthTests();
-    const renderPipeline = this.GetRenderPipelineForT2TCopyWithDepthTests(bindGroupLayout, true, {
+    const bindGroupLayout = this.getBindGroupLayoutForT2TCopyWithDepthTests();
+    const renderPipeline = this.getRenderPipelineForT2TCopyWithDepthTests(bindGroupLayout, true, {
       format: depthFormat,
       depthWriteEnabled: false,
       depthCompare: 'equal',
     });
-    const bindGroup = this.GetBindGroupForT2TCopyWithDepthTests(bindGroupLayout, copySize[2]);
+    const bindGroup = this.getBindGroupForT2TCopyWithDepthTests(bindGroupLayout, copySize[2]);
 
     const outputColorTexture = this.createTextureTracked({
       format: 'rgba8unorm',
@@ -861,7 +861,7 @@ g.test('color_textures,non_compressed,non_array')
       dstCopyLevel,
     } = t.params;
 
-    t.DoCopyTextureToTextureTest(
+    t.doCopyTextureToTextureTest(
       dimension,
       srcTextureSize,
       dstTextureSize,
@@ -937,7 +937,7 @@ g.test('color_textures,compressed,non_array')
     const { blockWidth: dstBlockWidth, blockHeight: dstBlockHeight } =
       getBlockInfoForColorTextureFormat(dstFormat);
 
-    t.DoCopyTextureToTextureTest(
+    t.doCopyTextureToTextureTest(
       dimension,
       {
         width: textureSizeInBlocks.src.width * srcBlockWidth,
@@ -1016,7 +1016,7 @@ g.test('color_textures,non_compressed,array')
       dstCopyLevel,
     } = t.params;
 
-    t.DoCopyTextureToTextureTest(
+    t.doCopyTextureToTextureTest(
       dimension,
       textureSize.srcTextureSize,
       textureSize.dstTextureSize,
@@ -1079,7 +1079,7 @@ g.test('color_textures,compressed,array')
     const { blockWidth: dstBlockWidth, blockHeight: dstBlockHeight } =
       getBlockInfoForColorTextureFormat(dstFormat);
 
-    t.DoCopyTextureToTextureTest(
+    t.doCopyTextureToTextureTest(
       dimension,
       {
         width: textureSizeInBlocks.src.width * srcBlockWidth,
@@ -1189,7 +1189,7 @@ g.test('zero_sized')
     const srcFormat = 'rgba8unorm';
     const dstFormat = 'rgba8unorm';
 
-    t.DoCopyTextureToTextureTest(
+    t.doCopyTextureToTextureTest(
       dimension,
       textureSize,
       textureSize,
@@ -1277,8 +1277,8 @@ g.test('copy_depth_stencil')
 
     let initialStencilData: undefined | Uint8Array = undefined;
     if (isStencilTextureFormat(format)) {
-      initialStencilData = t.GetInitialStencilDataPerMipLevel(srcTextureSize, format, srcCopyLevel);
-      t.InitializeStencilAspect(
+      initialStencilData = t.getInitialStencilDataPerMipLevel(srcTextureSize, format, srcCopyLevel);
+      t.initializeStencilAspect(
         sourceTexture,
         initialStencilData,
         srcCopyLevel,
@@ -1287,7 +1287,7 @@ g.test('copy_depth_stencil')
       );
     }
     if (isDepthTextureFormat(format)) {
-      t.InitializeDepthAspect(sourceTexture, format, srcCopyLevel, srcCopyBaseArrayLayer, copySize);
+      t.initializeDepthAspect(sourceTexture, format, srcCopyLevel, srcCopyBaseArrayLayer, copySize);
     }
 
     const encoder = t.device.createCommandEncoder();
@@ -1308,7 +1308,7 @@ g.test('copy_depth_stencil')
 
     if (isStencilTextureFormat(format)) {
       assert(initialStencilData !== undefined);
-      t.VerifyStencilAspect(
+      t.verifyStencilAspect(
         destinationTexture,
         initialStencilData,
         dstCopyLevel,
@@ -1317,7 +1317,7 @@ g.test('copy_depth_stencil')
       );
     }
     if (isDepthTextureFormat(format)) {
-      t.VerifyDepthAspect(
+      t.verifyDepthAspect(
         destinationTexture,
         format,
         dstCopyLevel,

--- a/src/webgpu/api/operation/command_buffer/image_copy.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/image_copy.spec.ts
@@ -737,7 +737,7 @@ class ImageCopyTest extends AllFeaturesMaxLimitsGPUTest {
     }
   }
 
-  DoUploadToStencilTest(
+  doUploadToStencilTest(
     format: DepthStencilFormat,
     textureSize: readonly [number, number, number],
     uploadMethod: 'WriteTexture' | 'CopyB2T',
@@ -832,7 +832,7 @@ class ImageCopyTest extends AllFeaturesMaxLimitsGPUTest {
     this.expectGPUBufferValuesEqual(outputBuffer, expectedData);
   }
 
-  DoCopyFromStencilTest(
+  doCopyFromStencilTest(
     format: DepthStencilFormat,
     textureSize: readonly [number, number, number],
     bytesPerRow: number,
@@ -1046,7 +1046,7 @@ class ImageCopyTest extends AllFeaturesMaxLimitsGPUTest {
     };
   }
 
-  DoCopyTextureToBufferWithDepthAspectTest(
+  doCopyTextureToBufferWithDepthAspectTest(
     format: DepthStencilFormat,
     copySize: readonly [number, number, number],
     bytesPerRowPadding: number,
@@ -1765,7 +1765,7 @@ g.test('undefined_params')
     });
   });
 
-function CopyMethodSupportedWithDepthStencilFormat(
+function copyMethodSupportedWithDepthStencilFormat(
   aspect: 'depth-only' | 'stencil-only',
   format: DepthStencilFormat,
   copyMethod: 'WriteTexture' | 'CopyB2T' | 'CopyT2B'
@@ -1800,7 +1800,7 @@ aspect and copyTextureToBuffer() with depth aspect.
       .combine('format', kDepthStencilFormats)
       .combine('copyMethod', ['WriteTexture', 'CopyB2T', 'CopyT2B'] as const)
       .combine('aspect', ['depth-only', 'stencil-only'] as const)
-      .filter(t => CopyMethodSupportedWithDepthStencilFormat(t.aspect, t.format, t.copyMethod))
+      .filter(t => copyMethodSupportedWithDepthStencilFormat(t.aspect, t.format, t.copyMethod))
       .beginSubcases()
       .combineWithParams(kRowsPerImageAndBytesPerRowParams.paddings)
       .combineWithParams(kRowsPerImageAndBytesPerRowParams.copySizes)
@@ -1838,7 +1838,7 @@ aspect and copyTextureToBuffer() with depth aspect.
     ] as const;
     if (copyMethod === 'CopyT2B') {
       if (aspect === 'depth-only') {
-        t.DoCopyTextureToBufferWithDepthAspectTest(
+        t.doCopyTextureToBufferWithDepthAspectTest(
           format,
           copySize,
           bytesPerRowPadding,
@@ -1848,7 +1848,7 @@ aspect and copyTextureToBuffer() with depth aspect.
           mipLevel
         );
       } else {
-        t.DoCopyFromStencilTest(format, textureSize, bytesPerRow, rowsPerImage, 0, mipLevel);
+        t.doCopyFromStencilTest(format, textureSize, bytesPerRow, rowsPerImage, 0, mipLevel);
       }
     } else {
       assert(
@@ -1861,7 +1861,7 @@ aspect and copyTextureToBuffer() with depth aspect.
         method: copyMethod,
       });
 
-      t.DoUploadToStencilTest(
+      t.doUploadToStencilTest(
         format,
         textureSize,
         copyMethod,
@@ -1890,7 +1890,7 @@ copyTextureToBuffer() with depth aspect.
       .combine('format', kDepthStencilFormats)
       .combine('copyMethod', ['WriteTexture', 'CopyB2T', 'CopyT2B'] as const)
       .combine('aspect', ['depth-only', 'stencil-only'] as const)
-      .filter(t => CopyMethodSupportedWithDepthStencilFormat(t.aspect, t.format, t.copyMethod))
+      .filter(t => copyMethodSupportedWithDepthStencilFormat(t.aspect, t.format, t.copyMethod))
       .beginSubcases()
       .combineWithParams(kOffsetsAndSizesParams.offsetsAndPaddings)
       .filter(t => t.offsetInBlocks % 4 === 0)
@@ -1910,9 +1910,9 @@ copyTextureToBuffer() with depth aspect.
     const textureSize = [copySize[0] << mipLevel, copySize[1] << mipLevel, copyDepth] as const;
     if (copyMethod === 'CopyT2B') {
       if (aspect === 'depth-only') {
-        t.DoCopyTextureToBufferWithDepthAspectTest(format, copySize, 0, 0, 0, 0, mipLevel);
+        t.doCopyTextureToBufferWithDepthAspectTest(format, copySize, 0, 0, 0, 0, mipLevel);
       } else {
-        t.DoCopyFromStencilTest(
+        t.doCopyFromStencilTest(
           format,
           textureSize,
           bytesPerRow,
@@ -1932,7 +1932,7 @@ copyTextureToBuffer() with depth aspect.
         method: copyMethod,
       });
       const initialDataSize = minDataSize + dataPaddingInBytes;
-      t.DoUploadToStencilTest(
+      t.doUploadToStencilTest(
         format,
         textureSize,
         copyMethod,

--- a/src/webgpu/api/operation/command_buffer/render/state_tracking.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/render/state_tracking.spec.ts
@@ -11,7 +11,7 @@ import * as ttu from '../../../../texture_test_utils.js';
 import { TexelView } from '../../../../util/texture/texel_view.js';
 
 class VertexAndIndexStateTrackingTest extends AllFeaturesMaxLimitsGPUTest {
-  GetRenderPipelineForTest(arrayStride: number): GPURenderPipeline {
+  getRenderPipelineForTest(arrayStride: number): GPURenderPipeline {
     return this.device.createRenderPipeline({
       layout: 'auto',
       vertex: {
@@ -128,7 +128,7 @@ g.test('set_index_buffer_without_changing_buffer')
 
     vertexBuffer.unmap();
 
-    const renderPipeline = t.GetRenderPipelineForTest(t.kVertexAttributeSize);
+    const renderPipeline = t.getRenderPipelineForTest(t.kVertexAttributeSize);
 
     const outputTextureSize = [kPositions.length - 1, 1, 1];
     const outputTexture = t.createTextureTracked({
@@ -222,7 +222,7 @@ g.test('set_vertex_buffer_without_changing_buffer')
 
     vertexBuffer.unmap();
 
-    const renderPipeline = t.GetRenderPipelineForTest(t.kVertexAttributeSize);
+    const renderPipeline = t.getRenderPipelineForTest(t.kVertexAttributeSize);
 
     const outputTextureSize = [kPositions.length, 1, 1];
     const outputTexture = t.createTextureTracked({
@@ -321,8 +321,8 @@ g.test('change_pipeline_before_and_after_vertex_buffer')
     vertexBuffer.unmap();
 
     // Create two render pipelines with different vertex attribute strides
-    const renderPipeline1 = t.GetRenderPipelineForTest(t.kVertexAttributeSize);
-    const renderPipeline2 = t.GetRenderPipelineForTest(t.kVertexAttributeSize * 2);
+    const renderPipeline1 = t.getRenderPipelineForTest(t.kVertexAttributeSize);
+    const renderPipeline2 = t.getRenderPipelineForTest(t.kVertexAttributeSize * 2);
 
     const kPointsCount = kPositions.length - 1;
     const outputTextureSize = [kPointsCount, 1, 1];
@@ -582,7 +582,7 @@ g.test('set_index_buffer_before_non_indexed_draw')
     // Initialize the index buffer with 2 uint16 indices (2, 3).
     const indexBuffer = t.makeBufferWithContents(new Uint16Array([2, 3]), GPUBufferUsage.INDEX);
 
-    const renderPipeline = t.GetRenderPipelineForTest(t.kVertexAttributeSize);
+    const renderPipeline = t.getRenderPipelineForTest(t.kVertexAttributeSize);
 
     const kPointsCount = 4;
     const outputTextureSize = [kPointsCount, 1, 1];

--- a/src/webgpu/api/operation/compute_pipeline/overrides.spec.ts
+++ b/src/webgpu/api/operation/compute_pipeline/overrides.spec.ts
@@ -7,7 +7,7 @@ import { range } from '../../../../common/util/util.js';
 import { AllFeaturesMaxLimitsGPUTest } from '../../../gpu_test.js';
 
 class F extends AllFeaturesMaxLimitsGPUTest {
-  async ExpectShaderOutputWithConstants(
+  async expectShaderOutputWithConstants(
     isAsync: boolean,
     expected: Uint32Array | Float32Array,
     constants: Record<string, GPUPipelineConstantValue>,
@@ -60,7 +60,7 @@ g.test('basic')
   .params(u => u.combine('isAsync', [true, false]))
   .fn(async t => {
     const count = 11;
-    await t.ExpectShaderOutputWithConstants(
+    await t.expectShaderOutputWithConstants(
       t.params.isAsync,
       new Uint32Array(range(count, i => i)),
       {
@@ -118,7 +118,7 @@ g.test('numeric_id')
   )
   .params(u => u.combine('isAsync', [true, false]))
   .fn(async t => {
-    await t.ExpectShaderOutputWithConstants(
+    await t.expectShaderOutputWithConstants(
       t.params.isAsync,
       new Uint32Array([1, 2, 3]),
       {
@@ -222,7 +222,7 @@ g.test('precision')
   .fn(async t => {
     const c1 = 3.14159;
     const c2 = 3.141592653589793;
-    await t.ExpectShaderOutputWithConstants(
+    await t.expectShaderOutputWithConstants(
       t.params.isAsync,
       // These values will get rounded to f32 and createComputePipeline, so the values coming out from the shader won't be the exact same one as shown here.
       new Float32Array([c1, c2]),
@@ -262,7 +262,7 @@ g.test('workgroup_size')
   .fn(async t => {
     const { isAsync, type, size, v } = t.params;
     const workgroup_size_str = v === 'x' ? 'd' : v === 'y' ? '1, d' : '1, 1, d';
-    await t.ExpectShaderOutputWithConstants(
+    await t.expectShaderOutputWithConstants(
       isAsync,
       new Uint32Array([size]),
       {

--- a/src/webgpu/api/operation/render_pipeline/overrides.spec.ts
+++ b/src/webgpu/api/operation/render_pipeline/overrides.spec.ts
@@ -7,7 +7,7 @@ import { AllFeaturesMaxLimitsGPUTest } from '../../../gpu_test.js';
 import { PerTexelComponent } from '../../../util/texture/texel_data.js';
 
 class F extends AllFeaturesMaxLimitsGPUTest {
-  async ExpectShaderOutputWithConstants(
+  async expectShaderOutputWithConstants(
     isAsync: boolean,
     format: GPUTextureFormat,
     expected: PerTexelComponent<number>,
@@ -149,7 +149,7 @@ g.test('basic')
   )
   .fn(async t => {
     const format = 'bgra8unorm';
-    await t.ExpectShaderOutputWithConstants(
+    await t.expectShaderOutputWithConstants(
       t.params.isAsync,
       format,
       t.params.expected,
@@ -193,7 +193,7 @@ g.test('precision')
   )
   .fn(async t => {
     const format = kPrecisionTestFormat;
-    await t.ExpectShaderOutputWithConstants(
+    await t.expectShaderOutputWithConstants(
       t.params.isAsync,
       format,
       t.params.expected,
@@ -435,7 +435,7 @@ g.test('multi_entry_points')
       }
       `,
     });
-    await t.ExpectShaderOutputWithConstants(
+    await t.expectShaderOutputWithConstants(
       t.params.isAsync,
       format,
       t.params.expected,

--- a/src/webgpu/api/operation/render_pipeline/sample_mask.spec.ts
+++ b/src/webgpu/api/operation/render_pipeline/sample_mask.spec.ts
@@ -300,7 +300,7 @@ class F extends AllFeaturesMaxLimitsGPUTest {
     });
   }
 
-  GetTargetTexture(
+  getTargetTexture(
     sampleCount: number,
     rasterizationMask: number,
     pipeline: GPURenderPipeline,
@@ -432,7 +432,7 @@ class F extends AllFeaturesMaxLimitsGPUTest {
     };
   }
 
-  CheckColorAttachmentResult(
+  checkColorAttachmentResult(
     texture: GPUTexture,
     sampleCount: number,
     rasterizationMask: number,
@@ -455,7 +455,7 @@ class F extends AllFeaturesMaxLimitsGPUTest {
     this.expectGPUBufferValuesEqual(buffer, expected);
   }
 
-  CheckDepthStencilResult(
+  checkDepthStencilResult(
     aspect: 'depth-only' | 'stencil-only',
     depthStencilTexture: GPUTexture,
     sampleCount: number,
@@ -574,14 +574,14 @@ textureLoad each sample index from the texture and write to a storage buffer to 
       },
     });
 
-    const { color, depthStencil } = t.GetTargetTexture(
+    const { color, depthStencil } = t.getTargetTexture(
       sampleCount,
       rasterizationMask,
       pipeline,
       fragmentMaskUniformBuffer
     );
 
-    t.CheckColorAttachmentResult(
+    t.checkColorAttachmentResult(
       color,
       sampleCount,
       rasterizationMask,
@@ -589,7 +589,7 @@ textureLoad each sample index from the texture and write to a storage buffer to 
       fragmentShaderOutputMask
     );
 
-    t.CheckDepthStencilResult(
+    t.checkDepthStencilResult(
       'depth-only',
       depthStencil,
       sampleCount,
@@ -598,7 +598,7 @@ textureLoad each sample index from the texture and write to a storage buffer to 
       fragmentShaderOutputMask
     );
 
-    t.CheckDepthStencilResult(
+    t.checkDepthStencilResult(
       'stencil-only',
       depthStencil,
       sampleCount,
@@ -696,7 +696,7 @@ color' <= color.
       alphaValues[1] = alpha1;
       t.device.queue.writeBuffer(alphaValueUniformBuffer, 0, alphaValues);
 
-      const { color, depthStencil } = t.GetTargetTexture(
+      const { color, depthStencil } = t.getTargetTexture(
         sampleCount,
         rasterizationMask,
         pipeline,

--- a/src/webgpu/api/operation/rendering/color_target_state.spec.ts
+++ b/src/webgpu/api/operation/rendering/color_target_state.spec.ts
@@ -10,7 +10,7 @@ TODO:
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { assert, TypedArrayBufferView, unreachable } from '../../../../common/util/util.js';
 import {
-  IsDualSourceBlendingFactor,
+  IsDualSourceBlendingFactor as isDualSourceBlendingFactor,
   kBlendFactors,
   kBlendOperations,
 } from '../../../capability_info.js';
@@ -208,8 +208,8 @@ g.test('blending,GPUBlendComponent')
   )
   .fn(t => {
     if (
-      IsDualSourceBlendingFactor(t.params.srcFactor) ||
-      IsDualSourceBlendingFactor(t.params.dstFactor)
+      isDualSourceBlendingFactor(t.params.srcFactor) ||
+      isDualSourceBlendingFactor(t.params.dstFactor)
     ) {
       t.skipIfDeviceDoesNotHaveFeature('dual-source-blending');
     }
@@ -254,8 +254,8 @@ g.test('blending,GPUBlendComponent')
     }
 
     const useBlendSrc1 =
-      IsDualSourceBlendingFactor(t.params.srcFactor) ||
-      IsDualSourceBlendingFactor(t.params.dstFactor);
+      isDualSourceBlendingFactor(t.params.srcFactor) ||
+      isDualSourceBlendingFactor(t.params.dstFactor);
 
     const pipeline = t.device.createRenderPipeline({
       layout: 'auto',

--- a/src/webgpu/api/operation/rendering/indirect_draw.spec.ts
+++ b/src/webgpu/api/operation/rendering/indirect_draw.spec.ts
@@ -16,7 +16,7 @@ const notFilled = new Uint8Array([0, 0, 0, 0]);
 const kRenderTargetFormat = 'rgba8unorm';
 
 class F extends AllFeaturesMaxLimitsGPUTest {
-  MakeIndexBuffer(): GPUBuffer {
+  makeIndexBuffer(): GPUBuffer {
     return this.makeBufferWithContents(
       /* prettier-ignore */ new Uint32Array([
         0, 1, 2, // The bottom left triangle
@@ -26,7 +26,7 @@ class F extends AllFeaturesMaxLimitsGPUTest {
     );
   }
 
-  MakeVertexBuffer(isIndexed: boolean): GPUBuffer {
+  makeVertexBuffer(isIndexed: boolean): GPUBuffer {
     /* prettier-ignore */
     const vertices = isIndexed
       ? [
@@ -49,7 +49,7 @@ class F extends AllFeaturesMaxLimitsGPUTest {
     return this.makeBufferWithContents(new Float32Array(vertices), GPUBufferUsage.VERTEX);
   }
 
-  MakeIndirectBuffer(isIndexed: boolean, indirectOffset: number): GPUBuffer {
+  makeIndirectBuffer(isIndexed: boolean, indirectOffset: number): GPUBuffer {
     const o = indirectOffset / Uint32Array.BYTES_PER_ELEMENT;
 
     const parametersSize = isIndexed
@@ -165,8 +165,8 @@ Params:
   .fn(t => {
     const { isIndexed, indirectOffset } = t.params;
 
-    const vertexBuffer = t.MakeVertexBuffer(isIndexed);
-    const indirectBuffer = t.MakeIndirectBuffer(isIndexed, indirectOffset);
+    const vertexBuffer = t.makeVertexBuffer(isIndexed);
+    const indirectBuffer = t.makeIndirectBuffer(isIndexed, indirectOffset);
 
     const pipeline = t.device.createRenderPipeline({
       layout: 'auto',
@@ -226,7 +226,7 @@ Params:
     renderPass.setVertexBuffer(0, vertexBuffer, 0);
 
     if (isIndexed) {
-      renderPass.setIndexBuffer(t.MakeIndexBuffer(), 'uint32', 0);
+      renderPass.setIndexBuffer(t.makeIndexBuffer(), 'uint32', 0);
       renderPass.drawIndexedIndirect(indirectBuffer, indirectOffset);
     } else {
       renderPass.drawIndirect(indirectBuffer, indirectOffset);

--- a/src/webgpu/api/operation/resource_init/buffer.spec.ts
+++ b/src/webgpu/api/operation/resource_init/buffer.spec.ts
@@ -22,7 +22,7 @@ const kBufferUsagesForMappedAtCreationTests = [
 ];
 
 class F extends AllFeaturesMaxLimitsGPUTest {
-  GetBufferUsageFromMapMode(mapMode: GPUMapModeFlags): number {
+  getBufferUsageFromMapMode(mapMode: GPUMapModeFlags): number {
     switch (mapMode) {
       case GPUMapMode.READ:
         return GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ;
@@ -34,7 +34,7 @@ class F extends AllFeaturesMaxLimitsGPUTest {
     }
   }
 
-  CheckGPUBufferContent(
+  checkGPUBufferContent(
     buffer: GPUBuffer,
     bufferUsage: GPUBufferUsageFlags,
     expectedData: Uint8Array
@@ -43,7 +43,7 @@ class F extends AllFeaturesMaxLimitsGPUTest {
     this.expectGPUBufferValuesEqual(buffer, expectedData, 0, { method: mappable ? 'map' : 'copy' });
   }
 
-  TestBufferZeroInitInBindGroup(
+  testBufferZeroInitInBindGroup(
     computeShaderModule: GPUShaderModule,
     buffer: GPUBuffer,
     bufferOffset: number,
@@ -87,10 +87,10 @@ class F extends AllFeaturesMaxLimitsGPUTest {
     computePass.end();
     this.queue.submit([encoder.finish()]);
 
-    this.CheckBufferAndOutputTexture(buffer, boundBufferSize + bufferOffset, outputTexture);
+    this.checkBufferAndOutputTexture(buffer, boundBufferSize + bufferOffset, outputTexture);
   }
 
-  CreateRenderPipelineForTest(
+  createRenderPipelineForTest(
     vertexShaderModule: GPUShaderModule,
     testVertexBuffer: boolean
   ): GPURenderPipeline {
@@ -127,7 +127,7 @@ class F extends AllFeaturesMaxLimitsGPUTest {
     return this.device.createRenderPipeline(renderPipelineDescriptor);
   }
 
-  RecordInitializeTextureColor(
+  recordInitializeTextureColor(
     encoder: GPUCommandEncoder,
     texture: GPUTexture,
     color: GPUColor
@@ -145,7 +145,7 @@ class F extends AllFeaturesMaxLimitsGPUTest {
     renderPass.end();
   }
 
-  CheckBufferAndOutputTexture(
+  checkBufferAndOutputTexture(
     buffer: GPUBuffer,
     bufferSize: number,
     outputTexture: GPUTexture,
@@ -202,7 +202,7 @@ have already been initialized to 0.`
     const { mapMode } = t.params;
 
     const bufferSize = 32;
-    const bufferUsage = t.GetBufferUsageFromMapMode(mapMode);
+    const bufferUsage = t.getBufferUsageFromMapMode(mapMode);
     const buffer = t.createBufferTracked({
       size: bufferSize,
       usage: bufferUsage,
@@ -216,7 +216,7 @@ have already been initialized to 0.`
     buffer.unmap();
 
     const expectedData = new Uint8Array(bufferSize);
-    t.CheckGPUBufferContent(buffer, bufferUsage, expectedData);
+    t.checkGPUBufferContent(buffer, bufferUsage, expectedData);
   });
 
 g.test('map_partial_buffer')
@@ -231,7 +231,7 @@ already been initialized to 0.`
     const bufferSize = 32;
     const appliedOffset = offset >= 0 ? offset : bufferSize + offset;
 
-    const bufferUsage = t.GetBufferUsageFromMapMode(mapMode);
+    const bufferUsage = t.getBufferUsageFromMapMode(mapMode);
     const buffer = t.createBufferTracked({
       size: bufferSize,
       usage: bufferUsage,
@@ -251,7 +251,7 @@ already been initialized to 0.`
       buffer.unmap();
     }
 
-    t.CheckGPUBufferContent(buffer, bufferUsage, expectedData);
+    t.checkGPUBufferContent(buffer, bufferUsage, expectedData);
   });
 
 g.test('mapped_at_creation_whole_buffer')
@@ -278,7 +278,7 @@ array buffer of getMappedRange() and the GPUBuffer itself have all been initiali
     buffer.unmap();
 
     const expectedData = new Uint8Array(bufferSize);
-    t.CheckGPUBufferContent(buffer, bufferUsage, expectedData);
+    t.checkGPUBufferContent(buffer, bufferUsage, expectedData);
   });
 
 g.test('mapped_at_creation_partial_buffer')
@@ -317,7 +317,7 @@ array buffer of getMappedRange() and the GPUBuffer itself have all been initiali
       buffer.unmap();
     }
 
-    t.CheckGPUBufferContent(buffer, bufferUsage, expectedData);
+    t.checkGPUBufferContent(buffer, bufferUsage, expectedData);
   });
 
 g.test('copy_buffer_to_buffer_copy_source')
@@ -335,7 +335,7 @@ CopyBufferToBuffer(), the contents of the GPUBuffer have already been initialize
 
     const expectedData = new Uint8Array(bufferSize);
     // copyBufferToBuffer() is called inside t.CheckGPUBufferContent().
-    t.CheckGPUBufferContent(buffer, bufferUsage, expectedData);
+    t.checkGPUBufferContent(buffer, bufferUsage, expectedData);
   });
 
 g.test('copy_buffer_to_texture')
@@ -375,7 +375,7 @@ CopyBufferToTexture(), the contents of the GPUBuffer have already been initializ
     );
     t.queue.submit([encoder.finish()]);
 
-    t.CheckBufferAndOutputTexture(srcBuffer, srcBufferSize, dstTexture, textureSize, {
+    t.checkBufferAndOutputTexture(srcBuffer, srcBufferSize, dstTexture, textureSize, {
       R: 0.0,
       G: 0.0,
       B: 0.0,
@@ -404,7 +404,7 @@ remaining part of it will be initialized to 0.`
     t.queue.submit([encoder.finish()]);
 
     const expectedBufferData = new Uint8Array(bufferSize);
-    t.CheckGPUBufferContent(dstBuffer, bufferUsage, expectedBufferData);
+    t.checkGPUBufferContent(dstBuffer, bufferUsage, expectedBufferData);
   });
 
 g.test('copy_texture_to_partial_buffer')
@@ -524,7 +524,7 @@ g.test('uniform_buffer')
     });
 
     // Verify the whole range of the buffer has been initialized to 0 in a compute shader.
-    t.TestBufferZeroInitInBindGroup(computeShaderModule, buffer, bufferOffset, boundBufferSize);
+    t.testBufferZeroInitInBindGroup(computeShaderModule, buffer, bufferOffset, boundBufferSize);
   });
 
 g.test('readonly_storage_buffer')
@@ -559,7 +559,7 @@ g.test('readonly_storage_buffer')
     });
 
     // Verify the whole range of the buffer has been initialized to 0 in a compute shader.
-    t.TestBufferZeroInitInBindGroup(computeShaderModule, buffer, bufferOffset, boundBufferSize);
+    t.testBufferZeroInitInBindGroup(computeShaderModule, buffer, bufferOffset, boundBufferSize);
   });
 
 g.test('storage_buffer')
@@ -594,7 +594,7 @@ g.test('storage_buffer')
     });
 
     // Verify the whole range of the buffer has been initialized to 0 in a compute shader.
-    t.TestBufferZeroInitInBindGroup(computeShaderModule, buffer, bufferOffset, boundBufferSize);
+    t.testBufferZeroInitInBindGroup(computeShaderModule, buffer, bufferOffset, boundBufferSize);
   });
 
 g.test('vertex_buffer')
@@ -606,7 +606,7 @@ g.test('vertex_buffer')
   .fn(t => {
     const { bufferOffset } = t.params;
 
-    const renderPipeline = t.CreateRenderPipelineForTest(
+    const renderPipeline = t.createRenderPipelineForTest(
       t.device.createShaderModule({
         code: `
       struct VertexOut {
@@ -657,7 +657,7 @@ g.test('vertex_buffer')
     renderPass.end();
     t.queue.submit([encoder.finish()]);
 
-    t.CheckBufferAndOutputTexture(vertexBuffer, bufferSize, outputTexture);
+    t.checkBufferAndOutputTexture(vertexBuffer, bufferSize, outputTexture);
   });
 
 g.test('index_buffer')
@@ -669,7 +669,7 @@ GPUBuffer, all the contents in that GPUBuffer have been initialized to 0.`
   .fn(t => {
     const { bufferOffset } = t.params;
 
-    const renderPipeline = t.CreateRenderPipelineForTest(
+    const renderPipeline = t.createRenderPipelineForTest(
       t.device.createShaderModule({
         code: `
     struct VertexOut {
@@ -722,7 +722,7 @@ GPUBuffer, all the contents in that GPUBuffer have been initialized to 0.`
     renderPass.end();
     t.queue.submit([encoder.finish()]);
 
-    t.CheckBufferAndOutputTexture(indexBuffer, bufferSize, outputTexture);
+    t.checkBufferAndOutputTexture(indexBuffer, bufferSize, outputTexture);
   });
 
 g.test('indirect_buffer_for_draw_indirect')
@@ -737,7 +737,7 @@ have been initialized to 0.`
   .fn(t => {
     const { test_indexed_draw, bufferOffset } = t.params;
 
-    const renderPipeline = t.CreateRenderPipelineForTest(
+    const renderPipeline = t.createRenderPipelineForTest(
       t.device.createShaderModule({
         code: `
     struct VertexOut {
@@ -772,7 +772,7 @@ have been initialized to 0.`
 
     // Initialize outputTexture to green.
     const encoder = t.device.createCommandEncoder();
-    t.RecordInitializeTextureColor(encoder, outputTexture, { r: 0.0, g: 1.0, b: 0.0, a: 1.0 });
+    t.recordInitializeTextureColor(encoder, outputTexture, { r: 0.0, g: 1.0, b: 0.0, a: 1.0 });
 
     const renderPass = encoder.beginRenderPass({
       colorAttachments: [
@@ -802,7 +802,7 @@ have been initialized to 0.`
 
     // The indirect buffer should be lazily cleared to 0, so we actually draw nothing and the color
     // attachment will keep its original color (green) after we end the render pass.
-    t.CheckBufferAndOutputTexture(indirectBuffer, bufferSize, outputTexture);
+    t.checkBufferAndOutputTexture(indirectBuffer, bufferSize, outputTexture);
   });
 
 g.test('indirect_buffer_for_dispatch_indirect')
@@ -848,7 +848,7 @@ g.test('indirect_buffer_for_dispatch_indirect')
 
     // Initialize outputTexture to green.
     const encoder = t.device.createCommandEncoder();
-    t.RecordInitializeTextureColor(encoder, outputTexture, { r: 0.0, g: 1.0, b: 0.0, a: 1.0 });
+    t.recordInitializeTextureColor(encoder, outputTexture, { r: 0.0, g: 1.0, b: 0.0, a: 1.0 });
 
     const bindGroup = t.device.createBindGroup({
       layout: computePipeline.getBindGroupLayout(0),
@@ -871,5 +871,5 @@ g.test('indirect_buffer_for_dispatch_indirect')
 
     // The indirect buffer should be lazily cleared to 0, so we actually draw nothing and the color
     // attachment will keep its original color (green) after we end the compute pass.
-    t.CheckBufferAndOutputTexture(indirectBuffer, bufferSize, outputTexture);
+    t.checkBufferAndOutputTexture(indirectBuffer, bufferSize, outputTexture);
   });

--- a/src/webgpu/api/operation/storage_texture/read_only.spec.ts
+++ b/src/webgpu/api/operation/storage_texture/read_only.spec.ts
@@ -19,7 +19,7 @@ import {
 import { AllFeaturesMaxLimitsGPUTest } from '../../../gpu_test.js';
 import { kValidShaderStages, TValidShaderStage } from '../../../util/shader.js';
 
-function ComponentCount(format: ColorTextureFormat): number {
+function getComponentCountForFormat(format: ColorTextureFormat): number {
   switch (format) {
     case 'r32float':
     case 'r32sint':
@@ -60,14 +60,14 @@ class F extends AllFeaturesMaxLimitsGPUTest {
 
     const texelData = new ArrayBuffer(bytesPerBlock * width * height * depthOrArrayLayers);
     const texelTypedDataView = this.getTypedArrayBufferViewForTexelData(texelData, format);
-    const componentCount = ComponentCount(format);
+    const componentCount = getComponentCountForFormat(format);
     const outputBufferData = new ArrayBuffer(4 * 4 * width * height * depthOrArrayLayers);
     const outputBufferTypedData = this.getTypedArrayBufferForOutputBufferData(
       outputBufferData,
       format
     );
 
-    const SetData = (
+    const setData = (
       texelValue: number,
       outputValue: number,
       texelDataIndex: number,
@@ -94,18 +94,18 @@ class F extends AllFeaturesMaxLimitsGPUTest {
               case 'rgba16uint':
               case 'rgba32uint': {
                 const texelValue = 4 * texelDataIndex + component + 1;
-                SetData(texelValue, texelValue, texelDataIndex, component);
+                setData(texelValue, texelValue, texelDataIndex, component);
                 break;
               }
               case 'rgba8uint': {
                 const texelValue = (4 * texelDataIndex + component + 1) % 256;
-                SetData(texelValue, texelValue, texelDataIndex, component);
+                setData(texelValue, texelValue, texelDataIndex, component);
                 break;
               }
               case 'rgba8unorm': {
                 const texelValue = (4 * texelDataIndex + component + 1) % 256;
                 const outputValue = texelValue / 255.0;
-                SetData(texelValue, outputValue, texelDataIndex, component);
+                setData(texelValue, outputValue, texelDataIndex, component);
                 break;
               }
               case 'bgra8unorm': {
@@ -114,7 +114,7 @@ class F extends AllFeaturesMaxLimitsGPUTest {
                 // BGRA -> RGBA
                 assert(component < 4);
                 const outputComponent = [2, 1, 0, 3][component];
-                SetData(texelValue, outputValue, texelDataIndex, component, outputComponent);
+                setData(texelValue, outputValue, texelDataIndex, component, outputComponent);
                 break;
               }
               case 'r32sint':
@@ -123,32 +123,32 @@ class F extends AllFeaturesMaxLimitsGPUTest {
               case 'rgba32sint': {
                 const texelValue =
                   (texelDataIndex & 1 ? 1 : -1) * (4 * texelDataIndex + component + 1);
-                SetData(texelValue, texelValue, texelDataIndex, component);
+                setData(texelValue, texelValue, texelDataIndex, component);
                 break;
               }
               case 'rgba8sint': {
                 const texelValue = ((4 * texelDataIndex + component + 1) % 256) - 128;
-                SetData(texelValue, texelValue, texelDataIndex, component);
+                setData(texelValue, texelValue, texelDataIndex, component);
                 break;
               }
               case 'rgba8snorm': {
                 const texelValue = ((4 * texelDataIndex + component + 1) % 256) - 128;
                 const outputValue = Math.max(texelValue / 127.0, -1.0);
-                SetData(texelValue, outputValue, texelDataIndex, component);
+                setData(texelValue, outputValue, texelDataIndex, component);
                 break;
               }
               case 'r32float':
               case 'rg32float':
               case 'rgba32float': {
                 const texelValue = (4 * texelDataIndex + component + 1) / 10.0;
-                SetData(texelValue, texelValue, texelDataIndex, component);
+                setData(texelValue, texelValue, texelDataIndex, component);
                 break;
               }
               case 'rgba16float': {
                 const texelValue = (4 * texelDataIndex + component + 1) / 10.0;
                 const f16Array = new Float16Array(1);
                 f16Array[0] = texelValue;
-                SetData(texelValue, f16Array[0], texelDataIndex, component);
+                setData(texelValue, f16Array[0], texelDataIndex, component);
                 break;
               }
               default:

--- a/src/webgpu/api/operation/texture_view/write.spec.ts
+++ b/src/webgpu/api/operation/texture_view/write.spec.ts
@@ -54,16 +54,16 @@ const kColorsFloat = [
   { R: 0.4, G: 0.3, B: 0.6, A: 0.8 },
 ];
 
-function FloatToIntColor(c: number) {
+function floatToIntColor(c: number) {
   return Math.floor(c * 100);
 }
 
 const kColorsInt = kColorsFloat.map(c => {
   return {
-    R: FloatToIntColor(c.R),
-    G: FloatToIntColor(c.G),
-    B: FloatToIntColor(c.B),
-    A: FloatToIntColor(c.A),
+    R: floatToIntColor(c.R),
+    G: floatToIntColor(c.G),
+    B: floatToIntColor(c.B),
+    A: floatToIntColor(c.A),
   };
 });
 

--- a/src/webgpu/api/operation/vertex_state/index_format.spec.ts
+++ b/src/webgpu/api/operation/vertex_state/index_format.spec.ts
@@ -49,7 +49,7 @@ const { byteLength, bytesPerRow, rowsPerImage } = getTextureCopyLayout(kTextureF
 ]);
 
 class IndexFormatTest extends AllFeaturesMaxLimitsGPUTest {
-  MakeRenderPipeline(
+  makeRenderPipeline(
     topology: GPUPrimitiveTopology,
     stripIndexFormat?: GPUIndexFormat
   ): GPURenderPipeline {
@@ -98,9 +98,9 @@ class IndexFormatTest extends AllFeaturesMaxLimitsGPUTest {
     });
   }
 
-  CreateIndexBuffer(indices: readonly number[], indexFormat: GPUIndexFormat): GPUBuffer {
-    const typedArrayConstructor = { uint16: Uint16Array, uint32: Uint32Array }[indexFormat];
-    return this.makeBufferWithContents(new typedArrayConstructor(indices), GPUBufferUsage.INDEX);
+  createIndexBuffer(indices: readonly number[], indexFormat: GPUIndexFormat): GPUBuffer {
+    const TypedArrayConstructor = { uint16: Uint16Array, uint32: Uint32Array }[indexFormat];
+    return this.makeBufferWithContents(new TypedArrayConstructor(indices), GPUBufferUsage.INDEX);
   }
 
   run(
@@ -114,9 +114,9 @@ class IndexFormatTest extends AllFeaturesMaxLimitsGPUTest {
     // The indexFormat must be set in render pipeline descriptor that specifies a strip primitive
     // topology for primitive restart testing
     if (primitiveTopology === 'line-strip' || primitiveTopology === 'triangle-strip') {
-      pipeline = this.MakeRenderPipeline(primitiveTopology, indexFormat);
+      pipeline = this.makeRenderPipeline(primitiveTopology, indexFormat);
     } else {
-      pipeline = this.MakeRenderPipeline(primitiveTopology);
+      pipeline = this.makeRenderPipeline(primitiveTopology);
     }
 
     const colorAttachment = this.createTextureTracked({
@@ -155,7 +155,7 @@ class IndexFormatTest extends AllFeaturesMaxLimitsGPUTest {
     return result;
   }
 
-  CreateExpectedUint8Array(renderShape: Raster8x4): Uint8Array {
+  createExpectedUint8Array(renderShape: Raster8x4): Uint8Array {
     const arrayBuffer = new Uint8Array(byteLength);
     for (let row = 0; row < renderShape.length; row++) {
       for (let col = 0; col < renderShape[row].length; col++) {
@@ -187,10 +187,10 @@ g.test('index_format,uint16')
     // And the index buffer size - offset must be not less than the size required by triangle
     // list, otherwise it also render nothing.
     const indices: number[] = [1, 2, 0, 0, 0, 0, 0, 1, 3, 0];
-    const indexBuffer = t.CreateIndexBuffer(indices, 'uint16');
+    const indexBuffer = t.createIndexBuffer(indices, 'uint16');
     const result = t.run(indexBuffer, _indexCount, 'uint16', indexOffset);
 
-    const expectedTextureValues = t.CreateExpectedUint8Array(_expectedShape);
+    const expectedTextureValues = t.createExpectedUint8Array(_expectedShape);
     t.expectGPUBufferValuesEqual(result, expectedTextureValues);
   });
 
@@ -208,10 +208,10 @@ g.test('index_format,uint32')
     // And the index buffer size - offset must be not less than the size required by triangle
     // list, otherwise it also render nothing.
     const indices: number[] = [1, 2, 0, 0, 0, 0, 0, 1, 3, 0];
-    const indexBuffer = t.CreateIndexBuffer(indices, 'uint32');
+    const indexBuffer = t.createIndexBuffer(indices, 'uint32');
     const result = t.run(indexBuffer, _indexCount, 'uint32', indexOffset);
 
-    const expectedTextureValues = t.CreateExpectedUint8Array(_expectedShape);
+    const expectedTextureValues = t.createExpectedUint8Array(_expectedShape);
     t.expectGPUBufferValuesEqual(result, expectedTextureValues);
   });
 
@@ -227,11 +227,11 @@ g.test('index_format,change_pipeline_after_setIndexBuffer')
     const indexFormat32 = 'uint32';
 
     const indices: number[] = [1, 2, 0, 0, 0, 0, 0, 1, 3, 0];
-    const indexBuffer = t.CreateIndexBuffer(indices, indexFormat32);
+    const indexBuffer = t.createIndexBuffer(indices, indexFormat32);
 
     const kPrimitiveTopology = 'triangle-strip';
-    const pipeline32 = t.MakeRenderPipeline(kPrimitiveTopology, indexFormat32);
-    const pipeline16 = t.MakeRenderPipeline(kPrimitiveTopology, indexFormat16);
+    const pipeline32 = t.makeRenderPipeline(kPrimitiveTopology, indexFormat32);
+    const pipeline16 = t.makeRenderPipeline(kPrimitiveTopology, indexFormat16);
 
     const colorAttachment = t.createTextureTracked({
       format: kTextureFormat,
@@ -270,7 +270,7 @@ g.test('index_format,change_pipeline_after_setIndexBuffer')
     );
     t.device.queue.submit([encoder.finish()]);
 
-    const expectedTextureValues = t.CreateExpectedUint8Array(expectedShape);
+    const expectedTextureValues = t.createExpectedUint8Array(expectedShape);
     t.expectGPUBufferValuesEqual(result, expectedTextureValues);
   });
 
@@ -285,10 +285,10 @@ g.test('index_format,setIndexBuffer_before_setPipeline')
     const indexFormat = 'uint32';
 
     const indices: number[] = [1, 2, 0, 0, 0, 0, 0, 1, 3, 0];
-    const indexBuffer = t.CreateIndexBuffer(indices, indexFormat);
+    const indexBuffer = t.createIndexBuffer(indices, indexFormat);
 
     const kPrimitiveTopology = 'triangle-strip';
-    const pipeline = t.MakeRenderPipeline(kPrimitiveTopology, indexFormat);
+    const pipeline = t.makeRenderPipeline(kPrimitiveTopology, indexFormat);
 
     const colorAttachment = t.createTextureTracked({
       format: kTextureFormat,
@@ -330,7 +330,7 @@ g.test('index_format,setIndexBuffer_before_setPipeline')
     );
     t.device.queue.submit([encoder.finish()]);
 
-    const expectedTextureValues = t.CreateExpectedUint8Array(expectedShape);
+    const expectedTextureValues = t.createExpectedUint8Array(expectedShape);
     t.expectGPUBufferValuesEqual(result, expectedTextureValues);
   });
 
@@ -346,9 +346,9 @@ g.test('index_format,setIndexBuffer_different_formats')
 
     // Create a pipeline to be used by different index formats.
     const kPrimitiveTopology = 'triangle-list';
-    const pipeline = t.MakeRenderPipeline(kPrimitiveTopology);
+    const pipeline = t.makeRenderPipeline(kPrimitiveTopology);
 
-    const expectedTextureValues = t.CreateExpectedUint8Array(kBottomLeftTriangle);
+    const expectedTextureValues = t.createExpectedUint8Array(kBottomLeftTriangle);
 
     const colorAttachment = t.createTextureTracked({
       format: kTextureFormat,
@@ -366,7 +366,7 @@ g.test('index_format,setIndexBuffer_different_formats')
       const indexFormat = 'uint32';
       const indexOffset = 12;
       const indexCount = 7;
-      const indexBuffer = t.CreateIndexBuffer(indices, indexFormat);
+      const indexBuffer = t.createIndexBuffer(indices, indexFormat);
 
       const pass = encoder.beginRenderPass({
         colorAttachments: [
@@ -398,7 +398,7 @@ g.test('index_format,setIndexBuffer_different_formats')
       const indexFormat = 'uint16';
       const indexOffset = 6;
       const indexCount = 6;
-      const indexBuffer = t.CreateIndexBuffer(indices, indexFormat);
+      const indexBuffer = t.createIndexBuffer(indices, indexFormat);
 
       const pass = encoder.beginRenderPass({
         colorAttachments: [
@@ -576,9 +576,9 @@ is different from what you would get if the topology were incorrect.
   .fn(t => {
     const { indexFormat, primitiveTopology, _indices, _expectedShape } = t.params;
 
-    const indexBuffer = t.CreateIndexBuffer(_indices, indexFormat);
+    const indexBuffer = t.createIndexBuffer(_indices, indexFormat);
     const result = t.run(indexBuffer, _indices.length, indexFormat, 0, primitiveTopology);
 
-    const expectedTextureValues = t.CreateExpectedUint8Array(_expectedShape);
+    const expectedTextureValues = t.createExpectedUint8Array(_expectedShape);
     t.expectGPUBufferValuesEqual(result, expectedTextureValues);
   });

--- a/src/webgpu/api/validation/createBindGroup.spec.ts
+++ b/src/webgpu/api/validation/createBindGroup.spec.ts
@@ -156,7 +156,7 @@ g.test('binding_must_contain_resource_defined_in_layout')
 
     const resource = vtu.getBindingResource(t, resourceType);
 
-    const IsStorageTextureResourceType = (resourceType: BindableResource) => {
+    const isStorageTextureResourceType = (resourceType: BindableResource) => {
       switch (resourceType) {
         case 'readonlyStorageTex':
         case 'readwriteStorageTex':
@@ -180,7 +180,7 @@ g.test('binding_must_contain_resource_defined_in_layout')
       case 'readonlyStorageTex':
       case 'readwriteStorageTex':
       case 'writeonlyStorageTex':
-        resourceBindingIsCompatible = IsStorageTextureResourceType(resourceType);
+        resourceBindingIsCompatible = isStorageTextureResourceType(resourceType);
         break;
       default:
         resourceBindingIsCompatible = info.resource === resourceType;

--- a/src/webgpu/api/validation/encoding/cmds/clearBuffer.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/clearBuffer.spec.ts
@@ -9,7 +9,7 @@ import { kMaxSafeMultipleOf8 } from '../../../../util/math.js';
 import * as vtu from '../../validation_test_utils.js';
 
 class F extends AllFeaturesMaxLimitsGPUTest {
-  TestClearBuffer(options: {
+  testClearBuffer(options: {
     buffer: GPUBuffer;
     offset: number | undefined;
     size: number | undefined;
@@ -70,7 +70,7 @@ g.test('buffer,device_mismatch')
       })
     );
 
-    t.TestClearBuffer({
+    t.testClearBuffer({
       buffer,
       offset: 0,
       size,
@@ -93,7 +93,7 @@ g.test('default_args')
       usage: GPUBufferUsage.COPY_DST,
     });
 
-    t.TestClearBuffer({
+    t.testClearBuffer({
       buffer,
       offset,
       size,
@@ -115,7 +115,7 @@ g.test('buffer_usage')
       usage,
     });
 
-    t.TestClearBuffer({
+    t.testClearBuffer({
       buffer,
       offset: 0,
       size: 16,
@@ -150,7 +150,7 @@ g.test('size_alignment')
       usage: GPUBufferUsage.COPY_DST,
     });
 
-    t.TestClearBuffer({
+    t.testClearBuffer({
       buffer,
       offset: 0,
       size,
@@ -184,7 +184,7 @@ g.test('offset_alignment')
       usage: GPUBufferUsage.COPY_DST,
     });
 
-    t.TestClearBuffer({
+    t.testClearBuffer({
       buffer,
       offset,
       size: 8,
@@ -208,7 +208,7 @@ g.test('overflow')
       usage: GPUBufferUsage.COPY_DST,
     });
 
-    t.TestClearBuffer({
+    t.testClearBuffer({
       buffer,
       offset,
       size,
@@ -236,7 +236,7 @@ g.test('out_of_bounds')
       usage: GPUBufferUsage.COPY_DST,
     });
 
-    t.TestClearBuffer({
+    t.testClearBuffer({
       buffer,
       offset,
       size,

--- a/src/webgpu/api/validation/encoding/cmds/copyBufferToBuffer.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/copyBufferToBuffer.spec.ts
@@ -30,7 +30,7 @@ import { kMaxSafeMultipleOf8 } from '../../../../util/math.js';
 import * as vtu from '../../validation_test_utils.js';
 
 class F extends AllFeaturesMaxLimitsGPUTest {
-  TestCopyBufferToBuffer(options: {
+  testCopyBufferToBuffer(options: {
     srcBuffer: GPUBuffer;
     srcOffset: number;
     dstBuffer: GPUBuffer;
@@ -83,7 +83,7 @@ g.test('buffer_state')
       ? 'FinishError'
       : 'SubmitError';
 
-    t.TestCopyBufferToBuffer({
+    t.testCopyBufferToBuffer({
       srcBuffer,
       srcOffset: 0,
       dstBuffer,
@@ -122,7 +122,7 @@ g.test('buffer,device_mismatch')
       })
     );
 
-    t.TestCopyBufferToBuffer({
+    t.testCopyBufferToBuffer({
       srcBuffer,
       srcOffset: 0,
       dstBuffer,
@@ -153,7 +153,7 @@ g.test('buffer_usage')
     const isSuccess = srcUsage === GPUBufferUsage.COPY_SRC && dstUsage === GPUBufferUsage.COPY_DST;
     const expectation = isSuccess ? 'Success' : 'FinishError';
 
-    t.TestCopyBufferToBuffer({
+    t.testCopyBufferToBuffer({
       srcBuffer,
       srcOffset: 0,
       dstBuffer,
@@ -183,7 +183,7 @@ g.test('copy_size_alignment')
       usage: GPUBufferUsage.COPY_DST,
     });
 
-    t.TestCopyBufferToBuffer({
+    t.testCopyBufferToBuffer({
       srcBuffer,
       srcOffset: 0,
       dstBuffer,
@@ -218,7 +218,7 @@ g.test('copy_offset_alignment')
       usage: GPUBufferUsage.COPY_DST,
     });
 
-    t.TestCopyBufferToBuffer({
+    t.testCopyBufferToBuffer({
       srcBuffer,
       srcOffset,
       dstBuffer,
@@ -255,7 +255,7 @@ g.test('copy_overflow')
       usage: GPUBufferUsage.COPY_DST,
     });
 
-    t.TestCopyBufferToBuffer({
+    t.testCopyBufferToBuffer({
       srcBuffer,
       srcOffset,
       dstBuffer,
@@ -290,7 +290,7 @@ g.test('copy_out_of_bounds')
       usage: GPUBufferUsage.COPY_DST,
     });
 
-    t.TestCopyBufferToBuffer({
+    t.testCopyBufferToBuffer({
       srcBuffer,
       srcOffset,
       dstBuffer,
@@ -315,7 +315,7 @@ g.test('copy_within_same_buffer')
       usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.COPY_DST,
     });
 
-    t.TestCopyBufferToBuffer({
+    t.testCopyBufferToBuffer({
       srcBuffer: buffer,
       srcOffset,
       dstBuffer: buffer,

--- a/src/webgpu/api/validation/encoding/cmds/copyTextureToTexture.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/copyTextureToTexture.spec.ts
@@ -20,7 +20,7 @@ import { align, lcm } from '../../../../util/math.js';
 import * as vtu from '../../validation_test_utils.js';
 
 class F extends AllFeaturesMaxLimitsGPUTest {
-  TestCopyTextureToTexture(
+  testCopyTextureToTexture(
     source: GPUTexelCopyTextureInfo,
     destination: GPUTexelCopyTextureInfo,
     copySize: GPUExtent3D,
@@ -41,7 +41,7 @@ class F extends AllFeaturesMaxLimitsGPUTest {
     }
   }
 
-  GetPhysicalSubresourceSize(
+  getPhysicalSubresourceSize(
     dimension: GPUTextureDimension,
     textureSize: Required<GPUExtent3DDict>,
     format: GPUTextureFormat,
@@ -101,7 +101,7 @@ g.test('copy_with_invalid_or_destroyed_texture')
         : 'SubmitError'
       : 'FinishError';
 
-    t.TestCopyTextureToTexture(
+    t.testCopyTextureToTexture(
       { texture: srcTexture },
       { texture: dstTexture },
       { width: 1, height: 1, depthOrArrayLayers: 1 },
@@ -143,7 +143,7 @@ g.test('texture,device_mismatch')
       })
     );
 
-    t.TestCopyTextureToTexture(
+    t.testCopyTextureToTexture(
       { texture: srcTexture },
       { texture: dstTexture },
       { width: 1, height: 1, depthOrArrayLayers: 1 },
@@ -196,7 +196,7 @@ Test copyTextureToTexture must specify mipLevels that are in range.
     });
 
     const isSuccess = srcCopyLevel < srcLevelCount && dstCopyLevel < dstLevelCount;
-    t.TestCopyTextureToTexture(
+    t.testCopyTextureToTexture(
       { texture: srcTexture, mipLevel: srcCopyLevel },
       { texture: dstTexture, mipLevel: dstCopyLevel },
       { width: 1, height: 1, depthOrArrayLayers: 1 },
@@ -234,7 +234,7 @@ Test that copyTextureToTexture source/destination need COPY_SRC/COPY_DST usages.
     const isSuccess =
       srcUsage === GPUTextureUsage.COPY_SRC && dstUsage === GPUTextureUsage.COPY_DST;
 
-    t.TestCopyTextureToTexture(
+    t.testCopyTextureToTexture(
       { texture: srcTexture },
       { texture: dstTexture },
       { width: 1, height: 1, depthOrArrayLayers: 1 },
@@ -278,7 +278,7 @@ Test that textures in copyTextureToTexture must have the same sample count.
     });
 
     const isSuccess = srcSampleCount === dstSampleCount;
-    t.TestCopyTextureToTexture(
+    t.testCopyTextureToTexture(
       { texture: srcTexture },
       { texture: dstTexture },
       { width: 4, height: 4, depthOrArrayLayers: 1 },
@@ -338,7 +338,7 @@ TODO: Check the source and destination constraints separately.
     });
 
     const isSuccess = copyWidth === kWidth && copyHeight === kHeight;
-    t.TestCopyTextureToTexture(
+    t.testCopyTextureToTexture(
       { texture: srcTexture, origin: srcCopyOrigin },
       { texture: dstTexture, origin: dstCopyOrigin },
       { width: copyWidth, height: copyHeight, depthOrArrayLayers: 1 },
@@ -402,7 +402,7 @@ Test the formats of textures in copyTextureToTexture must be copy-compatible.
       getBaseFormatForTextureFormat(dstFormat as ColorTextureFormat) ?? dstFormat;
     const isSuccess = srcBaseFormat === dstBaseFormat;
 
-    t.TestCopyTextureToTexture(
+    t.testCopyTextureToTexture(
       { texture: srcTexture },
       { texture: dstTexture },
       textureSize,
@@ -465,8 +465,8 @@ Note: this is only tested for 2D textures as it is the only dimension compatible
       usage: GPUTextureUsage.COPY_DST,
     });
 
-    const srcSizeAtLevel = t.GetPhysicalSubresourceSize('2d', srcTextureSize, format, srcCopyLevel);
-    const dstSizeAtLevel = t.GetPhysicalSubresourceSize('2d', dstTextureSize, format, dstCopyLevel);
+    const srcSizeAtLevel = t.getPhysicalSubresourceSize('2d', srcTextureSize, format, srcCopyLevel);
+    const dstSizeAtLevel = t.getPhysicalSubresourceSize('2d', dstTextureSize, format, dstCopyLevel);
 
     const copyOrigin = { x: copyBoxOffsets.x, y: copyBoxOffsets.y, z: 0 };
 
@@ -483,13 +483,13 @@ Note: this is only tested for 2D textures as it is the only dimension compatible
       copyHeight === srcSizeAtLevel.height &&
       copyWidth === dstSizeAtLevel.width &&
       copyHeight === dstSizeAtLevel.height;
-    t.TestCopyTextureToTexture(
+    t.testCopyTextureToTexture(
       { texture: srcTexture, origin: { x: 0, y: 0, z: 0 }, mipLevel: srcCopyLevel },
       { texture: dstTexture, origin: copyOrigin, mipLevel: dstCopyLevel },
       { width: copyWidth, height: copyHeight, depthOrArrayLayers: 1 },
       isSuccess ? 'Success' : 'FinishError'
     );
-    t.TestCopyTextureToTexture(
+    t.testCopyTextureToTexture(
       { texture: srcTexture, origin: copyOrigin, mipLevel: srcCopyLevel },
       { texture: dstTexture, origin: { x: 0, y: 0, z: 0 }, mipLevel: dstCopyLevel },
       { width: copyWidth, height: copyHeight, depthOrArrayLayers: 1 },
@@ -564,13 +564,13 @@ Test that copyTextureToTexture copy boxes must be in range of the subresource.
       usage: GPUTextureUsage.COPY_DST,
     });
 
-    const srcSizeAtLevel = t.GetPhysicalSubresourceSize(
+    const srcSizeAtLevel = t.getPhysicalSubresourceSize(
       dimension,
       textureSize,
       kFormat,
       srcCopyLevel
     );
-    const dstSizeAtLevel = t.GetPhysicalSubresourceSize(
+    const dstSizeAtLevel = t.getPhysicalSubresourceSize(
       dimension,
       textureSize,
       kFormat,
@@ -609,7 +609,7 @@ Test that copyTextureToTexture copy boxes must be in range of the subresource.
           copyOrigin.z + copyDepth <= textureSize.depthOrArrayLayers;
       }
 
-      t.TestCopyTextureToTexture(
+      t.testCopyTextureToTexture(
         { texture: srcTexture, origin: { x: 0, y: 0, z: 0 }, mipLevel: srcCopyLevel },
         { texture: dstTexture, origin: copyOrigin, mipLevel: dstCopyLevel },
         { width: copyWidth, height: copyHeight, depthOrArrayLayers: copyDepth },
@@ -636,7 +636,7 @@ Test that copyTextureToTexture copy boxes must be in range of the subresource.
           copyOrigin.z + copyDepth <= textureSize.depthOrArrayLayers;
       }
 
-      t.TestCopyTextureToTexture(
+      t.testCopyTextureToTexture(
         { texture: srcTexture, origin: copyOrigin, mipLevel: srcCopyLevel },
         { texture: dstTexture, origin: { x: 0, y: 0, z: 0 }, mipLevel: dstCopyLevel },
         { width: copyWidth, height: copyHeight, depthOrArrayLayers: copyDepth },
@@ -675,7 +675,7 @@ TODO: Extend to 1D and 3D textures.`
     const isSuccess =
       Math.min(srcCopyOriginZ, dstCopyOriginZ) + copyExtentDepth <=
       Math.max(srcCopyOriginZ, dstCopyOriginZ);
-    t.TestCopyTextureToTexture(
+    t.testCopyTextureToTexture(
       { texture: testTexture, origin: { x: 0, y: 0, z: srcCopyOriginZ } },
       { texture: testTexture, origin: { x: 0, y: 0, z: dstCopyOriginZ } },
       { width: 16, height: 16, depthOrArrayLayers: copyExtentDepth },
@@ -734,7 +734,7 @@ Test the validations on the member 'aspect' of GPUTexelCopyTextureInfo in CopyTe
     const isSourceAspectValid = kValidAspectsForFormat[format].includes(sourceAspect);
     const isDestinationAspectValid = kValidAspectsForFormat[format].includes(destinationAspect);
 
-    t.TestCopyTextureToTexture(
+    t.testCopyTextureToTexture(
       { texture: srcTexture, origin: { x: 0, y: 0, z: 0 }, aspect: sourceAspect },
       { texture: dstTexture, origin: { x: 0, y: 0, z: 0 }, aspect: destinationAspect },
       kTextureSize,
@@ -808,13 +808,13 @@ TODO: Express the offsets in "block size" so as to be able to test non-4x4 compr
       usage: GPUTextureUsage.COPY_DST,
     });
 
-    const srcSizeAtLevel = t.GetPhysicalSubresourceSize(
+    const srcSizeAtLevel = t.getPhysicalSubresourceSize(
       dimension,
       kTextureSize,
       format,
       srcCopyLevel
     );
-    const dstSizeAtLevel = t.GetPhysicalSubresourceSize(
+    const dstSizeAtLevel = t.getPhysicalSubresourceSize(
       dimension,
       kTextureSize,
       format,
@@ -853,7 +853,7 @@ TODO: Express the offsets in "block size" so as to be able to test non-4x4 compr
         copyOrigin.y + copyHeight <= dstSizeAtLevel.height &&
         copyOrigin.z + copyDepth <= kTextureSize.depthOrArrayLayers;
 
-      t.TestCopyTextureToTexture(
+      t.testCopyTextureToTexture(
         { texture: srcTexture, origin: { x: 0, y: 0, z: 0 }, mipLevel: srcCopyLevel },
         { texture: dstTexture, origin: copyOrigin, mipLevel: dstCopyLevel },
         { width: copyWidth, height: copyHeight, depthOrArrayLayers: copyDepth },
@@ -870,7 +870,7 @@ TODO: Express the offsets in "block size" so as to be able to test non-4x4 compr
         copyHeight <= dstSizeAtLevel.height &&
         copyOrigin.z + copyDepth <= kTextureSize.depthOrArrayLayers;
 
-      t.TestCopyTextureToTexture(
+      t.testCopyTextureToTexture(
         { texture: srcTexture, origin: copyOrigin, mipLevel: srcCopyLevel },
         { texture: dstTexture, origin: { x: 0, y: 0, z: 0 }, mipLevel: dstCopyLevel },
         { width: copyWidth, height: copyHeight, depthOrArrayLayers: copyDepth },

--- a/src/webgpu/api/validation/layout_shader_compat.spec.ts
+++ b/src/webgpu/api/validation/layout_shader_compat.spec.ts
@@ -113,7 +113,7 @@ class F extends AllFeaturesMaxLimitsGPUTest {
     });
   }
 
-  GetBindableResourceShaderDeclaration(bindableResource: BindableResourceType): string {
+  getBindableResourceShaderDeclaration(bindableResource: BindableResourceType): string {
     switch (bindableResource) {
       case 'compareSamp':
         return 'var tmp : sampler_comparison';
@@ -140,7 +140,7 @@ class F extends AllFeaturesMaxLimitsGPUTest {
   }
 }
 
-const BindingResourceCompatibleWithShaderStages = function (
+const bindingResourceCompatibleWithShaderStages = function (
   bindingResource: BindableResourceType,
   shaderStages: number
 ): boolean {
@@ -180,11 +180,11 @@ g.test('pipeline_layout_shader_exact_match')
           // We don't test using non-filtering sampler in shader because it has the same declaration
           // as filtering sampler.
           p.bindingInShader === 'nonFiltSamp' ||
-          !BindingResourceCompatibleWithShaderStages(
+          !bindingResourceCompatibleWithShaderStages(
             p.bindingInPipelineLayout,
             p.pipelineLayoutVisibility
           ) ||
-          !BindingResourceCompatibleWithShaderStages(p.bindingInShader, p.shaderStageWithBinding)
+          !bindingResourceCompatibleWithShaderStages(p.bindingInShader, p.shaderStageWithBinding)
       )
   )
   .fn(t => {
@@ -237,7 +237,7 @@ g.test('pipeline_layout_shader_exact_match')
     }
 
     const layout = t.createPipelineLayout(bindingInPipelineLayout, pipelineLayoutVisibility);
-    const bindResourceDeclaration = `@group(0) @binding(0) ${t.GetBindableResourceShaderDeclaration(
+    const bindResourceDeclaration = `@group(0) @binding(0) ${t.getBindableResourceShaderDeclaration(
       bindingInShader
     )}`;
     const staticallyUseBinding = isBindingStaticallyUsed ? '_ = tmp; ' : '';

--- a/src/webgpu/api/validation/queue/writeBuffer.spec.ts
+++ b/src/webgpu/api/validation/queue/writeBuffer.spec.ts
@@ -57,27 +57,27 @@ g.test('ranges')
   .fn(t => {
     const queue = t.device.queue;
 
-    function runTest(arrayType: TypedArrayBufferViewConstructor, testBuffer: boolean) {
-      const elementSize = arrayType.BYTES_PER_ELEMENT;
+    function runTest(ArrayType: TypedArrayBufferViewConstructor, testBuffer: boolean) {
+      const elementSize = ArrayType.BYTES_PER_ELEMENT;
       const bufferSize = 16 * elementSize;
       const buffer = t.createBufferTracked({
         size: bufferSize,
         usage: GPUBufferUsage.COPY_DST,
       });
       const arraySm: TypedArrayBufferView | ArrayBuffer = testBuffer
-        ? new arrayType(8).buffer
-        : new arrayType(8);
+        ? new ArrayType(8).buffer
+        : new ArrayType(8);
       const arrayMd: TypedArrayBufferView | ArrayBuffer = testBuffer
-        ? new arrayType(16).buffer
-        : new arrayType(16);
+        ? new ArrayType(16).buffer
+        : new ArrayType(16);
       const arrayLg: TypedArrayBufferView | ArrayBuffer = testBuffer
-        ? new arrayType(32).buffer
-        : new arrayType(32);
+        ? new ArrayType(32).buffer
+        : new ArrayType(32);
 
       if (elementSize < 4) {
         const array15: TypedArrayBufferView | ArrayBuffer = testBuffer
-          ? new arrayType(15).buffer
-          : new arrayType(15);
+          ? new ArrayType(15).buffer
+          : new ArrayType(15);
 
         // Writing the full buffer that isn't 4-byte aligned.
         t.shouldThrow('OperationError', () => queue.writeBuffer(buffer, 0, array15));

--- a/src/webgpu/api/validation/render_pipeline/fragment_state.spec.ts
+++ b/src/webgpu/api/validation/render_pipeline/fragment_state.spec.ts
@@ -8,7 +8,7 @@ import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { assert, range } from '../../../../common/util/util.js';
 import {
   getDefaultLimits,
-  IsDualSourceBlendingFactor,
+  IsDualSourceBlendingFactor as isDualSourceBlendingFactor,
   kBlendFactors,
   kBlendOperations,
 } from '../../../capability_info.js';
@@ -295,7 +295,7 @@ g.test('targets_blend')
   )
   .fn(t => {
     const { isAsync, component, srcFactor, dstFactor, operation } = t.params;
-    if (IsDualSourceBlendingFactor(srcFactor) || IsDualSourceBlendingFactor(dstFactor)) {
+    if (isDualSourceBlendingFactor(srcFactor) || isDualSourceBlendingFactor(dstFactor)) {
       t.skipIfDeviceDoesNotHaveFeature('dual-source-blending');
     }
 
@@ -311,7 +311,7 @@ g.test('targets_blend')
     };
     const format = 'rgba8unorm';
     const useDualSourceBlending =
-      IsDualSourceBlendingFactor(srcFactor) || IsDualSourceBlendingFactor(dstFactor);
+      isDualSourceBlendingFactor(srcFactor) || isDualSourceBlendingFactor(dstFactor);
     const fragmentShaderCode = getFragmentShaderCodeWithOutput(
       [{ values, plainType: 'f32', componentCount: 4 }],
       null,
@@ -447,10 +447,10 @@ g.test('pipeline_output_targets,blend')
     t.skipIfTextureFormatNotSupported(format);
 
     const useDualSourceBlending =
-      IsDualSourceBlendingFactor(colorSrcFactor) ||
-      IsDualSourceBlendingFactor(colorDstFactor) ||
-      IsDualSourceBlendingFactor(alphaSrcFactor) ||
-      IsDualSourceBlendingFactor(alphaDstFactor);
+      isDualSourceBlendingFactor(colorSrcFactor) ||
+      isDualSourceBlendingFactor(colorDstFactor) ||
+      isDualSourceBlendingFactor(alphaSrcFactor) ||
+      isDualSourceBlendingFactor(alphaDstFactor);
     if (useDualSourceBlending) {
       t.skipIfDeviceDoesNotHaveFeature('dual-source-blending');
     }
@@ -605,7 +605,7 @@ g.test('dual_source_blending,use_blend_src')
       ),
     });
 
-    const _success = !IsDualSourceBlendingFactor(blendFactor) || useBlendSrc1;
+    const _success = !isDualSourceBlendingFactor(blendFactor) || useBlendSrc1;
     const isAsync = false;
     vtu.doCreateRenderPipelineTest(t, isAsync, _success, descriptor);
   });

--- a/src/webgpu/api/validation/resource_usages/buffer/in_pass_encoder.spec.ts
+++ b/src/webgpu/api/validation/resource_usages/buffer/in_pass_encoder.spec.ts
@@ -126,7 +126,7 @@ export class BufferResourceUsageTest extends AllFeaturesMaxLimitsGPUTest {
   }
 }
 
-function IsBufferUsageInBindGroup(bufferUsage: BufferUsage): boolean {
+function isBufferUsageInBindGroup(bufferUsage: BufferUsage): boolean {
   switch (bufferUsage) {
     case 'uniform':
     case 'storage':
@@ -461,7 +461,7 @@ dispatch calls refer to different usage scopes.`
   .fn(t => {
     const { usage0, usage1, inSamePass, hasOverlap } = t.params;
 
-    const UseBufferOnComputePassEncoder = (
+    const useBufferOnComputePassEncoder = (
       computePassEncoder: GPUComputePassEncoder,
       buffer: GPUBuffer,
       usage: 'uniform' | 'storage' | 'read-only-storage' | 'indirect',
@@ -505,15 +505,15 @@ dispatch calls refer to different usage scopes.`
 
     const offset0 = 0;
     const offset1 = hasOverlap ? offset0 : kBoundBufferSize;
-    UseBufferOnComputePassEncoder(computePassEncoder, buffer, usage0, offset0);
+    useBufferOnComputePassEncoder(computePassEncoder, buffer, usage0, offset0);
 
     if (inSamePass) {
-      UseBufferOnComputePassEncoder(computePassEncoder, buffer, usage1, offset1);
+      useBufferOnComputePassEncoder(computePassEncoder, buffer, usage1, offset1);
       computePassEncoder.end();
     } else {
       computePassEncoder.end();
       const anotherComputePassEncoder = encoder.beginComputePass();
-      UseBufferOnComputePassEncoder(anotherComputePassEncoder, buffer, usage1, offset1);
+      useBufferOnComputePassEncoder(anotherComputePassEncoder, buffer, usage1, offset1);
       anotherComputePassEncoder.end();
     }
 
@@ -537,9 +537,9 @@ there is no draw call in the render pass.
       .beginSubcases()
       .combine('hasOverlap', [true, false])
       .combine('visibility0', ['compute', 'fragment'] as const)
-      .unless(t => t.visibility0 === 'compute' && !IsBufferUsageInBindGroup(t.usage0))
+      .unless(t => t.visibility0 === 'compute' && !isBufferUsageInBindGroup(t.usage0))
       .combine('visibility1', ['compute', 'fragment'] as const)
-      .unless(t => t.visibility1 === 'compute' && !IsBufferUsageInBindGroup(t.usage1))
+      .unless(t => t.visibility1 === 'compute' && !isBufferUsageInBindGroup(t.usage1))
   )
   .fn(t => {
     const { usage0, usage1, hasOverlap, visibility0, visibility1 } = t.params;
@@ -558,7 +558,7 @@ there is no draw call in the render pass.
       numStorageBuffersNeededInFragmentStage
     );
 
-    const UseBufferOnRenderPassEncoder = (
+    const useBufferOnRenderPassEncoder = (
       buffer: GPUBuffer,
       offset: number,
       type: BufferUsage,
@@ -600,9 +600,9 @@ there is no draw call in the render pass.
     const encoder = t.device.createCommandEncoder();
     const renderPassEncoder = t.beginSimpleRenderPass(encoder);
     const offset0 = 0;
-    UseBufferOnRenderPassEncoder(buffer, offset0, usage0, visibility0, renderPassEncoder);
+    useBufferOnRenderPassEncoder(buffer, offset0, usage0, visibility0, renderPassEncoder);
     const offset1 = hasOverlap ? offset0 : kBoundBufferSize;
-    UseBufferOnRenderPassEncoder(buffer, offset1, usage1, visibility1, renderPassEncoder);
+    useBufferOnRenderPassEncoder(buffer, offset1, usage1, visibility1, renderPassEncoder);
     renderPassEncoder.end();
 
     const fail = (usage0 === 'storage') !== (usage1 === 'storage');
@@ -734,7 +734,7 @@ have tests covered (https://github.com/gpuweb/cts/issues/2232)
         GPUBufferUsage.INDIRECT,
     });
 
-    const UseBufferOnRenderPassEncoder = (
+    const useBufferOnRenderPassEncoder = (
       bufferAccessibleInDraw: boolean,
       bufferIndex: number,
       offset: number,
@@ -772,7 +772,7 @@ have tests covered (https://github.com/gpuweb/cts/issues/2232)
       }
     };
 
-    const MakeDrawCallWithOneUsage = (
+    const makeDrawCallWithOneUsage = (
       usage: BufferUsage,
       offset: number,
       renderPassEncoder: GPURenderPassEncoder
@@ -811,7 +811,7 @@ have tests covered (https://github.com/gpuweb/cts/issues/2232)
     const bufferIndex0 = visibility0 === 'fragment' ? 0 : 1;
     const usedBindGroupLayouts: GPUBindGroupLayout[] = [];
 
-    UseBufferOnRenderPassEncoder(
+    useBufferOnRenderPassEncoder(
       usage0AccessibleInDraw,
       bufferIndex0,
       offset0,
@@ -838,7 +838,7 @@ have tests covered (https://github.com/gpuweb/cts/issues/2232)
       if (!usage0AccessibleInDraw) {
         renderPassEncoder.draw(1);
       } else {
-        MakeDrawCallWithOneUsage(usage0, offset0, renderPassEncoder);
+        makeDrawCallWithOneUsage(usage0, offset0, renderPassEncoder);
       }
     }
 
@@ -851,14 +851,14 @@ have tests covered (https://github.com/gpuweb/cts/issues/2232)
     } else if (visibility0 === 'fragment' && usage0AccessibleInDraw) {
       // When buffer is bound to different bind groups or bound as vertex buffers in one render pass
       // encoder, the second buffer binding should consume the slot 1.
-      if (IsBufferUsageInBindGroup(usage0) && IsBufferUsageInBindGroup(usage1)) {
+      if (isBufferUsageInBindGroup(usage0) && isBufferUsageInBindGroup(usage1)) {
         bufferIndex1 = 1;
       } else if (usage0 === 'vertex' && usage1 === 'vertex') {
         bufferIndex1 = 1;
       }
     }
 
-    UseBufferOnRenderPassEncoder(
+    useBufferOnRenderPassEncoder(
       usage1AccessibleInDraw,
       bufferIndex1,
       offset1,
@@ -885,9 +885,9 @@ have tests covered (https://github.com/gpuweb/cts/issues/2232)
       if (!usage0AccessibleInDraw && !usage1AccessibleInDraw) {
         renderPassEncoder.draw(1);
       } else if (usage0AccessibleInDraw && !usage1AccessibleInDraw) {
-        MakeDrawCallWithOneUsage(usage0, offset0, renderPassEncoder);
+        makeDrawCallWithOneUsage(usage0, offset0, renderPassEncoder);
       } else if (!usage0AccessibleInDraw && usage1AccessibleInDraw) {
-        MakeDrawCallWithOneUsage(usage1, offset1, renderPassEncoder);
+        makeDrawCallWithOneUsage(usage1, offset1, renderPassEncoder);
       } else {
         if (usage1 === 'indexedIndirect') {
           // If the index buffer has already been set (as usage0), we won't need to set another
@@ -961,7 +961,7 @@ different render pass encoders belong to different usage scopes.`
       numStorageBuffersNeededInFragmentStage
     );
 
-    const UseBufferOnRenderPassEncoderInDrawCall = (
+    const useBufferOnRenderPassEncoderInDrawCall = (
       offset: number,
       usage: BufferUsage,
       renderPassEncoder: GPURenderPassEncoder
@@ -1020,16 +1020,16 @@ different render pass encoders belong to different usage scopes.`
     const renderPassEncoder = t.beginSimpleRenderPass(encoder);
 
     const offset0 = 0;
-    UseBufferOnRenderPassEncoderInDrawCall(offset0, usage0, renderPassEncoder);
+    useBufferOnRenderPassEncoderInDrawCall(offset0, usage0, renderPassEncoder);
 
     const offset1 = hasOverlap ? offset0 : kBoundBufferSize;
     if (inSamePass) {
-      UseBufferOnRenderPassEncoderInDrawCall(offset1, usage1, renderPassEncoder);
+      useBufferOnRenderPassEncoderInDrawCall(offset1, usage1, renderPassEncoder);
       renderPassEncoder.end();
     } else {
       renderPassEncoder.end();
       const anotherRenderPassEncoder = t.beginSimpleRenderPass(encoder);
-      UseBufferOnRenderPassEncoderInDrawCall(offset1, usage1, anotherRenderPassEncoder);
+      useBufferOnRenderPassEncoderInDrawCall(offset1, usage1, anotherRenderPassEncoder);
       anotherRenderPassEncoder.end();
     }
 

--- a/src/webgpu/api/validation/resource_usages/buffer/in_pass_misc.spec.ts
+++ b/src/webgpu/api/validation/resource_usages/buffer/in_pass_misc.spec.ts
@@ -258,20 +258,20 @@ g.test('subresources,buffer_usages_in_copy_and_pass')
       ] as const)
       .combine('pass', ['render', 'compute'] as const)
       .unless(({ usage0, usage1, pass }) => {
-        const IsCopy = (usage: BufferUsage | 'copy-src' | 'copy-dst') => {
+        const isCopy = (usage: BufferUsage | 'copy-src' | 'copy-dst') => {
           return usage === 'copy-src' || usage === 'copy-dst';
         };
         // We intend to test copy usages in this test.
-        if (!IsCopy(usage0) && !IsCopy(usage1)) {
+        if (!isCopy(usage0) && !isCopy(usage1)) {
           return true;
         }
         // When both usage0 and usage1 are copy usages, 'pass' is meaningless so in such situation
         // we just need to reserve one value as 'pass'.
-        if (IsCopy(usage0) && IsCopy(usage1)) {
+        if (isCopy(usage0) && isCopy(usage1)) {
           return pass === 'compute';
         }
 
-        const IsValidComputeUsage = (usage: BufferUsage | 'copy-src' | 'copy-dst') => {
+        const isValidComputeUsage = (usage: BufferUsage | 'copy-src' | 'copy-dst') => {
           switch (usage) {
             case 'vertex':
             case 'index':
@@ -282,7 +282,7 @@ g.test('subresources,buffer_usages_in_copy_and_pass')
           }
         };
         if (pass === 'compute') {
-          return !IsValidComputeUsage(usage0) || !IsValidComputeUsage(usage1);
+          return !isValidComputeUsage(usage0) || !isValidComputeUsage(usage1);
         }
 
         return false;
@@ -317,7 +317,7 @@ g.test('subresources,buffer_usages_in_copy_and_pass')
       usage: kUsages,
     });
 
-    const UseBufferOnCommandEncoder = (
+    const useBufferOnCommandEncoder = (
       usage:
         | 'copy-src'
         | 'copy-dst'
@@ -424,8 +424,8 @@ g.test('subresources,buffer_usages_in_copy_and_pass')
     };
 
     const encoder = t.device.createCommandEncoder();
-    UseBufferOnCommandEncoder(usage0, encoder);
-    UseBufferOnCommandEncoder(usage1, encoder);
+    useBufferOnCommandEncoder(usage0, encoder);
+    useBufferOnCommandEncoder(usage1, encoder);
     t.expectValidationError(() => {
       encoder.finish();
     }, false);

--- a/src/webgpu/api/validation/resource_usages/texture/in_render_common.spec.ts
+++ b/src/webgpu/api/validation/resource_usages/texture/in_render_common.spec.ts
@@ -17,7 +17,7 @@ export const kTextureBindingTypes = [
   'readonly-storage-texture',
   'readwrite-storage-texture',
 ] as const;
-export function IsReadOnlyTextureBindingType(t: TextureBindingType): boolean {
+export function isReadOnlyTextureBindingType(t: TextureBindingType): boolean {
   return t === 'sampled-texture' || t === 'readonly-storage-texture';
 }
 
@@ -533,7 +533,7 @@ g.test('subresources,multiple_bind_groups')
     }
 
     const bothReadOnly =
-      IsReadOnlyTextureBindingType(bgUsage0) && IsReadOnlyTextureBindingType(bgUsage1);
+      isReadOnlyTextureBindingType(bgUsage0) && isReadOnlyTextureBindingType(bgUsage1);
     const isMipLevelNotOverlapped = t.isRangeNotOverlapped(
       bg0Levels.base,
       bg0Levels.base + bg0Levels.count - 1,

--- a/src/webgpu/api/validation/resource_usages/texture/in_render_misc.spec.ts
+++ b/src/webgpu/api/validation/resource_usages/texture/in_render_misc.spec.ts
@@ -10,7 +10,7 @@ import * as vtu from '../../validation_test_utils.js';
 import {
   TextureBindingType,
   kTextureBindingTypes,
-  IsReadOnlyTextureBindingType,
+  isReadOnlyTextureBindingType,
 } from '../texture/in_render_common.spec.js';
 
 function skipIfStorageTexturesUsedAndNotAvailableInFragmentStage(
@@ -168,7 +168,7 @@ g.test('subresources,set_bind_group_on_same_index_color_texture')
     renderPassEncoder.end();
 
     const noConflict =
-      (IsReadOnlyTextureBindingType(view1Binding) && IsReadOnlyTextureBindingType(view2Binding)) ||
+      (isReadOnlyTextureBindingType(view1Binding) && isReadOnlyTextureBindingType(view2Binding)) ||
       view1Binding === view2Binding;
     t.expectValidationError(() => {
       encoder.finish();
@@ -483,8 +483,8 @@ g.test('subresources,set_unused_bind_group')
     //   the render pass’s usage scope.
     const success =
       !inRenderPass ||
-      (IsReadOnlyTextureBindingType(textureUsage0) &&
-        IsReadOnlyTextureBindingType(textureUsage1)) ||
+      (isReadOnlyTextureBindingType(textureUsage0) &&
+        isReadOnlyTextureBindingType(textureUsage1)) ||
       textureUsage0 === textureUsage1;
     t.expectValidationError(() => {
       encoder.finish();
@@ -540,7 +540,7 @@ g.test('subresources,texture_usages_in_copy_and_render_pass')
       }),
     });
 
-    const UseTextureOnCommandEncoder = (
+    const useTextureOnCommandEncoder = (
       texture: GPUTexture,
       usage: 'copy-src' | 'copy-dst' | 'color-attachment' | TextureBindingType,
       encoder: GPUCommandEncoder
@@ -597,8 +597,8 @@ g.test('subresources,texture_usages_in_copy_and_render_pass')
       }
     };
     const encoder = t.device.createCommandEncoder();
-    UseTextureOnCommandEncoder(texture, usage0, encoder);
-    UseTextureOnCommandEncoder(texture, usage1, encoder);
+    useTextureOnCommandEncoder(texture, usage0, encoder);
+    useTextureOnCommandEncoder(texture, usage1, encoder);
     t.expectValidationError(() => {
       encoder.finish();
     }, false);


### PR DESCRIPTION
This is probably my OCD but, JavaScript style is almost universally, constructors are Capitalized and everything else is not.

Personally I wish we'd turn on the "new-cap" rule for eslint but unfortunately there are some slightly more difficult usages in the shader tests.

So, instead, thought I'd just try to refactor most code using C++ style to use JavaScript style so there are less examples to copy from.

Feel free to reject this PR if you think this is too intrusive.
