### PR TITLE
Clean unnecessary swizzle related casts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@types/w3c-image-capture": "^1.0.10",
         "@typescript-eslint/eslint-plugin": "^6.9.1",
         "@typescript-eslint/parser": "^6.9.1",
-        "@webgpu/types": "^0.1.64",
+        "@webgpu/types": "^0.1.66",
         "ansi-colors": "4.1.3",
         "babel-plugin-add-header-comment": "^1.0.3",
         "babel-plugin-const-enum": "^1.2.0",
@@ -1539,9 +1539,9 @@
       "dev": true
     },
     "node_modules/@webgpu/types": {
-      "version": "0.1.64",
-      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.64.tgz",
-      "integrity": "sha512-84kRIAGV46LJTlJZWxShiOrNL30A+9KokD7RB3dRCIqODFjodS5tCD5yyiZ8kIReGVZSDfA3XkkwyyOIF6K62A==",
+      "version": "0.1.66",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.66.tgz",
+      "integrity": "sha512-YA2hLrwLpDsRueNDXIMqN9NTzD6bCDkuXbOSe0heS+f8YE8usA6Gbv1prj81pzVHrbaAma7zObnIC+I6/sXJgA==",
       "dev": true,
       "license": "BSD-3-Clause"
     },
@@ -10077,9 +10077,9 @@
       "dev": true
     },
     "@webgpu/types": {
-      "version": "0.1.64",
-      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.64.tgz",
-      "integrity": "sha512-84kRIAGV46LJTlJZWxShiOrNL30A+9KokD7RB3dRCIqODFjodS5tCD5yyiZ8kIReGVZSDfA3XkkwyyOIF6K62A==",
+      "version": "0.1.66",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.66.tgz",
+      "integrity": "sha512-YA2hLrwLpDsRueNDXIMqN9NTzD6bCDkuXbOSe0heS+f8YE8usA6Gbv1prj81pzVHrbaAma7zObnIC+I6/sXJgA==",
       "dev": true
     },
     "abbrev": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@types/w3c-image-capture": "^1.0.10",
     "@typescript-eslint/eslint-plugin": "^6.9.1",
     "@typescript-eslint/parser": "^6.9.1",
-    "@webgpu/types": "^0.1.64",
+    "@webgpu/types": "^0.1.66",
     "ansi-colors": "4.1.3",
     "babel-plugin-add-header-comment": "^1.0.3",
     "babel-plugin-const-enum": "^1.2.0",

--- a/src/webgpu/api/operation/texture_view/texture_component_swizzle.spec.ts
+++ b/src/webgpu/api/operation/texture_view/texture_component_swizzle.spec.ts
@@ -254,8 +254,7 @@ g.test('read_swizzle')
         .combine('otherSwizzleIndexOffset', [0, 1, 5]) // used to choose a different 2nd swizzle. 0 = same swizzle as 1st
   )
   .fn(async t => {
-    // MAINTENANCE_TODO: Remove this cast once texture-component-swizzle is added to @webgpu/types
-    t.skipIfDeviceDoesNotHaveFeature('texture-component-swizzle' as GPUFeatureName);
+    t.skipIfDeviceDoesNotHaveFeature('texture-component-swizzle');
     const { format, func, channel, compare, input, aspect, swizzle, otherSwizzleIndexOffset } =
       t.params;
     t.skipIfTextureFormatNotSupported(format);

--- a/src/webgpu/api/validation/capability_checks/features/texture_component_swizzle.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/features/texture_component_swizzle.spec.ts
@@ -54,8 +54,7 @@ g.test('invalid_swizzle')
     ])
   )
   .beforeAllSubcases(t => {
-    // MAINTENANCE_TODO: Remove this cast once texture-component-swizzle is added to @webgpu/types
-    t.selectDeviceOrSkipTestCase('texture-component-swizzle' as GPUFeatureName);
+    t.selectDeviceOrSkipTestCase('texture-component-swizzle');
   })
   .fn(t => {
     const { invalidSwizzle } = t.params;
@@ -79,12 +78,6 @@ g.test('only_identity_swizzle')
   )
   .params(u => u.beginSubcases().combine('swizzle', kSwizzleTests))
   .fn(t => {
-    // MAINTENANCE_TODO: Remove this check if the spec is updated to say that all implementations must validate this.
-    t.skipIf(
-      !t.adapter.features.has('texture-component-swizzle'),
-      'skip on browsers that have not implemented texture-component-swizzle'
-    );
-
     const { swizzle } = t.params;
     const texture = t.createTextureTracked({
       format: 'rgba8unorm',
@@ -118,8 +111,7 @@ g.test('no_render_no_resolve_no_storage')
       .combine('swizzle', kSwizzleTests)
   )
   .beforeAllSubcases(t => {
-    // MAINTENANCE_TODO: Remove this cast once texture-component-swizzle is added to @webgpu/types
-    t.selectDeviceOrSkipTestCase('texture-component-swizzle' as GPUFeatureName);
+    t.selectDeviceOrSkipTestCase('texture-component-swizzle');
   })
   .fn(t => {
     const { swizzle, useCase } = t.params;
@@ -264,8 +256,7 @@ g.test('compatibility_mode')
   `
   )
   .beforeAllSubcases(t => {
-    // MAINTENANCE_TODO: Remove this cast once texture-component-swizzle is added to @webgpu/types
-    t.selectDeviceOrSkipTestCase('texture-component-swizzle' as GPUFeatureName);
+    t.selectDeviceOrSkipTestCase('texture-component-swizzle');
   })
   .params(u =>
     u

--- a/src/webgpu/api/validation/capability_checks/features/texture_component_swizzle_utils.ts
+++ b/src/webgpu/api/validation/capability_checks/features/texture_component_swizzle_utils.ts
@@ -5,12 +5,6 @@ declare global {
 
   // Note this is a four-character string that only includes `"r"`, `"g"`, `"b"`, `"a"`, `"0"`, or `"1"`.
   type GPUTextureComponentSwizzle = string;
-
-  // MAINTENANCE_TODO: Remove these types once texture-component-swizzle is added to @webgpu/types
-  /* prettier-ignore */
-  interface GPUTextureViewDescriptor {
-    swizzle?: GPUTextureComponentSwizzle; // "rgba" by default
-  }
 }
 
 // Note: There are 4 settings with 6 options which is 1296 combinations. So we don't check them all. Just a few below.

--- a/src/webgpu/capability_info.ts
+++ b/src/webgpu/capability_info.ts
@@ -924,6 +924,8 @@ export const kFeatureNameInfo: {
   'core-features-and-limits':           {},
   'texture-formats-tier1':              {},
   'texture-formats-tier2':              {},
+  'primitive-index':                    {},
+  'texture-component-swizzle':          {},
 };
 /** List of all GPUFeatureName values. */
 export const kFeatureNames = keysOf(kFeatureNameInfo);

--- a/src/webgpu/util/texture/base.ts
+++ b/src/webgpu/util/texture/base.ts
@@ -216,8 +216,7 @@ export function reifyTextureDescriptor(
 export function reifyTextureViewDescriptor(
   textureDescriptor: Readonly<GPUTextureDescriptor>,
   view: Readonly<GPUTextureViewDescriptor>
-  // MAINTENANCE_TODO: Remove | swizzle cast once texture-component-swizzle is added to @webgpu/types
-): Required<Omit<GPUTextureViewDescriptor, 'label' | 'swizzle'>> {
+): Required<Omit<GPUTextureViewDescriptor, 'label'>> {
   const texture = reifyTextureDescriptor(textureDescriptor);
 
   // IDL defaulting
@@ -225,6 +224,7 @@ export function reifyTextureViewDescriptor(
   const baseMipLevel = view.baseMipLevel ?? 0;
   const baseArrayLayer = view.baseArrayLayer ?? 0;
   const aspect = view.aspect ?? 'all';
+  const swizzle = view.swizzle ?? 'rgba';
 
   // Spec defaulting
 
@@ -253,6 +253,7 @@ export function reifyTextureViewDescriptor(
     mipLevelCount,
     baseArrayLayer,
     arrayLayerCount,
+    swizzle,
   };
 }
 


### PR DESCRIPTION
Following https://github.com/gpuweb/cts/pull/4427, this PR cleans unnecessary swizzle related casts as we're updating @webgpu/types  to 0.1.66.

* Issue: #4421

