### PR TITLE
Fix "resoruces" typo in resources.ts

### DIFF
--- a/src/common/framework/resources.ts
+++ b/src/common/framework/resources.ts
@@ -87,7 +87,7 @@ export function getCrossOriginResourcePath(pathRelativeToResourcesDir: string, o
 /**
  * Get a path to a resource in the `resources` directory, relative to the current execution context
  * (html file or worker .js file), for `fetch()`, `<img>`, `<video>`, etc. Pass the cross origin host
- * name if wants to load resoruce from cross origin host.
+ * name if wants to load resource from cross origin host.
  */
 export function getResourcePath(pathRelativeToResourcesDir: string) {
   return baseResourcePath + '/' + pathRelativeToResourcesDir;


### PR DESCRIPTION


Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [ ] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [ ] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [ ] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
