### PR TITLE
Test compound assignment order of eval

### DIFF
--- a/src/webgpu/listing_meta.json
+++ b/src/webgpu/listing_meta.json
@@ -2040,6 +2040,7 @@
   "webgpu:shader,execution,stage:basic_compute:*": { "subcaseMS": 1.000 },
   "webgpu:shader,execution,stage:basic_render:*": { "subcaseMS": 1.000 },
   "webgpu:shader,execution,statement,compound:decl:*": { "subcaseMS": 29.767 },
+  "webgpu:shader,execution,statement,compound:eval_order:*": { "subcaseMS": 54.311 },
   "webgpu:shader,execution,statement,discard:all:*": { "subcaseMS": 36.094 },
   "webgpu:shader,execution,statement,discard:continuing:*": { "subcaseMS": 276.268 },
   "webgpu:shader,execution,statement,discard:derivatives:*": { "subcaseMS": 15.287 },


### PR DESCRIPTION
Test that the lhs is evaluated before the rhs in a compound assignment statement.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) are accurate and complete.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Tests avoid [over-parameterization](https://github.com/gpuweb/cts/blob/main/docs/organization.md#parameterization) (see case count report).

When landing this PR, be sure to make any necessary issue status updates.
