### PR TITLE
CTS for subgroup_uniformity language feature

### DIFF
--- a/src/webgpu/capability_info.ts
+++ b/src/webgpu/capability_info.ts
@@ -934,6 +934,7 @@ export const kKnownWGSLLanguageFeatures = [
   'pointer_composite_access',
   'uniform_buffer_standard_layout',
   'subgroup_id',
+  'subgroup_uniformity',
 ] as const;
 
 export type WGSLLanguageFeature = (typeof kKnownWGSLLanguageFeatures)[number];

--- a/src/webgpu/listing_meta.json
+++ b/src/webgpu/listing_meta.json
@@ -2943,6 +2943,7 @@
   "webgpu:shader,validation,uniformity,uniformity:short_circuit_expressions:*": { "subcaseMS": 1.401 },
   "webgpu:shader,validation,uniformity,uniformity:subgroups,parameters:*": { "subcaseMS": 81.282 },
   "webgpu:shader,validation,uniformity,uniformity:unary_expressions:*": { "subcaseMS": 1.279 },
+  "webgpu:shader,validation,uniformity,uniformity:uniform_subgroup_ops:*": { "subcaseMS": 192.075 },
   "webgpu:util,texture,color_space_conversions:util_matches_2d_canvas:*": { "subcaseMS": 1.001 },
   "webgpu:util,texture,texel_data:float_texel_data_in_shader:*": { "subcaseMS": 2.042 },
   "webgpu:util,texture,texel_data:sint_texel_data_in_shader:*": { "subcaseMS": 2.573 },


### PR DESCRIPTION
CTS for https://github.com/gpuweb/gpuweb/pull/5431

Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
