### PR TITLE
tier1/2 add pipeline auto-layout tests.

### DIFF
--- a/src/webgpu/api/validation/capability_checks/features/texture_formats_tier1.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/features/texture_formats_tier1.spec.ts
@@ -249,3 +249,70 @@ g.test('bind_group_layout,storage_texture')
       });
     }, !enable_feature);
   });
+
+g.test('pipeline_auto_layout,storage_texture')
+  .desc(
+    `
+  Test creating a pipeline with auto layout with a storage texture binding format enabled by
+  'texture-formats-tier1' fails if the feature is not enabled.
+  `
+  )
+  .params(u =>
+    u
+      .combine('format', kTextureFormatsTier1EnablesStorageReadOnlyWriteOnly)
+      .combine('access', ['read', 'write'] as const) // Tier1 enables read-only/write-only for these
+      .combine('enable_feature', [true, false])
+      .beginSubcases()
+      .combine('isAsync', [false, true] as const)
+      .combine('type', ['compute', 'render'] as const)
+  )
+  .beforeAllSubcases(t => {
+    const { enable_feature } = t.params;
+    if (enable_feature) {
+      t.selectDeviceOrSkipTestCase('texture-formats-tier1');
+    }
+  })
+  .fn(t => {
+    const { format, access, enable_feature, isAsync, type } = t.params;
+
+    const code = `
+      @group(0) @binding(0) var tex1d: texture_storage_1d<${format}, ${access}>;
+      @group(0) @binding(1) var tex2d: texture_storage_1d<${format}, ${access}>;
+      @group(0) @binding(2) var tex3d: texture_storage_1d<${format}, ${access}>;
+
+      fn useTextures() {
+        _ = tex1d;
+        _ = tex2d;
+        _ = tex3d;
+      }
+
+      @compute @workgroup_size(1) fn cs() {
+        useTextures();
+      }
+
+      @vertex fn vs() -> @builtin(position) vec4f {
+        return vec4f(0);
+      }
+      @fragment fn fs() -> @location(0) vec4f {
+        useTextures();
+        return vec4f(0);
+      }
+    `;
+
+    const module = t.device.createShaderModule({ code });
+
+    if (type === 'compute') {
+      const descriptor: GPUComputePipelineDescriptor = {
+        layout: 'auto',
+        compute: { module },
+      };
+      vtu.doCreateComputePipelineTest(t, isAsync, enable_feature, descriptor);
+    } else {
+      const descriptor: GPURenderPipelineDescriptor = {
+        layout: 'auto',
+        vertex: { module },
+        fragment: { module, targets: [{ format: 'rgba8unorm' }] },
+      };
+      vtu.doCreateRenderPipelineTest(t, isAsync, enable_feature, descriptor);
+    }
+  });

--- a/src/webgpu/api/validation/capability_checks/features/texture_formats_tier2.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/features/texture_formats_tier2.spec.ts
@@ -69,7 +69,7 @@ g.test('pipeline_auto_layout,storage_texture')
   .desc(
     `
   Test creating a pipeline with auto layout with a storage texture binding format enabled by
-  'texture-formats-tier1' fails if the feature is not enabled.
+  'texture-formats-tier2' fails if the feature is not enabled.
   `
   )
   .params(u =>

--- a/src/webgpu/api/validation/capability_checks/features/texture_formats_tier2.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/features/texture_formats_tier2.spec.ts
@@ -83,7 +83,7 @@ g.test('pipeline_auto_layout,storage_texture')
   .beforeAllSubcases(t => {
     const { enable_feature } = t.params;
     if (enable_feature) {
-      t.selectDeviceOrSkipTestCase('texture-formats-tier1');
+      t.selectDeviceOrSkipTestCase('texture-formats-tier2');
     }
   })
   .fn(t => {

--- a/src/webgpu/api/validation/capability_checks/features/texture_formats_tier2.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/features/texture_formats_tier2.spec.ts
@@ -11,6 +11,7 @@ when the feature is not enabled. This includes:
 import { makeTestGroup } from '../../../../../common/framework/test_group.js';
 import { kTextureFormatsTier2EnablesStorageReadWrite } from '../../../../format_info.js';
 import { UniqueFeaturesOrLimitsGPUTest } from '../../../../gpu_test.js';
+import * as vtu from '../../validation_test_utils.js';
 
 export const g = makeTestGroup(UniqueFeaturesOrLimitsGPUTest);
 
@@ -62,4 +63,70 @@ g.test('bind_group_layout,storage_binding_read_write_access')
         ],
       });
     }, !enable_feature);
+  });
+
+g.test('pipeline_auto_layout,storage_texture')
+  .desc(
+    `
+  Test creating a pipeline with auto layout with a storage texture binding format enabled by
+  'texture-formats-tier1' fails if the feature is not enabled.
+  `
+  )
+  .params(u =>
+    u
+      .combine('format', kTextureFormatsTier2EnablesStorageReadWrite)
+      .combine('enable_feature', [true, false])
+      .beginSubcases()
+      .combine('isAsync', [false, true] as const)
+      .combine('type', ['compute', 'render'] as const)
+  )
+  .beforeAllSubcases(t => {
+    const { enable_feature } = t.params;
+    if (enable_feature) {
+      t.selectDeviceOrSkipTestCase('texture-formats-tier1');
+    }
+  })
+  .fn(t => {
+    const { format, enable_feature, isAsync, type } = t.params;
+
+    const code = `
+      @group(0) @binding(0) var tex1d: texture_storage_1d<${format}, read_write>;
+      @group(0) @binding(1) var tex2d: texture_storage_1d<${format}, read_write>;
+      @group(0) @binding(2) var tex3d: texture_storage_1d<${format}, read_write>;
+
+      fn useTextures() {
+        _ = tex1d;
+        _ = tex2d;
+        _ = tex3d;
+      }
+
+      @compute @workgroup_size(1) fn cs() {
+        useTextures();
+      }
+
+      @vertex fn vs() -> @builtin(position) vec4f {
+        return vec4f(0);
+      }
+      @fragment fn fs() -> @location(0) vec4f {
+        useTextures();
+        return vec4f(0);
+      }
+    `;
+
+    const module = t.device.createShaderModule({ code });
+
+    if (type === 'compute') {
+      const descriptor: GPUComputePipelineDescriptor = {
+        layout: 'auto',
+        compute: { module },
+      };
+      vtu.doCreateComputePipelineTest(t, isAsync, enable_feature, descriptor);
+    } else {
+      const descriptor: GPURenderPipelineDescriptor = {
+        layout: 'auto',
+        vertex: { module },
+        fragment: { module, targets: [{ format: 'rgba8unorm' }] },
+      };
+      vtu.doCreateRenderPipelineTest(t, isAsync, enable_feature, descriptor);
+    }
   });


### PR DESCRIPTION
Note: these tests will fail on most browsers until tier1 formats are added to their WGSL code. WGSL is supposed to accept these formats regardless of whether or not the they are supported by the device. pipeline / bindGroupLayout creation is what prevents them from being used.
