### PR TITLE
Refactor isTextureFormatUsableAsStorageFormatInCreateShaderModule

### DIFF
--- a/src/webgpu/format_info.ts
+++ b/src/webgpu/format_info.ts
@@ -2534,11 +2534,9 @@ export function isTextureFormatUsableAsStorageFormatInCreateShaderModule(
   device: GPUDevice,
   format: GPUTextureFormat
 ): boolean {
-  if (format === 'bgra8unorm') {
-    return true;
-  }
-  const info = kTextureFormatInfo[format];
-  return !!(info.color?.storage || info.depth?.storage || info.stencil?.storage);
+  return kPossibleStorageTextureFormats.includes(
+    format as (typeof kPossibleStorageTextureFormats)[number]
+  );
 }
 
 function isTextureFormatUsableAsReadWriteStorageTexture(

--- a/src/webgpu/shader/validation/types/textures.spec.ts
+++ b/src/webgpu/shader/validation/types/textures.spec.ts
@@ -5,6 +5,7 @@ Validation tests for various texture types in shaders.
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import {
   getTextureFormatType,
+  isTextureFormatUsableAsStorageFormatInCreateShaderModule,
   kAllTextureFormats,
   kPossibleStorageTextureFormats,
 } from '../../../format_info.js';
@@ -108,7 +109,10 @@ Besides, the shader compilation should always pass regardless of whether the for
   )
   .fn(t => {
     const { format, access, comma } = t.params;
-    const isFormatValid = (kPossibleStorageTextureFormats as string[]).includes(format);
+    const isFormatValid = isTextureFormatUsableAsStorageFormatInCreateShaderModule(
+      t.device,
+      format
+    );
     const isAccessValid = kAccessModes.includes(access);
     const wgsl = `@group(0) @binding(0) var tex: texture_storage_2d<${format}, ${access}${comma}>;`;
     t.expectCompileResult(isFormatValid && isAccessValid, wgsl);


### PR DESCRIPTION
The function had an incomplete list. I was originally going to remove this function based on #4418 but after looking into it I still think the function is better than checking for array membership in each test that needs it, even though there is only one such test at the moment. 

It's a single place that can encapsulate what to do to do a check. It's a single place to hide the type casting. It's also a single place to fix if someone wants to change the internals for how this info is stored. It's a central place to make device dependent changes if that ever comes up.
