### PR TITLE
Check for `unrestricted_pointer_parameters` support

### DIFF
--- a/src/webgpu/shader/validation/decl/override.spec.ts
+++ b/src/webgpu/shader/validation/decl/override.spec.ts
@@ -4,6 +4,7 @@ Validation tests for override declarations
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { keysOf } from '../../../../common/util/data_tables.js';
+import { WGSLLanguageFeature } from '../../../capability_info.js';
 import { ShaderValidationTest } from '../shader_validation_test.js';
 
 export const g = makeTestGroup(ShaderValidationTest);
@@ -240,7 +241,9 @@ g.test('function_scope')
     t.expectCompileResult(false, code);
   });
 
-const kArrayCases = {
+const kArrayCases: {
+  [k: string]: { code: string; valid_with_override_size: boolean; feature?: WGSLLanguageFeature };
+} = {
   workgroup_var: {
     code: `var<workgroup> a: array<u32, size>;`,
     valid_with_override_size: true,
@@ -264,6 +267,7 @@ const kArrayCases = {
   workgroup_ptr_param: {
     code: `fn f(a: ptr<workgroup, array<u32, size>>) {}`,
     valid_with_override_size: true,
+    feature: 'unrestricted_pointer_parameters',
   },
   private_ptr_param: {
     code: `fn f(a: ptr<private, array<u32, size>>) {}`,
@@ -298,6 +302,11 @@ g.test('array_size')
   .params(u => u.combine('case', keysOf(kArrayCases)).combine('stage', ['const', 'override']))
   .fn(t => {
     const testcase = kArrayCases[t.params.case];
+
+    if (testcase.feature) {
+      t.skipIfLanguageFeatureNotSupported(testcase.feature);
+    }
+
     const wgsl = `
 ${t.params.stage} size = 1;
 ${testcase.code}


### PR DESCRIPTION
Skip the `workgroup_ptr_param` test case when `unrestricted_pointer_parameters` is not available.

**Requirements for PR author:**

- [ ] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [ ] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [ ] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) are accurate and complete.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Tests avoid [over-parameterization](https://github.com/gpuweb/cts/blob/main/docs/organization.md#parameterization) (see case count report).

When landing this PR, be sure to make any necessary issue status updates.
