### PR TITLE
Test16-bit UNORM/SNORM format capabilities with TextureFormatsTier1

### DIFF
--- a/src/webgpu/api/validation/capability_checks/features/texture_formats_tier1.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/features/texture_formats_tier1.spec.ts
@@ -14,7 +14,7 @@ when the feature is not enabled. This includes:
 
 import { makeTestGroup } from '../../../../../common/framework/test_group.js';
 import {
-  kTextureFormatTier1AllowsRenderAttachmentBlendableMultisampleResolve,
+  kTextureFormatTier1AllowsRenderAttachmentBlendableMultisample,
   kTextureFormatsTier1EnablesStorageReadOnlyWriteOnly,
 } from '../../../../format_info.js';
 import { UniqueFeaturesOrLimitsGPUTest } from '../../../../gpu_test.js';
@@ -42,7 +42,7 @@ g.test('texture_usage,render_attachment')
   )
   .params(u =>
     u
-      .combine('format', kTextureFormatTier1AllowsRenderAttachmentBlendableMultisampleResolve)
+      .combine('format', kTextureFormatTier1AllowsRenderAttachmentBlendableMultisample)
       .combine('enable_feature', [true, false])
   )
   .beforeAllSubcases(t => {
@@ -72,7 +72,7 @@ g.test('texture_usage,multisample')
   )
   .params(u =>
     u
-      .combine('format', kTextureFormatTier1AllowsRenderAttachmentBlendableMultisampleResolve)
+      .combine('format', kTextureFormatTier1AllowsRenderAttachmentBlendableMultisample)
       .combine('enable_feature', [true, false])
   )
   .beforeAllSubcases(t => {
@@ -140,7 +140,7 @@ g.test('render_pipeline,color_target')
       .combine('isAsync', [false, true])
       .combine('format', [
         'rgba8unorm',
-        ...kTextureFormatTier1AllowsRenderAttachmentBlendableMultisampleResolve,
+        ...kTextureFormatTier1AllowsRenderAttachmentBlendableMultisample,
       ] as const)
       .combine('enable_feature', [true, false])
       .combine('check', ['RENDER_ATTACHMENT', 'blendable', 'multisample'] as const)

--- a/src/webgpu/format_info.ts
+++ b/src/webgpu/format_info.ts
@@ -1710,8 +1710,26 @@ export const kStencilTextureFormats = kDepthStencilFormats.filter(
   v => kTextureFormatInfo[v].stencil
 );
 
-export const kTextureFormatTier1AllowsRenderAttachmentBlendableMultisampleResolve: readonly ColorTextureFormat[] =
-  ['r8snorm', 'rg8snorm', 'rgba8snorm', 'rg11b10ufloat'] as const;
+export const kTextureFormatTier1AllowsResolve: readonly ColorTextureFormat[] = [
+  'r8snorm',
+  'rg8snorm',
+  'rgba8snorm',
+  'rg11b10ufloat',
+] as const;
+
+export const kTextureFormatTier1AllowsRenderAttachmentBlendableMultisample: readonly ColorTextureFormat[] =
+  [
+    'r16unorm',
+    'r16snorm',
+    'rg16unorm',
+    'rg16snorm',
+    'rgba16unorm',
+    'rgba16snorm',
+    'r8snorm',
+    'rg8snorm',
+    'rgba8snorm',
+    'rg11b10ufloat',
+  ] as const;
 
 export const kTextureFormatsTier1EnablesStorageReadOnlyWriteOnly: readonly ColorTextureFormat[] = [
   'r8unorm',
@@ -2183,12 +2201,14 @@ export function filterFormatsByFeature<T>(
   return formats.filter(f => f === undefined || kTextureFormatInfo[f].feature === feature);
 }
 
-function isTextureFormatTier1EnablesRenderAttachmentBlendableMultisampleResolve(
-  format: GPUTextureFormat
-) {
-  return kTextureFormatTier1AllowsRenderAttachmentBlendableMultisampleResolve.includes(
+function isTextureFormatTier1EnablesRenderAttachmentBlendableMultisample(format: GPUTextureFormat) {
+  return kTextureFormatTier1AllowsRenderAttachmentBlendableMultisample.includes(
     format as ColorTextureFormat
   );
+}
+
+function isTextureFormatTier1EnablesResolve(format: GPUTextureFormat) {
+  return kTextureFormatTier1AllowsResolve.includes(format as ColorTextureFormat);
 }
 
 function isTextureFormatTier1EnablesStorageReadOnlyWriteOnly(format: GPUTextureFormat) {
@@ -2318,7 +2338,7 @@ export function isTextureFormatColorRenderable(
   if (format === 'rg11b10ufloat') {
     return device.features.has('rg11b10ufloat-renderable');
   }
-  if (isTextureFormatTier1EnablesRenderAttachmentBlendableMultisampleResolve(format)) {
+  if (isTextureFormatTier1EnablesRenderAttachmentBlendableMultisample(format)) {
     return device.features.has('texture-formats-tier1');
   }
   return !!kAllTextureFormatInfo[format].colorRender;
@@ -2369,7 +2389,7 @@ export function isTextureFormatPossiblyUsableAsRenderAttachment(format: GPUTextu
   return (
     isDepthOrStencilTextureFormat(format) ||
     !!info.colorRender ||
-    isTextureFormatTier1EnablesRenderAttachmentBlendableMultisampleResolve(format)
+    isTextureFormatTier1EnablesRenderAttachmentBlendableMultisample(format)
   );
 }
 
@@ -2380,8 +2400,7 @@ export function isTextureFormatPossiblyUsableAsRenderAttachment(format: GPUTextu
 export function isTextureFormatPossiblyUsableAsColorRenderAttachment(format: GPUTextureFormat) {
   const info = kTextureFormatInfo[format];
   return (
-    !!info.colorRender ||
-    isTextureFormatTier1EnablesRenderAttachmentBlendableMultisampleResolve(format)
+    !!info.colorRender || isTextureFormatTier1EnablesRenderAttachmentBlendableMultisample(format)
   );
 }
 
@@ -2392,8 +2411,7 @@ export function isTextureFormatPossiblyUsableAsColorRenderAttachment(format: GPU
 export function isTextureFormatPossiblyMultisampled(format: GPUTextureFormat) {
   const info = kTextureFormatInfo[format];
   return (
-    info.multisample ||
-    isTextureFormatTier1EnablesRenderAttachmentBlendableMultisampleResolve(format)
+    info.multisample || isTextureFormatTier1EnablesRenderAttachmentBlendableMultisample(format)
   );
 }
 
@@ -2602,7 +2620,7 @@ export function isTextureFormatMultisampled(device: GPUDevice, format: GPUTextur
   if (format === 'rg11b10ufloat') {
     return device.features.has('rg11b10ufloat-renderable');
   }
-  if (isTextureFormatTier1EnablesRenderAttachmentBlendableMultisampleResolve(format)) {
+  if (isTextureFormatTier1EnablesRenderAttachmentBlendableMultisample(format)) {
     return device.features.has('texture-formats-tier1');
   }
   return kAllTextureFormatInfo[format].multisample;
@@ -2616,7 +2634,7 @@ export function isTextureFormatResolvable(device: GPUDevice, format: GPUTextureF
   if (format === 'rg11b10ufloat') {
     return device.features.has('rg11b10ufloat-renderable');
   }
-  if (isTextureFormatTier1EnablesRenderAttachmentBlendableMultisampleResolve(format)) {
+  if (isTextureFormatTier1EnablesResolve(format)) {
     return device.features.has('texture-formats-tier1');
   }
   // You can't resolve a non-multisampled format.


### PR DESCRIPTION
Texture-formats-tier1 supports r6unorm/r16snorm/rg16unorm/rg16snorm/rgba16unorm/rgba16snorm texture formats with the RENDER_ATTACHMENT,blendable, multisampling capabilities. This commit adds tests for these formats to be consistent with the spec.


<hr>

**Requirements for PR author:**

- [√ ] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [√ ] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [√ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [√ ] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
