### PR TITLE
Correct expectation in texture_formats_tier1.spec.ts

### DIFF
--- a/src/webgpu/api/validation/capability_checks/features/texture_formats_tier1.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/features/texture_formats_tier1.spec.ts
@@ -15,6 +15,7 @@ when the feature is not enabled. This includes:
 import { makeTestGroup } from '../../../../../common/framework/test_group.js';
 import {
   kTextureFormatTier1AllowsRenderAttachmentBlendableMultisample,
+  kTextureFormatTier1ThrowsWhenNotEnabled,
   kTextureFormatsTier1EnablesStorageReadOnlyWriteOnly,
 } from '../../../../format_info.js';
 import { UniqueFeaturesOrLimitsGPUTest } from '../../../../gpu_test.js';
@@ -54,13 +55,17 @@ g.test('texture_usage,render_attachment')
   .fn(t => {
     const { format, enable_feature } = t.params;
 
-    t.expectValidationError(() => {
-      t.createTextureTracked({
-        format,
-        size: [1, 1, 1],
-        usage: GPUTextureUsage.RENDER_ATTACHMENT,
-      });
-    }, !enable_feature);
+    t.expectValidationErrorOrException(
+      () => {
+        t.createTextureTracked({
+          format,
+          size: [1, 1, 1],
+          usage: GPUTextureUsage.RENDER_ATTACHMENT,
+        });
+      },
+      !enable_feature,
+      kTextureFormatTier1ThrowsWhenNotEnabled.includes(format)
+    );
   });
 
 g.test('texture_usage,multisample')
@@ -84,14 +89,18 @@ g.test('texture_usage,multisample')
   .fn(t => {
     const { format, enable_feature } = t.params;
 
-    t.expectValidationError(() => {
-      t.createTextureTracked({
-        format,
-        size: [1, 1, 1],
-        usage: GPUTextureUsage.RENDER_ATTACHMENT,
-        sampleCount: 4,
-      });
-    }, !enable_feature);
+    t.expectValidationErrorOrException(
+      () => {
+        t.createTextureTracked({
+          format,
+          size: [1, 1, 1],
+          usage: GPUTextureUsage.RENDER_ATTACHMENT,
+          sampleCount: 4,
+        });
+      },
+      !enable_feature,
+      kTextureFormatTier1ThrowsWhenNotEnabled.includes(format)
+    );
   });
 
 g.test('texture_usage,storage_binding')
@@ -115,13 +124,17 @@ g.test('texture_usage,storage_binding')
   .fn(t => {
     const { format, enable_feature } = t.params;
 
-    t.expectValidationError(() => {
-      t.createTextureTracked({
-        format,
-        size: [1, 1, 1],
-        usage: GPUTextureUsage.STORAGE_BINDING,
-      });
-    }, !enable_feature);
+    t.expectValidationErrorOrException(
+      () => {
+        t.createTextureTracked({
+          format,
+          size: [1, 1, 1],
+          usage: GPUTextureUsage.STORAGE_BINDING,
+        });
+      },
+      !enable_feature,
+      kTextureFormatTier1ThrowsWhenNotEnabled.includes(format)
+    );
   });
 
 g.test('render_pipeline,color_target')
@@ -196,7 +209,7 @@ g.test('render_pipeline,color_target')
       isAsync,
       enable_feature || format === 'rgba8unorm',
       pipelineDescriptor,
-      'GPUPipelineError'
+      kTextureFormatTier1ThrowsWhenNotEnabled.includes(format) ? 'TypeError' : 'GPUPipelineError'
     );
   });
 
@@ -234,20 +247,24 @@ g.test('bind_group_layout,storage_texture')
   .fn(t => {
     const { format, access, enable_feature } = t.params;
 
-    t.expectValidationError(() => {
-      t.device.createBindGroupLayout({
-        entries: [
-          {
-            binding: 0,
-            visibility: GPUShaderStage.COMPUTE,
-            storageTexture: {
-              format,
-              access,
+    t.expectValidationErrorOrException(
+      () => {
+        t.device.createBindGroupLayout({
+          entries: [
+            {
+              binding: 0,
+              visibility: GPUShaderStage.COMPUTE,
+              storageTexture: {
+                format,
+                access,
+              },
             },
-          },
-        ],
-      });
-    }, !enable_feature);
+          ],
+        });
+      },
+      !enable_feature,
+      kTextureFormatTier1ThrowsWhenNotEnabled.includes(format)
+    );
   });
 
 g.test('pipeline_auto_layout,storage_texture')

--- a/src/webgpu/format_info.ts
+++ b/src/webgpu/format_info.ts
@@ -1717,6 +1717,15 @@ export const kTextureFormatTier1AllowsResolve: readonly ColorTextureFormat[] = [
   'rg11b10ufloat',
 ] as const;
 
+export const kTextureFormatTier1ThrowsWhenNotEnabled: readonly ColorTextureFormat[] = [
+  'r16unorm',
+  'r16snorm',
+  'rg16unorm',
+  'rg16snorm',
+  'rgba16unorm',
+  'rgba16snorm',
+] as const;
+
 export const kTextureFormatTier1AllowsRenderAttachmentBlendableMultisample: readonly ColorTextureFormat[] =
   [
     'r16unorm',

--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -1211,6 +1211,23 @@ export class GPUTestBase extends Fixture<GPUTestSubcaseBatchState> {
     }
   }
 
+  /**
+   * Expect a validation error or exception inside the callback.
+   *
+   * Tests should always do just one WebGPU call in the callback, to make sure that's what's tested.
+   */
+  expectValidationErrorOrException(
+    fn: () => void,
+    shouldError: boolean = true,
+    shouldThrow: boolean = true
+  ): void {
+    if (shouldThrow) {
+      this.shouldThrow(shouldError, fn);
+    } else {
+      this.expectValidationError(fn, shouldError);
+    }
+  }
+
   /** Create a GPUBuffer and track it for cleanup at the end of the test. */
   createBufferTracked(descriptor: GPUBufferDescriptor): GPUBuffer {
     return this.trackForCleanup(this.device.createBuffer(descriptor));


### PR DESCRIPTION
…/#dom-gpudevice-createtexture

2. Validate texture format required features of descriptor.format with this.[[device]]. If format requires a feature and device.[[features]] does not contain the feature:

  Throw a TypeError.

but the test was expectation a validation error instead of an exception which does not align with the specification.

Correct this by expecting an exception.




Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
