### PR TITLE
Add invariant test when not an entry point parameter.

### DIFF
--- a/src/webgpu/shader/validation/shader_io/invariant.spec.ts
+++ b/src/webgpu/shader/validation/shader_io/invariant.spec.ts
@@ -80,6 +80,25 @@ g.test('valid_only_with_vertex_position_builtin')
     t.expectCompileResult(t.params.name === 'position', code);
   });
 
+g.test('valid_only_with_position_in_non_entry_point_struct')
+  .desc(
+    `Test that the invariant attribute requires position, regardless if the struct is used in an entry point`
+  )
+  .params(u => u.combine('has_position', [true, false] as const))
+  .fn(t => {
+    let code = 'struct A {\n';
+    code += '  @invariant';
+    if (t.params.has_position) {
+      code += ' @builtin(position)';
+    }
+    code += '  a : vec4f,\n';
+    code += '}\n';
+    code += '@group(0) @binding(0) var<storage> a: A;\n';
+    code += '@compute @workgroup_size(1) fn main() { let b = a; }';
+
+    t.expectCompileResult(t.params.has_position, code);
+  });
+
 g.test('not_valid_on_user_defined_io')
   .desc(`Test that the invariant attribute is not accepted on user-defined IO attributes.`)
   .params(u => u.combine('use_invariant', [true, false] as const).beginSubcases())


### PR DESCRIPTION
When the `@invariant` attribute is validated, the requirement to have a `@builtin(position)` is regardless of if the struct is used as part of an entry point parameter.

Add a CTS test to validate that `@invariant` is validated this requirement.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [ ] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
