### PR TITLE
Bump @webgpu/types to 0.1.68

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@types/w3c-image-capture": "^1.0.10",
         "@typescript-eslint/eslint-plugin": "^6.9.1",
         "@typescript-eslint/parser": "^6.9.1",
-        "@webgpu/types": "^0.1.66",
+        "@webgpu/types": "^0.1.68",
         "ansi-colors": "4.1.3",
         "babel-plugin-add-header-comment": "^1.0.3",
         "babel-plugin-const-enum": "^1.2.0",
@@ -1539,9 +1539,9 @@
       "dev": true
     },
     "node_modules/@webgpu/types": {
-      "version": "0.1.66",
-      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.66.tgz",
-      "integrity": "sha512-YA2hLrwLpDsRueNDXIMqN9NTzD6bCDkuXbOSe0heS+f8YE8usA6Gbv1prj81pzVHrbaAma7zObnIC+I6/sXJgA==",
+      "version": "0.1.68",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.68.tgz",
+      "integrity": "sha512-3ab1B59Ojb6RwjOspYLsTpCzbNB3ZaamIAxBMmvnNkiDoLTZUOBXZ9p5nAYVEkQlDdf6qAZWi1pqj9+ypiqznA==",
       "dev": true,
       "license": "BSD-3-Clause"
     },
@@ -10077,9 +10077,9 @@
       "dev": true
     },
     "@webgpu/types": {
-      "version": "0.1.66",
-      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.66.tgz",
-      "integrity": "sha512-YA2hLrwLpDsRueNDXIMqN9NTzD6bCDkuXbOSe0heS+f8YE8usA6Gbv1prj81pzVHrbaAma7zObnIC+I6/sXJgA==",
+      "version": "0.1.68",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.68.tgz",
+      "integrity": "sha512-3ab1B59Ojb6RwjOspYLsTpCzbNB3ZaamIAxBMmvnNkiDoLTZUOBXZ9p5nAYVEkQlDdf6qAZWi1pqj9+ypiqznA==",
       "dev": true
     },
     "abbrev": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@types/w3c-image-capture": "^1.0.10",
     "@typescript-eslint/eslint-plugin": "^6.9.1",
     "@typescript-eslint/parser": "^6.9.1",
-    "@webgpu/types": "^0.1.66",
+    "@webgpu/types": "^0.1.68",
     "ansi-colors": "4.1.3",
     "babel-plugin-add-header-comment": "^1.0.3",
     "babel-plugin-const-enum": "^1.2.0",

--- a/src/webgpu/api/validation/capability_checks/limits/limit_utils.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/limit_utils.ts
@@ -404,9 +404,11 @@ export class LimitTestsImpl extends GPUTestBase {
     this._adapter = await gpu.requestAdapter();
     const limit = this.limit;
     // MAINTENANCE_TODO: consider removing this skip if the spec has no optional limits.
+    // Note: The cast below is required because an optional limit has no entry
+    // in capability_info.ts kLimitInfoKeys, kLimitInfoDefaults, kLimitInfoData
     this.skipIf(
       (this._adapter?.limits[limit] === undefined && !!this.limitTestParams.limitOptional) ||
-        getDefaultLimitsForCTS()[limit] === undefined,
+        !(limit in getDefaultLimitsForCTS()),
       `${limit} is missing but optional for now`
     );
     this.defaultLimit = getDefaultLimitForAdapter(this.adapter, limit);

--- a/src/webgpu/api/validation/encoding/encoder_open_state.spec.ts
+++ b/src/webgpu/api/validation/encoding/encoder_open_state.spec.ts
@@ -98,6 +98,7 @@ const kRenderPassEncoderCommandInfo: {
   setScissorRect: {},
   setBlendConstant: {},
   setStencilReference: {},
+  setImmediates: {},
   beginOcclusionQuery: {},
   endOcclusionQuery: {},
   executeBundles: {},
@@ -122,6 +123,7 @@ const kRenderBundleEncoderCommandInfo: {
   setBindGroup: {},
   setIndexBuffer: {},
   setVertexBuffer: {},
+  setImmediates: {},
   pushDebugGroup: {},
   popDebugGroup: {},
   insertDebugMarker: {},
@@ -139,6 +141,7 @@ const kComputePassEncoderCommandInfo: {
 } = {
   setBindGroup: {},
   setPipeline: {},
+  setImmediates: {},
   dispatchWorkgroups: {},
   dispatchWorkgroupsIndirect: {},
   pushDebugGroup: {},
@@ -286,6 +289,13 @@ g.test('render_pass_commands')
       .beginSubcases()
       .combine('finishBeforeCommand', ['no', 'pass', 'encoder'])
   )
+  .beforeAllSubcases(t => {
+    // MAINTENANCE_TODO: Remove when setImmediates is added to spec.
+    t.skipIf(
+      t.params.command === 'setImmediates' && !('setImmediates' in GPURenderPassEncoder.prototype),
+      'setImmediates not supported'
+    );
+  })
   .fn(t => {
     const { command, finishBeforeCommand } = t.params;
     if (command === 'multiDrawIndirect' || command === 'multiDrawIndexedIndirect') {
@@ -440,6 +450,14 @@ g.test('render_bundle_commands')
       .beginSubcases()
       .combine('finishBeforeCommand', [false, true])
   )
+  .beforeAllSubcases(t => {
+    // MAINTENANCE_TODO: Remove when setImmediates is added to spec.
+    t.skipIf(
+      t.params.command === 'setImmediates' &&
+        !('setImmediates' in GPURenderBundleEncoder.prototype),
+      'setImmediates not supported'
+    );
+  })
   .fn(t => {
     const { command, finishBeforeCommand } = t.params;
 
@@ -455,6 +473,11 @@ g.test('render_bundle_commands')
     const bundleEncoder = t.device.createRenderBundleEncoder({
       colorFormats: ['rgba8unorm'],
     });
+
+    t.skipIf(
+      command === 'setImmediates' && !('setImmediates' in bundleEncoder),
+      'setImmediates not supported'
+    );
 
     if (finishBeforeCommand) {
       bundleEncoder.finish();
@@ -540,6 +563,13 @@ g.test('compute_pass_commands')
       .beginSubcases()
       .combine('finishBeforeCommand', ['no', 'pass', 'encoder'])
   )
+  .beforeAllSubcases(t => {
+    // MAINTENANCE_TODO: Remove when setImmediates is added to spec.
+    t.skipIf(
+      t.params.command === 'setImmediates' && !('setImmediates' in GPUComputePassEncoder.prototype),
+      'setImmediates not supported'
+    );
+  })
   .fn(t => {
     const { command, finishBeforeCommand } = t.params;
 

--- a/src/webgpu/capability_info.ts
+++ b/src/webgpu/capability_info.ts
@@ -817,6 +817,10 @@ const [kLimitInfoKeys, kLimitInfoDefaults, kLimitInfoData] =
   'maxComputeWorkgroupSizeY':                  [           ,       256,             128,                          ],
   'maxComputeWorkgroupSizeZ':                  [           ,        64,              64,                          ],
   'maxComputeWorkgroupsPerDimension':          [           ,     65535,           65535,                          ],
+  // MAINTENANCE_TODO(4535): Consider allowing optional non-conforming limits. Currently they are not allowed.
+  // Any limit here is immediately required by all implementations.
+  // Also, consider having this table statically check that all limits listed in @webgpu/types exist in
+  // this table.
 } as const];
 
 /**


### PR DESCRIPTION
Note: There's a bunch of issues here that need to be fixed in other PRs

1. Should `maxImmediateSize` and `setImmediates` have been added to `@webgpu/types`? Add them there makes things here fail. If they should be removed we need a PR upstream

2. src/webgpu/api/validation/encoding/encoder_open_state.spec.ts is broken on all implementations. https://github.com/gpuweb/gpuweb/issues/5207
