### PR TITLE
Refactor depth_clamp_and_clip test

### DIFF
--- a/src/webgpu/api/operation/rendering/depth_clip_clamp.spec.ts
+++ b/src/webgpu/api/operation/rendering/depth_clip_clamp.spec.ts
@@ -52,10 +52,6 @@ have unexpected values then get drawn to the color buffer, which is later checke
       t.skipIfDeviceDoesNotHaveFeature('depth-clip-control');
     }
 
-    const hasStorageBuffers = t.isCompatibility
-      ? t.device.limits.maxStorageBuffersInFragmentStage! > 0
-      : true;
-
     /** Number of depth values to test for both vertex output and frag_depth output. */
     const kNumDepthValues = 8;
     /** Test every combination of vertex output and frag_depth output. */
@@ -112,13 +108,7 @@ have unexpected values then get drawn to the color buffer, which is later checke
       @group(0) @binding(0) var <storage, read_write> output: Output;
 
       fn checkZ(vf: VFTest) {
-        ${
-          hasStorageBuffers
-            ? `
-          output.fragInputZDiff[vf.vertexIndex] = vf.pos.z - expectedFragPosZ(vf.vertexIndex);
-        `
-            : ''
-        }
+        output.fragInputZDiff[vf.vertexIndex] = vf.pos.z - expectedFragPosZ(vf.vertexIndex);
       }
 
       @fragment
@@ -149,9 +139,14 @@ have unexpected values then get drawn to the color buffer, which is later checke
       }
 
       struct FCheck {
-        @builtin(frag_depth) depth: f32,
         @location(0) color: f32,
       };
+
+      ${
+        multisampled
+          ? '@group(0) @binding(0) var depthTex: texture_multisampled_2d<f32>;'
+          : '@group(0) @binding(0) var depthTex: texture_2d<f32>;'
+      }
 
       @fragment
       fn fcheck(vf: VFCheck) -> FCheck {
@@ -169,9 +164,13 @@ have unexpected values then get drawn to the color buffer, which is later checke
           expectedDepthBufferValue = 0.5;
         }
 
+        let actualDepthBufferValue = textureLoad(depthTex, vec2u(vf.vertexIndex, 0), 0).r;
+        let actualVsExpectedDiff = abs(expectedDepthBufferValue - actualDepthBufferValue);
         var f: FCheck;
-        f.depth = expectedDepthBufferValue;
         f.color = 1.0; // Color written if the resulting depth is unexpected.
+        if (actualVsExpectedDiff < 1e-5) {
+          f.color = 0.0;
+        }
         return f;
       }
     `;
@@ -180,6 +179,7 @@ have unexpected values then get drawn to the color buffer, which is later checke
     // Draw points at different vertex depths and fragment depths into the depth attachment,
     // with a viewport of [0.25,0.75].
     const testPipeline = t.device.createRenderPipeline({
+      label: 'testPipeline',
       layout: 'auto',
       vertex: { module, entryPoint: 'vtest' },
       primitive: {
@@ -195,18 +195,29 @@ have unexpected values then get drawn to the color buffer, which is later checke
       },
     });
 
-    // Use depth comparison to check that the depth attachment now has the expected values.
+    const checkBindGroupLayout = t.device.createBindGroupLayout({
+      entries: [
+        {
+          binding: 0,
+          visibility: GPUShaderStage.FRAGMENT,
+          texture: {
+            sampleType: 'unfilterable-float',
+            multisampled,
+          },
+        },
+      ],
+    });
+
+    const checkPipelineLayout = t.device.createPipelineLayout({
+      bindGroupLayouts: [checkBindGroupLayout],
+    });
+
+    // Read the depth values and output 0 if they match expected, 1 if they don't
     const checkPipeline = t.device.createRenderPipeline({
-      layout: 'auto',
+      label: 'checkPipeline',
+      layout: checkPipelineLayout,
       vertex: { module, entryPoint: 'vcheck' },
       primitive: { topology: 'point-list' },
-      depthStencil: {
-        format,
-        // NOTE: This check is probably very susceptible to floating point error. If it fails, maybe
-        // replace it with two checks (less + greater) with an epsilon applied in the check shader?
-        depthCompare: 'not-equal', // Expect every depth value to be exactly equal.
-        depthWriteEnabled: true, // If the check failed, overwrite with the expected result.
-      },
       multisample: multisampled ? { count: 4 } : undefined,
       fragment: { module, entryPoint: 'fcheck', targets: [{ format: 'r8unorm' }] },
     });
@@ -214,7 +225,10 @@ have unexpected values then get drawn to the color buffer, which is later checke
     const dsTexture = t.createTextureTracked({
       format,
       size: [kNumTestPoints],
-      usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC,
+      usage:
+        GPUTextureUsage.RENDER_ATTACHMENT |
+        GPUTextureUsage.TEXTURE_BINDING |
+        GPUTextureUsage.COPY_SRC,
       sampleCount: multisampled ? 4 : 1,
     });
     const dsTextureView = dsTexture.createView();
@@ -254,12 +268,10 @@ have unexpected values then get drawn to the color buffer, which is later checke
       size: 4 * kNumTestPoints,
       usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC,
     });
-    const testBindGroup = hasStorageBuffers
-      ? t.device.createBindGroup({
-          layout: testPipeline.getBindGroupLayout(0),
-          entries: [{ binding: 0, resource: { buffer: fragInputZFailedBuffer } }],
-        })
-      : undefined;
+    const testBindGroup = t.device.createBindGroup({
+      layout: testPipeline.getBindGroupLayout(0),
+      entries: [{ binding: 0, resource: { buffer: fragInputZFailedBuffer } }],
+    });
 
     const enc = t.device.createCommandEncoder();
     {
@@ -278,9 +290,7 @@ have unexpected values then get drawn to the color buffer, which is later checke
         },
       });
       pass.setPipeline(testPipeline);
-      if (hasStorageBuffers) {
-        pass.setBindGroup(0, testBindGroup);
-      }
+      pass.setBindGroup(0, testBindGroup);
       pass.setViewport(0, 0, kNumTestPoints, 1, kViewportMinDepth, kViewportMaxDepth);
       pass.draw(kNumTestPoints);
       pass.end();
@@ -291,7 +301,11 @@ have unexpected values then get drawn to the color buffer, which is later checke
       ]);
     }
     {
-      const clearValue = [0, 0, 0, 0]; // Will see this color if the check passed.
+      const checkBindGroup = t.device.createBindGroup({
+        layout: checkBindGroupLayout,
+        entries: [{ binding: 0, resource: dsTexture.createView({ aspect: 'depth-only' }) }],
+      });
+      const clearValue = [0.5, 0.5, 0.5, 0.5]; // We should only see 0.0 or 1.0
       const pass = enc.beginRenderPass({
         colorAttachments: [
           checkTextureMSView
@@ -304,18 +318,9 @@ have unexpected values then get drawn to the color buffer, which is later checke
               }
             : { view: checkTextureView, clearValue, loadOp: 'clear', storeOp: 'store' },
         ],
-        depthStencilAttachment: {
-          view: dsTextureView,
-          depthLoadOp: 'load',
-          depthStoreOp: 'store',
-          ...(isStencilTextureFormat(format) && {
-            stencilClearValue: 0,
-            stencilLoadOp: 'clear',
-            stencilStoreOp: 'discard',
-          }),
-        },
       });
       pass.setPipeline(checkPipeline);
+      pass.setBindGroup(0, checkBindGroup);
       pass.setViewport(0, 0, kNumTestPoints, 1, 0.0, 1.0);
       pass.draw(kNumTestPoints);
       pass.end();
@@ -330,13 +335,11 @@ have unexpected values then get drawn to the color buffer, which is later checke
     }
     t.device.queue.submit([enc.finish()]);
 
-    if (hasStorageBuffers) {
-      t.expectGPUBufferValuesPassCheck(
-        fragInputZFailedBuffer,
-        a => checkElementsBetween(a, [() => -1e-5, () => 1e-5]),
-        { type: Float32Array, typedLength: kNumTestPoints }
-      );
-    }
+    t.expectGPUBufferValuesPassCheck(
+      fragInputZFailedBuffer,
+      a => checkElementsBetween(a, [() => -1e-5, () => 1e-5]),
+      { type: Float32Array, typedLength: kNumTestPoints }
+    );
 
     const kCheckPassedValue = 0;
     const predicatePrinter: CheckElementsSupplementalTableRows = [


### PR DESCRIPTION
The test had the comment that using `depthCompare: 'not-equal'` might not work so, switch the test to just reading the depth texture directly and comparing in the shader. This makes 4 cases pass on M1 Mac. Tested Intel Mac, AMD Mac, AMD Linux, GL Linux. For those there was no change. They were not failing the same 4 test cases that are fixed on M1 with this change.

Note: the hasStorageBuffers was removed because
maxStorageBuffersInFragmentShader can no longer be 0, even in compat.



![Screenshot 2025-06-11 at 11 56 41](https://github.com/user-attachments/assets/60a5a6f1-b8f0-4f59-8eb5-772f02689f2a)


Interestingly, Safari TP doesn't fail the 4 cases that Chrome is failing without these changes.

![Screenshot 2025-06-11 at 12 52 43](https://github.com/user-attachments/assets/59655e69-660e-4224-8215-7616d54eabe3)



