### PR TITLE
wgsl: test uniformity analysis of break-if condition

### DIFF
--- a/src/webgpu/shader/validation/uniformity/uniformity.spec.ts
+++ b/src/webgpu/shader/validation/uniformity/uniformity.spec.ts
@@ -185,7 +185,14 @@ function generateOp(op: string): string {
   }
 }
 
-function generateConditionalStatement(statement: string, condition: string, op: string): string {
+const kStatementKinds = ['if', 'for', 'while', 'switch', 'break-if'] as const;
+type kStatementType = (typeof kStatementKinds)[number];
+
+function generateConditionalStatement(
+  statement: kStatementType,
+  condition: string,
+  op: string
+): string {
   const code = ``;
   switch (statement) {
     case 'if': {
@@ -215,8 +222,19 @@ function generateConditionalStatement(statement: string, condition: string, op: 
       }
       `;
     }
-    default: {
-      unreachable(`Unhandled statement`);
+    case 'break-if': {
+      // The initial 'if' prevents the loop from being infinite.  Its condition
+      // is uniform, to ensure the first iteration of the the body executes
+      // uniformly. The uniformity of the second iteration depends entirely on
+      // the uniformity of the break-if condition.
+      return `loop {
+        if ${generateCondition('uniform_storage_ro')} { break; }
+        ${generateOp(op)}
+        continuing {
+          break if ${generateCondition(condition)};
+        }
+      }
+      `;
     }
   }
 
@@ -227,7 +245,7 @@ g.test('basics')
   .desc(`Test collective operations in simple uniform or non-uniform control flow.`)
   .params(u =>
     u
-      .combine('statement', ['if', 'for', 'while', 'switch'] as const)
+      .combine('statement', kStatementKinds)
       .beginSubcases()
       .combineWithParams(kConditions)
       .combineWithParams(kCollectiveOps)
@@ -315,7 +333,7 @@ g.test('basics,subgroups')
   .desc(`Test subgroup operations in simple uniform or non-uniform control flow.`)
   .params(u =>
     u
-      .combine('statement', ['if', 'for', 'while', 'switch'] as const)
+      .combine('statement', kStatementKinds)
       .beginSubcases()
       .combineWithParams(kConditions)
       .combine('op', kSubgroupOps)


### PR DESCRIPTION
Use a code gadget designed to carry the uniformity of the break-if condition value into the execution uniformity of the second iteration of the enclosing loop.

Fixed: #4471




Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [ ] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [ ] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
