### PR TITLE
Refactor that not all storage texture support read-only

### DIFF
--- a/src/webgpu/api/operation/storage_texture/read_only.spec.ts
+++ b/src/webgpu/api/operation/storage_texture/read_only.spec.ts
@@ -553,7 +553,7 @@ g.test('basic')
   .fn(t => {
     const { format, shaderStage, dimension, depthOrArrayLayers } = t.params;
     t.skipIfTextureFormatNotSupported(format);
-    t.skipIfTextureFormatNotUsableAsStorageTexture(format);
+    t.skipIfTextureFormatNotUsableWithStorageAccessMode('read-only', format);
 
     if (t.isCompatibility) {
       if (shaderStage === 'fragment') {

--- a/src/webgpu/api/operation/storage_texture/read_write.spec.ts
+++ b/src/webgpu/api/operation/storage_texture/read_write.spec.ts
@@ -321,7 +321,7 @@ g.test('basic')
   .fn(t => {
     const { format, shaderStage, textureDimension, depthOrArrayLayers } = t.params;
     t.skipIfTextureFormatNotSupported(format);
-    t.skipIfTextureFormatNotUsableAsReadWriteStorageTexture(format);
+    t.skipIfTextureFormatNotUsableWithStorageAccessMode('read-write', format);
 
     if (t.isCompatibility) {
       if (shaderStage === 'fragment') {

--- a/src/webgpu/api/operation/texture_view/write.spec.ts
+++ b/src/webgpu/api/operation/texture_view/write.spec.ts
@@ -346,7 +346,7 @@ TODO: Test rgb10a2uint when TexelRepresentation.numericRange is made per-compone
     switch (method) {
       case 'storage-write-compute':
       case 'storage-write-fragment':
-        t.skipIfTextureFormatNotUsableAsStorageTexture(format);
+        t.skipIfTextureFormatNotUsableWithStorageAccessMode('write-only', format);
         break;
       case 'render-pass-store':
         t.skipIfTextureFormatNotUsableAsRenderAttachment(format);

--- a/src/webgpu/api/validation/capability_checks/features/texture_formats.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/features/texture_formats.spec.ts
@@ -336,7 +336,7 @@ g.test('storage_texture_binding_layout')
   })
   .fn(t => {
     const { format, enable_required_feature } = t.params;
-    t.skipIfTextureFormatNotUsableAsStorageTexture(format);
+    t.skipIfTextureFormatNotUsableWithStorageAccessMode('write-only', format);
 
     t.shouldThrow(enable_required_feature ? false : 'TypeError', () => {
       t.device.createBindGroupLayout({

--- a/src/webgpu/api/validation/createBindGroup.spec.ts
+++ b/src/webgpu/api/validation/createBindGroup.spec.ts
@@ -873,7 +873,11 @@ g.test('storage_texture,format')
   .fn(t => {
     const { storageTextureFormat, resourceFormat } = t.params;
     t.skipIfTextureFormatNotSupported(storageTextureFormat, resourceFormat);
-    t.skipIfTextureFormatNotUsableAsStorageTexture(storageTextureFormat, resourceFormat);
+    t.skipIfTextureFormatNotUsableWithStorageAccessMode(
+      'write-only',
+      storageTextureFormat,
+      resourceFormat
+    );
 
     const bindGroupLayout = t.device.createBindGroupLayout({
       entries: [

--- a/src/webgpu/api/validation/createBindGroupLayout.spec.ts
+++ b/src/webgpu/api/validation/createBindGroupLayout.spec.ts
@@ -21,8 +21,7 @@ import {
   getBindingLimitForBindingType,
 } from '../../capability_info.js';
 import {
-  isTextureFormatUsableAsReadWriteStorageTexture,
-  isTextureFormatUsableAsStorageTexture,
+  isTextureFormatUsableWithStorageAccessMode,
   kAllTextureFormats,
 } from '../../format_info.js';
 
@@ -511,11 +510,7 @@ g.test('storage_texture,formats')
     const { format, access } = t.params;
     t.skipIfTextureFormatNotSupported(format);
 
-    const success =
-      isTextureFormatUsableAsStorageTexture(t.device, format) &&
-      !(
-        access === 'read-write' && !isTextureFormatUsableAsReadWriteStorageTexture(t.device, format)
-      );
+    const success = isTextureFormatUsableWithStorageAccessMode(t.device, format, access);
 
     t.expectValidationError(() => {
       t.device.createBindGroupLayout({

--- a/src/webgpu/api/validation/createTexture.spec.ts
+++ b/src/webgpu/api/validation/createTexture.spec.ts
@@ -16,13 +16,13 @@ import {
   getBlockInfoForTextureFormat,
   isTextureFormatMultisampled,
   isTextureFormatColorRenderable,
-  isTextureFormatUsableAsStorageTexture,
   isTextureFormatPossiblyUsableAsColorRenderAttachment,
   isTextureFormatPossiblyStorageReadable,
   isColorTextureFormat,
   textureFormatsAreViewCompatible,
   textureDimensionAndFormatCompatibleForDevice,
   getMaxValidTextureSizeForFormatAndDimension,
+  isTextureFormatUsableWithStorageAccessMode,
 } from '../../format_info.js';
 import { maxMipLevelCount } from '../../util/texture/base.js';
 
@@ -373,7 +373,7 @@ g.test('sampleCount,valid_sampleCount_with_other_parameter_varies')
 
     const satisfyWithStorageUsageRequirement =
       (usage & GPUConst.TextureUsage.STORAGE_BINDING) === 0 ||
-      isTextureFormatUsableAsStorageTexture(t.device, format);
+      isTextureFormatUsableWithStorageAccessMode(t.device, format, 'write-only');
 
     const success =
       (sampleCount === 1 && satisfyWithStorageUsageRequirement) ||
@@ -1029,7 +1029,8 @@ g.test('texture_usage')
     // Note that we unconditionally test copy usages for all formats and
     // expect failure if copying from or to is not supported.
     if (usage & GPUTextureUsage.STORAGE_BINDING) {
-      if (!isTextureFormatUsableAsStorageTexture(t.device, format)) success = false;
+      if (!isTextureFormatUsableWithStorageAccessMode(t.device, format, 'write-only'))
+        success = false;
     }
     if (usage & GPUTextureUsage.RENDER_ATTACHMENT) {
       if (appliedDimension === '1d') success = false;

--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -29,17 +29,16 @@ import {
   EncodableTextureFormat,
   isCompressedTextureFormat,
   getRequiredFeatureForTextureFormat,
-  isTextureFormatUsableAsStorageTexture,
   isTextureFormatUsableAsRenderAttachment,
   isTextureFormatMultisampled,
   is32Float,
   isSintOrUintFormat,
   isTextureFormatResolvable,
-  isTextureFormatUsableAsReadWriteStorageTexture,
   isDepthTextureFormat,
   isStencilTextureFormat,
   textureViewDimensionAndFormatCompatibleForDevice,
   textureDimensionAndFormatCompatibleForDevice,
+  isTextureFormatUsableWithStorageAccessMode,
 } from './format_info.js';
 import { checkElementsEqual, checkElementsBetween } from './util/check_contents.js';
 import { CommandBufferMaker, EncoderType } from './util/command_buffer_maker.js';
@@ -565,22 +564,17 @@ export class GPUTestBase extends Fixture<GPUTestSubcaseBatchState> {
     }
   }
 
-  skipIfTextureFormatNotUsableAsStorageTexture(...formats: (GPUTextureFormat | undefined)[]) {
-    for (const format of formats) {
-      if (format && !isTextureFormatUsableAsStorageTexture(this.device, format)) {
-        this.skip(`Texture with ${format} is not usable as a storage texture`);
-      }
-    }
-  }
-
-  skipIfTextureFormatNotUsableAsReadWriteStorageTexture(
+  skipIfTextureFormatNotUsableWithStorageAccessMode(
+    access: GPUStorageTextureAccess | 'read' | 'write' | 'read_write',
     ...formats: (GPUTextureFormat | undefined)[]
   ) {
     for (const format of formats) {
       if (!format) continue;
 
-      if (!isTextureFormatUsableAsReadWriteStorageTexture(this.device, format)) {
-        this.skip(`Texture with ${format} is not usable as a storage texture`);
+      if (!isTextureFormatUsableWithStorageAccessMode(this.device, format, access)) {
+        this.skip(
+          `Texture with ${format} is not usable as a storage texture with access ${access}`
+        );
       }
     }
   }
@@ -638,7 +632,7 @@ export class GPUTestBase extends Fixture<GPUTestSubcaseBatchState> {
         this.skipIfTextureFormatNotUsableAsRenderAttachment(format);
       }
       if (usage & GPUTextureUsage.STORAGE_BINDING) {
-        this.skipIfTextureFormatNotUsableAsStorageTexture(format);
+        this.skipIfTextureFormatNotUsableWithStorageAccessMode('write-only', format);
       }
     }
   }

--- a/src/webgpu/listing_meta.json
+++ b/src/webgpu/listing_meta.json
@@ -913,6 +913,7 @@
   "webgpu:idl,constructable:pipeline_errors:*": { "subcaseMS": 0.101 },
   "webgpu:idl,constructable:uncaptured_error_event:*": { "subcaseMS": 0.101 },
   "webgpu:idl,javascript:device,EventTarget:*": { "subcaseMS": 79.123 },
+  "webgpu:print_environment:info:*": { "subcaseMS": 17.347 },
   "webgpu:shader,execution,expression,access,array,index:abstract_scalar:*": { "subcaseMS": 235.962 },
   "webgpu:shader,execution,expression,access,array,index:bool:*": { "subcaseMS": 663.038 },
   "webgpu:shader,execution,expression,access,array,index:concrete_scalar:*": { "subcaseMS": 1439.796 },

--- a/src/webgpu/shader/execution/expression/call/builtin/textureDimensions.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureDimensions.spec.ts
@@ -485,7 +485,7 @@ Parameters:
   .fn(t => {
     skipIfNoStorageTexturesInStage(t, t.params.stage);
     t.skipIfTextureFormatNotSupported(t.params.format);
-    t.skipIfTextureFormatNotUsableAsStorageTexture(t.params.format);
+    t.skipIfTextureFormatNotUsableWithStorageAccessMode(t.params.access, t.params.format);
 
     const values = testValues(t.params);
     const texture = t.createTextureTracked({

--- a/src/webgpu/shader/execution/expression/call/builtin/textureLoad.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureLoad.spec.ts
@@ -712,7 +712,7 @@ Parameters:
     const { format, stage, samplePoints, C } = t.params;
 
     t.skipIfTextureFormatNotSupported(format);
-    t.skipIfTextureFormatNotUsableAsStorageTexture(format);
+    t.skipIfTextureFormatNotUsableWithStorageAccessMode('read-only', format);
     skipIfStorageTexturesNotSupportedInStage(t, stage);
 
     // We want at least 3 blocks or something wide enough for 3 mip levels.
@@ -791,7 +791,7 @@ Parameters:
     const { format, stage, samplePoints, C, baseMipLevel } = t.params;
 
     t.skipIfTextureFormatNotSupported(format);
-    t.skipIfTextureFormatNotUsableAsStorageTexture(format);
+    t.skipIfTextureFormatNotUsableWithStorageAccessMode('read-only', format);
     skipIfStorageTexturesNotSupportedInStage(t, stage);
 
     // We want at least 3 blocks or something wide enough for 3 mip levels.
@@ -883,7 +883,7 @@ Parameters:
       t.params;
 
     t.skipIfTextureFormatNotSupported(format);
-    t.skipIfTextureFormatNotUsableAsStorageTexture(format);
+    t.skipIfTextureFormatNotUsableWithStorageAccessMode('read-only', format);
     skipIfStorageTexturesNotSupportedInStage(t, stage);
 
     // We want at least 3 blocks or something wide enough for 3 mip levels.
@@ -971,7 +971,7 @@ Parameters:
     const { format, stage, samplePoints, C } = t.params;
 
     t.skipIfTextureFormatNotSupported(format);
-    t.skipIfTextureFormatNotUsableAsStorageTexture(format);
+    t.skipIfTextureFormatNotUsableWithStorageAccessMode('read-only', format);
     skipIfStorageTexturesNotSupportedInStage(t, stage);
 
     // We want at least 3 blocks or something wide enough for 3 mip levels.

--- a/src/webgpu/shader/execution/expression/call/builtin/textureNumLayers.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureNumLayers.spec.ts
@@ -213,10 +213,7 @@ Parameters
     const { stage, format, access_mode, view_type } = t.params;
     skipIfNoStorageTexturesInStage(t, stage);
     t.skipIfTextureFormatNotSupported(format);
-    t.skipIfTextureFormatNotUsableAsStorageTexture(format);
-    if (access_mode === 'read_write') {
-      t.skipIfTextureFormatNotUsableAsReadWriteStorageTexture(format);
-    }
+    t.skipIfTextureFormatNotUsableWithStorageAccessMode(access_mode, format);
 
     const texture = t.createTextureTracked({
       format,

--- a/src/webgpu/shader/execution/expression/call/builtin/textureStore.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/textureStore.spec.ts
@@ -100,7 +100,8 @@ g.test('texel_formats')
   )
   .fn(t => {
     const { format, stage, access, viewDimension, mipLevel } = t.params;
-    t.skipIfTextureFormatNotUsableAsStorageTexture(format);
+    t.skipIfTextureFormatNotSupported(format);
+    t.skipIfTextureFormatNotUsableWithStorageAccessMode(access, format);
 
     const { componentType } = getTextureFormatTypeInfo(format);
     const values = inputArray(format);

--- a/src/webgpu/shader/execution/memory_model/texture_intra_invocation_coherence.spec.ts
+++ b/src/webgpu/shader/execution/memory_model/texture_intra_invocation_coherence.spec.ts
@@ -151,7 +151,7 @@ g.test('texture_intra_invocation_coherence')
   .fn(t => {
     t.skipIfLanguageFeatureNotSupported('readonly_and_readwrite_storage_textures');
     t.skipIfTextureFormatNotSupported(t.params.format);
-    t.skipIfTextureFormatNotUsableAsReadWriteStorageTexture(t.params.format);
+    t.skipIfTextureFormatNotUsableWithStorageAccessMode('read-write', t.params.format);
 
     const wgx = 16;
     const wgy = t.device.limits.maxComputeInvocationsPerWorkgroup / wgx;

--- a/src/webgpu/shader/validation/expression/call/builtin/textureDimensions.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/textureDimensions.spec.ts
@@ -160,7 +160,8 @@ Validates the return type of ${builtin} is the expected type.
   )
   .fn(t => {
     const { returnType, textureType, format } = t.params;
-    t.skipIfTextureFormatNotUsableAsStorageTexture(format);
+    t.skipIfTextureFormatNotSupported(format);
+    t.skipIfTextureFormatNotUsableWithStorageAccessMode('write-only', format);
 
     const returnVarType = kValuesTypes[returnType];
     const { returnType: returnRequiredType, hasLevelArg } =
@@ -170,7 +171,7 @@ Validates the return type of ${builtin} is the expected type.
     const levelWGSL = hasLevelArg ? ', 0' : '';
 
     const code = `
-@group(0) @binding(0) var t: ${textureType}<${format}, read>;
+@group(0) @binding(0) var t: ${textureType}<${format}, write>;
 @fragment fn fs() -> @location(0) vec4f {
   let v: ${varWGSL} = textureDimensions(t${levelWGSL});
   return vec4f(0);

--- a/src/webgpu/shader/validation/expression/call/builtin/textureLoad.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/textureLoad.spec.ts
@@ -210,7 +210,8 @@ Validates that only incorrect coords arguments are rejected by ${builtin}
   )
   .fn(t => {
     const { textureType, coordType, format, value } = t.params;
-    t.skipIfTextureFormatNotUsableAsStorageTexture(format);
+    t.skipIfTextureFormatNotSupported(format);
+    t.skipIfTextureFormatNotUsableWithStorageAccessMode('read-only', format);
 
     const coordArgType = kValuesTypes[coordType];
     const { coordsArgTypes, hasArrayIndexArg } =
@@ -308,7 +309,8 @@ Validates that only incorrect array_index arguments are rejected by ${builtin}
   )
   .fn(t => {
     const { textureType, arrayIndexType, format, value } = t.params;
-    t.skipIfTextureFormatNotUsableAsStorageTexture(format);
+    t.skipIfTextureFormatNotSupported(format);
+    t.skipIfTextureFormatNotUsableWithStorageAccessMode('read-only', format);
 
     const arrayIndexArgType = kValuesTypes[arrayIndexType];
     const args = [arrayIndexArgType.create(value)];

--- a/src/webgpu/shader/validation/expression/call/builtin/textureNumLayers.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/textureNumLayers.spec.ts
@@ -87,14 +87,15 @@ Validates the return type of ${builtin} is the expected type.
   )
   .fn(t => {
     const { returnType, textureType, format } = t.params;
-    t.skipIfTextureFormatNotUsableAsStorageTexture(format);
+    t.skipIfTextureFormatNotSupported(format);
+    t.skipIfTextureFormatNotUsableWithStorageAccessMode('write-only', format);
 
     const returnVarType = kValuesTypes[returnType];
 
     const varWGSL = returnVarType.toString();
 
     const code = `
-@group(0) @binding(0) var t: ${textureType}<${format}, read>;
+@group(0) @binding(0) var t: ${textureType}<${format}, write>;
 @fragment fn fs() -> @location(0) vec4f {
   let v: ${varWGSL} = textureNumLayers(t);
   return vec4f(0);

--- a/src/webgpu/shader/validation/expression/call/builtin/textureStore.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/textureStore.spec.ts
@@ -153,7 +153,8 @@ Validates that only incorrect value arguments are rejected by ${builtin}
   )
   .fn(t => {
     const { textureType, valueType, format, value } = t.params;
-    t.skipIfTextureFormatNotUsableAsStorageTexture(format);
+    t.skipIfTextureFormatNotSupported(format);
+    t.skipIfTextureFormatNotUsableWithStorageAccessMode('write-only', format);
 
     const valueArgType = kValuesTypes[valueType];
     const args = [valueArgType.create(value)];

--- a/src/webgpu/shader/validation/types/textures.spec.ts
+++ b/src/webgpu/shader/validation/types/textures.spec.ts
@@ -26,7 +26,8 @@ g.test('texel_formats')
   )
   .fn(t => {
     const { format, shaderScalarType } = t.params;
-    t.skipIfTextureFormatNotUsableAsStorageTexture(format);
+    t.skipIfTextureFormatNotSupported(format);
+    t.skipIfTextureFormatNotUsableWithStorageAccessMode('read-only', format);
     const validShaderScalarType = getPlainTypeInfo(getTextureFormatType(format));
     const shaderValueType = `vec4<${shaderScalarType}>`;
     const wgsl = `


### PR DESCRIPTION
The code assumed all textures marked as 'storage: true' could both do `read-only` and `write-only` but `bgra8norm` can never do `read-only`.

Refactor be able to separately check for read-only and write-only usage.

Issue:
* https://github.com/gpuweb/gpuweb/issues/5232
* https://github.com/gpuweb/cts/issues/4412

