### PR TITLE
Add validation test for semicolon before break-if.

### DIFF
--- a/src/webgpu/shader/validation/statement/continuing.spec.ts
+++ b/src/webgpu/shader/validation/statement/continuing.spec.ts
@@ -163,6 +163,10 @@ const kTests = {
     src: 'loop { if a == 4 { break; } continuing { for(;a < 4;) { return vec4f(2); } } }',
     pass: false,
   },
+  continuing_semicolon_break_if: {
+    src: 'loop { continuing { ; break if (true); } }',
+    pass: true,
+  },
 };
 
 g.test('placement')


### PR DESCRIPTION
Add a test that an empty `;` line is handled correctly before a `break-if` in a `continuing` statement.

Issue: https://crbug.com/dawn/453961764

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [ ] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
