### PR TITLE
Show default device in standalone runner

### DIFF
--- a/src/common/internal/logging/logger.ts
+++ b/src/common/internal/logging/logger.ts
@@ -9,6 +9,7 @@ export type LogResults = Map<string, LiveTestCaseResult>;
 export class Logger {
   readonly overriddenDebugMode: boolean | undefined;
   readonly results: LogResults = new Map();
+  defaultDeviceDescription: string | undefined;
 
   constructor({ overrideDebugMode }: { overrideDebugMode?: boolean } = {}) {
     this.overriddenDebugMode = overrideDebugMode;
@@ -27,6 +28,7 @@ export class Logger {
     return JSON.stringify(
       {
         version,
+        defaultDevice: this.defaultDeviceDescription,
         results: Array.from(
           new Map(
             [...this.results].filter(([key, value]) => (predFunc ? predFunc(key, value) : true))

--- a/src/common/runtime/standalone.ts
+++ b/src/common/runtime/standalone.ts
@@ -11,7 +11,11 @@ import { LiveTestCaseResult } from '../internal/logging/result.js';
 import { parseQuery } from '../internal/query/parseQuery.js';
 import { TestQueryLevel } from '../internal/query/query.js';
 import { TestTreeNode, TestSubtree, TestTreeLeaf, TestTree } from '../internal/tree.js';
-import { setDefaultRequestAdapterOptions } from '../util/navigator_gpu.js';
+import {
+  getDefaultRequestAdapterOptions,
+  getGPU,
+  setDefaultRequestAdapterOptions,
+} from '../util/navigator_gpu.js';
 import { ErrorWithExtra, unreachable } from '../util/util.js';
 
 import {
@@ -651,6 +655,14 @@ void (async () => {
     });
   };
   addOptionsToPage(options, kStandaloneOptionsInfos);
+
+  let deviceDescription = '<unable to get WebGPU adapter>';
+  const adapter = await getGPU(null).requestAdapter(getDefaultRequestAdapterOptions());
+  if (adapter) {
+    deviceDescription = `${adapter.info.vendor} ${adapter.info.architecture} (${adapter.info.description})`;
+  }
+  $('#device')[0].textContent = 'Default WebGPU adapter: ' + deviceDescription;
+  logger.defaultDeviceDescription = deviceDescription;
 
   if (qs.length !== 1) {
     showInfo('currently, there must be exactly one ?q=');

--- a/standalone/index.html
+++ b/standalone/index.html
@@ -438,6 +438,9 @@
          You must reload the page for the options to take effect.</p>
     </details>
     <p>
+      <div id="device"></div>
+    </p>
+    <p>
       <input type=button id=expandall value="Expand All (slow!)">
       <label><input type=checkbox id=autoCloseOnPass> Auto-close each subtree when it passes</label>
     </p>


### PR DESCRIPTION
This makes it easier to know what device you are running on. Also save the default device description to the JSON results file.
