### PR TITLE
Add tests for the primitive_id builtin

### DIFF
--- a/src/webgpu/shader/validation/shader_io/builtins.spec.ts
+++ b/src/webgpu/shader/validation/shader_io/builtins.spec.ts
@@ -38,6 +38,7 @@ export const kBuiltins = [
   { name: 'clip_distances', stage: 'vertex', io: 'out', type: 'array<f32,6>' },
   { name: 'clip_distances', stage: 'vertex', io: 'out', type: 'array<f32,7>' },
   { name: 'clip_distances', stage: 'vertex', io: 'out', type: 'array<f32,8>' },
+  { name: 'primitive_id', stage: 'fragment', io: 'in', type: 'u32' },
 ] as const;
 
 // List of types to test against.
@@ -338,6 +339,8 @@ g.test('reuse_builtin_name')
         code += 'enable subgroup;\n';
       } else if (t.params.name === 'clip_distances') {
         code += 'enable clip_distances;\n';
+      } else if (t.params.name === 'primitive_id') {
+        code += 'enable chromium_experimental_primitive_id;\n';
       }
     }
     if (t.params.use === 'alias') {

--- a/src/webgpu/shader/validation/shader_io/util.ts
+++ b/src/webgpu/shader/validation/shader_io/util.ts
@@ -30,6 +30,9 @@ export function generateShader({
   if (attribute.includes('clip_distances')) {
     code += 'enable clip_distances;\n';
   }
+  if (attribute.includes('primitive_id')) {
+    code += 'enable chromium_experimental_primitive_id;\n';
+  }
 
   if (use_struct) {
     // Generate a struct that wraps the entry point IO variable.

--- a/src/webgpu/shader/validation/shader_validation_test.ts
+++ b/src/webgpu/shader/validation/shader_validation_test.ts
@@ -9,6 +9,7 @@ const kEnables: Record<string, GPUFeatureName> = {
   f16: 'shader-f16',
   subgroups: 'subgroups' as GPUFeatureName,
   clip_distances: 'clip-distances' as GPUFeatureName,
+  chromium_experimental_primitive_id: 'chromium-experimental-primitive-id' as GPUFeatureName,
 };
 
 /**

--- a/src/webgpu/shader/validation/uniformity/uniformity.spec.ts
+++ b/src/webgpu/shader/validation/uniformity/uniformity.spec.ts
@@ -394,6 +394,10 @@ const kFragmentBuiltinValues = [
     builtin: `subgroup_size`,
     type: `u32`,
   },
+  {
+    builtin: `primitive_id`,
+    type: `u32`,
+  },
 ];
 
 g.test('fragment_builtin_values')
@@ -428,7 +432,13 @@ g.test('fragment_builtin_values')
         unreachable(`Unhandled type`);
       }
     }
-    const enable = t.params.builtin.includes('subgroup') ? 'enable subgroups;' : '';
+    let enable = '';
+    if (t.params.builtin.includes('subgroup')) {
+      enable = 'enable subgroups;\n';
+    } else if (t.params.builtin === 'primitive_id') {
+      enable = 'enable chromium_experimental_primitive_id;\n';
+    }
+
     const code = `
 ${enable}
 @group(0) @binding(0) var s : sampler;


### PR DESCRIPTION
Adds some initial tests for the primitive_id WGSL builtin. Currently uses `enable chromium_experimental_primitive_id` to enable, but that can change once the spec is fleshed out and accepted by the group. Feature is not exposed to compat mode.

Associated spec change is https://github.com/gpuweb/gpuweb/pull/5273 I'm totally fine if we want to wait to land this till that is approved by the group and this can revert to using the final feature strings.

Issue: https://github.com/gpuweb/gpuweb/issues/1786

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
