### PR TITLE
Add parsing configuration for Tier1 multisampled texture formats

### DIFF
--- a/src/webgpu/util/texture.ts
+++ b/src/webgpu/util/texture.ts
@@ -193,6 +193,79 @@ const kLoadValueFromStorageInfo: Partial<{
       )
     `,
   },
+  r16unorm: {
+    storageType: 'u32',
+    texelType: 'vec4f',
+    unpackWGSL: `
+    let raw = extractBits(getSrc(byteOffset / 4), (byteOffset % 4 / 2) * 16, 16);
+    return vec4f(f32(raw) / 65535.0, 0.123, 0.123, 0.123);
+  `,
+  },
+  r16snorm: {
+    storageType: 'i32',
+    texelType: 'vec4f',
+    unpackWGSL: `
+    let raw = extractBits(getSrc(byteOffset / 4), (byteOffset % 4 / 2) * 16, 16);
+    let signedVal = i32(raw);
+    return vec4f(f32(signedVal) / 32767.0, 0.123, 0.123, 0.123);
+  `,
+  },
+  rg16unorm: {
+    storageType: 'u32',
+    texelType: 'vec4f',
+    unpackWGSL: `
+    let v = getSrc(byteOffset / 4);
+    let r = extractBits(v, 0, 16);
+    let g = extractBits(v, 16, 16);
+    return vec4f(f32(r) / 65535.0, f32(g) / 65535.0, 0.123, 0.123);
+  `,
+  },
+  rg16snorm: {
+    storageType: 'i32',
+    texelType: 'vec4f',
+    unpackWGSL: `
+    let v = getSrc(byteOffset / 4);
+    let r = i32(extractBits(v, 0, 16));
+    let g = i32(extractBits(v, 16, 16));
+    return vec4f(f32(r) / 32767.0, f32(g) / 32767.0, 0.123, 0.123);
+  `,
+  },
+  rgba16unorm: {
+    storageType: 'u32',
+    texelType: 'vec4f',
+    unpackWGSL: `
+    let v0 = getSrc(byteOffset / 4);
+    let v1 = getSrc(byteOffset / 4 + 1);
+    let r = extractBits(v0, 0, 16);
+    let g = extractBits(v0, 16, 16);
+    let b = extractBits(v1, 0, 16);
+    let a = extractBits(v1, 16, 16);
+    return vec4f(
+      f32(r) / 65535.0,
+      f32(g) / 65535.0,
+      f32(b) / 65535.0,
+      f32(a) / 65535.0
+    );
+  `,
+  },
+  rgba16snorm: {
+    storageType: 'i32',
+    texelType: 'vec4f',
+    unpackWGSL: `
+    let v0 = getSrc(byteOffset / 4);
+    let v1 = getSrc(byteOffset / 4 + 1);
+    let r = i32(extractBits(v0, 0, 16));
+    let g = i32(extractBits(v0, 16, 16));
+    let b = i32(extractBits(v1, 0, 16));
+    let a = i32(extractBits(v1, 16, 16));
+    return vec4f(
+      f32(r) / 32767.0,
+      f32(g) / 32767.0,
+      f32(b) / 32767.0,
+      f32(a) / 32767.0
+    );
+  `,
+  },
   r32float: {
     storageType: 'f32',
     texelType: 'vec4f',


### PR DESCRIPTION
Texture-formats-tier1 supports the multisampling capabilities on below formats:

r16unorm, rg16unorm, rgba16unorm, r16snorm, r16snorm, rgba16snorm, r8snorm,
rg8snorm and rgba8snorm.

This commit added parsing configuration for these texture format in kLoadValueFromStorageInfo.
The changes align with Texture Formats Tier1 requirements and enable accurate validation of
 multisampled texture reading across shader stages.

Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [ ] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [ ] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [ ] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
