### PR TITLE
Explicitly specify rootDir in tsconfig.json to satisfy upcoming TypeScript v6.

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "lib": ["dom", "ES2023"],
     "module": "esnext",
+    "rootDir": "./src",
     // Use types only from these packages (not everything in package.json, which is the default).
     // Note that TypeScript's `/// <reference />` is the same as adding an entry here - it's global
     // to the whole project.


### PR DESCRIPTION
See [1] and [2] where the "rootDir" needs to be explicitly specified, otherwise it will default to "." unlike v5 which was defaulted to the common root folder of all input files.

This fixes a build error in the downstream Chromium repository, see https://issues.chromium.org/issues/485931998.

[1] https://devblogs.microsoft.com/typescript/announcing-typescript-6-0-beta/#up-front-adjustments
[2] https://devblogs.microsoft.com/typescript/announcing-typescript-6-0-beta/#rootdir-now-defaults-to-.