### PR TITLE
Test swizzle assignment eval order

### DIFF
--- a/src/webgpu/listing_meta.json
+++ b/src/webgpu/listing_meta.json
@@ -2066,6 +2066,8 @@
   "webgpu:shader,execution,statement,increment_decrement:vec4_element_decrement:*": { "subcaseMS": 5.300 },
   "webgpu:shader,execution,statement,increment_decrement:vec4_element_increment:*": { "subcaseMS": 6.300 },
   "webgpu:shader,execution,statement,phony:executes:*": { "subcaseMS": 129.949 },
+  "webgpu:shader,execution,statement,swizzle_assignment:compound_eval_order:*": { "subcaseMS": 16.651 },
+  "webgpu:shader,execution,statement,swizzle_assignment:eval_order:*": { "subcaseMS": 17.193 },
   "webgpu:shader,execution,statement,swizzle_assignment:swizzle_assignment_vars:*": { "subcaseMS": 1200.970 },
   "webgpu:shader,execution,statement,swizzle_assignment:swizzle_compound_assignment:*": { "subcaseMS": 0.091 },
   "webgpu:shader,execution,value_init:array,nested:*": { "subcaseMS": 3004.523 },

--- a/src/webgpu/shader/execution/statement/swizzle_assignment.spec.ts
+++ b/src/webgpu/shader/execution/statement/swizzle_assignment.spec.ts
@@ -7,6 +7,7 @@ import { keysOf } from '../../../../common/util/data_tables.js';
 import { TypedArrayBufferView } from '../../../../common/util/util.js';
 import { Float16Array } from '../../../../external/petamoriken/float16/float16.js';
 import { AllFeaturesMaxLimitsGPUTest, GPUTest } from '../../../gpu_test.js';
+import { runFlowControlTest } from '../flow_control/harness.js';
 
 export const g = makeTestGroup(AllFeaturesMaxLimitsGPUTest);
 
@@ -419,4 +420,77 @@ fn main() {
   }
 }`;
     runSwizzleAssignmentTest(t, elemType, expected, wgsl);
+  });
+
+g.test('eval_order')
+  .desc(
+    'Tests that the vec pointer on the lhs of a swizzle assignment is evaluated before the rhs, and the load of the lhs vec happens after rhs.'
+  )
+  .fn(t => {
+    t.skipIfLanguageFeatureNotSupported('swizzle_assignment');
+    runFlowControlTest(t, f => ({
+      entrypoint: `
+  arr[0] = vec4u(1, 1, 1, 1);
+  ${f.expect_order(0)}
+  arr[foo()].xy = bar();
+  ${f.expect_order(3)}
+  if (all(arr[0] == vec4u(4, 5, 3, 8))) {
+    ${f.expect_order(4)}
+  } else {
+    ${f.expect_not_reached()}
+  }
+`,
+      extra: `
+var<private> arr : array<vec4u, 1>;
+fn foo() -> u32 {
+  ${f.expect_order(1)}
+  arr[0].x = 6;       // overwritten by swizzle
+  arr[0].z = 7;       // overwritten by bar()
+  arr[0].w = 8;       // persists
+  return 0;
+}
+fn bar() -> vec2u {
+  ${f.expect_order(2)}
+  arr[0].z = 3;       // persists
+  return vec2u(4, 5); // will set x,y
+}
+`,
+    }));
+  });
+
+g.test('compound_eval_order')
+  .desc(
+    'Tests that the lhs of a swizzle compound assignment is evaluated before the rhs, and another load of the lhs vec happens after rhs evaluation, without re-evaluating the pointer to the lhs vec.'
+  )
+  .fn(t => {
+    t.skipIfLanguageFeatureNotSupported('swizzle_assignment');
+    runFlowControlTest(t, f => ({
+      entrypoint: `
+  arr[0] = vec4u(1, 1, 1, 1);
+  ${f.expect_order(0)}
+  arr[foo()].xy += bar();
+  ${f.expect_order(3)}
+  if (all(arr[0] == vec4u(10, 6, 3, 8))) {
+    ${f.expect_order(4)}
+  } else {
+    ${f.expect_not_reached()}
+  }
+`,
+      extra: `
+var<private> arr : array<vec4u, 1>;
+fn foo() -> u32 {
+  ${f.expect_order(1)}
+  arr[0].x = 6;       // modifies x before add
+  arr[0].z = 7;       // overwritten by bar()
+  arr[0].w = 8;       // persists
+  return 0;
+}
+fn bar() -> vec2u {
+  ${f.expect_order(2)}
+  arr[0].x = 2;       // no visible effect
+  arr[0].z = 3;       // persists
+  return vec2u(4, 5); // will add to x,y
+}
+`,
+    }));
   });


### PR DESCRIPTION
Test that the lhs swizzle's vector pointer is evaluated before the rhs. For a regular assignment, the vector value can be loaded after rhs evaluation (because rhs side effects on the target components will be overwritten anyways). However for a compound assignment, the lhs value of the swizzle must be loaded before rhs evaluation, and the vector should be re-loaded after rhs evaluation for use as the "old components" in the store of the whole result vector, because side effects from the rhs on non-swizzled components should persist.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) are accurate and complete.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Tests avoid [over-parameterization](https://github.com/gpuweb/cts/blob/main/docs/organization.md#parameterization) (see case count report).

When landing this PR, be sure to make any necessary issue status updates.
