### PR TITLE
Revert "Rollin Immediates"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@types/w3c-image-capture": "^1.0.10",
         "@typescript-eslint/eslint-plugin": "^6.9.1",
         "@typescript-eslint/parser": "^6.9.1",
-        "@webgpu/types": "^0.1.67",
+        "@webgpu/types": "^0.1.66",
         "ansi-colors": "4.1.3",
         "babel-plugin-add-header-comment": "^1.0.3",
         "babel-plugin-const-enum": "^1.2.0",
@@ -1539,9 +1539,9 @@
       "dev": true
     },
     "node_modules/@webgpu/types": {
-      "version": "0.1.67",
-      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.67.tgz",
-      "integrity": "sha512-uk53+2ECGUkWoDFez/hymwpRfdgdIn6y1ref70fEecGMe5607f4sozNFgBk0oxlr7j2CRGWBEc3IBYMmFdGGTQ==",
+      "version": "0.1.66",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.66.tgz",
+      "integrity": "sha512-YA2hLrwLpDsRueNDXIMqN9NTzD6bCDkuXbOSe0heS+f8YE8usA6Gbv1prj81pzVHrbaAma7zObnIC+I6/sXJgA==",
       "dev": true,
       "license": "BSD-3-Clause"
     },
@@ -10077,9 +10077,9 @@
       "dev": true
     },
     "@webgpu/types": {
-      "version": "0.1.67",
-      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.67.tgz",
-      "integrity": "sha512-uk53+2ECGUkWoDFez/hymwpRfdgdIn6y1ref70fEecGMe5607f4sozNFgBk0oxlr7j2CRGWBEc3IBYMmFdGGTQ==",
+      "version": "0.1.66",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.66.tgz",
+      "integrity": "sha512-YA2hLrwLpDsRueNDXIMqN9NTzD6bCDkuXbOSe0heS+f8YE8usA6Gbv1prj81pzVHrbaAma7zObnIC+I6/sXJgA==",
       "dev": true
     },
     "abbrev": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@types/w3c-image-capture": "^1.0.10",
     "@typescript-eslint/eslint-plugin": "^6.9.1",
     "@typescript-eslint/parser": "^6.9.1",
-    "@webgpu/types": "^0.1.67",
+    "@webgpu/types": "^0.1.66",
     "ansi-colors": "4.1.3",
     "babel-plugin-add-header-comment": "^1.0.3",
     "babel-plugin-const-enum": "^1.2.0",

--- a/src/webgpu/api/validation/encoding/encoder_open_state.spec.ts
+++ b/src/webgpu/api/validation/encoding/encoder_open_state.spec.ts
@@ -98,7 +98,6 @@ const kRenderPassEncoderCommandInfo: {
   setScissorRect: {},
   setBlendConstant: {},
   setStencilReference: {},
-  setImmediates: {},
   beginOcclusionQuery: {},
   endOcclusionQuery: {},
   executeBundles: {},
@@ -123,7 +122,6 @@ const kRenderBundleEncoderCommandInfo: {
   setBindGroup: {},
   setIndexBuffer: {},
   setVertexBuffer: {},
-  setImmediates: {},
   pushDebugGroup: {},
   popDebugGroup: {},
   insertDebugMarker: {},
@@ -143,7 +141,6 @@ const kComputePassEncoderCommandInfo: {
   setPipeline: {},
   dispatchWorkgroups: {},
   dispatchWorkgroupsIndirect: {},
-  setImmediates: {},
   pushDebugGroup: {},
   popDebugGroup: {},
   insertDebugMarker: {},
@@ -394,12 +391,6 @@ g.test('render_pass_commands')
             renderPass.setStencilReference(0);
           }
           break;
-        case 'setImmediates':
-          {
-            const data = new Uint32Array(1);
-            renderPass.setImmediates(0, data, 0, 1);
-          }
-          break;
         case 'beginOcclusionQuery':
           {
             renderPass.beginOcclusionQuery(0);
@@ -511,12 +502,6 @@ g.test('render_bundle_commands')
             bundleEncoder.setVertexBuffer(1, buffer);
           }
           break;
-        case 'setImmediates':
-          {
-            const data = new Uint32Array(1);
-            bundleEncoder.setImmediates(0, data, 0, 1);
-          }
-          break;
         case 'pushDebugGroup':
           {
             bundleEncoder.pushDebugGroup('group');
@@ -597,12 +582,6 @@ g.test('compute_pass_commands')
         case 'dispatchWorkgroupsIndirect':
           {
             computePass.dispatchWorkgroupsIndirect(indirectBuffer, 0);
-          }
-          break;
-        case 'setImmediates':
-          {
-            const data = new Uint32Array(1);
-            computePass.setImmediates(0, data, 0, 1);
           }
           break;
         case 'pushDebugGroup':

--- a/src/webgpu/capability_info.ts
+++ b/src/webgpu/capability_info.ts
@@ -776,7 +776,6 @@ const [kLimitInfoKeys, kLimitInfoDefaults, kLimitInfoData] =
   'maxComputeWorkgroupSizeY':                  [           ,       256,             128,                          ],
   'maxComputeWorkgroupSizeZ':                  [           ,        64,              64,                          ],
   'maxComputeWorkgroupsPerDimension':          [           ,     65535,           65535,                          ],
-  'maxImmediateSize':                          [           ,        64,              64,                          ],
 } as const];
 
 // MAINTENANCE_TODO: Remove when the compat spec is merged.


### PR DESCRIPTION
Reverts gpuweb/cts#4517

This change broke lots of tests. immediate support is not yet part of the spec. Implementations are not required to support it.

I thought about trying to fix all the places that would need checks but I think it's best just to revert this ASAP and working on making tests pass even when immediate support is not available can be fixed in another PR