### PR TITLE
Make gen_version fail gracefully if git is not available

### DIFF
--- a/src/common/tools/version.ts
+++ b/src/common/tools/version.ts
@@ -1,6 +1,6 @@
-/* eslint-disable-next-line n/no-restricted-require */
 export const version = (() => {
   try {
+    /* eslint-disable-next-line n/no-restricted-require */
     return require('child_process')
       .execSync('git describe --always --abbrev=0 --dirty')
       .toString()

--- a/src/common/tools/version.ts
+++ b/src/common/tools/version.ts
@@ -1,5 +1,12 @@
 /* eslint-disable-next-line n/no-restricted-require */
-export const version = require('child_process')
-  .execSync('git describe --always --abbrev=0 --dirty')
-  .toString()
-  .trim();
+export const version = (() => {
+  try {
+    return require('child_process')
+      .execSync('git describe --always --abbrev=0 --dirty')
+      .toString()
+      .trim();
+  } catch {
+    // Fail gracefully if git is not available.
+    return 'unknown';
+  }
+})();


### PR DESCRIPTION
Chrome infra wants to `npx grunt node` on a VM that doesn't have Git. gen_version is not actually used in `out-node` builds but `npx grunt node` triggers it anyway (it just doesn't copy the result to the output). Changing this in the gruntfile is hard (there are weird dependencies because the gen directory needs to be cleaned every time to delete old files) but this is fine.

Issue: none, see #4452

<hr>

**Requirements for PR author:**

- [n/a] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [n/a] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [n/a] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [n/a] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [n/a] Tests are properly located in the test tree.
- [n/a] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [n/a] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
