### PR TITLE
Additional bitwise shift test cases

### DIFF
--- a/src/webgpu/shader/validation/expression/binary/bitwise_shift.spec.ts
+++ b/src/webgpu/shader/validation/expression/binary/bitwise_shift.spec.ts
@@ -205,10 +205,14 @@ const kLeftShiftCases = [
     rhs: `1u`,
     pass: false,
   },
+
+  // Negative operand overflow for abstract
+  { lhs: `-1`, rhs: `63`, pass: true },
+  { lhs: `-1`, rhs: `64`, pass: false },
 ];
 
 g.test('shift_left_concrete')
-  .desc('Tests validation of binary left shift of concrete values')
+  .desc('Tests validation of binary left shift (including abstract, despite the test name)')
   .params(u =>
     u
       .combine('case', kLeftShiftCases) //
@@ -246,10 +250,14 @@ const kRightShiftCases = [
   { lhs: `1`, rhs: `-1`, pass: false },
   { lhs: `1i`, rhs: `-1`, pass: false },
   { lhs: `1u`, rhs: `-1`, pass: false },
+
+  // Abstract shifts are permitted to underflow
+  { lhs: `1`, rhs: `64`, pass: true },
+  { lhs: `-1`, rhs: `64`, pass: true },
 ];
 
 g.test('shift_right_concrete')
-  .desc('Tests validation of binary right shift of concrete values')
+  .desc('Tests validation of binary right shift (including abstract, despite the test name)')
   .params(u =>
     u
       .combine('case', kRightShiftCases) //
@@ -295,21 +303,25 @@ g.test('partial_eval_errors')
     u
       .combine('op', ['<<', '>>'] as const)
       .combine('type', ['i32', 'u32'] as const)
+      .combine('vectorize', [undefined, 2, 3, 4] as const)
       .beginSubcases()
       .combine('stage', ['shader', 'pipeline'] as const)
       .combine('value', [31, 32, 33, 64] as const)
   )
   .fn(t => {
     const u32 = Type.u32;
+    const vec_size = t.params.vectorize;
     let rhs = 'o';
     if (t.params.stage === 'shader') {
       rhs = `${u32.create(t.params.value).wgsl()}`;
     }
+
+    const vecType = vec_size ? `vec${vec_size}<${t.params.type}>` : t.params.type;
     const wgsl = `
 override o = 0u;
-fn foo() -> ${t.params.type} {
-  var v : ${t.params.type} = 0;
-  return v ${t.params.op} ${rhs};
+fn foo() -> ${vecType} {
+  var v : ${vecType} = ${vectorize('0', vec_size)};
+  return v ${t.params.op} ${vectorize(rhs, vec_size)};
 }`;
 
     const expect = t.params.value < 32;


### PR DESCRIPTION
Additional test cases for bitwise shifts:

* More overflow and underflow cases for abstract integers
* Vector version of the partial eval errors test case 

Chrome: Passes
Safari: `1 >> 64` and `-1 >> 64` fail due to unexpected compile error. Vector partial eval fails but the scalar version was already failing.
Firefox: Fails due to multiple issues.

Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [ ] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) are accurate and complete.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Tests avoid [over-parameterization](https://github.com/gpuweb/cts/blob/main/docs/organization.md#parameterization) (see case count report).

When landing this PR, be sure to make any necessary issue status updates.
