### PR TITLE
Fix buffer usage validity in `abort_over_invalid_error` test

### DIFF
--- a/src/webgpu/api/validation/buffer/mapping.spec.ts
+++ b/src/webgpu/api/validation/buffer/mapping.spec.ts
@@ -413,7 +413,7 @@ g.test('mapAsync,abort_over_invalid_error')
     const { mapMode, unmapBeforeResolve } = t.params;
     const bufferSize = 8;
     const buffer = t.createBufferTracked({
-      usage: 0,
+      usage: GPUBufferUsage.STORAGE,
       size: bufferSize,
     });
 


### PR DESCRIPTION
Fixes a regression introduced by https://github.com/gpuweb/cts/pull/4575.

A usage of 0 is not allowed by the spec, setting it to `GPUBufferUsage.STORAGE` should get this test working properly.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [ ] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) are accurate and complete.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Tests avoid [over-parameterization](https://github.com/gpuweb/cts/blob/main/docs/organization.md#parameterization) (see case count report).

When landing this PR, be sure to make any necessary issue status updates.
