### PR TITLE
Allow GPUTexture where GPUTextureView is used

### DIFF
--- a/src/webgpu/api/validation/render_pass/render_pass_descriptor.spec.ts
+++ b/src/webgpu/api/validation/render_pass/render_pass_descriptor.spec.ts
@@ -62,7 +62,8 @@ class F extends AllFeaturesMaxLimitsGPUTest {
     texture: GPUTexture,
     textureViewDescriptor?: GPUTextureViewDescriptor
   ): GPURenderPassColorAttachment {
-    const view = texture.createView(textureViewDescriptor);
+    const { bindTextureResource = false } = this.params as { bindTextureResource?: boolean };
+    const view = bindTextureResource ? texture : texture.createView(textureViewDescriptor);
 
     return {
       view,
@@ -76,7 +77,8 @@ class F extends AllFeaturesMaxLimitsGPUTest {
     texture: GPUTexture,
     textureViewDescriptor?: GPUTextureViewDescriptor
   ): GPURenderPassDepthStencilAttachment {
-    const view = texture.createView(textureViewDescriptor);
+    const { bindTextureResource = false } = this.params as { bindTextureResource?: boolean };
+    const view = bindTextureResource ? texture : texture.createView(textureViewDescriptor);
 
     return {
       view,
@@ -105,6 +107,7 @@ const kArrayLayerCount = 10;
 
 g.test('attachments,one_color_attachment')
   .desc(`Test that a render pass works with only one color attachment.`)
+  .paramsSubcasesOnly(u => u.combine('bindTextureResource', [false, true] as const))
   .fn(t => {
     const colorTexture = t.createTestTexture({ format: 'rgba8unorm' });
     const descriptor = {
@@ -116,6 +119,7 @@ g.test('attachments,one_color_attachment')
 
 g.test('attachments,one_depth_stencil_attachment')
   .desc(`Test that a render pass works with only one depthStencil attachment.`)
+  .paramsSubcasesOnly(u => u.combine('bindTextureResource', [false, true] as const))
   .fn(t => {
     const depthStencilTexture = t.createTestTexture({ format: 'depth24plus-stencil8' });
     const descriptor = {

--- a/src/webgpu/api/validation/render_pass/resolve.spec.ts
+++ b/src/webgpu/api/validation/render_pass/resolve.spec.ts
@@ -32,8 +32,9 @@ Test various validation behaviors when a resolveTarget is provided.
 `
   )
   .paramsSimple([
-    // control case should be valid
+    // control cases should be valid
     { _valid: true },
+    { bindTextureResource: true, _valid: true },
     // a single sampled resolve source should cause a validation error.
     { colorAttachmentSamples: 1, _valid: false },
     // a multisampled resolve target should cause a validation error.
@@ -78,6 +79,7 @@ Test various validation behaviors when a resolveTarget is provided.
   ] as const)
   .fn(t => {
     const {
+      bindTextureResource = false,
       colorAttachmentFormat = 'rgba8unorm',
       resolveTargetFormat = 'rgba8unorm',
       otherAttachmentFormat = 'rgba8unorm',
@@ -139,6 +141,8 @@ Test various validation behaviors when a resolveTarget is provided.
             storeOp: 'discard',
             resolveTarget: resolveTargetInvalid
               ? vtu.getErrorTextureView(t)
+              : bindTextureResource
+              ? resolveTarget
               : resolveTarget.createView({
                   dimension: resolveTargetViewArrayLayerCount === 1 ? '2d' : '2d-array',
                   mipLevelCount: resolveTargetViewMipCount,


### PR DESCRIPTION
Spec PR: https://github.com/gpuweb/gpuweb/pull/5228

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.) They pass in a Chromium build patched with https://chromium-review.googlesource.com/c/chromium/src/+/6656722
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
