### PR TITLE
Rename isTextureFormatUsableAsStorageFormat to isTextureFormatUsableAsStorageTexture

### DIFF
--- a/src/webgpu/api/validation/createBindGroupLayout.spec.ts
+++ b/src/webgpu/api/validation/createBindGroupLayout.spec.ts
@@ -22,7 +22,7 @@ import {
 } from '../../capability_info.js';
 import {
   isTextureFormatUsableAsReadWriteStorageTexture,
-  isTextureFormatUsableAsStorageFormat,
+  isTextureFormatUsableAsStorageTexture,
   kAllTextureFormats,
 } from '../../format_info.js';
 
@@ -512,7 +512,7 @@ g.test('storage_texture,formats')
     t.skipIfTextureFormatNotSupported(format);
 
     const success =
-      isTextureFormatUsableAsStorageFormat(t.device, format) &&
+      isTextureFormatUsableAsStorageTexture(t.device, format) &&
       !(
         access === 'read-write' && !isTextureFormatUsableAsReadWriteStorageTexture(t.device, format)
       );

--- a/src/webgpu/api/validation/createTexture.spec.ts
+++ b/src/webgpu/api/validation/createTexture.spec.ts
@@ -16,7 +16,7 @@ import {
   getBlockInfoForTextureFormat,
   isTextureFormatMultisampled,
   isTextureFormatColorRenderable,
-  isTextureFormatUsableAsStorageFormat,
+  isTextureFormatUsableAsStorageTexture,
   isTextureFormatPossiblyUsableAsColorRenderAttachment,
   isTextureFormatPossiblyStorageReadable,
   isColorTextureFormat,
@@ -373,7 +373,7 @@ g.test('sampleCount,valid_sampleCount_with_other_parameter_varies')
 
     const satisfyWithStorageUsageRequirement =
       (usage & GPUConst.TextureUsage.STORAGE_BINDING) === 0 ||
-      isTextureFormatUsableAsStorageFormat(t.device, format);
+      isTextureFormatUsableAsStorageTexture(t.device, format);
 
     const success =
       (sampleCount === 1 && satisfyWithStorageUsageRequirement) ||
@@ -1029,7 +1029,7 @@ g.test('texture_usage')
     // Note that we unconditionally test copy usages for all formats and
     // expect failure if copying from or to is not supported.
     if (usage & GPUTextureUsage.STORAGE_BINDING) {
-      if (!isTextureFormatUsableAsStorageFormat(t.device, format)) success = false;
+      if (!isTextureFormatUsableAsStorageTexture(t.device, format)) success = false;
     }
     if (usage & GPUTextureUsage.RENDER_ATTACHMENT) {
       if (appliedDimension === '1d') success = false;

--- a/src/webgpu/format_info.ts
+++ b/src/webgpu/format_info.ts
@@ -1680,7 +1680,7 @@ type TextureFormatInfo_TypeCheck = {
  * * isTextureFormatResolvable
  * * isTextureFormatBlendable
  * * isTextureFormatMultisampled
- * * isTextureFormatUsableAsStorageFormat
+ * * isTextureFormatUsableAsStorageTexture
  * * isTextureFormatUsableAsReadWriteStorageTexture
  * * isTextureFormatUsableAsStorageFormatInCreateShaderModule
  *
@@ -2426,7 +2426,7 @@ export const kCompatModeUnsupportedStorageTextureFormats: readonly GPUTextureFor
  * can be used in general. If you want to know if the format can used when compiling
  * a shader @see {@link isTextureFormatUsableAsStorageFormatInCreateShaderModule}
  */
-export function isTextureFormatUsableAsStorageFormat(
+export function isTextureFormatUsableAsStorageTexture(
   device: GPUDevice,
   format: GPUTextureFormat
 ): boolean {
@@ -2473,7 +2473,7 @@ export function isTextureFormatUsableAsReadWriteStorageTexture(
   format: GPUTextureFormat
 ): boolean {
   return (
-    isTextureFormatUsableAsStorageFormat(device, format) &&
+    isTextureFormatUsableAsStorageTexture(device, format) &&
     !!kTextureFormatInfo[format].color?.readWriteStorage
   );
 }

--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -29,7 +29,7 @@ import {
   EncodableTextureFormat,
   isCompressedTextureFormat,
   getRequiredFeatureForTextureFormat,
-  isTextureFormatUsableAsStorageFormat,
+  isTextureFormatUsableAsStorageTexture,
   isTextureFormatUsableAsRenderAttachment,
   isTextureFormatMultisampled,
   is32Float,
@@ -567,7 +567,7 @@ export class GPUTestBase extends Fixture<GPUTestSubcaseBatchState> {
 
   skipIfTextureFormatNotUsableAsStorageTexture(...formats: (GPUTextureFormat | undefined)[]) {
     for (const format of formats) {
-      if (format && !isTextureFormatUsableAsStorageFormat(this.device, format)) {
+      if (format && !isTextureFormatUsableAsStorageTexture(this.device, format)) {
         this.skip(`Texture with ${format} is not usable as a storage texture`);
       }
     }


### PR DESCRIPTION
This matches GPUTest.skipIfTextureFormatNotUsableAsStorageTexture



