### PR TITLE
Add copyBufferToTexture and copyTextureToBuffer validation tests

### DIFF
--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -637,6 +637,13 @@ export class GPUTestBase extends Fixture<GPUTestSubcaseBatchState> {
     }
   }
 
+  skipIfTextureFormatDoesNotSupportCopyTextureToBuffer(format: GPUTextureFormat) {
+    this.skipIf(
+      !this.canCallCopyTextureToBufferWithTextureFormat(format),
+      `can not use copyTextureToBuffer with ${format}`
+    );
+  }
+
   /** Skips this test case if the `langFeature` is *not* supported. */
   skipIfLanguageFeatureNotSupported(langFeature: WGSLLanguageFeature) {
     if (!this.hasLanguageFeature(langFeature)) {


### PR DESCRIPTION
In particular test that for copyBufferToTexture, and copyTextureToBuffer

* bytesPerRow must be a multiple of 256
* offset must be a multiple of bytesPerBlock
* the last row does not need to be a multiple of 256

  In other words, If the copy size is 4x2 of a r8unorm texture that's 4 bytes per row. To get from row 0 to row 1 in the buffer, bytesPerRow must be a multiple of 256. But, the size requirement for the buffer is only 256 + 4, not 256 * 2

* origin.x must be a multiple of blockWidth
* origin.y must be a multiple of blockHeight
* copySize.width must be a multiple of blockWidth
* copySize.height must be a multiple of blockHeight
