### PR TITLE
Add swizzle assignment validation tests

### DIFF
--- a/src/webgpu/shader/validation/statement/swizzle_assignment.spec.ts
+++ b/src/webgpu/shader/validation/statement/swizzle_assignment.spec.ts
@@ -1,0 +1,105 @@
+export const description = `
+Validation tests for swizzle assignments.
+`;
+
+import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { ShaderValidationTest } from '../shader_validation_test.js';
+
+export const g = makeTestGroup(ShaderValidationTest);
+
+g.test('valid')
+  .desc('Valid swizzle assignments')
+  .params(u =>
+    u.combine('elemType', ['f32', 'i32', 'u32'] as const).combine('vecSize', [2, 3, 4] as const)
+  )
+  .fn(t => {
+    t.skipIfLanguageFeatureNotSupported('swizzle_assignment');
+    const { elemType, vecSize } = t.params;
+    const swizzle = 'xyzw'.substring(0, vecSize);
+    const vecType = `vec${swizzle.length}<${elemType}>`;
+    const code = `
+@fragment
+fn main() {
+  var v = vec4<${elemType}>(0);
+  v.${swizzle} = ${vecType}(1);
+}
+`;
+    t.expectCompileResult(true, code);
+  });
+
+g.test('invalid_lhs_not_reference')
+  .desc('Invalid swizzle assignment where LHS is not a reference')
+  .params(u => u.combine('lhs', ['vec4f()', 'const_vec', 'foo()']))
+  .fn(t => {
+    t.skipIfLanguageFeatureNotSupported('swizzle_assignment');
+    const code = `
+const const_vec = vec4f();
+
+fn foo() -> vec4f {
+  return vec4f();
+}
+
+@fragment
+fn main() {
+  var v = vec4f();
+  ${t.params.lhs}.xyz = vec3(0.0);
+}
+`;
+    t.expectCompileResult(false, code);
+  });
+
+g.test('invalid_duplicate_components')
+  .desc('Invalid swizzle assignment with duplicate LHS components')
+  .fn(t => {
+    t.skipIfLanguageFeatureNotSupported('swizzle_assignment');
+    const code = `
+@fragment
+fn main() {
+  var v = vec4f();
+  v.xx = vec2f();
+}
+`;
+    t.expectCompileResult(false, code);
+  });
+
+g.test('invalid_component_mismatch')
+  .desc('Invalid swizzle assignment with mismatched number of components')
+  .fn(t => {
+    t.skipIfLanguageFeatureNotSupported('swizzle_assignment');
+    const code = `
+@fragment
+fn main() {
+  var v = vec4f();
+  v.xy = vec3f();
+}
+`;
+    t.expectCompileResult(false, code);
+  });
+
+g.test('invalid_component_oob')
+  .desc('Invalid swizzle assignment with components out of bounds')
+  .fn(t => {
+    t.skipIfLanguageFeatureNotSupported('swizzle_assignment');
+    const code = `
+@fragment
+fn main() {
+  var v = vec3f();
+  v.xyzw = vec4f();
+}
+`;
+    t.expectCompileResult(false, code);
+  });
+
+g.test('invalid_type_mismatch')
+  .desc('Invalid swizzle assignment with mismatched types')
+  .fn(t => {
+    t.skipIfLanguageFeatureNotSupported('swizzle_assignment');
+    const code = `
+@fragment
+fn main() {
+  var v = vec4f();
+  v.xy = vec2i();
+}
+`;
+    t.expectCompileResult(false, code);
+  });


### PR DESCRIPTION
These are validation tests only. A larger set of valid swizzle assignments are covered in the execution tests.

Most of these currently fail in dawn, but do pass with my local WIP implementation of swizzle assignment.

Issue: #4579

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) are accurate and complete.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Tests avoid [over-parameterization](https://github.com/gpuweb/cts/blob/main/docs/organization.md#parameterization) (see case count report).

When landing this PR, be sure to make any necessary issue status updates.
