### PR TITLE
Fix swizzle operation test

### DIFF
--- a/src/webgpu/api/operation/texture_view/texture_component_swizzle.spec.ts
+++ b/src/webgpu/api/operation/texture_view/texture_component_swizzle.spec.ts
@@ -3,6 +3,18 @@ Operational tests for the 'texture-component-swizzle' feature.
 
 Test that:
 * when the feature is on, swizzling is applied correctly.
+
+Note: for texture_depth_xxx we only get f32
+What happens in the GPU (at least in Metal)
+
+  1. we start with [depthOrCompareResult, depthOrCompareResult, depthOrCompareResult, 1]
+  2. we then swizzle
+  3. we then read the RED channel
+
+Gather will do this 4 times and give us the result of step 3 in each channel.
+
+The WebGPU spec says we should be starting with [depthOrCompare, 0, 0, 1] and the
+implementation should deal with this.
 `;
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
@@ -332,18 +344,17 @@ ${sampledColors.map((c, i) => `${i % 2}, ${(i / 2) | 0}, ${JSON.stringify(c)}`).
 
     const testData = [swizzle, otherSwizzle].map(swizzle => {
       const swizzledColors = readColors.map(readColor => swizzleTexel(readColor, swizzle));
-      const expRGBAColor = isBuiltinGather(func)
+      const expColor = isBuiltinGather(func)
         ? gather(swizzledColors, channel)
+        : isSingleChannelInput(input)
+        ? {
+            R: swizzledColors[0].R,
+            G: swizzledColors[0].R,
+            B: swizzledColors[0].R,
+            A: swizzledColors[0].R,
+          }
         : swizzledColors[0];
-      const expColor =
-        !isBuiltinGather(func) && isSingleChannelInput(input)
-          ? {
-              R: expRGBAColor.R,
-              G: expRGBAColor.R,
-              B: expRGBAColor.R,
-              A: expRGBAColor.R,
-            }
-          : expRGBAColor;
+
       const expTexelView = TexelView.fromTexelsAsColors(expFormat, _coords => expColor);
       const textureView = texture.createView({
         label: `swizzle texture view(${swizzle})`,
@@ -534,6 +545,12 @@ ${testData
     const uniformValues = new ArrayBuffer(uniformBuffer.size);
     const asF32 = new Float32Array(uniformValues);
     asF32.set([tx / texture.width, ty / texture.height]);
+    t.debug(
+      () =>
+        `texcoords: ${[...asF32]}  tx = ${tx}, ty = ${ty}, size: ${texture.width}, ${
+          texture.height
+        }`
+    );
     t.device.queue.writeBuffer(uniformBuffer, 0, new Uint32Array(uniformValues));
 
     const bindGroup0 = t.device.createBindGroup({


### PR DESCRIPTION
Handling single channel inputs (texture_depth_xx) was happening at the wrong step.

Issue: #4421 

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [X] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
