### PR TITLE
Compat: getCurrentTexture and textureBindingViewDimension

### DIFF
--- a/src/webgpu/web_platform/canvas/getCurrentTexture.spec.ts
+++ b/src/webgpu/web_platform/canvas/getCurrentTexture.spec.ts
@@ -433,3 +433,24 @@ TODO: test more canvas types, and ways to update the rendering
         break;
     }
   });
+
+g.test('compatibility')
+  .desc(
+    `
+Test that the texture returned from getCurrentTexture has textureBindingViewDimension
+and that it's undefined in core and '2d' in compatibility mode.
+  `
+  )
+  .params(u =>
+    u //
+      .combine('canvasType', kAllCanvasTypes)
+  )
+  .fn(t => {
+    const { canvasType } = t.params;
+    const ctx = t.initCanvasContext(canvasType);
+    const texture = ctx.getCurrentTexture();
+    t.expect(() => 'textureBindingViewDimension' in texture);
+
+    const expected = t.isCompatibility ? '2d' : undefined;
+    t.expect(texture.textureBindingViewDimension === expected);
+  });


### PR DESCRIPTION
Check that textures returned from canvas context getCurrentTexture have `textureBindingViewDimension` and that it's undefined in core and is `'2d'` in compatibility mode.

I don't know what other implementations would have an issue here but the current spec requires these to work just like any other texture and chromium has some special cases here. This test failed in chromium until it was fixed.


