### PR TITLE
Add test of single element swizzle assignment

### DIFF
--- a/src/webgpu/shader/validation/decl/assignment_statement.spec.ts
+++ b/src/webgpu/shader/validation/decl/assignment_statement.spec.ts
@@ -1,0 +1,82 @@
+export const description = `
+Validation tests for assignment statements.
+`;
+
+import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { keysOf } from '../../../../common/util/data_tables.js';
+import { ShaderValidationTest } from '../shader_validation_test.js';
+
+export const g = makeTestGroup(ShaderValidationTest);
+
+g.test('scalar_assignment')
+  .desc('Test simple scalar assignments.')
+  .fn(t => {
+    const code = `
+      @fragment
+      fn main() {
+        var a: i32 = 0;
+        a = 1;
+        let b: f32 = 0.0;
+        var c: f32;
+        c = b;
+      }
+    `;
+    t.expectCompileResult(true, code);
+  });
+
+g.test('vector_full_assignment')
+  .desc('Test full vector assignments.')
+  .fn(t => {
+    const code = `
+      @fragment
+      fn main() {
+        var v1: vec3<f32> = vec3(0.0, 0.0, 0.0);
+        var v2: vec3<f32>;
+        v2 = v1;
+        v2 = vec3(1.0, 2.0, 3.0);
+      }
+    `;
+    t.expectCompileResult(true, code);
+  });
+
+g.test('vector_indexed_assignment')
+  .desc('Test vector indexed assignments.')
+  .fn(t => {
+    const code = `
+      @fragment
+      fn main() {
+        var v: vec3<i32> = vec3(0, 0, 0);
+        v[0] = 1;
+        v[2] = 5;
+      }
+    `;
+    t.expectCompileResult(true, code);
+  });
+
+const kSwizzleTests = {
+  single: {
+    src: 'v.x = 1.0',
+    pass: true,
+  },
+  multi: {
+    src: 'v.xy = vec2(1.0, 2.0)',
+    pass: false,
+  },
+  swizzleswizzle: {
+    src: 'v.xy.x = 1.0',
+    pass: false,
+  },
+};
+
+g.test('vector_swizzle_assignment')
+  .desc('Test vector swizzle assignments.')
+  .params(u => u.combine('case', keysOf(kSwizzleTests)))
+  .fn(t => {
+    const wgsl = `
+      @fragment
+      fn main() {
+        var v: vec4<f32> = vec4(0.0, 0.0, 0.0, 0.0);
+        ${kSwizzleTests[t.params.case].src};
+      }`;
+    t.expectCompileResult(kSwizzleTests[t.params.case].pass, wgsl);
+  });


### PR DESCRIPTION
Single element swizzle assignment currently fails in Tint when the object of the swizzle is also a swizzle (i.e. v.xy.x = 1.0).  This appears to be a valid assignment which should be covered by CTS so added it here. Since there didn't seem to be an existing validation test for simple assignment statements, I created a new file with a couple other simple tests. As multi-element swizzle assignment is not yet part of the spec, also added a test to check that it fails.



<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) are accurate and complete.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Tests avoid [over-parameterization](https://github.com/gpuweb/cts/blob/main/docs/organization.md#parameterization) (see case count report).

When landing this PR, be sure to make any necessary issue status updates.
