### PR TITLE
Compat: Check that textureBindingViewDimension can not pass in cube-array

### DIFF
--- a/src/webgpu/compat/api/validation/texture/createTexture.spec.ts
+++ b/src/webgpu/compat/api/validation/texture/createTexture.spec.ts
@@ -66,7 +66,9 @@ g.test('invalidTextureBindingViewDimension')
       textureBindingViewDimension === '2d'
         ? 1
         : 6;
-    const shouldError = getTextureDimensionFromView(textureBindingViewDimension) !== dimension;
+    const shouldError =
+      getTextureDimensionFromView(textureBindingViewDimension) !== dimension ||
+      textureBindingViewDimension === 'cube-array';
     t.expectGPUErrorInCompatibilityMode(
       'validation',
       () => {

--- a/src/webgpu/util/texture/base.ts
+++ b/src/webgpu/util/texture/base.ts
@@ -127,7 +127,9 @@ export function virtualMipSize(
  * Get texture dimension from view dimension in order to create an compatible texture for a given
  * view dimension.
  */
-export function getTextureDimensionFromView(viewDimension: GPUTextureViewDimension) {
+export function getTextureDimensionFromView(
+  viewDimension: GPUTextureViewDimension
+): GPUTextureDimension {
   switch (viewDimension) {
     case '1d':
       return '1d';


### PR DESCRIPTION
Issue: [5496](https://github.com/gpuweb/gpuweb/issues/5496)

Note: we should not merge this until that issue is approved

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [X] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
