### PR TITLE
Additional test cases for encoder states

### DIFF
--- a/src/webgpu/api/validation/encoding/encoder_open_state.spec.ts
+++ b/src/webgpu/api/validation/encoding/encoder_open_state.spec.ts
@@ -274,15 +274,13 @@ g.test('render_pass_commands')
     `
     Test that functions of GPURenderPassEncoder generate a validation error if the encoder or the
     pass is already finished.
-
-    - TODO: Consider testing: nothing before command, end before command, end+finish before command.
   `
   )
   .params(u =>
     u
       .combine('command', kRenderPassEncoderCommands)
       .beginSubcases()
-      .combine('finishBeforeCommand', [false, true])
+      .combine('finishBeforeCommand', ['no', 'pass', 'encoder'])
   )
   .fn(t => {
     const { command, finishBeforeCommand } = t.params;
@@ -305,8 +303,10 @@ g.test('render_pass_commands')
 
     const bindGroup = t.createBindGroupForTest();
 
-    if (finishBeforeCommand) {
+    if (finishBeforeCommand !== 'no') {
       renderPass.end();
+    }
+    if (finishBeforeCommand === 'encoder') {
       encoder.finish();
     }
 
@@ -404,23 +404,25 @@ g.test('render_pass_commands')
           break;
         case 'pushDebugGroup':
           {
-            encoder.pushDebugGroup('group');
+            renderPass.pushDebugGroup('group');
           }
           break;
         case 'popDebugGroup':
           {
-            encoder.popDebugGroup();
+            renderPass.popDebugGroup();
           }
           break;
         case 'insertDebugMarker':
           {
-            encoder.insertDebugMarker('marker');
+            renderPass.insertDebugMarker('marker');
           }
           break;
         default:
           unreachable();
       }
-    }, finishBeforeCommand);
+    }, finishBeforeCommand !== 'no');
+    // TODO(https://github.com/gpuweb/gpuweb/issues/5207): resolve whether this
+    // is correct or should be changed to `finishBeforeCommand === 'encoder'`.
   });
 
 g.test('render_bundle_commands')
@@ -524,15 +526,13 @@ g.test('compute_pass_commands')
     `
     Test that functions of GPUComputePassEncoder generate a validation error if the encoder or the
     pass is already finished.
-
-    - TODO: Consider testing: nothing before command, end before command, end+finish before command.
   `
   )
   .params(u =>
     u
       .combine('command', kComputePassEncoderCommands)
       .beginSubcases()
-      .combine('finishBeforeCommand', [false, true])
+      .combine('finishBeforeCommand', ['no', 'pass', 'encoder'])
   )
   .fn(t => {
     const { command, finishBeforeCommand } = t.params;
@@ -549,8 +549,10 @@ g.test('compute_pass_commands')
 
     const bindGroup = t.createBindGroupForTest();
 
-    if (finishBeforeCommand) {
+    if (finishBeforeCommand !== 'no') {
       computePass.end();
+    }
+    if (finishBeforeCommand === 'encoder') {
       encoder.finish();
     }
 
@@ -594,5 +596,7 @@ g.test('compute_pass_commands')
         default:
           unreachable();
       }
-    }, finishBeforeCommand);
+    }, finishBeforeCommand !== 'no');
+    // TODO(https://github.com/gpuweb/gpuweb/issues/5207): resolve whether this
+    // is correct or should be changed to `finishBeforeCommand === 'encoder'`.
   });

--- a/src/webgpu/api/validation/encoding/encoder_open_state.spec.ts
+++ b/src/webgpu/api/validation/encoding/encoder_open_state.spec.ts
@@ -274,6 +274,10 @@ g.test('render_pass_commands')
     `
     Test that functions of GPURenderPassEncoder generate a validation error if the encoder or the
     pass is already finished.
+
+    TODO(https://github.com/gpuweb/gpuweb/issues/5207): Resolve whether the error condition
+    \`finishBeforeCommand !== 'no'\` is correct, or should be changed to
+    \`finishBeforeCommand === 'encoder'\`.
   `
   )
   .params(u =>
@@ -421,8 +425,6 @@ g.test('render_pass_commands')
           unreachable();
       }
     }, finishBeforeCommand !== 'no');
-    // TODO(https://github.com/gpuweb/gpuweb/issues/5207): resolve whether this
-    // is correct or should be changed to `finishBeforeCommand === 'encoder'`.
   });
 
 g.test('render_bundle_commands')
@@ -526,6 +528,10 @@ g.test('compute_pass_commands')
     `
     Test that functions of GPUComputePassEncoder generate a validation error if the encoder or the
     pass is already finished.
+
+    TODO(https://github.com/gpuweb/gpuweb/issues/5207): Resolve whether the error condition
+    \`finishBeforeCommand !== 'no'\` is correct, or should be changed to
+    \`finishBeforeCommand === 'encoder'\`.
   `
   )
   .params(u =>
@@ -597,6 +603,4 @@ g.test('compute_pass_commands')
           unreachable();
       }
     }, finishBeforeCommand !== 'no');
-    // TODO(https://github.com/gpuweb/gpuweb/issues/5207): resolve whether this
-    // is correct or should be changed to `finishBeforeCommand === 'encoder'`.
   });

--- a/src/webgpu/api/validation/encoding/encoder_state.spec.ts
+++ b/src/webgpu/api/validation/encoding/encoder_state.spec.ts
@@ -184,7 +184,7 @@ g.test('call_after_successful_finish')
         break;
     }
 
-    if (!IsEncoderFinished && !callCmd.startsWith("finish")) {
+    if (!IsEncoderFinished && !callCmd.startsWith('finish')) {
       encoder.finish();
     }
   });

--- a/src/webgpu/api/validation/encoding/encoder_state.spec.ts
+++ b/src/webgpu/api/validation/encoding/encoder_state.spec.ts
@@ -52,6 +52,9 @@ g.test('pass_end_invalid_order')
     `
   Test that beginning a {compute,render} pass before ending the previous {compute,render} pass
   causes an error.
+
+  TODO(https://github.com/gpuweb/gpuweb/issues/5207): Resolve whether a validation error
+  should be raised immediately if '!firstPassEnd && endPasses = [1, 0]'.
   `
   )
   .params(u =>
@@ -81,8 +84,6 @@ g.test('pass_end_invalid_order')
 
     const passes = [firstPass, secondPass];
     for (const index of endPasses) {
-      // TODO(https://github.com/gpuweb/gpuweb/issues/5207): should a validation error
-      // be raised here if `!firstPassEnd && endPasses = [1, 0]`?
       passes[index].end();
     }
 

--- a/src/webgpu/api/validation/encoding/encoder_state.spec.ts
+++ b/src/webgpu/api/validation/encoding/encoder_state.spec.ts
@@ -81,6 +81,8 @@ g.test('pass_end_invalid_order')
 
     const passes = [firstPass, secondPass];
     for (const index of endPasses) {
+      // TODO(https://github.com/gpuweb/gpuweb/issues/5207): should a validation error
+      // be raised here if `!firstPassEnd && endPasses = [1, 0]`?
       passes[index].end();
     }
 
@@ -275,7 +277,7 @@ g.test('pass_begin_invalid_encoder')
     const querySet = t.trackForCleanup(
       t.device.createQuerySet({
         type: 'timestamp',
-        count: 1,
+        count: 2,
       })
     );
 
@@ -291,7 +293,7 @@ g.test('pass_begin_invalid_encoder')
     const mismatchedQuerySet = t.trackForCleanup(
       t.mismatchedDevice.createQuerySet({
         type: 'timestamp',
-        count: 1,
+        count: 2,
       })
     );
 


### PR DESCRIPTION
Additional tests related to encoder states.

* In the `encoder_open_state` tests, add the case of attempting to record commands onto a finished pass while the encoder is still open. Previously, the test only covered the case where both the pass and the encoder are finished.
* In the `call_after_successful_finish` test, add the case where the call made after the successful finish is another call to `finish`. This is motivated by a [bug in Firefox](https://bugzilla.mozilla.org/show_bug.cgi?id=1972949).
* Test that it is possible to open passes on an invalid encoder.

The following tests are failing:
* In Chrome, the `encoder_open_state` tests for both render and compute passes. I noted this issue in https://github.com/gpuweb/gpuweb/issues/5207#issuecomment-2932996352. The issue description is a more convoluted case that is covered by an existing test, but this case is pretty much the same issue so I noted it in a comment. I also added a TODO on the other, existing test.
* In Safari, the `encoder_open_state:render_pass_commands` tests for the debug commands. Unlike the rest of the render pass commands, these cases were previously encoding the command onto the parent encoder rather than the render pass. This seemed unintentional, so I changed it, but maybe there's a special case here I'm not aware of.

I am not sure how to turn on "compatibility mode validation". I did try the tests in compatibility mode, if that's all this is.

<hr>

**Requirements for PR author:**

- [ ] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [ ] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [ ] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
