### PR TITLE
Add operation tests for transient attachment usage

### DIFF
--- a/src/webgpu/api/operation/render_pass/resolve.spec.ts
+++ b/src/webgpu/api/operation/render_pass/resolve.spec.ts
@@ -55,6 +55,11 @@ Test basic render pass resolve behavior for combinations of:
       .unless(t => !t.depthStencilAttachment && t.transientDepthStencilAttachment)
   )
   .fn(t => {
+    // MAINTENANCE_TODO(#4509): Remove this when TRANSIENT_ATTACHMENT is added to the WebGPU spec.
+    if (t.params.transientColorAttachment || t.params.transientDepthStencilAttachment) {
+      t.skipIfTransientAttachmentNotSupported();
+    }
+
     const targets: GPUColorTargetState[] = [];
     for (let i = 0; i < t.params.numColorAttachments; i++) {
       targets.push({ format: kFormat });

--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -676,6 +676,15 @@ export class GPUTestBase extends Fixture<GPUTestSubcaseBatchState> {
     return lf !== undefined && lf.has(langFeature);
   }
 
+  /** Skips this test case if the GPUTextureUsage `TRANSIENT_ATTACHMENT` is *not* supported. */
+  skipIfTransientAttachmentNotSupported() {
+    const isTransientAttachmentSupported = 'TRANSIENT_ATTACHMENT' in GPUTextureUsage;
+    this.skipIf(
+      !isTransientAttachmentSupported,
+      'GPUTextureUsage TRANSIENT_ATTACHMENT is not supported'
+    );
+  }
+
   /**
    * Expect a GPUBuffer's contents to pass the provided check.
    *


### PR DESCRIPTION
Superseding https://github.com/gpuweb/cts/pull/4513, this PR adds operation tests for transient attachment usage.

FYI I ran successfully those tests in Chromium patched with https://chromium-review.googlesource.com/c/chromium/src/+/7172047

<img width="1840" height="1191" alt="image" src="https://github.com/user-attachments/assets/ed5baa2b-b7aa-4811-b443-5bff465aa4ac" />

Issue: https://github.com/gpuweb/cts/pull/4509
Dawn issue: https://issues.chromium.org/issues/462468372

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
