### PR TITLE
Add new builtins to maxInterStageShaderVariables test

### DIFF
--- a/src/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/limits/maxInterStageShaderVariables.spec.ts
@@ -21,34 +21,35 @@ const kExtraItems = [
   'sample_mask_out', // special - see below
 ] as const;
 
-function getCombinations<T>(arr: readonly T[], sizes: number[]): T[][] {
-  const combos: T[][] = [];
-
-  function backtrack(start: number, path: T[], size: number) {
-    if (path.length === size) {
-      combos.push(path.slice());
-      return;
-    }
-
-    for (let i = start; i < arr.length; i++) {
-      path.push(arr[i]);
-      backtrack(i + 1, path, size);
-      path.pop();
-    }
+/**
+ * Generates every combination of size elements from array
+ * combinations([a, b, c], 2) generates [a, b], [a, c], [b, c]
+ */
+function* combinations<T>(
+  arr: readonly T[],
+  size: number,
+  start = 0,
+  path: T[] = []
+): Generator<T[]> {
+  if (path.length === size) {
+    yield [...path];
+    return;
   }
 
-  sizes.forEach(size => {
-    backtrack(0, [], size);
-  });
-
-  return combos;
+  for (let i = start; i < arr.length; i++) {
+    path.push(arr[i]);
+    yield* combinations(arr, size, i + 1, path);
+    path.pop();
+  }
 }
 
 const kTestItems = [...kItemsThatCountAgainstLimit, ...kExtraItems] as const;
 const kTestItemCombinations = [
   [], // no builtins case
-  ...getCombinations(kTestItems, [1, 2, 3]),
-  kTestItems, // all case
+  ...combinations(kTestItems, 1), // one builtin
+  ...combinations(kTestItems, 2), // 2 builtins
+  ...combinations(kTestItems, 3), // 3 builtins
+  kTestItems, // all builtins case
 ] as const;
 
 const requiresSubgroupsFeature = (items: Set<(typeof kTestItems)[number]>) =>


### PR DESCRIPTION
primitive_index, subgroup_id, subgroup_size were missing from the test.

note: Chromium doesn't currently count these. Bugs filed. Also, chromium doesn't currently count correctly for the pre-existing ones. Fixes in progress.

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [X] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) are accurate and complete.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Tests avoid [over-parameterization](https://github.com/gpuweb/cts/blob/main/docs/organization.md#parameterization) (see case count report).

When landing this PR, be sure to make any necessary issue status updates.
