### PR TITLE
Skip invalid subgroupBroadcast tests

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/subgroupBroadcast.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/subgroupBroadcast.spec.ts
@@ -273,6 +273,8 @@ fn main(@builtin(subgroup_invocation_id) id : u32,
     t.expectGPUBufferValuesEqual(outputBuffer, new Uint32Array(expect));
   });
 
+const kUnattemptedBroadcast = 555 << 16;
+
 /**
  * Checks the results of broadcast in compute shaders.
  *
@@ -280,6 +282,8 @@ fn main(@builtin(subgroup_invocation_id) id : u32,
  *                 * first half is subgroup_invocation_id
  *                 * second half is subgroup_size
  * @param output An array uint32s containing the broadcast results
+ *               If the broadcast was not attempted due to generating a dynamic error,
+ *               the value will be kUnattemptedWrite | ballot-based subgroup size
  * @param numInvs The number of invocations
  * @param broadcast The broadcast invocation (or 'first' to indicate the lowest active)
  * @param filter A functor indicating whether the invocation participates in the broadcast
@@ -310,6 +314,16 @@ function checkCompute(
     const size = metadata[i + numInvs];
 
     const res = output[i];
+    const upper = res & 0xffff0000;
+    if (upper === kUnattemptedBroadcast) {
+      const lower = res & 0xffff;
+      if (Number(broadcastedId) < lower) {
+        return new Error(`Invocation ${i}: expected a valid broadcast:
+-       broadcast id: ${id}
+- real subgroup size: ${lower}`);
+      }
+      continue;
+    }
 
     if (filter(id, size)) {
       let seen = mapping.get(res) ?? 0;
@@ -351,30 +365,25 @@ g.test('compute,all_active')
     u
       .combine('wgSize', kWGSizes)
       .beginSubcases()
-      // Only values < 4 are used because it is a dynamic error to broadcast an inactive invocation.
-      .combine('id', [0, 1, 2, 3] as const)
+      .combine('id', [0, 1, 2, 3, 7, 13, 25, 46] as const)
   )
   .fn(async t => {
     t.skipIfDeviceDoesNotHaveFeature('subgroups' as GPUFeatureName);
     const wgThreads = t.params.wgSize[0] * t.params.wgSize[1] * t.params.wgSize[2];
-
-    interface SubgroupProperties extends GPUAdapterInfo {
-      subgroupMinSize: number;
-    }
-    const { subgroupMinSize } = t.device.adapterInfo as SubgroupProperties;
-    const mod = wgThreads % subgroupMinSize;
-    t.skipIf(
-      mod > 0 && mod <= t.params.id,
-      "Can't guarantee enough invocations for defined behaviour"
-    );
 
     const broadcast =
       t.params.id === 0
         ? `subgroupBroadcastFirst(input[lid])`
         : `subgroupBroadcast(input[lid], ${t.params.id})`;
 
+    const diagnostic = t.hasLanguageFeature('subgroup_uniformity')
+      ? ''
+      : 'diagnostic(off, subgroup_uniformity);';
+
     const wgsl = `
 enable subgroups;
+
+${diagnostic}
 
 @group(0) @binding(0)
 var<storage> input : array<u32>;
@@ -390,6 +399,12 @@ var<storage, read_write> output : array<u32>;
 @group(0) @binding(2)
 var<storage, read_write> metadata: Metadata;
 
+fn ballotSize() -> u32 {
+  let b = subgroupBallot(true);
+  let count = countOneBits(b);
+  return count.x + count.y + count.z + count.w;
+}
+
 @compute @workgroup_size(${t.params.wgSize[0]}, ${t.params.wgSize[1]}, ${t.params.wgSize[2]})
 fn main(
   @builtin(local_invocation_index) lid : u32,
@@ -399,7 +414,13 @@ fn main(
   metadata.id[lid] = id;
   metadata.size[lid] = subgroupSize;
 
-  output[lid] = ${broadcast};
+  // subgroup_invocation_id is dense in compute shaders
+  let realSize = ballotSize();
+  if ${t.params.id} < realSize {
+    output[lid] = ${broadcast};
+  } else {
+    output[lid] = ${kUnattemptedBroadcast}u | realSize;
+  }
 }`;
 
     const inputData = new Uint32Array([...iterRange(wgThreads, x => x)]);
@@ -434,7 +455,7 @@ g.test('compute,split')
         return t.predicate !== 'upper_half';
       })
       .beginSubcases()
-      .combine('id', [0, 1, 2, 3] as const)
+      .combine('id', [0, 1, 2, 3, 7, 13, 25, 46] as const)
       .combine('wgSize', kWGSizes)
   )
   .fn(async t => {
@@ -447,11 +468,6 @@ g.test('compute,split')
       subgroupMaxSize: number;
     }
     const { subgroupMinSize, subgroupMaxSize } = t.device.adapterInfo as SubgroupProperties;
-    const mod = wgThreads % subgroupMinSize;
-    t.skipIf(
-      mod > 0 && mod <= t.params.id,
-      "Can't guarantee enough invocations for defined behaviour"
-    );
     for (let size = subgroupMinSize; size <= subgroupMaxSize; size *= 2) {
       t.skipIf(!testcase.filter(t.params.id, size), 'Skipping potential undefined behavior');
     }
@@ -479,6 +495,12 @@ var<storage, read_write> output : array<u32>;
 @group(0) @binding(2)
 var<storage, read_write> metadata: Metadata;
 
+fn ballotSize() -> u32 {
+  let b = subgroupBallot(true);
+  let count = countOneBits(b);
+  return count.x + count.y + count.z + count.w;
+}
+
 @compute @workgroup_size(${t.params.wgSize[0]}, ${t.params.wgSize[1]}, ${t.params.wgSize[2]})
 fn main(
   @builtin(local_invocation_index) lid : u32,
@@ -488,10 +510,16 @@ fn main(
   metadata.id[lid] = id;
   metadata.size[lid] = subgroupSize;
 
-  if ${testcase.cond} {
-    output[lid] = ${broadcast};
+  // subgroup_invocation_id is dense in compute shaders
+  let realSize = ballotSize();
+  if ${t.params.id} < realSize {
+    if ${testcase.cond} {
+      output[lid] = ${broadcast};
+    } else {
+      return;
+    }
   } else {
-    return;
+    output[lid] = ${kUnattemptedBroadcast}u | realSize;
   }
 }`;
 


### PR DESCRIPTION
Fixes #4532

* Skip tests in `compute,active_all` and `compute,split` if the broadcasted ID is not guaranteed to appear in all subgroups
  * For subgroup size 4 this skips 4 subtests (ID=3 for [3,3,3], [15,3,3], [3,15,3], and [3,3,15] sizes)
  * For subgroup size 8 this skips 1 subtest (ID=3 for [3,3,3] size)




Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [ ] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [ ] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [ ] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) are accurate and complete.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Tests avoid [over-parameterization](https://github.com/gpuweb/cts/blob/main/docs/organization.md#parameterization) (see case count report).

When landing this PR, be sure to make any necessary issue status updates.
