### PR TITLE
Add test for GPUTextureFormats' resolve capability with tier1

### DIFF
--- a/src/webgpu/api/validation/capability_checks/features/texture_formats_tier1.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/features/texture_formats_tier1.spec.ts
@@ -235,7 +235,7 @@ g.test('render_pass,resolvable')
     }
   })
   .fn(t => {
-    const { format, enable_feature } = t.params;
+    const { format } = t.params;
 
     const size = [1, 1, 1];
     const sampleCount = 4;

--- a/src/webgpu/api/validation/capability_checks/features/texture_formats_tier1.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/features/texture_formats_tier1.spec.ts
@@ -17,6 +17,7 @@ import {
   kTextureFormatTier1AllowsRenderAttachmentBlendableMultisample,
   kTextureFormatTier1ThrowsWhenNotEnabled,
   kTextureFormatsTier1EnablesStorageReadOnlyWriteOnly,
+  kTextureFormatTier1AllowsResolve,
 } from '../../../../format_info.js';
 import { UniqueFeaturesOrLimitsGPUTest } from '../../../../gpu_test.js';
 import * as vtu from '../../validation_test_utils.js';
@@ -217,13 +218,58 @@ g.test('render_pass,resolvable')
   .desc(
     `
   Test creating a render pass with resolve with a color target format enabled by
-  'texture-formats-tier1' fails if the feature is not enabled.
+  'texture-formats-tier1' success if the feature is enabled.
 
-  It's not clear this can be tested because you won't be able to create a render pipeline
-  that passes validation which you need before you can create a render pass that resolves.
+  Note: It's not possible to test the failure case (feature disabled).
+  Because you won't be able to create a render pipeline that passes validation which
+  you need before you can create a render pass that resolves.
   `
   )
-  .unimplemented();
+  .params(u =>
+    u.combine('format', kTextureFormatTier1AllowsResolve).combine('enable_feature', [true])
+  )
+  .beforeAllSubcases(t => {
+    const { enable_feature } = t.params;
+    if (enable_feature) {
+      t.selectDeviceOrSkipTestCase('texture-formats-tier1');
+    }
+  })
+  .fn(t => {
+    const { format, enable_feature } = t.params;
+
+    const size = [1, 1, 1];
+    const sampleCount = 4;
+
+    const msaaTexture = t.createTextureTracked({
+      format,
+      size,
+      sampleCount,
+      usage: GPUTextureUsage.RENDER_ATTACHMENT,
+    });
+
+    const resolveTexture = t.createTextureTracked({
+      format,
+      size,
+      usage: GPUTextureUsage.RENDER_ATTACHMENT,
+    });
+
+    const descriptor: GPURenderPassDescriptor = {
+      colorAttachments: [
+        {
+          view: msaaTexture.createView(),
+          resolveTarget: resolveTexture.createView(),
+          loadOp: 'clear',
+          storeOp: 'store',
+        },
+      ],
+    };
+
+    const encoder = t.device.createCommandEncoder();
+
+    t.expectValidationError(() => {
+      encoder.beginRenderPass(descriptor);
+    }, !enable_feature);
+  });
 
 g.test('bind_group_layout,storage_texture')
   .desc(

--- a/src/webgpu/api/validation/capability_checks/features/texture_formats_tier1.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/features/texture_formats_tier1.spec.ts
@@ -265,10 +265,7 @@ g.test('render_pass,resolvable')
     };
 
     const encoder = t.device.createCommandEncoder();
-
-    t.expectValidationError(() => {
-      encoder.beginRenderPass(descriptor);
-    }, !enable_feature);
+    encoder.beginRenderPass(descriptor);
   });
 
 g.test('bind_group_layout,storage_texture')


### PR DESCRIPTION
Texture-formats-tier1 supports resolve capability on below formats:

 r8snorm, rg8snorm, rgba8snorm, rg11b10ufloat.

This commit adds test for these formats to be consistent with the spec.

<hr>

**Requirements for PR author:**

- [ √] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [ √] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [√ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [ √] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
