### PR TITLE
Fix type of index in uniformity tests

### DIFF
--- a/src/webgpu/shader/validation/uniformity/uniformity.spec.ts
+++ b/src/webgpu/shader/validation/uniformity/uniformity.spec.ts
@@ -8,6 +8,8 @@ import { ShaderValidationTest } from '../shader_validation_test.js';
 export const g = makeTestGroup(ShaderValidationTest);
 
 const kCollectiveOps = [
+  { op: 'control_case_compute', stage: 'compute' },
+  { op: 'control_case_fragment', stage: 'fragment' },
   { op: 'textureSample', stage: 'fragment' },
   { op: 'textureSampleBias', stage: 'fragment' },
   { op: 'textureSampleCompare', stage: 'fragment' },
@@ -115,6 +117,11 @@ function generateCondition(condition: string): string {
 
 function generateOp(op: string): string {
   switch (op) {
+    case 'control_case':
+    case 'control_case_compute':
+    case 'control_case_fragment': {
+      return ``;
+    }
     case 'textureSample': {
       return `let x = ${op}(tex, s, vec2(0,0));\n`;
     }
@@ -243,7 +250,7 @@ g.test('basics')
  @group(2) @binding(0) var ro_storage_texture : texture_storage_2d<rgba8unorm, read>;
  @group(2) @binding(1) var rw_storage_texture : texture_storage_2d<rgba8unorm, read_write>;
 
- var<private> priv_var : array<f32, 4> = array(0,0,0,0);
+ var<private> priv_var : array<u32, 4> = array(0,0,0,0);
 
  const c = false;
  override o : f32;
@@ -272,10 +279,11 @@ g.test('basics')
 
     code += `\n}\n`;
 
-    t.expectCompileResult(t.params.expectation, code);
+    t.expectCompileResult(t.params.expectation || t.params.op.startsWith('control_case'), code);
   });
 
 const kSubgroupOps = [
+  'control_case',
   'subgroupAdd',
   'subgroupInclusiveAdd',
   'subgroupExclusiveAdd',
@@ -329,7 +337,7 @@ g.test('basics,subgroups')
  @group(2) @binding(0) var ro_storage_texture : texture_storage_2d<rgba8unorm, read>;
  @group(2) @binding(1) var rw_storage_texture : texture_storage_2d<rgba8unorm, read_write>;
 
- var<private> priv_var : array<f32, 4> = array(0,0,0,0);
+ var<private> priv_var : array<u32, 4> = array(0,0,0,0);
 
  const c = false;
  override o : f32;
@@ -358,7 +366,7 @@ g.test('basics,subgroups')
 
     code += `\n}\n`;
 
-    t.expectCompileResult(t.params.expectation, code);
+    t.expectCompileResult(t.params.expectation || t.params.op.startsWith('control_case'), code);
   });
 
 const kFragmentBuiltinValues = [


### PR DESCRIPTION
This slipped through because the test expects a shader validation failure from the uniformity analysis, so the type error is seen as a "pass". Added a control case operation to make sure that all of the conditions compile successfully when no collective operations are used.

Fixes #4430


Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [X] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
