### PR TITLE
Add logical operation override tests.

### DIFF
--- a/src/webgpu/listing_meta.json
+++ b/src/webgpu/listing_meta.json
@@ -1900,6 +1900,8 @@
   "webgpu:shader,execution,memory_model,weak:read:*": { "subcaseMS": 185.400 },
   "webgpu:shader,execution,memory_model,weak:store:*": { "subcaseMS": 184.500 },
   "webgpu:shader,execution,memory_model,weak:store_buffer:*": { "subcaseMS": 185.850 },
+  "webgpu:shader,execution,override:logical:*": { "subcaseMS": 87.335 },
+  "webgpu:shader,execution,override:logical_lhs:*": { "subcaseMS": 66.057 },
   "webgpu:shader,execution,padding:array_of_matCx3:*": { "subcaseMS": 8.650 },
   "webgpu:shader,execution,padding:array_of_struct:*": { "subcaseMS": 5.801 },
   "webgpu:shader,execution,padding:array_of_vec3:*": { "subcaseMS": 10.500 },

--- a/src/webgpu/shader/execution/override.spec.ts
+++ b/src/webgpu/shader/execution/override.spec.ts
@@ -1,0 +1,89 @@
+export const description = `Test override execution`;
+
+import { makeTestGroup } from '../../../common/framework/test_group.js';
+import { AllFeaturesMaxLimitsGPUTest } from '../../gpu_test.js';
+import { checkElementsEqual } from '../../util/check_contents.js';
+import { keysOf } from '../../../common/util/data_tables.js';
+
+export const g = makeTestGroup(AllFeaturesMaxLimitsGPUTest);
+
+const kOverrideCases = {
+  logical_lhs_override: {
+    code: `x == 2 && 1 < 2`,
+  },
+  logical_rhs_override: {
+    code: `1 > 2 || x == 2`,
+  },
+  logical_both_override: {
+    code: `x > 2 || x == 2`,
+  }
+};
+
+g.test('logical')
+  .desc(`Test replacing an override in the LHS of a logical statement`)
+  .params(u =>
+    u.combine('case', keysOf(kOverrideCases))
+  )
+  .fn(async t => {
+    const expr = kOverrideCases[t.params.case].code;
+    const code = `
+override x: u32 = 2;
+override y: bool = ${expr};
+
+@group(0) @binding(0) var<storage, read_write> v : vec4u;
+
+@compute @workgroup_size(1)
+fn main() {
+  if (y) {
+      v = vec4u(4, 4, 4, 4);
+  } else {
+      v = vec4u(1, 1, 1, 1);
+  }
+}`;
+
+    const pipeline = t.device.createComputePipeline({
+      layout: 'auto',
+      compute: {
+        module: t.device.createShaderModule({
+          code,
+        }),
+        entryPoint: 'main',
+      },
+    });
+
+    const buffer = t.makeBufferWithContents(
+      new Uint32Array([0, 0, 0, 0]),
+      GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC | GPUBufferUsage.COPY_DST
+    );
+
+    const bg = t.device.createBindGroup({
+      layout: pipeline.getBindGroupLayout(0),
+      entries: [
+        {
+          binding: 0,
+          resource: {
+            buffer,
+          },
+        },
+      ],
+    });
+
+    const encoder = t.device.createCommandEncoder();
+    const pass = encoder.beginComputePass();
+    pass.setPipeline(pipeline);
+    pass.setBindGroup(0, bg);
+    pass.dispatchWorkgroups(1, 1, 1);
+    pass.end();
+    t.queue.submit([encoder.finish()]);
+
+    const bufferReadback = await t.readGPUBufferRangeTyped(buffer, {
+      srcByteOffset: 0,
+      type: Uint32Array,
+      typedLength: 4,
+      method: 'copy',
+    });
+    const got: Uint32Array = bufferReadback.data;
+    const expected = new Uint32Array([4, 4, 4, 4]);
+
+    t.expectOK(checkElementsEqual(got, expected));
+  });

--- a/src/webgpu/shader/validation/decl/override.spec.ts
+++ b/src/webgpu/shader/validation/decl/override.spec.ts
@@ -206,6 +206,21 @@ const kInitCases = {
     override y : i32;`,
     valid: true,
   },
+  logical_lhs_override: {
+    code: `override x = 2;
+      override y = x == 2 && 1 < 2;`,
+    valid: true,
+  },
+  logical_rhs_override: {
+    code: `override x = 2;
+      override y = 1 < 2 || x == 2;`,
+    valid: true,
+  },
+  logical_both_override: {
+    code: `override x = 2;
+      override y = x > 2 || x == 2;`,
+    valid: true,
+  }
 };
 
 g.test('initializer')


### PR DESCRIPTION
Add some shader validation and execution tests for overrides with logical expressions where the expression uses another override in both sides of the logical op, just the left hand side or just the right hand side.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [ ] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
