### PR TITLE
Add more operation tests for transient attachment

### DIFF
--- a/src/webgpu/api/operation/render_pass/transient_attachment.spec.ts
+++ b/src/webgpu/api/operation/render_pass/transient_attachment.spec.ts
@@ -1,7 +1,6 @@
 export const description = `API Operation Tests for transient attachment in render passes.`;
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
-import { range } from '../../../../common/util/util.js';
 import { AllFeaturesMaxLimitsGPUTest } from '../../../gpu_test.js';
 
 const kSize = 4;
@@ -64,14 +63,14 @@ g.test('overlapping_transient_attachments')
 
     const encoder = t.device.createCommandEncoder();
 
-    // Create 3 transient textures
-    const [t1, t2, t3] = range(3, () =>
-      t.createTextureTracked({
-        size: [kSize, kSize, 1],
-        format: 'rgba8unorm',
-        usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TRANSIENT_ATTACHMENT,
-      })
-    );
+    const desc = {
+      size: [kSize, kSize, 1],
+      format: 'rgba8unorm',
+      usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TRANSIENT_ATTACHMENT,
+    } as const;
+    const t1 = t.createTextureTracked(desc);
+    const t2 = t.createTextureTracked(desc);
+    const t3 = t.createTextureTracked(desc);
 
     const passes = [
       [t1, t2], // Pass 1


### PR DESCRIPTION
This PR adds more operation tests for transient attachment as requested in https://issues.chromium.org/issues/462468372

Issue: https://github.com/gpuweb/cts/pull/4509

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located in the test tree.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) allow a reader to "read only the test plans and evaluate coverage completeness", and accurately reflect the test code.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Helpers and types promote readability and maintainability.

When landing this PR, be sure to make any necessary issue status updates.