### PR TITLE
Adjust maxFractionalDiff for canvas color-space-conversion

### DIFF
--- a/src/webgpu/web_platform/copyToTexture/canvas.spec.ts
+++ b/src/webgpu/web_platform/copyToTexture/canvas.spec.ts
@@ -836,8 +836,15 @@ g.test('color_space_conversion')
       maxDiffULPsForNormFormat: 1,
     };
     if (srcColorSpace !== dstColorSpace) {
-      // Color space conversion seems prone to errors up to about 0.0003 on f32, 0.0007 on f16.
-      texelCompareOptions.maxFractionalDiff = 0.001;
+      if (dstColorFormat.endsWith('32float')) {
+        texelCompareOptions.maxFractionalDiff = 0.0003;
+      } else if (dstColorFormat.endsWith('16float')) {
+        texelCompareOptions.maxFractionalDiff = 0.0007;
+      } else if (dstColorFormat === 'rg11b10ufloat') {
+        texelCompareOptions.maxFractionalDiff = 0.015;
+      } else {
+        texelCompareOptions.maxFractionalDiff = 0.001;
+      }
     } else {
       texelCompareOptions.maxDiffULPsForFloatFormat = 1;
     }


### PR DESCRIPTION
This was failing for `'rg11b10ufloat'` which is new. Rather than increase the tolerance for all formats, set it specifically for certain formats.

[It appears to pass](https://dawn-review.googlesource.com/c/dawn/+/268914?checksResultsFilter=canvas&tab=checks)

Note: I didn't really think through why it's off by so much. Maybe we should file a bug to investigate.

You can see failures without this change [here](https://dawn-review.googlesource.com/c/dawn/+/267296?checksPatchset=3&tab=checks) or try running the current version [here](https://gpuweb.github.io/cts/standalone/?runnow=1&q=webgpu:web_platform,copyToTexture,canvas:color_space_conversion:srcColorSpace=%22display-p3%22;dstColorSpace=%22srgb%22;dstColorFormat=%22rg11b10ufloat%22;dstPremultiplied=false;srcDoFlipYDuringCopy=false) in a browser that supports `copyExternalImageToTexture` for `rg11b10ufloat`. Stable browsers will fail the test with a validation error as the spec recently changed so that a format that is renderable and float or unorm must support `copyEI2T` 