### PR TITLE
Fix textureStore test

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/textureStore.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureStore.spec.ts
@@ -100,7 +100,7 @@ g.test('texel_formats')
   )
   .fn(t => {
     const { format, stage, access, viewDimension, mipLevel } = t.params;
-    t.skipIfTextureFormatNotUsableAsReadWriteStorageTexture(format);
+    t.skipIfTextureFormatNotUsableAsStorageTexture(format);
 
     const { componentType } = getTextureFormatTypeInfo(format);
     const values = inputArray(format);


### PR DESCRIPTION
It needs all storage readable texture formats
but it was filtering on read-write texture formats.

