### PR TITLE
Improve the sensitivity of the `array_zero_value` tests

### DIFF
--- a/src/webgpu/shader/validation/expression/call/builtin/value_constructor.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/value_constructor.spec.ts
@@ -18,6 +18,7 @@ import { ShaderValidationTest } from '../../../shader_validation_test.js';
 
 export const g = makeTestGroup(ShaderValidationTest);
 
+const kDeclTypes = ['const', 'let', 'var'];
 const kScalarTypes = ['bool', 'i32', 'u32', 'f32', 'f16'];
 
 g.test('scalar_zero_value')
@@ -479,11 +480,14 @@ const kArrayCases: Record<string, ArrayCase> = {
 
 g.test('array_zero_value')
   .desc('Tests zero value array constructors')
-  .params(u => u.combine('case', keysOf(kArrayCases)))
+  .params(u =>
+    u
+      .combine('case', keysOf(kArrayCases)) //
+      .combine('decltype', kDeclTypes)
+  )
   .fn(t => {
     const testcase = kArrayCases[t.params.case];
     const decl = `array<${testcase.element}, ${testcase.size}>`;
-    const decltype = testcase.valid ? 'const' : 'let';
     const code = `override o : i32 = 1;
     struct valid_S {
       x : u32
@@ -492,18 +496,21 @@ g.test('array_zero_value')
       x : array<u32>
     }
     fn main() {
-      ${decltype} x : ${decl} = ${decl}();
+      ${t.params.decltype} x : ${decl} = ${decl}();
     }`;
     t.expectCompileResult(testcase.valid, code);
   });
 
 g.test('array_value')
   .desc('Tests array value constructor')
-  .params(u => u.combine('case', keysOf(kArrayCases)))
+  .params(u =>
+    u
+      .combine('case', keysOf(kArrayCases)) //
+      .combine('decltype', kDeclTypes)
+  )
   .fn(t => {
     const testcase = kArrayCases[t.params.case];
     const decl = `array<${testcase.element}, ${testcase.size}>`;
-    const decltype = testcase.valid ? 'const' : 'let';
     const code = `override o : i32 = 1;
     struct valid_S {
       x : u32
@@ -512,7 +519,7 @@ g.test('array_value')
       x : array<u32>
     }
     fn main() {
-      ${decltype} x : ${decl} = ${decl}(${testcase.values});
+      ${t.params.decltype} x : ${decl} = ${decl}(${testcase.values});
     }`;
     t.expectCompileResult(testcase.valid, code);
   });
@@ -580,28 +587,34 @@ const kStructCases = {
 
 g.test('struct_zero_value')
   .desc('Tests zero value struct constructors')
-  .params(u => u.combine('case', keysOf(kStructCases)))
+  .params(u =>
+    u
+      .combine('case', keysOf(kStructCases)) //
+      .combine('decltype', kDeclTypes)
+  )
   .fn(t => {
     const testcase = kStructCases[t.params.case];
-    const decltype = testcase.valid ? 'const' : 'let';
     const code = `
     ${testcase.decls}
     fn main() {
-      ${decltype} x : ${testcase.name} = ${testcase.name}();
+      ${t.params.decltype} x : ${testcase.name} = ${testcase.name}();
     }`;
     t.expectCompileResult(testcase.valid, code);
   });
 
 g.test('struct_value')
   .desc('Tests struct value constructors')
-  .params(u => u.combine('case', keysOf(kStructCases)))
+  .params(u =>
+    u
+      .combine('case', keysOf(kStructCases)) //
+      .combine('decltype', kDeclTypes)
+  )
   .fn(t => {
     const testcase = kStructCases[t.params.case];
-    const decltype = testcase.valid ? 'const' : 'let';
     const code = `
     ${testcase.decls}
     fn main() {
-      ${decltype} x : ${testcase.name} = ${testcase.name}(${testcase.values});
+      ${t.params.decltype} x : ${testcase.name} = ${testcase.name}(${testcase.values});
     }`;
     t.expectCompileResult(testcase.valid, code);
   });

--- a/src/webgpu/shader/validation/expression/call/builtin/value_constructor.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/value_constructor.spec.ts
@@ -483,6 +483,7 @@ g.test('array_zero_value')
   .fn(t => {
     const testcase = kArrayCases[t.params.case];
     const decl = `array<${testcase.element}, ${testcase.size}>`;
+    const decltype = testcase.valid ? 'const' : 'let';
     const code = `override o : i32 = 1;
     struct valid_S {
       x : u32
@@ -490,7 +491,9 @@ g.test('array_zero_value')
     struct invalid_S {
       x : array<u32>
     }
-    const x : ${decl} = ${decl}();`;
+    fn main() {
+      ${decltype} x : ${decl} = ${decl}();
+    }`;
     t.expectCompileResult(testcase.valid, code);
   });
 
@@ -500,6 +503,7 @@ g.test('array_value')
   .fn(t => {
     const testcase = kArrayCases[t.params.case];
     const decl = `array<${testcase.element}, ${testcase.size}>`;
+    const decltype = testcase.valid ? 'const' : 'let';
     const code = `override o : i32 = 1;
     struct valid_S {
       x : u32
@@ -507,7 +511,9 @@ g.test('array_value')
     struct invalid_S {
       x : array<u32>
     }
-    const x : ${decl} = ${decl}(${testcase.values});`;
+    fn main() {
+      ${decltype} x : ${decl} = ${decl}(${testcase.values});
+    }`;
     t.expectCompileResult(testcase.valid, code);
   });
 
@@ -577,9 +583,12 @@ g.test('struct_zero_value')
   .params(u => u.combine('case', keysOf(kStructCases)))
   .fn(t => {
     const testcase = kStructCases[t.params.case];
+    const decltype = testcase.valid ? 'const' : 'let';
     const code = `
     ${testcase.decls}
-    const x : ${testcase.name} = ${testcase.name}();`;
+    fn main() {
+      ${decltype} x : ${testcase.name} = ${testcase.name}();
+    }`;
     t.expectCompileResult(testcase.valid, code);
   });
 
@@ -588,9 +597,12 @@ g.test('struct_value')
   .params(u => u.combine('case', keysOf(kStructCases)))
   .fn(t => {
     const testcase = kStructCases[t.params.case];
+    const decltype = testcase.valid ? 'const' : 'let';
     const code = `
     ${testcase.decls}
-    const x : ${testcase.name} = ${testcase.name}(${testcase.values});`;
+    fn main() {
+      ${decltype} x : ${testcase.name} = ${testcase.name}(${testcase.values});
+    }`;
     t.expectCompileResult(testcase.valid, code);
   });
 


### PR DESCRIPTION
In the cases where `valid = true`, we want to test with a `const` declaration, to ensure that the constructor is supported in const exprs. But in cases where `valid = false`, some of the subject types are not constructible, and may be rejected in a const declaration for that reason, even if the implementation is not properly restricting the use of zero-value constructors.

This changes the test to use `const` when `valid = true` and `let` when `valid = false`, which make the the tests more sensitive to the functionality they are intending to cover.

Tests still pass in Chrome. The `valid_array` case is failing in Safari either with or without this change. With this change, the `invalid_rta`, `invalid_override_array`, and `invalid_atomic` cases fail in Firefox, which I believe accurately reflects defects in the implementation. 

<hr>

**Requirements for PR author:**

- [ ] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [ ] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [ ] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) are accurate and complete.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Tests avoid [over-parameterization](https://github.com/gpuweb/cts/blob/main/docs/organization.md#parameterization) (see case count report).

When landing this PR, be sure to make any necessary issue status updates.
