### PR TITLE
Update copyExternalImageToTexture test formats

### DIFF
--- a/src/webgpu/api/validation/queue/copyToTexture/CopyExternalImageToTexture.spec.ts
+++ b/src/webgpu/api/validation/queue/copyToTexture/CopyExternalImageToTexture.spec.ts
@@ -12,7 +12,10 @@ import {
 import { makeTestGroup } from '../../../../../common/framework/test_group.js';
 import { raceWithRejectOnTimeout, unreachable, assert } from '../../../../../common/util/util.js';
 import { kTextureUsages } from '../../../../capability_info.js';
-import { kAllTextureFormats, kValidTextureFormatsForCopyE2T } from '../../../../format_info.js';
+import {
+  kAllTextureFormats,
+  isTextureFormatUsableWithCopyExternalImageToTexture,
+} from '../../../../format_info.js';
 import { kResourceStates, AllFeaturesMaxLimitsGPUTest } from '../../../../gpu_test.js';
 import {
   CanvasType,
@@ -688,7 +691,7 @@ g.test('destination_texture,format')
     });
     void t.device.popErrorScope();
 
-    const success = (kValidTextureFormatsForCopyE2T as readonly string[]).includes(format);
+    const success = isTextureFormatUsableWithCopyExternalImageToTexture(t.device, format);
 
     t.runTest({ source: imageBitmap }, { texture: dstTexture }, copySize, success);
   });

--- a/src/webgpu/format_info.ts
+++ b/src/webgpu/format_info.ts
@@ -1829,6 +1829,24 @@ export const kOptionalTextureFormats = kAllTextureFormats.filter(
   t => kTextureFormatInfo[t].feature !== undefined
 );
 
+/** Formats added from 'texture-formats-tier1' to be usable with `copyExternalImageToTexture`.
+ * DO NOT EXPORT. Use kPossibleValidTextureFormatsForCopyE2T and
+ * filter with `isTextureFormatUsableWithCopyExternalImageToTexture`
+ * or `GPUTest.skipIfTextureFormatNotUsableWithCopyExternalImageToTexture`
+ */
+const kValidTextureFormatsForCopyE2TTier1 = [
+  'r16unorm',
+  'r16snorm',
+  'rg16unorm',
+  'rg16snorm',
+  'rgba16unorm',
+  'rgba16snorm',
+  'r8snorm',
+  'rg8snorm',
+  'rgba8snorm',
+  'rg11b10ufloat',
+] as const;
+
 /** Possibly Valid GPUTextureFormats for `copyExternalImageToTexture`, by spec. */
 export const kPossibleValidTextureFormatsForCopyE2T = [
   'r8unorm',
@@ -1844,10 +1862,11 @@ export const kPossibleValidTextureFormatsForCopyE2T = [
   'rgb10a2unorm',
   'rgba16float',
   'rgba32float',
+  ...kValidTextureFormatsForCopyE2TTier1,
 ] as const;
 
 /**
- * Valid GPUTextureFormats for `copyExternalImageToTexture`, by spec.
+ * Valid GPUTextureFormats for `copyExternalImageToTexture` for core and compat.
  * DO NOT EXPORT. Use kPossibleValidTextureFormatsForCopyE2T and
  * filter with `isTextureFormatUsableWithCopyExternalImageToTexture`
  * or `GPUTest.skipIfTextureFormatNotUsableWithCopyExternalImageToTexture`
@@ -1868,10 +1887,18 @@ const kValidTextureFormatsForCopyE2T = [
   'rgba32float',
 ] as const;
 
+/**
+ * Returns true if a texture can be used with copyExternalImageToTexture.
+ */
 export function isTextureFormatUsableWithCopyExternalImageToTexture(
   device: GPUDevice,
   format: GPUTextureFormat
 ): boolean {
+  if (device.features.has('texture-formats-tier1')) {
+    if ((kValidTextureFormatsForCopyE2TTier1 as readonly string[]).includes(format)) {
+      return true;
+    }
+  }
   return (kValidTextureFormatsForCopyE2T as readonly string[]).includes(format);
 }
 

--- a/src/webgpu/format_info.ts
+++ b/src/webgpu/format_info.ts
@@ -1660,6 +1660,7 @@ type TextureFormatInfo_TypeCheck = {
  * * isTextureFormatPossiblyStorageReadable
  * * isTextureFormatPossiblyStorageReadWritable
  * * isTextureFormatPossiblyFilterableAsTextureF32
+ * * isTextureFormatPossiblyUsableWithCopyExternalImageToTexture
  *
  * These are also usable before or during a test
  *
@@ -1683,6 +1684,7 @@ type TextureFormatInfo_TypeCheck = {
  * * isTextureFormatUsableAsStorageTexture
  * * isTextureFormatUsableAsReadWriteStorageTexture
  * * isTextureFormatUsableAsStorageFormatInCreateShaderModule
+ * * isTextureFormatUsableWithCopyExternalImageToTexture
  *
  * Per-GPUTextureFormat info.
  */
@@ -1827,8 +1829,8 @@ export const kOptionalTextureFormats = kAllTextureFormats.filter(
   t => kTextureFormatInfo[t].feature !== undefined
 );
 
-/** Valid GPUTextureFormats for `copyExternalImageToTexture`, by spec. */
-export const kValidTextureFormatsForCopyE2T = [
+/** Possibly Valid GPUTextureFormats for `copyExternalImageToTexture`, by spec. */
+export const kPossibleValidTextureFormatsForCopyE2T = [
   'r8unorm',
   'r16float',
   'r32float',
@@ -1843,6 +1845,35 @@ export const kValidTextureFormatsForCopyE2T = [
   'rgba16float',
   'rgba32float',
 ] as const;
+
+/**
+ * Valid GPUTextureFormats for `copyExternalImageToTexture`, by spec.
+ * DO NOT EXPORT. Use kPossibleValidTextureFormatsForCopyE2T and
+ * filter with `isTextureFormatUsableWithCopyExternalImageToTexture`
+ * or `GPUTest.skipIfTextureFormatNotUsableWithCopyExternalImageToTexture`
+ */
+const kValidTextureFormatsForCopyE2T = [
+  'r8unorm',
+  'r16float',
+  'r32float',
+  'rg8unorm',
+  'rg16float',
+  'rg32float',
+  'rgba8unorm',
+  'rgba8unorm-srgb',
+  'bgra8unorm',
+  'bgra8unorm-srgb',
+  'rgb10a2unorm',
+  'rgba16float',
+  'rgba32float',
+] as const;
+
+export function isTextureFormatUsableWithCopyExternalImageToTexture(
+  device: GPUDevice,
+  format: GPUTextureFormat
+): boolean {
+  return (kValidTextureFormatsForCopyE2T as readonly string[]).includes(format);
+}
 
 //
 // Other related stuff

--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -39,6 +39,7 @@ import {
   textureViewDimensionAndFormatCompatibleForDevice,
   textureDimensionAndFormatCompatibleForDevice,
   isTextureFormatUsableWithStorageAccessMode,
+  isTextureFormatUsableWithCopyExternalImageToTexture,
 } from './format_info.js';
 import { checkElementsEqual, checkElementsBetween } from './util/check_contents.js';
 import { CommandBufferMaker, EncoderType } from './util/command_buffer_maker.js';
@@ -641,6 +642,13 @@ export class GPUTestBase extends Fixture<GPUTestSubcaseBatchState> {
     this.skipIf(
       !this.canCallCopyTextureToBufferWithTextureFormat(format),
       `can not use copyTextureToBuffer with ${format}`
+    );
+  }
+
+  skipIfTextureFormatPossiblyNotUsableWithCopyExternalImageToTexture(format: GPUTextureFormat) {
+    this.skipIf(
+      !isTextureFormatUsableWithCopyExternalImageToTexture(this.device, format),
+      `can not use copyExternalImageToTexture with ${format}`
     );
   }
 

--- a/src/webgpu/web_platform/copyToTexture/ImageBitmap.spec.ts
+++ b/src/webgpu/web_platform/copyToTexture/ImageBitmap.spec.ts
@@ -13,7 +13,7 @@ TODO: Test zero-sized copies from all sources (just make sure params cover it) (
 import { makeTestGroup } from '../../../common/framework/test_group.js';
 import {
   getBaseFormatForRegularTextureFormat,
-  kValidTextureFormatsForCopyE2T,
+  kPossibleValidTextureFormatsForCopyE2T,
 } from '../../format_info.js';
 import { TextureUploadingUtils, kCopySubrectInfo } from '../../util/copy_to_texture.js';
 
@@ -55,7 +55,7 @@ g.test('from_ImageData')
       .combine('orientation', ['none', 'flipY'] as const)
       .combine('colorSpaceConversion', ['none', 'default'] as const)
       .combine('srcFlipYInCopy', [true, false])
-      .combine('dstFormat', kValidTextureFormatsForCopyE2T)
+      .combine('dstFormat', kPossibleValidTextureFormatsForCopyE2T)
       .combine('dstPremultiplied', [true, false])
       .beginSubcases()
       .combine('width', [1, 2, 4, 15, 255, 256])
@@ -76,6 +76,7 @@ g.test('from_ImageData')
       srcFlipYInCopy,
     } = t.params;
     t.skipIfTextureFormatNotSupported(dstFormat);
+    t.skipIfTextureFormatPossiblyNotUsableWithCopyExternalImageToTexture(dstFormat);
 
     const testColors = kTestColorsAll;
 
@@ -176,7 +177,7 @@ g.test('from_canvas')
       .combine('orientation', ['none', 'flipY'] as const)
       .combine('colorSpaceConversion', ['none', 'default'] as const)
       .combine('srcFlipYInCopy', [true, false])
-      .combine('dstFormat', kValidTextureFormatsForCopyE2T)
+      .combine('dstFormat', kPossibleValidTextureFormatsForCopyE2T)
       .combine('dstPremultiplied', [true, false])
       .beginSubcases()
       .combine('width', [1, 2, 4, 15, 255, 256])
@@ -195,7 +196,8 @@ g.test('from_canvas')
       dstPremultiplied,
       srcFlipYInCopy,
     } = t.params;
-    t.skipIfTextureFormatNotSupported(t.params.dstFormat);
+    t.skipIfTextureFormatNotSupported(dstFormat);
+    t.skipIfTextureFormatPossiblyNotUsableWithCopyExternalImageToTexture(dstFormat);
 
     // CTS sometimes runs on worker threads, where document is not available.
     // In this case, OffscreenCanvas can be used instead of <canvas>.

--- a/src/webgpu/web_platform/copyToTexture/ImageData.spec.ts
+++ b/src/webgpu/web_platform/copyToTexture/ImageData.spec.ts
@@ -5,7 +5,7 @@ copyExternalImageToTexture from ImageData source.
 import { makeTestGroup } from '../../../common/framework/test_group.js';
 import {
   getBaseFormatForRegularTextureFormat,
-  kValidTextureFormatsForCopyE2T,
+  kPossibleValidTextureFormatsForCopyE2T,
 } from '../../format_info.js';
 import { TextureUploadingUtils, kCopySubrectInfo } from '../../util/copy_to_texture.js';
 
@@ -43,7 +43,7 @@ g.test('from_ImageData')
   .params(u =>
     u
       .combine('srcDoFlipYDuringCopy', [true, false])
-      .combine('dstColorFormat', kValidTextureFormatsForCopyE2T)
+      .combine('dstColorFormat', kPossibleValidTextureFormatsForCopyE2T)
       .combine('dstPremultiplied', [true, false])
       .beginSubcases()
       .combine('width', [1, 2, 4, 15, 255, 256])
@@ -55,6 +55,7 @@ g.test('from_ImageData')
   .fn(t => {
     const { width, height, dstColorFormat, dstPremultiplied, srcDoFlipYDuringCopy } = t.params;
     t.skipIfTextureFormatNotSupported(dstColorFormat);
+    t.skipIfTextureFormatPossiblyNotUsableWithCopyExternalImageToTexture(dstColorFormat);
 
     const testColors = kTestColorsAll;
 

--- a/src/webgpu/web_platform/copyToTexture/canvas.spec.ts
+++ b/src/webgpu/web_platform/copyToTexture/canvas.spec.ts
@@ -7,7 +7,7 @@ import { skipTestCase } from '../../../common/util/util.js';
 import { kCanvasAlphaModes } from '../../capability_info.js';
 import {
   getBaseFormatForRegularTextureFormat,
-  kValidTextureFormatsForCopyE2T,
+  kPossibleValidTextureFormatsForCopyE2T,
   RegularTextureFormat,
 } from '../../format_info.js';
 import { TextureUploadingUtils } from '../../util/copy_to_texture.js';
@@ -486,7 +486,7 @@ g.test('copy_contents_from_2d_context_canvas')
   .params(u =>
     u
       .combine('canvasType', kAllCanvasTypes)
-      .combine('dstColorFormat', kValidTextureFormatsForCopyE2T)
+      .combine('dstColorFormat', kPossibleValidTextureFormatsForCopyE2T)
       .combine('dstAlphaMode', kCanvasAlphaModes)
       .combine('srcDoFlipYDuringCopy', [true, false])
       .beginSubcases()
@@ -494,8 +494,9 @@ g.test('copy_contents_from_2d_context_canvas')
       .combine('height', [1, 2, 4, 15])
   )
   .fn(t => {
-    t.skipIfTextureFormatNotSupported(t.params.dstColorFormat);
-    const { width, height, canvasType, dstAlphaMode } = t.params;
+    const { width, height, canvasType, dstAlphaMode, dstColorFormat } = t.params;
+    t.skipIfTextureFormatNotSupported(dstColorFormat);
+    t.skipIfTextureFormatPossiblyNotUsableWithCopyExternalImageToTexture(dstColorFormat);
 
     const { canvas, expectedSourceData } = t.init2DCanvasContent({
       canvasType,
@@ -547,7 +548,7 @@ g.test('copy_contents_from_gl_context_canvas')
     u
       .combine('canvasType', kAllCanvasTypes)
       .combine('contextName', ['webgl', 'webgl2'] as const)
-      .combine('dstColorFormat', kValidTextureFormatsForCopyE2T)
+      .combine('dstColorFormat', kPossibleValidTextureFormatsForCopyE2T)
       .combine('srcPremultiplied', [true, false])
       .combine('dstAlphaMode', kCanvasAlphaModes)
       .combine('srcDoFlipYDuringCopy', [true, false])
@@ -556,8 +557,17 @@ g.test('copy_contents_from_gl_context_canvas')
       .combine('height', [1, 2, 4, 15])
   )
   .fn(t => {
-    t.skipIfTextureFormatNotSupported(t.params.dstColorFormat);
-    const { width, height, canvasType, contextName, srcPremultiplied, dstAlphaMode } = t.params;
+    const {
+      width,
+      height,
+      canvasType,
+      contextName,
+      srcPremultiplied,
+      dstAlphaMode,
+      dstColorFormat,
+    } = t.params;
+    t.skipIfTextureFormatNotSupported(dstColorFormat);
+    t.skipIfTextureFormatPossiblyNotUsableWithCopyExternalImageToTexture(dstColorFormat);
 
     const { canvas, expectedSourceData } = t.initGLCanvasContent({
       canvasType,
@@ -613,7 +623,7 @@ g.test('copy_contents_from_gpu_context_canvas')
     u
       .combine('canvasType', kAllCanvasTypes)
       .combine('srcAndDstInSameGPUDevice', [true, false])
-      .combine('dstColorFormat', kValidTextureFormatsForCopyE2T)
+      .combine('dstColorFormat', kPossibleValidTextureFormatsForCopyE2T)
       // .combine('srcAlphaMode', kCanvasAlphaModes)
       .combine('srcAlphaMode', ['premultiplied'] as const)
       .combine('dstAlphaMode', kCanvasAlphaModes)
@@ -626,9 +636,17 @@ g.test('copy_contents_from_gpu_context_canvas')
     t.usesMismatchedDevice();
   })
   .fn(t => {
-    t.skipIfTextureFormatNotSupported(t.params.dstColorFormat);
-    const { width, height, canvasType, srcAndDstInSameGPUDevice, srcAlphaMode, dstAlphaMode } =
-      t.params;
+    const {
+      width,
+      height,
+      canvasType,
+      srcAndDstInSameGPUDevice,
+      srcAlphaMode,
+      dstAlphaMode,
+      dstColorFormat,
+    } = t.params;
+    t.skipIfTextureFormatNotSupported(dstColorFormat);
+    t.skipIfTextureFormatPossiblyNotUsableWithCopyExternalImageToTexture(dstColorFormat);
 
     const device = srcAndDstInSameGPUDevice ? t.device : t.mismatchedDevice;
     const { canvas: source, expectedSourceData } = t.initSourceWebGPUCanvas({
@@ -681,7 +699,7 @@ g.test('copy_contents_from_bitmaprenderer_context_canvas')
   .params(u =>
     u
       .combine('canvasType', kAllCanvasTypes)
-      .combine('dstColorFormat', kValidTextureFormatsForCopyE2T)
+      .combine('dstColorFormat', kPossibleValidTextureFormatsForCopyE2T)
       .combine('dstAlphaMode', kCanvasAlphaModes)
       .combine('srcDoFlipYDuringCopy', [true, false])
       .beginSubcases()
@@ -689,8 +707,9 @@ g.test('copy_contents_from_bitmaprenderer_context_canvas')
       .combine('height', [1, 2, 4, 15])
   )
   .fn(async t => {
-    t.skipIfTextureFormatNotSupported(t.params.dstColorFormat);
-    const { width, height, canvasType, dstAlphaMode } = t.params;
+    const { width, height, canvasType, dstAlphaMode, dstColorFormat } = t.params;
+    t.skipIfTextureFormatNotSupported(dstColorFormat);
+    t.skipIfTextureFormatPossiblyNotUsableWithCopyExternalImageToTexture(dstColorFormat);
 
     const canvas = createCanvas(t, canvasType, width, height);
 
@@ -755,7 +774,7 @@ g.test('color_space_conversion')
     u
       .combine('srcColorSpace', ['srgb', 'display-p3'] as const)
       .combine('dstColorSpace', ['srgb', 'display-p3'] as const)
-      .combine('dstColorFormat', kValidTextureFormatsForCopyE2T)
+      .combine('dstColorFormat', kPossibleValidTextureFormatsForCopyE2T)
       .combine('dstPremultiplied', [true, false])
       .combine('srcDoFlipYDuringCopy', [true, false])
       .beginSubcases()
@@ -763,7 +782,6 @@ g.test('color_space_conversion')
       .combine('height', [1, 2, 4, 15, 255, 256])
   )
   .fn(t => {
-    t.skipIfTextureFormatNotSupported(t.params.dstColorFormat);
     const {
       width,
       height,
@@ -773,6 +791,8 @@ g.test('color_space_conversion')
       dstPremultiplied,
       srcDoFlipYDuringCopy,
     } = t.params;
+    t.skipIfTextureFormatNotSupported(dstColorFormat);
+    t.skipIfTextureFormatPossiblyNotUsableWithCopyExternalImageToTexture(dstColorFormat);
     const { canvas, expectedSourceData } = t.init2DCanvasContentWithColorSpace({
       width,
       height,

--- a/src/webgpu/web_platform/copyToTexture/image.spec.ts
+++ b/src/webgpu/web_platform/copyToTexture/image.spec.ts
@@ -6,7 +6,7 @@ import { makeTestGroup } from '../../../common/framework/test_group.js';
 import { raceWithRejectOnTimeout } from '../../../common/util/util.js';
 import {
   getBaseFormatForRegularTextureFormat,
-  kValidTextureFormatsForCopyE2T,
+  kPossibleValidTextureFormatsForCopyE2T,
 } from '../../format_info.js';
 import * as ttu from '../../texture_test_utils.js';
 import { TextureUploadingUtils, kCopySubrectInfo } from '../../util/copy_to_texture.js';
@@ -58,7 +58,7 @@ g.test('from_image')
   .params(u =>
     u
       .combine('srcDoFlipYDuringCopy', [true, false])
-      .combine('dstColorFormat', kValidTextureFormatsForCopyE2T)
+      .combine('dstColorFormat', kPossibleValidTextureFormatsForCopyE2T)
       .combine('dstPremultiplied', [true, false])
       .beginSubcases()
       .combine('width', [1, 2, 4, 15, 255, 256])
@@ -70,6 +70,7 @@ g.test('from_image')
   .fn(async t => {
     const { width, height, dstColorFormat, dstPremultiplied, srcDoFlipYDuringCopy } = t.params;
     t.skipIfTextureFormatNotSupported(dstColorFormat);
+    t.skipIfTextureFormatPossiblyNotUsableWithCopyExternalImageToTexture(dstColorFormat);
 
     const imageCanvas = document.createElement('canvas');
     imageCanvas.width = width;


### PR DESCRIPTION
Update these tests so they can automatically handle new formats as they are enabled by features.

* Issue: [#5289](https://github.com/gpuweb/gpuweb/issues/5289)

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [X] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
