### PR TITLE
[NFC] Cleanup video test

### DIFF
--- a/src/webgpu/web_platform/external_texture/video.spec.ts
+++ b/src/webgpu/web_platform/external_texture/video.spec.ts
@@ -406,9 +406,7 @@ parameters are present.
       // quadrant. In this test we crop the video to each quadrant and check that desired color
       // is sampled from each corner of the cropped image.
       // visible rect clip applies on raw decoded frame, which defines based on video frame visible size.
-      const visibleRect = source.visibleRect ?? new DOMRectReadOnly();
-      const srcVideoHeight = visibleRect.height;
-      const srcVideoWidth = visibleRect.width;
+      const visibleRect = source.visibleRect!;
 
       const srcColorSpace = kVideoInfo[videoName].colorSpace;
       const presentColors = kVideoExpectedColors[srcColorSpace][dstColorSpace];
@@ -423,18 +421,18 @@ parameters are present.
           subRect: {
             x: visibleRect.x,
             y: visibleRect.y,
-            width: srcVideoWidth / 2,
-            height: srcVideoHeight / 2,
+            width: visibleRect.width / 2,
+            height: visibleRect.height / 2,
           },
           color: convertToUnorm8(presentColors[expect.topLeftColor]),
         },
         // Top right
         {
           subRect: {
-            x: visibleRect.x + srcVideoWidth / 2,
+            x: visibleRect.x + visibleRect.width / 2,
             y: visibleRect.y,
-            width: srcVideoWidth / 2,
-            height: srcVideoHeight / 2,
+            width: visibleRect.width / 2,
+            height: visibleRect.height / 2,
           },
           color: convertToUnorm8(presentColors[expect.topRightColor]),
         },
@@ -442,19 +440,19 @@ parameters are present.
         {
           subRect: {
             x: visibleRect.x,
-            y: visibleRect.y + srcVideoHeight / 2,
-            width: srcVideoWidth / 2,
-            height: srcVideoHeight / 2,
+            y: visibleRect.y + visibleRect.height / 2,
+            width: visibleRect.width / 2,
+            height: visibleRect.height / 2,
           },
           color: convertToUnorm8(presentColors[expect.bottomLeftColor]),
         },
         // Bottom right
         {
           subRect: {
-            x: visibleRect.x + srcVideoWidth / 2,
-            y: visibleRect.y + srcVideoHeight / 2,
-            width: srcVideoWidth / 2,
-            height: srcVideoHeight / 2,
+            x: visibleRect.x + visibleRect.width / 2,
+            y: visibleRect.y + visibleRect.height / 2,
+            width: visibleRect.width / 2,
+            height: visibleRect.height / 2,
           },
           color: convertToUnorm8(presentColors[expect.bottomRightColor]),
         },


### PR DESCRIPTION
* Inline visibleRect width and height access
* Assert visibleRect is non-null




Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [ ] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [ ] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [ ] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) are accurate and complete.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Tests avoid [over-parameterization](https://github.com/gpuweb/cts/blob/main/docs/organization.md#parameterization) (see case count report).

When landing this PR, be sure to make any necessary issue status updates.
