### PR TITLE
Skip fine derivative tests in compatibility mode

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/dpdxFine.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/dpdxFine.spec.ts
@@ -24,6 +24,7 @@ g.test('f32')
       .combine('non_uniform_discard', [false, true])
   )
   .fn(async t => {
+    t.skipIf(t.isCompatibility, `${builtin} not supported in compatibility mode`);
     const cases = await d.get('scalar');
     runDerivativeTest(t, cases, builtin, t.params.non_uniform_discard, t.params.vectorize);
   });

--- a/src/webgpu/shader/execution/expression/call/builtin/dpdyFine.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/dpdyFine.spec.ts
@@ -24,6 +24,7 @@ g.test('f32')
       .combine('non_uniform_discard', [false, true])
   )
   .fn(async t => {
+    t.skipIf(t.isCompatibility, `${builtin} not supported in compatibility mode`);
     const cases = await d.get('scalar');
     runDerivativeTest(t, cases, builtin, t.params.non_uniform_discard, t.params.vectorize);
   });

--- a/src/webgpu/shader/execution/expression/call/builtin/fwidthFine.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/fwidthFine.spec.ts
@@ -24,6 +24,7 @@ g.test('f32')
       .combine('non_uniform_discard', [false, true])
   )
   .fn(async t => {
+    t.skipIf(t.isCompatibility, `${builtin} not supported in compatibility mode`);
     const cases = await d.get('scalar');
     runFWidthTest(t, cases, builtin, t.params.non_uniform_discard, t.params.vectorize);
   });


### PR DESCRIPTION
`dpdxFine`, `dpdyFine`, and `fwidthFine` are not supported in compatibility mode.

Issue: #4503 

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [X] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
