### PR TITLE
Set batch size 1 for binary AF matrix tests

### DIFF
--- a/src/webgpu/shader/execution/expression/binary/af_matrix_addition.spec.ts
+++ b/src/webgpu/shader/execution/expression/binary/af_matrix_addition.spec.ts
@@ -8,7 +8,7 @@ import { Type } from '../../../../util/conversion.js';
 import { onlyConstInputSource, run } from '../expression.js';
 
 import { d } from './af_matrix_addition.cache.js';
-import { abstractFloatBinary } from './binary.js';
+import { abstractFloatBinary, kAbstractFloatMatrixBinaryOpBatchSize } from './binary.js';
 
 export const g = makeTestGroup(AllFeaturesMaxLimitsGPUTest);
 
@@ -36,6 +36,7 @@ Accuracy: Correctly rounded
       [Type.mat(cols, rows, Type.abstractFloat), Type.mat(cols, rows, Type.abstractFloat)],
       Type.mat(cols, rows, Type.abstractFloat),
       t.params,
-      cases
+      cases,
+      kAbstractFloatMatrixBinaryOpBatchSize
     );
   });

--- a/src/webgpu/shader/execution/expression/binary/af_matrix_matrix_multiplication.spec.ts
+++ b/src/webgpu/shader/execution/expression/binary/af_matrix_matrix_multiplication.spec.ts
@@ -8,7 +8,7 @@ import { Type } from '../../../../util/conversion.js';
 import { onlyConstInputSource, run } from '../expression.js';
 
 import { d } from './af_matrix_matrix_multiplication.cache.js';
-import { abstractFloatBinary } from './binary.js';
+import { abstractFloatBinary, kAbstractFloatMatrixBinaryOpBatchSize } from './binary.js';
 
 export const g = makeTestGroup(AllFeaturesMaxLimitsGPUTest);
 
@@ -40,6 +40,7 @@ Accuracy: Correctly rounded
       [Type.mat(x_cols, x_rows, Type.abstractFloat), Type.mat(y_cols, y_rows, Type.abstractFloat)],
       Type.mat(y_cols, x_rows, Type.abstractFloat),
       t.params,
-      cases
+      cases,
+      kAbstractFloatMatrixBinaryOpBatchSize
     );
   });

--- a/src/webgpu/shader/execution/expression/binary/af_matrix_scalar_multiplication.spec.ts
+++ b/src/webgpu/shader/execution/expression/binary/af_matrix_scalar_multiplication.spec.ts
@@ -8,7 +8,7 @@ import { Type } from '../../../../util/conversion.js';
 import { onlyConstInputSource, run } from '../expression.js';
 
 import { d } from './af_matrix_scalar_multiplication.cache.js';
-import { abstractFloatBinary } from './binary.js';
+import { abstractFloatBinary, kAbstractFloatMatrixBinaryOpBatchSize } from './binary.js';
 
 export const g = makeTestGroup(AllFeaturesMaxLimitsGPUTest);
 
@@ -36,7 +36,8 @@ Accuracy: Correctly rounded
       [Type.mat(cols, rows, Type.abstractFloat), Type.abstractFloat],
       Type.mat(cols, rows, Type.abstractFloat),
       t.params,
-      cases
+      cases,
+      kAbstractFloatMatrixBinaryOpBatchSize
     );
   });
 
@@ -64,6 +65,7 @@ Accuracy: Correctly rounded
       [Type.abstractFloat, Type.mat(cols, rows, Type.abstractFloat)],
       Type.mat(cols, rows, Type.abstractFloat),
       t.params,
-      cases
+      cases,
+      kAbstractFloatMatrixBinaryOpBatchSize
     );
   });

--- a/src/webgpu/shader/execution/expression/binary/af_matrix_subtraction.spec.ts
+++ b/src/webgpu/shader/execution/expression/binary/af_matrix_subtraction.spec.ts
@@ -8,7 +8,7 @@ import { Type } from '../../../../util/conversion.js';
 import { onlyConstInputSource, run } from '../expression.js';
 
 import { d } from './af_matrix_subtraction.cache.js';
-import { abstractFloatBinary } from './binary.js';
+import { abstractFloatBinary, kAbstractFloatMatrixBinaryOpBatchSize } from './binary.js';
 
 export const g = makeTestGroup(AllFeaturesMaxLimitsGPUTest);
 
@@ -36,6 +36,7 @@ Accuracy: Correctly rounded
       [Type.mat(cols, rows, Type.abstractFloat), Type.mat(cols, rows, Type.abstractFloat)],
       Type.mat(cols, rows, Type.abstractFloat),
       t.params,
-      cases
+      cases,
+      kAbstractFloatMatrixBinaryOpBatchSize
     );
   });

--- a/src/webgpu/shader/execution/expression/binary/af_matrix_vector_multiplication.spec.ts
+++ b/src/webgpu/shader/execution/expression/binary/af_matrix_vector_multiplication.spec.ts
@@ -8,7 +8,7 @@ import { Type } from '../../../../util/conversion.js';
 import { onlyConstInputSource, run } from '../expression.js';
 
 import { d } from './af_matrix_vector_multiplication.cache.js';
-import { abstractFloatBinary } from './binary.js';
+import { abstractFloatBinary, kAbstractFloatMatrixBinaryOpBatchSize } from './binary.js';
 
 export const g = makeTestGroup(AllFeaturesMaxLimitsGPUTest);
 
@@ -36,7 +36,8 @@ Accuracy: Correctly rounded
       [Type.mat(cols, rows, Type.abstractFloat), Type.vec(cols, Type.abstractFloat)],
       Type.vec(rows, Type.abstractFloat),
       t.params,
-      cases
+      cases,
+      kAbstractFloatMatrixBinaryOpBatchSize
     );
   });
 
@@ -64,6 +65,7 @@ Accuracy: Correctly rounded
       [Type.vec(rows, Type.abstractFloat), Type.mat(cols, rows, Type.abstractFloat)],
       Type.vec(cols, Type.abstractFloat),
       t.params,
-      cases
+      cases,
+      kAbstractFloatMatrixBinaryOpBatchSize
     );
   });

--- a/src/webgpu/shader/execution/expression/binary/binary.ts
+++ b/src/webgpu/shader/execution/expression/binary/binary.ts
@@ -25,3 +25,6 @@ export function abstractFloatBinary(op: string): ShaderBuilder {
 export function abstractIntBinary(op: string): ShaderBuilder {
   return abstractIntShaderBuilder(values => `(${values.map(v => `(${v})`).join(op)})`);
 }
+
+// See issue #4603 for why using 1 instead of the default
+export const kAbstractFloatMatrixBinaryOpBatchSize = 1;


### PR DESCRIPTION
Fixes: #4603

<hr>

**Requirements for PR author:**

- [ ] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [ ] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [ ] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) are accurate and complete.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Tests avoid [over-parameterization](https://github.com/gpuweb/cts/blob/main/docs/organization.md#parameterization) (see case count report).

When landing this PR, be sure to make any necessary issue status updates.
