### PR TITLE
const_array_elements limit test: split into MAX, MAX/8, MAX/64 cases

### DIFF
--- a/src/webgpu/shader/execution/limits.spec.ts
+++ b/src/webgpu/shader/execution/limits.spec.ts
@@ -412,11 +412,22 @@ g.test('workgroup_array_byte_size_override')
 
 g.test('const_array_elements')
   .desc(`Test that constant array expressions with the maximum number of elements are supported.`)
+  .params(
+    u =>
+      // Some backend shader compilers take too long to compile the maximum
+      // size. In that case the browser GPU process can time out.  The WGSL
+      // spec allows this as an 'uncategorized error'.
+      // To get some useful signal from this test, also check a const array
+      // with a significant size even though it may not be the maximum supported
+      // size listed in the spec.
+      u.combine('sizeDivisor', [64, 8, 1]) // Must include 1, to test largest size.
+  )
   .fn(t => {
-    const type = `array<u32, ${kMaxConstArrayElements}>`;
+    const elementCount = Math.ceil(kMaxConstArrayElements / t.params.sizeDivisor);
+    const type = `array<u32, ${elementCount}>`;
 
     let expr = `${type}(`;
-    for (let i = 0; i < kMaxConstArrayElements; i++) {
+    for (let i = 0; i < elementCount; i++) {
       expr += `${i}, `;
     }
     expr += `)`;
@@ -430,10 +441,5 @@ g.test('const_array_elements')
     }
     `;
 
-    runShaderTest(
-      t,
-      code,
-      new Uint32Array([...iterRange(kMaxConstArrayElements, _i => 0xdeadbeef)]),
-      i => i
-    );
+    runShaderTest(t, code, new Uint32Array([...iterRange(elementCount, _i => 0xdeadbeef)]), i => i);
   });


### PR DESCRIPTION
The MAX const array size is 2047.

The driver compiler can take a long time compiling the MAX case. For example a laptop with an Intel Gen12 LP GPU with the Mesa driver can take 28s to compile the shader.  This exceeds Chrome's GPU watchdog timeout (10s) and the test will fail.

Instead of completely disabling the test, split it into cases for MAX, MAX/8, and MAX/64 elements.  This lets us skip the very largest cases, but still attempt smaller bug significant array sizes. That lets us get some signal that the large-ish const arrays are viable.

The additional runtime for the new cases are insignificant compared to the full case.

Fixed: #4496




Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
