### PR TITLE
Fix fragment input deductions in `max_variables_count,input`

### DIFF
--- a/src/webgpu/api/validation/render_pipeline/inter_stage.spec.ts
+++ b/src/webgpu/api/validation/render_pipeline/inter_stage.spec.ts
@@ -315,15 +315,15 @@ g.test('max_variables_count,input')
     u.combine('isAsync', [false, true]).combineWithParams([
       // Number of user-defined output variables in test shader =
       //     device.limits.maxInterStageShaderVariables + numVariablesDelta
-      { numVariablesDelta: 0, useExtraBuiltinInputs: false },
-      { numVariablesDelta: 1, useExtraBuiltinInputs: false },
-      { numVariablesDelta: -1, useExtraBuiltinInputs: true },
-      { numVariablesDelta: -2, useExtraBuiltinInputs: true },
-      { numVariablesDelta: -3, useExtraBuiltinInputs: true },
+      { numVariablesDelta: 0, useExtraBuiltinInputs: false, _success: true },
+      { numVariablesDelta: 1, useExtraBuiltinInputs: false, _success: false },
+      { numVariablesDelta: -1, useExtraBuiltinInputs: true, _success: true },
+      { numVariablesDelta: -2, useExtraBuiltinInputs: true, _success: false },
+      { numVariablesDelta: -3, useExtraBuiltinInputs: true, _success: true },
     ] as const)
   )
   .fn(t => {
-    const { isAsync, numVariablesDelta, useExtraBuiltinInputs } = t.params;
+    const { isAsync, numVariablesDelta, useExtraBuiltinInputs, _success: success } = t.params;
 
     const numVec4 = t.device.limits.maxInterStageShaderVariables + numVariablesDelta;
 
@@ -340,7 +340,6 @@ g.test('max_variables_count,input')
         );
       }
     }
-    const success = inputs.length <= t.device.limits.maxInterStageShaderVariables;
 
     const descriptor = t.getDescriptorWithStates(
       t.getVertexStateWithOutputs(outputs),


### PR DESCRIPTION
Issue: #4538

See also <https://github.com/gpuweb/cts/pull/4539>.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.
