### PR TITLE
workgroup_size validation: support devices limited to 256 invocations

### DIFF
--- a/src/webgpu/shader/validation/shader_io/workgroup_size.spec.ts
+++ b/src/webgpu/shader/validation/shader_io/workgroup_size.spec.ts
@@ -162,7 +162,7 @@ const kWorkgroupSizeTests = {
   },
 
   override_expr: {
-    src: `override a = 5;
+    src: `override a = 3;
     override b = 6;
     @workgroup_size(a, b, a + b)`,
     pass: true,


### PR DESCRIPTION
On devices with maxComputeInvocationsPerWorkgroup=256, the webgpu:shader,validation,shader_io,workgroup_size:workgroup_size:attr="override_expr" test can fail when requesting a workgroup larger than 256.

Adjust the override expression case to generate no more than 256 invocations.




Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
