### PR TITLE
Increase the OOM allocation size to max precise value

### DIFF
--- a/src/webgpu/api/operation/buffers/map_oom.spec.ts
+++ b/src/webgpu/api/operation/buffers/map_oom.spec.ts
@@ -10,12 +10,7 @@ import { kMaxSafeMultipleOf8 } from '../../../util/math.js';
 const oomAndSizeParams = kUnitCaseParamsBuilder
   .combine('oom', [false, true])
   .expand('size', ({ oom }) => {
-    return oom
-      ? [
-          kMaxSafeMultipleOf8,
-          0x20_0000_0000, // 128 GB
-        ]
-      : [16];
+    return oom ? [kMaxSafeMultipleOf8] : [16];
   });
 
 export const g = makeTestGroup(AllFeaturesMaxLimitsGPUTest);


### PR DESCRIPTION
The current value causes issues with machines that have more than 128GB of RAM. This increase takes the allocation to the highest precisely representable value, which is ~8,192TB.

I am aware of no commercially available machine supports anything near this much RAM, so this should be good for the foreseeable future. If there is a device in the future with this much RAM, hopefully Number will have been re-specified to something like a float128 by then.

Fixes #4488

<hr>

**Requirements for PR author:**

- [ ] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [ ] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [ ] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
