### PR TITLE
Enable only results failures  by default

### DIFF
--- a/standalone/index.html
+++ b/standalone/index.html
@@ -452,7 +452,7 @@
     <fieldset>
       <legend>Serialize results:</legend>
       <p>
-        <label><input type="checkbox" id="saveOnlyFailures">Only result failures</label>
+        <label><input type="checkbox" id="saveOnlyFailures" checked>Only result failures</label>
       </p>
       <p>
          <input type="button" id="copyResultsJSON" value="Copy results as JSON">


### PR DESCRIPTION
This is a very minor change but there is general agreement that we want this as the default behavior.