### PR TITLE
remove use of 'subgroup_branching' diagnostic

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/quadBroadcast.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/quadBroadcast.spec.ts
@@ -330,7 +330,6 @@ predication filters are skipped.
 enable subgroups;
 
 diagnostic(off, subgroup_uniformity);
-diagnostic(off, subgroup_branching);
 
 @group(0) @binding(0)
 var<storage> inputs : u32; // unused

--- a/src/webgpu/shader/execution/expression/call/builtin/quadSwap.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/quadSwap.spec.ts
@@ -349,7 +349,6 @@ predication filters are skipped.
 enable subgroups;
 
 diagnostic(off, subgroup_uniformity);
-diagnostic(off, subgroup_branching);
 
 @group(0) @binding(0)
 var<storage> inputs : u32; // unused

--- a/src/webgpu/shader/execution/expression/call/builtin/subgroupAdd.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/subgroupAdd.spec.ts
@@ -305,7 +305,6 @@ g.test('compute,split')
 enable subgroups;
 
 diagnostic(off, subgroup_uniformity);
-diagnostic(off, subgroup_branching);
 
 @group(0) @binding(0)
 var<storage> input : array<u32>;

--- a/src/webgpu/shader/execution/expression/call/builtin/subgroupAll.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/subgroupAll.spec.ts
@@ -204,7 +204,6 @@ g.test('compute,split')
 enable subgroups;
 
 diagnostic(off, subgroup_uniformity);
-diagnostic(off, subgroup_branching);
 
 @group(0) @binding(0)
 var<storage> inputs : array<u32>;

--- a/src/webgpu/shader/execution/expression/call/builtin/subgroupAny.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/subgroupAny.spec.ts
@@ -204,7 +204,6 @@ g.test('compute,split')
 enable subgroups;
 
 diagnostic(off, subgroup_uniformity);
-diagnostic(off, subgroup_branching);
 
 @group(0) @binding(0)
 var<storage> inputs : array<u32>;

--- a/src/webgpu/shader/execution/expression/call/builtin/subgroupBallot.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/subgroupBallot.spec.ts
@@ -192,7 +192,6 @@ g.test('compute,split')
 enable subgroups;
 
 diagnostic(off, subgroup_uniformity);
-diagnostic(off, subgroup_branching);
 
 @group(0) @binding(0)
 var<storage, read_write> size : u32;
@@ -228,7 +227,6 @@ g.test('predicate')
     const wgsl = `
 enable subgroups;
 
-diagnostic(off, subgroup_branching);
 
 @group(0) @binding(0)
 var<storage, read_write> size : u32;
@@ -317,7 +315,6 @@ g.test('predicate_and_control_flow')
     const wgsl = `
 enable subgroups;
 
-diagnostic(off, subgroup_branching);
 diagnostic(off, subgroup_uniformity);
 
 @group(0) @binding(0)

--- a/src/webgpu/shader/execution/expression/call/builtin/subgroupBitwise.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/subgroupBitwise.spec.ts
@@ -372,7 +372,6 @@ g.test('compute,split')
 enable subgroups;
 
 diagnostic(off, subgroup_uniformity);
-diagnostic(off, subgroup_branching);
 
 @group(0) @binding(0)
 var<storage> inputs : array<u32>;

--- a/src/webgpu/shader/execution/expression/call/builtin/subgroupBroadcast.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/subgroupBroadcast.spec.ts
@@ -196,7 +196,6 @@ g.test('workgroup_uniform_load')
     const wgsl = `
 enable subgroups;
 
-diagnostic(off, subgroup_branching);
 
 var<workgroup> wgmem : u32;
 

--- a/src/webgpu/shader/execution/expression/call/builtin/subgroupMul.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/subgroupMul.spec.ts
@@ -330,7 +330,6 @@ g.test('compute,split')
 enable subgroups;
 
 diagnostic(off, subgroup_uniformity);
-diagnostic(off, subgroup_branching);
 
 @group(0) @binding(0)
 var<storage> input : array<u32>;


### PR DESCRIPTION
That was part of the original subgroups proposal, but was removed.




Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
