### PR TITLE
Support git version from environment

### DIFF
--- a/src/common/tools/version.ts
+++ b/src/common/tools/version.ts
@@ -1,5 +1,11 @@
 /* eslint-disable-next-line n/no-restricted-require */
-export const version = require('child_process')
-  .execSync('git describe --always --abbrev=0 --dirty')
-  .toString()
-  .trim();
+// Providing the version via an environment variable is supported so that these
+// tests can be run without the actual git checkout available.
+let possible_version = process.env.WEBGPU_CTS_GIT_VERSION;
+if (!possible_version) {
+  possible_version = require('child_process')
+    .execSync('git describe --always --abbrev=0 --dirty')
+    .toString()
+    .trim();
+}
+export const version = possible_version;


### PR DESCRIPTION
Adds support in version.ts for retrieving the version from the WEBGPU_CTS_GIT_VERSION environment variable instead of from calling "git describe" directly. This is so that the tests can be run in contexts where the actual git checkout is not available, such as in certain cases within Chromium.




Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [ ] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [ ] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [ ] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
