### PR TITLE
Test that select() does not short circuit

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/select.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/select.spec.ts
@@ -29,6 +29,7 @@ import {
   ScalarValue,
   Type,
 } from '../../../../../util/conversion.js';
+import { runFlowControlTest } from '../../../flow_control/harness.js';
 import { Case } from '../../case.js';
 import { run, allInputSources } from '../../expression.js';
 
@@ -265,4 +266,38 @@ g.test('vector')
       t.params,
       tests.cases
     );
+  });
+
+g.test('short_circuit')
+  .desc('Test that select does not short-circuit and evaluates arguments left-to-right')
+  .params(u =>
+    u
+      .combine('cond', [true, false])
+      .combine('preventValueOptimizations', [true, false])
+      .combine('overload', ['scalar', 'vec'] as const)
+  )
+  .fn(t => {
+    runFlowControlTest(t, f => {
+      const type = t.params.overload === 'scalar' ? 'i32' : 'vec3<i32>';
+      const cond =
+        t.params.overload === 'scalar'
+          ? `${f.value(t.params.cond)}`
+          : `vec3<bool>(${f.value(t.params.cond)})`;
+      return {
+        entrypoint: `
+          let res = select(f(), g(), ${cond});
+        `,
+        extra: `
+          fn f() -> ${type} {
+            ${f.expect_order(0)}
+            return ${type}();
+          }
+
+          fn g() -> ${type} {
+            ${f.expect_order(1)}
+            return ${type}();
+          }
+        `,
+      };
+    });
   });


### PR DESCRIPTION
Add a test that checks that `select()` does not short-circuit, and that lhs argument is evaluated before rhs. This currently fails on Tint with DXC as reported in http://crbug.com/478792488.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) are accurate and complete.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Tests avoid [over-parameterization](https://github.com/gpuweb/cts/blob/main/docs/organization.md#parameterization) (see case count report).

When landing this PR, be sure to make any necessary issue status updates.
