### PR TITLE
update shader validation types test for tier1 formats

### DIFF
--- a/src/webgpu/shader/validation/types/textures.spec.ts
+++ b/src/webgpu/shader/validation/types/textures.spec.ts
@@ -5,7 +5,6 @@ Validation tests for various texture types in shaders.
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import {
   getTextureFormatType,
-  isTextureFormatUsableAsStorageFormatInCreateShaderModule,
   kAllTextureFormats,
   kPossibleStorageTextureFormats,
 } from '../../../format_info.js';
@@ -109,10 +108,7 @@ Besides, the shader compilation should always pass regardless of whether the for
   )
   .fn(t => {
     const { format, access, comma } = t.params;
-    const isFormatValid = isTextureFormatUsableAsStorageFormatInCreateShaderModule(
-      t.device,
-      format
-    );
+    const isFormatValid = (kPossibleStorageTextureFormats as string[]).includes(format);
     const isAccessValid = kAccessModes.includes(access);
     const wgsl = `@group(0) @binding(0) var tex: texture_storage_2d<${format}, ${access}${comma}>;`;
     t.expectCompileResult(isFormatValid && isAccessValid, wgsl);


### PR DESCRIPTION
CreateShaderModule for a storage texture type for texture formats that require opting into the feature at the API level.


Chrome was just updated to support many Tier1 formats in the shader compiler.  (But not all, missing the *16{unorm|snorm} formats).  With this change, these tests now start passing on many storage texture types.



<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
