### PR TITLE
Refactor copyExternalImageToTexture tested formats.

### DIFF
--- a/src/webgpu/format_info.ts
+++ b/src/webgpu/format_info.ts
@@ -1829,63 +1829,25 @@ export const kOptionalTextureFormats = kAllTextureFormats.filter(
   t => kTextureFormatInfo[t].feature !== undefined
 );
 
-/** Formats added from 'texture-formats-tier1' to be usable with `copyExternalImageToTexture`.
- * DO NOT EXPORT. Use kPossibleValidTextureFormatsForCopyE2T and
- * filter with `isTextureFormatUsableWithCopyExternalImageToTexture`
- * or `GPUTest.skipIfTextureFormatNotUsableWithCopyExternalImageToTexture`
- */
-const kValidTextureFormatsForCopyE2TTier1 = [
-  'r16unorm',
-  'r16snorm',
-  'rg16unorm',
-  'rg16snorm',
-  'rgba16unorm',
-  'rgba16snorm',
-  'r8snorm',
-  'rg8snorm',
-  'rgba8snorm',
-  'rg11b10ufloat',
-] as const;
-
-/** Possibly Valid GPUTextureFormats for `copyExternalImageToTexture`, by spec. */
-export const kPossibleValidTextureFormatsForCopyE2T = [
-  'r8unorm',
-  'r16float',
-  'r32float',
-  'rg8unorm',
-  'rg16float',
-  'rg32float',
-  'rgba8unorm',
-  'rgba8unorm-srgb',
-  'bgra8unorm',
-  'bgra8unorm-srgb',
-  'rgb10a2unorm',
-  'rgba16float',
-  'rgba32float',
-  ...kValidTextureFormatsForCopyE2TTier1,
-] as const;
+function isSnormTextureFormat(format: GPUTextureFormat): boolean {
+  return format.endsWith('snorm');
+}
 
 /**
- * Valid GPUTextureFormats for `copyExternalImageToTexture` for core and compat.
- * DO NOT EXPORT. Use kPossibleValidTextureFormatsForCopyE2T and
- * filter with `isTextureFormatUsableWithCopyExternalImageToTexture`
- * or `GPUTest.skipIfTextureFormatNotUsableWithCopyExternalImageToTexture`
+ * Returns true if a texture can be possibly used with copyExternalImageToTexture.
+ * The texture may require certain features to be enabled.
  */
-const kValidTextureFormatsForCopyE2T = [
-  'r8unorm',
-  'r16float',
-  'r32float',
-  'rg8unorm',
-  'rg16float',
-  'rg32float',
-  'rgba8unorm',
-  'rgba8unorm-srgb',
-  'bgra8unorm',
-  'bgra8unorm-srgb',
-  'rgb10a2unorm',
-  'rgba16float',
-  'rgba32float',
-] as const;
+export function isTextureFormatPossiblyUsableWithCopyExternalImageToTexture(
+  format: GPUTextureFormat
+): boolean {
+  return (
+    isColorTextureFormat(format) &&
+    !isSintOrUintFormat(format) &&
+    !isCompressedTextureFormat(format) &&
+    !isSnormTextureFormat(format) &&
+    isTextureFormatPossiblyUsableAsColorRenderAttachment(format)
+  );
+}
 
 /**
  * Returns true if a texture can be used with copyExternalImageToTexture.
@@ -1894,12 +1856,13 @@ export function isTextureFormatUsableWithCopyExternalImageToTexture(
   device: GPUDevice,
   format: GPUTextureFormat
 ): boolean {
-  if (device.features.has('texture-formats-tier1')) {
-    if ((kValidTextureFormatsForCopyE2TTier1 as readonly string[]).includes(format)) {
-      return true;
-    }
-  }
-  return (kValidTextureFormatsForCopyE2T as readonly string[]).includes(format);
+  return (
+    isColorTextureFormat(format) &&
+    !isSintOrUintFormat(format) &&
+    !isCompressedTextureFormat(format) &&
+    !isSnormTextureFormat(format) &&
+    isTextureFormatColorRenderable(device, format)
+  );
 }
 
 //

--- a/src/webgpu/web_platform/copyToTexture/ImageBitmap.spec.ts
+++ b/src/webgpu/web_platform/copyToTexture/ImageBitmap.spec.ts
@@ -13,7 +13,8 @@ TODO: Test zero-sized copies from all sources (just make sure params cover it) (
 import { makeTestGroup } from '../../../common/framework/test_group.js';
 import {
   getBaseFormatForRegularTextureFormat,
-  kPossibleValidTextureFormatsForCopyE2T,
+  isTextureFormatPossiblyUsableWithCopyExternalImageToTexture,
+  kRegularTextureFormats,
 } from '../../format_info.js';
 import { TextureUploadingUtils, kCopySubrectInfo } from '../../util/copy_to_texture.js';
 
@@ -55,7 +56,8 @@ g.test('from_ImageData')
       .combine('orientation', ['none', 'flipY'] as const)
       .combine('colorSpaceConversion', ['none', 'default'] as const)
       .combine('srcFlipYInCopy', [true, false])
-      .combine('dstFormat', kPossibleValidTextureFormatsForCopyE2T)
+      .combine('dstFormat', kRegularTextureFormats)
+      .filter(t => isTextureFormatPossiblyUsableWithCopyExternalImageToTexture(t.dstFormat))
       .combine('dstPremultiplied', [true, false])
       .beginSubcases()
       .combine('width', [1, 2, 4, 15, 255, 256])
@@ -177,7 +179,8 @@ g.test('from_canvas')
       .combine('orientation', ['none', 'flipY'] as const)
       .combine('colorSpaceConversion', ['none', 'default'] as const)
       .combine('srcFlipYInCopy', [true, false])
-      .combine('dstFormat', kPossibleValidTextureFormatsForCopyE2T)
+      .combine('dstFormat', kRegularTextureFormats)
+      .filter(t => isTextureFormatPossiblyUsableWithCopyExternalImageToTexture(t.dstFormat))
       .combine('dstPremultiplied', [true, false])
       .beginSubcases()
       .combine('width', [1, 2, 4, 15, 255, 256])

--- a/src/webgpu/web_platform/copyToTexture/ImageData.spec.ts
+++ b/src/webgpu/web_platform/copyToTexture/ImageData.spec.ts
@@ -5,7 +5,8 @@ copyExternalImageToTexture from ImageData source.
 import { makeTestGroup } from '../../../common/framework/test_group.js';
 import {
   getBaseFormatForRegularTextureFormat,
-  kPossibleValidTextureFormatsForCopyE2T,
+  isTextureFormatPossiblyUsableWithCopyExternalImageToTexture,
+  kRegularTextureFormats,
 } from '../../format_info.js';
 import { TextureUploadingUtils, kCopySubrectInfo } from '../../util/copy_to_texture.js';
 
@@ -43,7 +44,8 @@ g.test('from_ImageData')
   .params(u =>
     u
       .combine('srcDoFlipYDuringCopy', [true, false])
-      .combine('dstColorFormat', kPossibleValidTextureFormatsForCopyE2T)
+      .combine('dstColorFormat', kRegularTextureFormats)
+      .filter(t => isTextureFormatPossiblyUsableWithCopyExternalImageToTexture(t.dstColorFormat))
       .combine('dstPremultiplied', [true, false])
       .beginSubcases()
       .combine('width', [1, 2, 4, 15, 255, 256])

--- a/src/webgpu/web_platform/copyToTexture/canvas.spec.ts
+++ b/src/webgpu/web_platform/copyToTexture/canvas.spec.ts
@@ -7,7 +7,8 @@ import { skipTestCase } from '../../../common/util/util.js';
 import { kCanvasAlphaModes } from '../../capability_info.js';
 import {
   getBaseFormatForRegularTextureFormat,
-  kPossibleValidTextureFormatsForCopyE2T,
+  isTextureFormatPossiblyUsableWithCopyExternalImageToTexture,
+  kRegularTextureFormats,
   RegularTextureFormat,
 } from '../../format_info.js';
 import { TextureUploadingUtils } from '../../util/copy_to_texture.js';
@@ -486,7 +487,8 @@ g.test('copy_contents_from_2d_context_canvas')
   .params(u =>
     u
       .combine('canvasType', kAllCanvasTypes)
-      .combine('dstColorFormat', kPossibleValidTextureFormatsForCopyE2T)
+      .combine('dstColorFormat', kRegularTextureFormats)
+      .filter(t => isTextureFormatPossiblyUsableWithCopyExternalImageToTexture(t.dstColorFormat))
       .combine('dstAlphaMode', kCanvasAlphaModes)
       .combine('srcDoFlipYDuringCopy', [true, false])
       .beginSubcases()
@@ -548,7 +550,8 @@ g.test('copy_contents_from_gl_context_canvas')
     u
       .combine('canvasType', kAllCanvasTypes)
       .combine('contextName', ['webgl', 'webgl2'] as const)
-      .combine('dstColorFormat', kPossibleValidTextureFormatsForCopyE2T)
+      .combine('dstColorFormat', kRegularTextureFormats)
+      .filter(t => isTextureFormatPossiblyUsableWithCopyExternalImageToTexture(t.dstColorFormat))
       .combine('srcPremultiplied', [true, false])
       .combine('dstAlphaMode', kCanvasAlphaModes)
       .combine('srcDoFlipYDuringCopy', [true, false])
@@ -623,7 +626,8 @@ g.test('copy_contents_from_gpu_context_canvas')
     u
       .combine('canvasType', kAllCanvasTypes)
       .combine('srcAndDstInSameGPUDevice', [true, false])
-      .combine('dstColorFormat', kPossibleValidTextureFormatsForCopyE2T)
+      .combine('dstColorFormat', kRegularTextureFormats)
+      .filter(t => isTextureFormatPossiblyUsableWithCopyExternalImageToTexture(t.dstColorFormat))
       // .combine('srcAlphaMode', kCanvasAlphaModes)
       .combine('srcAlphaMode', ['premultiplied'] as const)
       .combine('dstAlphaMode', kCanvasAlphaModes)
@@ -699,7 +703,8 @@ g.test('copy_contents_from_bitmaprenderer_context_canvas')
   .params(u =>
     u
       .combine('canvasType', kAllCanvasTypes)
-      .combine('dstColorFormat', kPossibleValidTextureFormatsForCopyE2T)
+      .combine('dstColorFormat', kRegularTextureFormats)
+      .filter(t => isTextureFormatPossiblyUsableWithCopyExternalImageToTexture(t.dstColorFormat))
       .combine('dstAlphaMode', kCanvasAlphaModes)
       .combine('srcDoFlipYDuringCopy', [true, false])
       .beginSubcases()
@@ -774,7 +779,8 @@ g.test('color_space_conversion')
     u
       .combine('srcColorSpace', ['srgb', 'display-p3'] as const)
       .combine('dstColorSpace', ['srgb', 'display-p3'] as const)
-      .combine('dstColorFormat', kPossibleValidTextureFormatsForCopyE2T)
+      .combine('dstColorFormat', kRegularTextureFormats)
+      .filter(t => isTextureFormatPossiblyUsableWithCopyExternalImageToTexture(t.dstColorFormat))
       .combine('dstPremultiplied', [true, false])
       .combine('srcDoFlipYDuringCopy', [true, false])
       .beginSubcases()

--- a/src/webgpu/web_platform/copyToTexture/image.spec.ts
+++ b/src/webgpu/web_platform/copyToTexture/image.spec.ts
@@ -6,7 +6,8 @@ import { makeTestGroup } from '../../../common/framework/test_group.js';
 import { raceWithRejectOnTimeout } from '../../../common/util/util.js';
 import {
   getBaseFormatForRegularTextureFormat,
-  kPossibleValidTextureFormatsForCopyE2T,
+  isTextureFormatPossiblyUsableWithCopyExternalImageToTexture,
+  kRegularTextureFormats,
 } from '../../format_info.js';
 import * as ttu from '../../texture_test_utils.js';
 import { TextureUploadingUtils, kCopySubrectInfo } from '../../util/copy_to_texture.js';
@@ -58,7 +59,8 @@ g.test('from_image')
   .params(u =>
     u
       .combine('srcDoFlipYDuringCopy', [true, false])
-      .combine('dstColorFormat', kPossibleValidTextureFormatsForCopyE2T)
+      .combine('dstColorFormat', kRegularTextureFormats)
+      .filter(t => isTextureFormatPossiblyUsableWithCopyExternalImageToTexture(t.dstColorFormat))
       .combine('dstPremultiplied', [true, false])
       .beginSubcases()
       .combine('width', [1, 2, 4, 15, 255, 256])


### PR DESCRIPTION
Rather than have a list of allowed formats, the new spec allows all regular texture formats that are renderable and not compressed, not snorm, not integer.

https://github.com/gpuweb/gpuweb/issues/5289
https://github.com/gpuweb/gpuweb/pull/5299
https://github.com/gpuweb/gpuweb/issues/5323

Note: with the change in the spec to be "color renderable+unorm/float", that means feature: ["rg11b10ufloat-renderable"](https://gpuweb.github.io/gpuweb/#rg11b10ufloat-renderable) enabling `copyExternalImageToTexture` for `rg11b10ufloat`

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [X] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
