### PR TITLE
Allow skipIfTextureFormatNotSupported in beforeAllSubcases

### DIFF
--- a/src/common/framework/fixture.ts
+++ b/src/common/framework/fixture.ts
@@ -78,8 +78,9 @@ export class Fixture<S extends SubcaseBatchState = SubcaseBatchState> {
   }
 
   /** @internal */
-  constructor(sharedState: S, rec: TestCaseRecorder, params: TestParams) {
-    this._sharedState = sharedState;
+  constructor(sharedState: SubcaseBatchState, rec: TestCaseRecorder, params: TestParams) {
+    // sharedState will always come from our own MakeSharedState, so it's safe to cast in practice.
+    this._sharedState = sharedState as S;
     this.rec = rec;
     this._params = params;
   }
@@ -427,12 +428,7 @@ export type SubcaseBatchStateFromFixture<F> = F extends Fixture<infer S> ? S : n
  * parameter.
  */
 export type FixtureClass<F extends Fixture = Fixture> = {
-  new (sharedState: SubcaseBatchStateFromFixture<F>, log: TestCaseRecorder, params: TestParams): F;
-  MakeSharedState(recorder: TestCaseRecorder, params: TestParams): SubcaseBatchStateFromFixture<F>;
-};
-export type FixtureClassInterface<F extends Fixture = Fixture> = {
-  /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-  new (...args: any[]): F;
+  new (sharedState: SubcaseBatchState, log: TestCaseRecorder, params: TestParams): F;
   MakeSharedState(recorder: TestCaseRecorder, params: TestParams): SubcaseBatchStateFromFixture<F>;
 };
 export type FixtureClassWithMixin<FC, M> = FC extends FixtureClass<infer F>

--- a/src/webgpu/api/operation/resource_init/check_texture/texture_zero_init_test.ts
+++ b/src/webgpu/api/operation/resource_init/check_texture/texture_zero_init_test.ts
@@ -1,4 +1,8 @@
-import { TestCaseRecorder, TestParams } from '../../../../../common/framework/fixture.js';
+import {
+  SubcaseBatchState,
+  TestCaseRecorder,
+  TestParams,
+} from '../../../../../common/framework/fixture.js';
 import {
   kUnitCaseParamsBuilder,
   ParamTypeOf,
@@ -22,7 +26,7 @@ import {
   isTextureFormatColorRenderable,
   isTextureFormatPossiblyUsableAsColorRenderAttachment,
 } from '../../../../format_info.js';
-import { AllFeaturesMaxLimitsGPUTest, GPUTestSubcaseBatchState } from '../../../../gpu_test.js';
+import { AllFeaturesMaxLimitsGPUTest } from '../../../../gpu_test.js';
 import { virtualMipSize } from '../../../../util/texture/base.js';
 import { createTextureUploadBuffer } from '../../../../util/texture/layout.js';
 import { BeginEndRange, SubresourceRange } from '../../../../util/texture/subresource.js';
@@ -187,7 +191,7 @@ export class TextureZeroInitTest extends AllFeaturesMaxLimitsGPUTest {
   readonly stateToTexelComponents: { [k in InitializedState]: PerTexelComponent<number> };
 
   private p: TextureZeroParams;
-  constructor(sharedState: GPUTestSubcaseBatchState, rec: TestCaseRecorder, params: TestParams) {
+  constructor(sharedState: SubcaseBatchState, rec: TestCaseRecorder, params: TestParams) {
     super(sharedState, rec, params);
     this.p = params as TextureZeroParams;
 

--- a/src/webgpu/api/validation/image_copy/layout_related.spec.ts
+++ b/src/webgpu/api/validation/image_copy/layout_related.spec.ts
@@ -181,6 +181,9 @@ Test the computation of requiredBytesInCopy by computing the minimum data size f
         return [p._offsetMultiplier * getBlockInfoForSizedTextureFormat(p.format).bytesPerBlock];
       })
   )
+  .beforeAllSubcases(t => {
+    t.skipIfTextureFormatNotSupported(t.params.format);
+  })
   .fn(t => {
     const {
       offset,

--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -1,7 +1,6 @@
 import {
   Fixture,
   FixtureClass,
-  FixtureClassInterface,
   FixtureClassWithMixin,
   SubcaseBatchState,
   TestCaseRecorder,
@@ -328,7 +327,9 @@ export class GPUTestSubcaseBatchState extends SubcaseBatchState {
  * This class is a Fixture + a getter that returns a GPUDevice
  * as well as helpers that use that device.
  */
-export class GPUTestBase extends Fixture<GPUTestSubcaseBatchState> {
+export class GPUTestBase<
+  S extends GPUTestSubcaseBatchState = GPUTestSubcaseBatchState,
+> extends Fixture<S> {
   public static override MakeSharedState(
     recorder: TestCaseRecorder,
     params: TestParams
@@ -1378,7 +1379,9 @@ export class GPUTestBase extends Fixture<GPUTestSubcaseBatchState> {
 /**
  * Fixture for WebGPU tests that uses a DeviceProvider
  */
-export class GPUTest extends GPUTestBase {
+export class GPUTest<
+  S extends GPUTestSubcaseBatchState = GPUTestSubcaseBatchState,
+> extends GPUTestBase<S> {
   // Should never be undefined in a test. If it is, init() must not have run/finished.
   private provider: DeviceProvider | undefined;
   private mismatchedProvider: DeviceProvider | undefined;
@@ -1580,7 +1583,7 @@ export function RequiredLimitsTestMixin<F extends FixtureClass<GPUTestBase>>(
   requiredLimitsHelper: RequiredLimitsHelper
 ): FixtureClassWithMixin<F, RequiredLimitsTestMixinType> {
   class RequiredLimitsImpl
-    extends (Base as FixtureClassInterface<GPUTestBase>)
+    extends (Base as FixtureClass<GPUTestBase>)
     implements RequiredLimitsTestMixinType
   {
     //
@@ -1690,11 +1693,8 @@ export class UniqueFeaturesOrLimitsGPUTest extends GPUTest {}
  * You could enable it manually but that spreads enabling to every test instead of being
  * centralized in one place, here.
  */
-export class AllFeaturesMaxLimitsGPUTest extends GPUTest {
-  public static override MakeSharedState(
-    recorder: TestCaseRecorder,
-    params: TestParams
-  ): GPUTestSubcaseBatchState {
+export class AllFeaturesMaxLimitsGPUTest extends GPUTest<AllFeaturesMaxLimitsGPUTestSubcaseBatchState> {
+  public static override MakeSharedState(recorder: TestCaseRecorder, params: TestParams) {
     return new AllFeaturesMaxLimitsGPUTestSubcaseBatchState(recorder, params);
   }
 }

--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -1655,13 +1655,6 @@ export class AllFeaturesMaxLimitsGPUTestSubcaseBatchState extends GPUTestSubcase
   ): void {
     unreachable('this function should not be called in AllFeaturesMaxLimitsGPUTest');
   }
-
-  /**
-   * Use skipIfDeviceDoesNotHaveFeature or skipIf(device.limits.maxXXX < requiredXXX) etc...
-   */
-  selectMismatchedDeviceOrSkipTestCase(descriptor: DeviceSelectionDescriptor): void {
-    unreachable('this function should not be called in AllFeaturesMaxLimitsGPUTest');
-  }
 }
 
 /**


### PR DESCRIPTION


Issue: #4424

<hr>

**Requirements for PR author:**

- [ ] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [ ] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [ ] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
