### PR TITLE
Correct vertex correctness tests

### DIFF
--- a/src/webgpu/api/operation/vertex_state/correctness.spec.ts
+++ b/src/webgpu/api/operation/vertex_state/correctness.spec.ts
@@ -774,10 +774,14 @@ g.test('non_zero_array_stride_and_attribute_offset')
     const arrayStride = t.makeLimitVariant('maxVertexBufferArrayStride', arrayStrideVariant);
     const formatInfo = kVertexFormatInfo[format];
     const formatSize = formatInfo.byteSize;
-    const offset = clamp(makeValueTestVariant(arrayStride, offsetVariant), {
-      min: 0,
-      max: arrayStride - formatSize,
-    });
+    const makeMultipleOf = Math.min(formatSize, 4);
+    const offset =
+      Math.floor(
+        clamp(makeValueTestVariant(arrayStride, offsetVariant), {
+          min: 0,
+          max: arrayStride - formatSize,
+        }) / makeMultipleOf
+      ) * makeMultipleOf;
 
     t.runTest([
       {
@@ -1073,7 +1077,12 @@ g.test('array_stride_zero')
   )
   .fn(t => {
     const { format, stepMode, offsetVariant } = t.params;
-    const offset = t.makeLimitVariant('maxVertexBufferArrayStride', offsetVariant);
+    const formatInfo = kVertexFormatInfo[format];
+    const formatSize = formatInfo.byteSize;
+    const makeMultipleOf = Math.min(formatSize, 4);
+    const offset =
+      Math.floor(t.makeLimitVariant('maxVertexBufferArrayStride', offsetVariant) / makeMultipleOf) *
+      makeMultipleOf;
     const kCount = 10;
 
     // Create the stride 0 part of the test, first by faking a single vertex being drawn and


### PR DESCRIPTION
The validation rules for https://www.w3.org/TR/webgpu/#abstract-opdef-validating-gpuvertexbufferlayout state

...
attrib.offset is a multiple of the minimum of 4 and byteSize(attrib.format). ...

however the test was allowing for non four byte alligned offsets and expecting a passing result.

This test passes on Chrome as Chrome reports

   maxVertexBufferArrayStride	2048

but was failing in Safari due to Safari reporting

   maxVertexBufferArrayStride	65532 (64k)

which can be observed visiting https://webgpufundamentals.org/webgpu/lessons/webgpu-limits-and-features.html

Correct this by aligning to the min of 4 or the vertex size.




Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
