### PR TITLE
Add test for compound assignment with swizzle

### DIFF
--- a/src/webgpu/shader/validation/decl/assignment_statement.spec.ts
+++ b/src/webgpu/shader/validation/decl/assignment_statement.spec.ts
@@ -80,3 +80,17 @@ g.test('vector_swizzle_assignment')
       }`;
     t.expectCompileResult(kSwizzleTests[t.params.case].pass, wgsl);
   });
+
+g.test('compound_assignment_with_swizzle')
+  .desc('Test compound assignment of a vector with a swizzle on the rhs.')
+  .fn(t => {
+    const code = `
+      @fragment
+      fn main() {
+        var v: vec3<i32> = vec3(1, 2, 3);
+        var w: vec4<i32> = vec4(10);
+        v *= w.xyz;
+      }
+    `;
+    t.expectCompileResult(true, code);
+  });


### PR DESCRIPTION
Add a test for compound assignment to a vector with a swizzle on the right hand side. This case covers the bug reported in https://crbug.com/480933709 and will be fixed in WebGPU with https://dawn-review.googlesource.com/c/dawn/+/288435.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) are accurate and complete.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Tests avoid [over-parameterization](https://github.com/gpuweb/cts/blob/main/docs/organization.md#parameterization) (see case count report).

When landing this PR, be sure to make any necessary issue status updates.
