### PR TITLE
Require compat mode limits

### DIFF
--- a/src/webgpu/api/operation/adapter/requestDevice.spec.ts
+++ b/src/webgpu/api/operation/adapter/requestDevice.spec.ts
@@ -258,8 +258,6 @@ g.test('limits,supported')
     assert(adapter !== null);
 
     const limitInfo = getDefaultLimitsForCTS()[limit];
-    // MAINTENANCE_TODO: Remove this skip when compatibility limits are merged into spec.
-    t.skipIf(limitInfo === undefined, 'limit is currently compatibility only');
     let value: number | undefined = -1;
     let result: number = -1;
     switch (limitValue) {
@@ -337,8 +335,6 @@ g.test('limit,better_than_supported')
     assert(adapter !== null);
 
     const limitInfo = getDefaultLimitsForCTS();
-    // MAINTENANCE_TODO: Remove this skip when compatibility limits are merged into spec.
-    t.skipIf(limitInfo[limit] === undefined, 'limit is currently compatibility only');
     const value = adapter.limits[limit]! * mul + add;
     const requiredLimits = {
       [limit]: clamp(value, { min: 0, max: limitInfo[limit].maximumValue }),
@@ -385,9 +381,6 @@ g.test('limit,out_of_range')
     const adapter = await gpu.requestAdapter();
     assert(adapter !== null);
     const limitInfo = getDefaultLimitsForCTS()[limit];
-    // MAINTENANCE_TODO: Remove this skip when compatibility limits are merged into spec.
-    t.skipIf(limitInfo === undefined, 'limit is currently compatibility only');
-
     const requiredLimits = {
       [limit]: value,
     };
@@ -445,9 +438,6 @@ g.test('limit,worse_than_default')
     assert(adapter !== null);
 
     const limitInfo = getDefaultLimitsForCTS()[limit];
-    // MAINTENANCE_TODO: Remove this skip when compatibility limits are merged into spec.
-    t.skipIf(limitInfo === undefined, 'limit is currently compatibility only');
-
     const value = limitInfo.default * mul + add;
     const requiredLimits = {
       [limit]: clamp(value, { min: 0, max: limitInfo.maximumValue }),

--- a/src/webgpu/api/validation/capability_checks/limits/maxStorageBuffersInFragmentStage.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxStorageBuffersInFragmentStage.spec.ts
@@ -24,10 +24,7 @@ const kExtraLimits: LimitsRequest = {
   maxBindGroups: 'adapterLimit',
 };
 
-export const { g, description } = makeLimitTestGroup(limit, {
-  // MAINTENANCE_TODO: remove once this limit is required.
-  limitOptional: true,
-});
+export const { g, description } = makeLimitTestGroup(limit);
 
 function createBindGroupLayout(
   device: GPUDevice,

--- a/src/webgpu/api/validation/capability_checks/limits/maxStorageBuffersInVertexStage.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxStorageBuffersInVertexStage.spec.ts
@@ -24,10 +24,7 @@ const kExtraLimits: LimitsRequest = {
   maxBindGroups: 'adapterLimit',
 };
 
-export const { g, description } = makeLimitTestGroup(limit, {
-  // MAINTENANCE_TODO: remove once this limit is required.
-  limitOptional: true,
-});
+export const { g, description } = makeLimitTestGroup(limit);
 
 function createBindGroupLayout(
   device: GPUDevice,

--- a/src/webgpu/api/validation/capability_checks/limits/maxStorageTexturesInFragmentStage.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxStorageTexturesInFragmentStage.spec.ts
@@ -25,10 +25,7 @@ const kExtraLimits: LimitsRequest = {
   maxBindGroups: 'adapterLimit',
 };
 
-export const { g, description } = makeLimitTestGroup(limit, {
-  // MAINTAINANCE_TODO: remove once this limit is required.
-  limitOptional: true,
-});
+export const { g, description } = makeLimitTestGroup(limit);
 
 function createBindGroupLayout(
   device: GPUDevice,

--- a/src/webgpu/api/validation/capability_checks/limits/maxStorageTexturesInVertexStage.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxStorageTexturesInVertexStage.spec.ts
@@ -24,10 +24,7 @@ const kExtraLimits: LimitsRequest = {
   maxBindGroups: 'adapterLimit',
 };
 
-export const { g, description } = makeLimitTestGroup(limit, {
-  // MAINTENANCE_TODO: remove once this limit is required.
-  limitOptional: true,
-});
+export const { g, description } = makeLimitTestGroup(limit);
 
 function createBindGroupLayout(
   device: GPUDevice,

--- a/src/webgpu/capability_info.ts
+++ b/src/webgpu/capability_info.ts
@@ -778,14 +778,6 @@ const [kLimitInfoKeys, kLimitInfoDefaults, kLimitInfoData] =
   'maxComputeWorkgroupsPerDimension':          [           ,     65535,           65535,                          ],
 } as const];
 
-// MAINTENANCE_TODO: Remove when the compat spec is merged.
-const kCompatOnlyLimits = [
-  'maxStorageTexturesInFragmentStage',
-  'maxStorageTexturesInVertexStage',
-  'maxStorageBuffersInFragmentStage',
-  'maxStorageBuffersInVertexStage',
-] as const;
-
 /**
  * Feature levels corresponding to core WebGPU and WebGPU
  * in compatibility mode. They can be passed to
@@ -823,14 +815,7 @@ export const kLimitClasses = Object.fromEntries(
 );
 
 export function getDefaultLimits(featureLevel: FeatureLevel) {
-  return Object.fromEntries(
-    Object.entries(kLimitInfos[featureLevel]).filter(([k]) => {
-      // Filter out compat-only limits when in core mode
-      return featureLevel === 'core'
-        ? !kCompatOnlyLimits.includes(k as (typeof kCompatOnlyLimits)[number])
-        : true;
-    })
-  ) as typeof kLimitInfoCore;
+  return kLimitInfos[featureLevel];
 }
 
 /**


### PR DESCRIPTION


Issue: #4523

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [X] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located in the test tree.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
