### PR TITLE
Test layout auto/storage texture formats/access modes

### DIFF
--- a/src/webgpu/api/validation/compute_pipeline.spec.ts
+++ b/src/webgpu/api/validation/compute_pipeline.spec.ts
@@ -7,6 +7,10 @@ Note: entry point matching tests are in shader_module/entry_point.spec.ts
 import { AllFeaturesMaxLimitsGPUTest } from '../.././gpu_test.js';
 import { makeTestGroup } from '../../../common/framework/test_group.js';
 import { keysOf } from '../../../common/util/data_tables.js';
+import {
+  isTextureFormatUsableWithStorageAccessMode,
+  kPossibleStorageTextureFormats,
+} from '../../format_info.js';
 import { kValue } from '../../util/constants.js';
 import { TShaderStage, getShaderWithEntryPoint } from '../../util/shader.js';
 
@@ -771,4 +775,39 @@ g.test('resource_compatibility')
       doResourcesMatch(apiResource, wgslResource),
       descriptor
     );
+  });
+
+g.test('storage_texture,format')
+  .desc(
+    `
+Test that a pipeline with auto layout and storage texture access combo that is not supported
+generates a validation error at createComputePipeline(Async)
+  `
+  )
+  .params(u =>
+    u //
+      .combine('format', kPossibleStorageTextureFormats)
+      .beginSubcases()
+      .combine('isAsync', [true, false] as const)
+      .combine('access', ['read', 'write', 'read_write'] as const)
+      .combine('dimension', ['1d', '2d', '3d'] as const)
+  )
+  .fn(t => {
+    const { format, isAsync, access, dimension } = t.params;
+    t.skipIfTextureFormatNotSupported(format);
+
+    const code = `
+      @group(0) @binding(0) var tex: texture_storage_${dimension}<${format}, ${access}>;
+      @compute @workgroup_size(1) fn main() {
+        _ = tex;
+      }
+    `;
+    const module = t.device.createShaderModule({ code });
+
+    const success = isTextureFormatUsableWithStorageAccessMode(t.device, format, access);
+    const descriptor: GPUComputePipelineDescriptor = {
+      layout: 'auto',
+      compute: { module },
+    };
+    vtu.doCreateComputePipelineTest(t, isAsync, success, descriptor);
   });

--- a/src/webgpu/api/validation/render_pipeline/misc.spec.ts
+++ b/src/webgpu/api/validation/render_pipeline/misc.spec.ts
@@ -3,6 +3,10 @@ misc createRenderPipeline and createRenderPipelineAsync validation tests.
 `;
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import {
+  isTextureFormatUsableWithStorageAccessMode,
+  kPossibleStorageTextureFormats,
+} from '../../../format_info.js';
 import { kDefaultVertexShaderCode, kDefaultFragmentShaderCode } from '../../../util/shader.js';
 import * as vtu from '../validation_test_utils.js';
 
@@ -146,4 +150,45 @@ g.test('external_texture')
     };
 
     vtu.doCreateRenderPipelineTest(t, false, true, descriptor);
+  });
+
+g.test('storage_texture,format')
+  .desc(
+    `
+Test that a pipeline with auto layout and storage texture access combo that is not supported
+generates a validation error at createComputePipeline(Async)
+  `
+  )
+  .params(u =>
+    u //
+      .combine('format', kPossibleStorageTextureFormats)
+      .beginSubcases()
+      .combine('isAsync', [true, false] as const)
+      .combine('access', ['read', 'write', 'read_write'] as const)
+      .combine('dimension', ['1d', '2d', '3d'] as const)
+  )
+  .fn(t => {
+    const { format, isAsync, access, dimension } = t.params;
+    t.skipIfTextureFormatNotSupported(format);
+
+    const code = `
+      @group(0) @binding(0) var tex: texture_storage_${dimension}<${format}, ${access}>;
+      @vertex fn vs() -> @builtin(position) vec4f {
+        return vec4f(0);
+      }
+
+      @fragment fn fs() -> @location(0) vec4f {
+        _ = tex;
+        return vec4f(0);
+      }
+    `;
+    const module = t.device.createShaderModule({ code });
+
+    const success = isTextureFormatUsableWithStorageAccessMode(t.device, format, access);
+    const descriptor: GPURenderPipelineDescriptor = {
+      layout: 'auto',
+      vertex: { module },
+      fragment: { module, targets: [{ format: 'rgba8unorm' }] },
+    };
+    vtu.doCreateRenderPipelineTest(t, isAsync, success, descriptor);
   });


### PR DESCRIPTION
I'm not sure if this is tested elsewhere. I didn't see it. This is testing that bindGroupLayouts that are invalid when calling createBindGroupLayout are also invalid if the bindgroup layout is auto-generated, specifically for storage texture formats and access modes.


