### PR TITLE
fix: properly apply `bindTextureResource` in `render_pass_descriptor:one_*_attachment` tests

### DIFF
--- a/src/webgpu/api/validation/render_pass/render_pass_descriptor.spec.ts
+++ b/src/webgpu/api/validation/render_pass/render_pass_descriptor.spec.ts
@@ -115,9 +115,10 @@ g.test('attachments,one_color_attachment')
   .desc(`Test that a render pass works with only one color attachment.`)
   .paramsSubcasesOnly(u => u.combine('bindTextureResource', [false, true] as const))
   .fn(t => {
+    const { bindTextureResource } = t.params;
     const colorTexture = t.createTestTexture({ format: 'rgba8unorm' });
     const descriptor = {
-      colorAttachments: [t.getColorAttachment(colorTexture)],
+      colorAttachments: [t.getColorAttachment(colorTexture, { bindTextureResource })],
     };
 
     t.tryRenderPass(true, descriptor);
@@ -127,10 +128,13 @@ g.test('attachments,one_depth_stencil_attachment')
   .desc(`Test that a render pass works with only one depthStencil attachment.`)
   .paramsSubcasesOnly(u => u.combine('bindTextureResource', [false, true] as const))
   .fn(t => {
+    const { bindTextureResource } = t.params;
     const depthStencilTexture = t.createTestTexture({ format: 'depth24plus-stencil8' });
     const descriptor = {
       colorAttachments: [],
-      depthStencilAttachment: t.getDepthStencilAttachment(depthStencilTexture),
+      depthStencilAttachment: t.getDepthStencilAttachment(depthStencilTexture, {
+        bindTextureResource,
+      }),
     };
 
     t.tryRenderPass(true, descriptor);


### PR DESCRIPTION
This is a bug in #4407, where this coverage was originally intended to be introduced.