### PR TITLE
Fix api,operation,adapter,requestDevice:invalid test

### DIFF
--- a/src/webgpu/api/operation/adapter/requestDevice.spec.ts
+++ b/src/webgpu/api/operation/adapter/requestDevice.spec.ts
@@ -8,7 +8,7 @@ potentially limited native resources.
 import { Fixture } from '../../../../common/framework/fixture.js';
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { getGPU } from '../../../../common/util/navigator_gpu.js';
-import { assert, assertReject, raceWithRejectOnTimeout } from '../../../../common/util/util.js';
+import { assert, assertReject } from '../../../../common/util/util.js';
 import {
   getDefaultLimitsForCTS,
   kFeatureNames,
@@ -69,8 +69,7 @@ g.test('invalid')
     Test that requesting device on an invalid adapter resolves with lost device.
     - Induce invalid adapter via a device lost from a device.destroy()
     - Check the device is lost with reason 'destroyed'
-    - Try creating another device on the now-stale adapter
-    - Check that returns a device lost with 'unknown'
+    - Try creating another device on the now-stale adapter fails.
     `
   )
   .fn(async t => {
@@ -87,12 +86,8 @@ g.test('invalid')
       t.expect(lostInfo.reason === 'destroyed');
     }
 
-    // The adapter should now be invalid since a device was lost. Requesting another device should
-    // return an already lost device.
-    const kTimeoutMS = 1000;
-    const device = await t.requestDeviceTracked(adapter);
-    const lost = await raceWithRejectOnTimeout(device.lost, kTimeoutMS, 'device was not lost');
-    t.expect(lost.reason === 'unknown');
+    // The adapter should now be invalid since a device was lost. Requesting another device is not possible anymore.
+    t.shouldReject('OperationError', t.requestDeviceTracked(adapter));
   });
 
 g.test('stale')


### PR DESCRIPTION
This PR addresses https://github.com/gpuweb/cts/pull/4336#issuecomment-3018550097

Spec change: https://github.com/gpuweb/gpuweb/pull/4789

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.) (It works in Chromium patched with https://dawn-review.googlesource.com/c/dawn/+/237274)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
