### PR TITLE
Fix usage of bgra8unorm when not-write only in createBindGroupLayout tests

### DIFF
--- a/src/webgpu/api/validation/createBindGroupLayout.spec.ts
+++ b/src/webgpu/api/validation/createBindGroupLayout.spec.ts
@@ -510,6 +510,10 @@ g.test('storage_texture,formats')
     const { format, access } = t.params;
     t.skipIfTextureFormatNotSupported(format);
 
+    if (format === 'bgra8unorm' && access !== 'write-only') {
+      t.skip(`bgra8unorm only supports write access mode`);
+    }
+
     const success = isTextureFormatUsableWithStorageAccessMode(t.device, format, access);
 
     t.expectValidationError(() => {


### PR DESCRIPTION
In the `createBindGroupLayout` `storage_texture,formats` tests we attempt to use bgra8unorm as one of the testing formats, but that usage was not part of the spec. This CL changes the test to skip for bgra8unorm when the access is not write.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [ ] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
