### PR TITLE
`maxInterStageShaderVariables`: decrement max fragment input outputs per fragment input built-in

### DIFF
--- a/src/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.ts
@@ -11,8 +11,10 @@ function getPipelineDescriptor(
   sampleMaskIn: boolean,
   sampleMaskOut: boolean
 ): GPURenderPipelineDescriptor {
-  const vertexOutputDeductions = (pointList ? 1 : 0);
-  const fragmentInputDeductions = (frontFacing ? 1 : 0) + (sampleIndex ? 1 : 0) + (sampleMaskIn ? 1 : 0);
+  const vertexOutputDeductions = pointList ? 1 : 0;
+  const fragmentInputDeductions = [frontFacing, sampleIndex, sampleMaskIn]
+    .map(p => (p ? 1 : 0) as number)
+    .reduce((acc, p) => acc + p);
 
   const vertexOutputVariables = testValue - vertexOutputDeductions;
   const fragmentInputVariables = testValue - fragmentInputDeductions;


### PR DESCRIPTION
Issue: #4538

Recommended review experience is commit-by-commit.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation (see #4538 ).
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
