### PR TITLE
Add debug info to fragment builtins.

### DIFF
--- a/src/webgpu/shader/execution/shader_io/fragment_builtins.spec.ts
+++ b/src/webgpu/shader/execution/shader_io/fragment_builtins.spec.ts
@@ -748,6 +748,33 @@ function checkSampleRectsApproximatelyEqual({
   return undefined;
 }
 
+function showExpected(
+  t: GPUTest,
+  width: number,
+  height: number,
+  sampleCount: number,
+  expected: Float32Array
+) {
+  t.debug(() => {
+    const lineSep = `    ${range(width, () => '+-- x --- y --- z --- w --').join('')}+`;
+    const lines = [''];
+    for (let y = 0; y < height; ++y) {
+      lines.push(lineSep);
+      for (let sampleIndex = 0; sampleIndex < sampleCount; ++sampleIndex) {
+        const line = [];
+        for (let x = 0; x < width; ++x) {
+          const offset = ((y * width + x) * sampleCount + sampleIndex) * 4;
+          const v = [...expected.slice(offset, offset + 4)];
+          line.push(`${v.map(v => v.toFixed(3)).join(' ')}`);
+        }
+        lines.push(`s${sampleIndex}: | ${line.join(' | ')} |`);
+      }
+    }
+    lines.push(lineSep);
+    return lines.join('\n');
+  });
+}
+
 g.test('inputs,position')
   .desc(
     `
@@ -819,6 +846,8 @@ g.test('inputs,position')
       clipSpacePoints,
       interpolateFn: computeFragmentPosition,
     });
+
+    showExpected(t, width, height, sampleCount, expected);
 
     // Since @builtin(position) is always a fragment position, never a sample position, check
     // the first coordinate. It should be 0.5, 0.5 always. This is just to double check
@@ -908,6 +937,8 @@ g.test('inputs,interStage')
       clipSpacePoints,
       interpolateFn: await createInterStageInterpolationFn(t, interStagePoints, type, sampling),
     });
+
+    showExpected(t, width, height, sampleCount, expected);
 
     t.expectOK(
       checkSampleRectsApproximatelyEqual({
@@ -1048,6 +1079,8 @@ g.test('inputs,interStage,centroid')
       ),
     });
 
+    showExpected(t, width, height, sampleCount, expected);
+
     t.expectOK(
       checkSampleRectsApproximatelyEqual({
         width,
@@ -1126,6 +1159,8 @@ g.test('inputs,sample_index')
       clipSpacePoints,
       interpolateFn: computeFragmentSampleIndex,
     });
+
+    showExpected(t, width, height, sampleCount, expected);
 
     t.expectOK(
       checkSampleRectsApproximatelyEqual({
@@ -1241,6 +1276,8 @@ g.test('inputs,front_facing')
       frontFace,
       interpolateFn: computeFragmentFrontFacing,
     });
+
+    showExpected(t, width, height, sampleCount, expected);
 
     assert(expected.indexOf(0) >= 0, 'expect some values to be 0');
     assert(expected.findIndex(v => v !== 0) >= 0, 'expect some values to be non 0');
@@ -1415,6 +1452,8 @@ g.test('inputs,sample_mask')
       clipSpacePoints,
       interpolateFn: computeSampleMask,
     });
+
+    showExpected(t, width, height, sampleCount, expected);
 
     t.expectOK(
       checkSampleRectsApproximatelyEqual({


### PR DESCRIPTION
This lets you visualize the expected results so it's easy to see what's being tested.

for example: https://gpuweb.github.io/cts/standalone/?debug=1&runnow=1&q=webgpu:shader,execution,shader_io,fragment_builtins:inputs,interStage:nearFar=[0,1];sampleCount=4;interpolation={%22type%22:%22perspective%22,%22sampling%22:%22sample%22}

```
DEBUG: 
    +-- x --- y --- z --- w --+-- x --- y --- z --- w --+-- x --- y --- z --- w --+-- x --- y --- z --- w --+
s0: | 3.905 4.905 5.905 6.905 | 3.010 4.010 5.010 6.010 | 2.197 3.197 4.197 5.197 | 1.454 2.454 3.454 4.454 |
s1: | 3.557 4.557 5.557 6.557 | 2.679 3.679 4.679 5.679 | 1.881 2.881 3.881 4.881 | 1.151 2.151 3.151 4.151 |
s2: | 4.415 5.415 6.415 7.415 | 3.439 4.439 5.439 6.439 | 2.556 3.556 4.556 5.556 | 1.754 2.754 3.754 4.754 |
s3: | 4.045 5.045 6.045 7.045 | 3.087 4.087 5.087 6.087 | 2.221 3.221 4.221 5.221 | 1.434 2.434 3.434 4.434 |
    +-- x --- y --- z --- w --+-- x --- y --- z --- w --+-- x --- y --- z --- w --+-- x --- y --- z --- w --+
s0: | 4.446 5.446 6.446 7.446 | 3.430 4.430 5.430 6.430 | 2.514 3.514 4.514 5.514 | 1.686 2.686 3.686 4.686 |
s1: | 4.060 5.060 6.060 7.060 | 3.064 4.064 5.064 6.064 | 2.167 3.167 4.167 5.167 | 1.355 2.355 3.355 4.355 |
s2: | 5.057 6.057 7.057 8.057 | 3.935 4.935 5.935 6.935 | 2.932 3.932 4.932 5.932 | 2.031 3.031 4.031 5.031 |
s3: | 4.643 5.643 6.643 7.643 | 3.544 4.544 5.544 6.544 | 2.562 3.562 4.562 5.562 | 1.679 2.679 3.679 4.679 |
    +-- x --- y --- z --- w --+-- x --- y --- z --- w --+-- x --- y --- z --- w --+-- x --- y --- z --- w --+
s0: | 5.122 6.122 7.122 8.122 | 3.947 4.947 5.947 6.947 | 2.902 3.902 4.902 5.902 | 1.967 2.967 3.967 4.967 |
s1: | 4.688 5.688 6.688 7.688 | 3.539 4.539 5.539 6.539 | 2.516 3.516 4.516 5.516 | 1.601 2.601 3.601 4.601 |
s2: | 5.872 6.872 7.872 8.872 | 4.557 5.557 6.557 7.557 | 3.399 4.399 5.399 6.399 | 2.370 3.370 4.370 5.370 |
s3: | 5.402 6.402 7.402 8.402 | 4.116 5.116 6.116 7.116 | 2.984 3.984 4.984 5.984 | 1.978 2.978 3.978 4.978 |
    +-- x --- y --- z --- w --+-- x --- y --- z --- w --+-- x --- y --- z --- w --+-- x --- y --- z --- w --+
s0: | 5.990 6.990 7.990 8.990 | 4.602 5.602 6.602 7.602 | 3.386 4.386 5.386 6.386 | 2.313 3.313 4.313 5.313 |
s1: | 5.494 6.494 7.494 8.494 | 4.139 5.139 6.139 7.139 | 2.952 3.952 4.952 5.952 | 1.904 2.904 3.904 4.904 |
s2: | 6.941 7.941 8.941 9.941 | 5.359 6.359 7.359 8.359 | 3.990 4.990 5.990 6.990 | 2.794 3.794 4.794 5.794 |
s3: | 6.397 7.397 8.397 9.397 | 4.854 5.854 6.854 7.854 | 3.520 4.520 5.520 6.520 | 2.353 3.353 4.353 5.353 |
    +-- x --- y --- z --- w --+-- x --- y --- z --- w --+-- x --- y --- z --- w --+-- x --- y --- z --- w --+
```

