### PR TITLE
Fix usage of bgra8unorm when non-write-only

### DIFF
--- a/src/webgpu/api/validation/compute_pipeline.spec.ts
+++ b/src/webgpu/api/validation/compute_pipeline.spec.ts
@@ -796,6 +796,10 @@ generates a validation error at createComputePipeline(Async)
     const { format, isAsync, access, dimension } = t.params;
     t.skipIfTextureFormatNotSupported(format);
 
+    if (format === 'bgra8unorm' && access !== 'write') {
+      t.skip(`bgra8unorm only supports write access mode`);
+    }
+
     const code = `
       @group(0) @binding(0) var tex: texture_storage_${dimension}<${format}, ${access}>;
       @compute @workgroup_size(1) fn main() {


### PR DESCRIPTION
In the `compute_pipeline` `storage_texture,format` tests we attempt to use `bgra8unorm` as one of the testing formats, but that usage was not part of the spec. This CL changes the test to skip for `bgra8unorm` when the access is not `write`.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [ ] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
