### PR TITLE
Update display size scale tests with video frame from video file

### DIFF
--- a/src/webgpu/web_platform/external_texture/video.spec.ts
+++ b/src/webgpu/web_platform/external_texture/video.spec.ts
@@ -7,8 +7,6 @@ Tests for external textures from HTMLVideoElement (and other video-type sources?
 TODO: consider whether external_texture and copyToTexture video tests should be in the same file
 TODO(#3193): Test video in BT.2020 color space
 TODO(#4364): Test camera capture with copyExternalImageToTexture (not necessarily in this file)
-TODO(#4605): Test importExternalTexture with video frame display size different with coded size from
-  a video file
 `;
 
 import { makeTestGroup } from '../../../common/framework/test_group.js';
@@ -33,6 +31,14 @@ import {
 const kHeight = 16;
 const kWidth = 16;
 const kFormat = 'rgba8unorm';
+
+const kDisplayScaleVideoNames = [
+  'four-colors-h264-bt601.mp4',
+  'four-colors-vp9-bt601.webm',
+  'four-colors-vp9-bt709.webm',
+] as const;
+type DisplayScale = 'smaller' | 'same' | 'larger';
+const kDisplayScales: DisplayScale[] = ['smaller', 'same', 'larger'];
 
 export const g = makeTestGroup(TextureUploadingUtils);
 
@@ -164,67 +170,55 @@ function checkNonStandardIsZeroCopyIfAvailable(): { checkNonStandardIsZeroCopy?:
   }
 }
 
-function createVideoFrameWithDisplayScale(
+async function createVideoFrameWithDisplayScale(
   t: GPUTest,
-  displayScale: 'smaller' | 'same' | 'larger'
-): { frame: VideoFrame; displayWidth: number; displayHeight: number } {
-  const canvas = createCanvas(t, 'onscreen', kWidth, kHeight);
-  const canvasContext = canvas.getContext('2d');
+  videoName: (typeof kDisplayScaleVideoNames)[number],
+  displayScale: DisplayScale
+): Promise<VideoFrame> {
+  let sourceFrame: VideoFrame | undefined;
+  let codedWidth: number | undefined;
+  let codedHeight: number | undefined;
 
-  if (canvasContext === null) {
-    t.skip(' onscreen canvas 2d context not available');
+  const videoElement = getVideoElement(t, videoName);
+
+  await startPlayingAndWaitForVideo(videoElement, async () => {
+    const source = await getVideoFrameFromVideoElement(t, videoElement);
+    sourceFrame = source;
+    codedWidth = source.codedWidth;
+    codedHeight = source.codedHeight;
+  });
+
+  if (sourceFrame === undefined || codedWidth === undefined || codedHeight === undefined) {
+    unreachable();
   }
 
-  const ctx = canvasContext;
-
-  const rectWidth = Math.floor(kWidth / 2);
-  const rectHeight = Math.floor(kHeight / 2);
-
-  // Red
-  ctx.fillStyle = `rgba(255, 0, 0, 1.0)`;
-  ctx.fillRect(0, 0, rectWidth, rectHeight);
-  // Lime
-  ctx.fillStyle = `rgba(0, 255, 0, 1.0)`;
-  ctx.fillRect(rectWidth, 0, kWidth - rectWidth, rectHeight);
-  // Blue
-  ctx.fillStyle = `rgba(0, 0, 255, 1.0)`;
-  ctx.fillRect(0, rectHeight, rectWidth, kHeight - rectHeight);
-  // Fuchsia
-  ctx.fillStyle = `rgba(255, 0, 255, 1.0)`;
-  ctx.fillRect(rectWidth, rectHeight, kWidth - rectWidth, kHeight - rectHeight);
-
-  const imageData = ctx.getImageData(0, 0, kWidth, kHeight);
-
-  let displayWidth = kWidth;
-  let displayHeight = kHeight;
+  let displayWidth = codedWidth;
+  let displayHeight = codedHeight;
   switch (displayScale) {
     case 'smaller':
-      displayWidth = Math.floor(kWidth / 2);
-      displayHeight = Math.floor(kHeight / 2);
+      displayWidth = Math.floor(codedWidth / 2);
+      displayHeight = Math.floor(codedHeight / 2);
       break;
     case 'same':
-      displayWidth = kWidth;
-      displayHeight = kHeight;
+      displayWidth = codedWidth;
+      displayHeight = codedHeight;
       break;
     case 'larger':
-      displayWidth = kWidth * 2;
-      displayHeight = kHeight * 2;
+      displayWidth = codedWidth * 2;
+      displayHeight = codedHeight * 2;
       break;
     default:
       unreachable();
   }
 
-  const frameInit: VideoFrameBufferInit = {
-    format: 'RGBA',
-    codedWidth: kWidth,
-    codedHeight: kHeight,
+  const frame = new VideoFrame(sourceFrame, {
     displayWidth,
     displayHeight,
-    timestamp: 0,
-  };
+    timestamp: sourceFrame.timestamp,
+  });
+  sourceFrame.close();
 
-  const frame = new VideoFrame(imageData.data.buffer, frameInit);
-  return { frame, displayWidth, displayHeight };
+  return frame;
 }
 
 g.test('importExternalTexture,sample')
@@ -446,23 +440,29 @@ Tests that we can import an VideoFrame with non-YUV pixel format into a GPUExter
     ]);
   });
 
-g.test('importExternalTexture,video_frame_display_size_diff_with_coded_size')
+g.test('importExternalTexture,video_frame_display_size_scale')
   .desc(
     `
-Tests that we can import a VideoFrame with display size different with its coded size, and
+Tests that we can import a VideoFrame with a display size different from its coded size, and
 sampling works without validation errors.
+
+For the importExternalTexture path with scaled video frame display size, we validate scaling
+using the available codec and color space assets: VP9/H.264 and bt.601/bt.709.
 `
   )
   .params(u =>
     u //
-      .combine('displayScale', ['smaller', 'same', 'larger'] as const)
+      .combine('videoName', kDisplayScaleVideoNames)
+      .combine('displayScale', kDisplayScales)
   )
-  .fn(t => {
+  .fn(async t => {
+    const { videoName, displayScale } = t.params;
+
     if (typeof VideoFrame === 'undefined') {
       t.skip('WebCodec is not supported');
     }
 
-    const { frame } = createVideoFrameWithDisplayScale(t, t.params.displayScale);
+    const frame = await createVideoFrameWithDisplayScale(t, videoName, displayScale);
 
     const colorAttachment = t.createTextureTracked({
       format: kFormat,
@@ -496,11 +496,30 @@ sampling works without validation errors.
     passEncoder.end();
     t.device.queue.submit([commandEncoder.finish()]);
 
+    // Build expected sampled colors by drawing the same source frame to a 2D canvas.
+    // This makes the check robust across codecs/container metadata while still validating
+    // that importExternalTexture sampling matches browser video rendering behavior.
+    const canvas = createCanvas(t, 'onscreen', kWidth, kHeight);
+    const canvasContext = canvas.getContext('2d', { colorSpace: 'srgb' });
+    if (canvasContext === null) {
+      frame.close();
+      t.skip(' onscreen canvas 2d context not available');
+    }
+    const ctx = canvasContext as CanvasRenderingContext2D;
+    ctx.drawImage(frame, 0, 0, kWidth, kHeight);
+    const imageData = ctx.getImageData(0, 0, kWidth, kHeight, { colorSpace: 'srgb' });
+    const bytes = imageData.data;
+    const sample = (x: number, y: number): Uint8Array => {
+      const xi = Math.floor(x);
+      const yi = Math.floor(y);
+      const i = (yi * kWidth + xi) * 4;
+      return new Uint8Array([bytes[i + 0], bytes[i + 1], bytes[i + 2], bytes[i + 3]]);
+    };
     const expected = {
-      topLeft: new Uint8Array([255, 0, 0, 255]),
-      topRight: new Uint8Array([0, 255, 0, 255]),
-      bottomLeft: new Uint8Array([0, 0, 255, 255]),
-      bottomRight: new Uint8Array([255, 0, 255, 255]),
+      topLeft: sample(kWidth * 0.25, kHeight * 0.25),
+      topRight: sample(kWidth * 0.75, kHeight * 0.25),
+      bottomLeft: sample(kWidth * 0.25, kHeight * 0.75),
+      bottomRight: sample(kWidth * 0.75, kHeight * 0.75),
     };
 
     ttu.expectSinglePixelComparisonsAreOkInTexture(t, { texture: colorAttachment }, [
@@ -533,21 +552,24 @@ g.test('importExternalTexture,video_frame_display_size_from_textureDimensions')
   .desc(
     `
 Tests that textureDimensions() for texture_external matches VideoFrame display size.
+
+For the importExternalTexture path with scaled video frame display size, we validate scaling
+using the available codec and color space assets: VP9/H.264 and bt.601/bt.709.
 `
   )
   .params(u =>
     u //
-      .combine('displayScale', ['smaller', 'same', 'larger'] as const)
+      .combine('videoName', kDisplayScaleVideoNames)
+      .combine('displayScale', kDisplayScales)
   )
-  .fn(t => {
+  .fn(async t => {
+    const { videoName, displayScale } = t.params;
+
     if (typeof VideoFrame === 'undefined') {
       t.skip('WebCodec is not supported');
     }
 
-    const { frame, displayWidth, displayHeight } = createVideoFrameWithDisplayScale(
-      t,
-      t.params.displayScale
-    );
+    const frame = await createVideoFrameWithDisplayScale(t, videoName, displayScale);
 
     const externalTexture = t.device.importExternalTexture({
       source: frame,
@@ -594,7 +616,10 @@ Tests that textureDimensions() for texture_external matches VideoFrame display s
     pass.end();
     t.device.queue.submit([encoder.finish()]);
 
-    t.expectGPUBufferValuesEqual(storageBuffer, new Uint32Array([displayWidth, displayHeight]));
+    t.expectGPUBufferValuesEqual(
+      storageBuffer,
+      new Uint32Array([frame.displayWidth, frame.displayHeight])
+    );
 
     frame.close();
   });

--- a/src/webgpu/web_platform/external_texture/video.spec.ts
+++ b/src/webgpu/web_platform/external_texture/video.spec.ts
@@ -234,14 +234,18 @@ async function createVideoFrameWithDisplayScale(
   const codedWidth = sourceFrame.codedWidth;
   const codedHeight = sourceFrame.codedHeight;
 
+  // 'same' means display size == coded size, which sourceFrame already satisfies.
+  // Return it directly instead of re-wrapping via the VideoFrame constructor.
+  if (displayScale === 'same') {
+    return sourceFrame;
+  }
+
   let displayWidth = codedWidth;
   let displayHeight = codedHeight;
   switch (displayScale) {
     case 'smaller':
       displayWidth = Math.floor(codedWidth / 2);
       displayHeight = Math.floor(codedHeight / 2);
-      break;
-    case 'same':
       break;
     case 'larger':
       displayWidth = codedWidth * 2;
@@ -499,8 +503,8 @@ differ from codedWidth/codedHeight, and that sampling produces correct results a
 
 'displayScale' controls the ratio of display size to coded size:
 - 'smaller': displayWidth/Height < codedWidth/Height (e.g., 0.5x). Only achievable by
-  explicitly setting displayWidth/Height via VideoFrame constructor; cannot occur naturally
-  in video container metadata (where SAR >= 1).
+  explicitly setting displayWidth/Height via VideoFrame constructor; rarely occurs naturally in
+  video container metadata, whose SAR is typically >= 1 in the tested assets.
 - 'same': displayWidth/Height == codedWidth/Height (square pixels, no scaling).
 - 'larger': displayWidth/Height > codedWidth/Height (e.g., 2x).
 `
@@ -557,41 +561,60 @@ differ from codedWidth/codedHeight, and that sampling produces correct results a
     passEncoder.end();
     t.device.queue.submit([commandEncoder.finish()]);
 
-    // Build expected sampled colors by drawing the same source frame to a 2D canvas at display size.
-    // This reference ensures importExternalTexture honors display dimensions (not coded dimensions)
-    // and produces results consistent with the browser's standard video rendering path,
-    // making the validation robust across different codecs and container metadata.
-    const canvas = createCanvas(t, 'onscreen', displayWidth, displayHeight);
-    const canvasContext = canvas.getContext('2d', { colorSpace: 'srgb' });
-    if (canvasContext === null) {
-      frame.close();
-      t.skip('onscreen canvas 2d context not available');
+    let expected: {
+      topLeft: Uint8Array;
+      topRight: Uint8Array;
+      bottomLeft: Uint8Array;
+      bottomRight: Uint8Array;
+    };
+    if (displayScale === 'same' && sourceType === 'video') {
+      // At 'same' displayScale there is no scaling, so sample points land on exactly the pixels
+      // 'importExternalTexture,sample' validates; reuse its precomputed kVideoExpectedColors table
+      // as an exact reference. drawImage would instead do its own YUV->RGB conversion that can
+      // disagree with importExternalTexture on real hardware (~0.1/channel), forcing a wide
+      // tolerance, so the fixed table keeps the check tight.
+      const srcColorSpace = kVideoInfo[videoName!].colorSpace;
+      const presentColors = kVideoExpectedColors[srcColorSpace]['srgb'];
+      const expect = kVideoInfo[videoName!].display;
+      expected = {
+        topLeft: convertToUnorm8(presentColors[expect.topLeftColor]),
+        topRight: convertToUnorm8(presentColors[expect.topRightColor]),
+        bottomLeft: convertToUnorm8(presentColors[expect.bottomLeftColor]),
+        bottomRight: convertToUnorm8(presentColors[expect.bottomRightColor]),
+      };
+    } else {
+      // 'smaller'/'larger' scale (any source): the table only has colors for the unscaled 'same'
+      // sample points, so there is no precomputed reference for scaled samples; drawImage at
+      // display size reproduces the browser's resize.
+      // 'canvas' source (any scale): the frame is already RGBA (no YUV), so drawImage is
+      // lossless and matches importExternalTexture exactly. Building the expectation from
+      // drawImage at display size also confirms importExternalTexture honors display (not coded)
+      // dimensions across codecs and container metadata.
+      const canvas = createCanvas(t, 'onscreen', displayWidth, displayHeight);
+      const canvasContext = canvas.getContext('2d', { colorSpace: 'srgb' });
+      if (canvasContext === null) {
+        frame.close();
+        t.skip('onscreen canvas 2d context not available');
+      }
+      const ctx = canvasContext as CanvasRenderingContext2D;
+      ctx.drawImage(frame, 0, 0, displayWidth, displayHeight);
+      const imageData = ctx.getImageData(0, 0, displayWidth, displayHeight, {
+        colorSpace: 'srgb',
+      });
+      const bytes = imageData.data;
+      const sample = (x: number, y: number): Uint8Array => {
+        const xi = Math.floor(x);
+        const yi = Math.floor(y);
+        const i = (yi * displayWidth + xi) * 4;
+        return new Uint8Array([bytes[i + 0], bytes[i + 1], bytes[i + 2], bytes[i + 3]]);
+      };
+      expected = {
+        topLeft: sample(displayWidth * 0.25, displayHeight * 0.25),
+        topRight: sample(displayWidth * 0.75, displayHeight * 0.25),
+        bottomLeft: sample(displayWidth * 0.25, displayHeight * 0.75),
+        bottomRight: sample(displayWidth * 0.75, displayHeight * 0.75),
+      };
     }
-    const ctx = canvasContext as CanvasRenderingContext2D;
-    ctx.drawImage(frame, 0, 0, displayWidth, displayHeight);
-    const imageData = ctx.getImageData(0, 0, displayWidth, displayHeight, { colorSpace: 'srgb' });
-    const bytes = imageData.data;
-    const sample = (x: number, y: number): Uint8Array => {
-      const xi = Math.floor(x);
-      const yi = Math.floor(y);
-      const i = (yi * displayWidth + xi) * 4;
-      return new Uint8Array([bytes[i + 0], bytes[i + 1], bytes[i + 2], bytes[i + 3]]);
-    };
-    const expected = {
-      topLeft: sample(displayWidth * 0.25, displayHeight * 0.25),
-      topRight: sample(displayWidth * 0.75, displayHeight * 0.25),
-      bottomLeft: sample(displayWidth * 0.25, displayHeight * 0.75),
-      bottomRight: sample(displayWidth * 0.75, displayHeight * 0.75),
-    };
-
-    // Tolerance: 'video' actual (importExternalTexture) and expected (2D-canvas drawImage) each do
-    // YUV->RGB conversion independently, so a single channel can diverge by ~0.25 (hardware/decoder
-    // dependent, e.g. green quadrant reads R~0.25 on some Nvidia GPUs). Use maxFractionalDiff 0.3 to
-    // absorb this. The four quadrant colors differ pairwise by >= 1.0 in some channel, so a real
-    // display-scaling bug (wrong quadrant) still gives a ~1.0 diff and is caught. 'canvas' sources
-    // are exact sRGB RGBA (no YUV), so leave undefined to use the tight default.
-    const comparisonOptions =
-      sourceType === 'video' ? { maxFractionalDiff: 0.3 } : undefined;
 
     ttu.expectSinglePixelComparisonsAreOkInTexture(
       t,
@@ -617,8 +640,7 @@ differ from codedWidth/codedHeight, and that sampling produces correct results a
           coord: { x: displayWidth * 0.75, y: displayHeight * 0.75 },
           exp: expected.bottomRight,
         },
-      ],
-      comparisonOptions
+      ]
     );
 
     frame.close();

--- a/src/webgpu/web_platform/external_texture/video.spec.ts
+++ b/src/webgpu/web_platform/external_texture/video.spec.ts
@@ -37,8 +37,11 @@ const kDisplayScaleVideoNames = [
   'four-colors-vp9-bt601.webm',
   'four-colors-vp9-bt709.webm',
 ] as const;
-type DisplayScale = 'smaller' | 'same' | 'larger';
-const kDisplayScales: DisplayScale[] = ['smaller', 'same', 'larger'];
+
+const kDisplaySizeSourceParams = [
+  ...kDisplayScaleVideoNames.map(videoName => ({ sourceType: 'video' as const, videoName })),
+  { sourceType: 'canvas' as const },
+];
 
 export const g = makeTestGroup(TextureUploadingUtils);
 
@@ -170,27 +173,66 @@ function checkNonStandardIsZeroCopyIfAvailable(): { checkNonStandardIsZeroCopy?:
   }
 }
 
+// Creates a VideoFrame and applies display-size scaling relative to coded size.
 async function createVideoFrameWithDisplayScale(
   t: GPUTest,
-  videoName: (typeof kDisplayScaleVideoNames)[number],
-  displayScale: DisplayScale
+  sourceType: 'video' | 'canvas',
+  videoName: (typeof kDisplayScaleVideoNames)[number] | undefined,
+  displayScale: 'smaller' | 'same' | 'larger'
 ): Promise<VideoFrame> {
-  let sourceFrame: VideoFrame | undefined;
-  let codedWidth: number | undefined;
-  let codedHeight: number | undefined;
+  let sourceFrame: VideoFrame;
 
-  const videoElement = getVideoElement(t, videoName);
+  if (sourceType === 'video') {
+    let source: VideoFrame | undefined;
 
-  await startPlayingAndWaitForVideo(videoElement, async () => {
-    const source = await getVideoFrameFromVideoElement(t, videoElement);
+    if (videoName === undefined) {
+      t.skip('videoName is required when sourceType is video');
+    }
+
+    const videoElement = getVideoElement(t, videoName);
+
+    await startPlayingAndWaitForVideo(videoElement, async () => {
+      source = await getVideoFrameFromVideoElement(t, videoElement);
+    });
+
+    if (source === undefined) {
+      t.skip(`Failed to get video frame for ${videoName}`);
+    }
+
     sourceFrame = source;
-    codedWidth = source.codedWidth;
-    codedHeight = source.codedHeight;
-  });
+  } else {
+    const canvasWidth = 320;
+    const canvasHeight = 240;
+    const canvas = createCanvas(t, 'onscreen', canvasWidth, canvasHeight);
+    const canvasContext = canvas.getContext('2d');
+    if (canvasContext === null) {
+      t.skip('onscreen canvas 2d context not available');
+    }
 
-  if (sourceFrame === undefined || codedWidth === undefined || codedHeight === undefined) {
-    unreachable();
+    const ctx = canvasContext;
+    const rectWidth = Math.floor(canvasWidth / 2);
+    const rectHeight = Math.floor(canvasHeight / 2);
+
+    ctx.fillStyle = `rgba(255, 0, 0, 1.0)`;
+    ctx.fillRect(0, 0, rectWidth, rectHeight);
+    ctx.fillStyle = `rgba(0, 255, 0, 1.0)`;
+    ctx.fillRect(rectWidth, 0, canvasWidth - rectWidth, rectHeight);
+    ctx.fillStyle = `rgba(0, 0, 255, 1.0)`;
+    ctx.fillRect(0, rectHeight, rectWidth, canvasHeight - rectHeight);
+    ctx.fillStyle = `rgba(255, 0, 255, 1.0)`;
+    ctx.fillRect(rectWidth, rectHeight, canvasWidth - rectWidth, canvasHeight - rectHeight);
+
+    const imageData = ctx.getImageData(0, 0, canvasWidth, canvasHeight);
+    sourceFrame = new VideoFrame(imageData.data.buffer, {
+      format: 'RGBA',
+      codedWidth: canvasWidth,
+      codedHeight: canvasHeight,
+      timestamp: 0,
+    });
   }
+
+  const codedWidth = sourceFrame.codedWidth;
+  const codedHeight = sourceFrame.codedHeight;
 
   let displayWidth = codedWidth;
   let displayHeight = codedHeight;
@@ -200,8 +242,6 @@ async function createVideoFrameWithDisplayScale(
       displayHeight = Math.floor(codedHeight / 2);
       break;
     case 'same':
-      displayWidth = codedWidth;
-      displayHeight = codedHeight;
       break;
     case 'larger':
       displayWidth = codedWidth * 2;
@@ -443,30 +483,51 @@ Tests that we can import an VideoFrame with non-YUV pixel format into a GPUExter
 g.test('importExternalTexture,video_frame_display_size_scale')
   .desc(
     `
-Tests that we can import a VideoFrame with a display size different from its coded size, and
-sampling works without validation errors.
+Tests that importExternalTexture correctly handles VideoFrames where displayWidth/displayHeight
+differ from codedWidth/codedHeight, and that sampling produces correct results at display dimensions.
 
-For the importExternalTexture path with scaled video frame display size, we validate scaling
-using the available codec and color space assets: VP9/H.264 and bt.601/bt.709.
+'sourceType' controls the VideoFrame backing storage type:
+- 'video': VideoFrame obtained from decoded video file via HTMLVideoElement. The frame is
+  typically GPU-backed (SharedImage), and may use the 0-copy import path if GPU supports it,
+  or fall back to 1-copy path. Tests multiple video codecs (H.264, VP9) and color spaces
+  (bt.601, bt.709) to ensure display scaling works across real-world video formats.
+
+- 'canvas': VideoFrame created from RGBA buffer data via canvas ImageData. The frame is
+  CPU-backed (no SharedImage) and always uses the 1-copy import path. This is the regression
+  test for crbug.com/471021591 where the 1-copy path incorrectly used visibleRect dimensions
+  instead of displayWidth/Height for the imported texture.
+
+'displayScale' controls the ratio of display size to coded size:
+- 'smaller': displayWidth/Height < codedWidth/Height (e.g., 0.5x). Only achievable by
+  explicitly setting displayWidth/Height via VideoFrame constructor; cannot occur naturally
+  in video container metadata (where SAR >= 1).
+- 'same': displayWidth/Height == codedWidth/Height (square pixels, no scaling).
+- 'larger': displayWidth/Height > codedWidth/Height (e.g., 2x).
 `
   )
   .params(u =>
     u //
-      .combine('videoName', kDisplayScaleVideoNames)
-      .combine('displayScale', kDisplayScales)
+      .combineWithParams(kDisplaySizeSourceParams)
+      .combine('displayScale', ['smaller', 'same', 'larger'] as const)
   )
   .fn(async t => {
-    const { videoName, displayScale } = t.params;
+    const { sourceType, displayScale } = t.params;
+    const videoName =
+      'videoName' in t.params
+        ? (t.params.videoName as (typeof kDisplayScaleVideoNames)[number])
+        : undefined;
 
     if (typeof VideoFrame === 'undefined') {
       t.skip('WebCodec is not supported');
     }
 
-    const frame = await createVideoFrameWithDisplayScale(t, videoName, displayScale);
+    const frame = await createVideoFrameWithDisplayScale(t, sourceType, videoName, displayScale);
+    const displayWidth = frame.displayWidth;
+    const displayHeight = frame.displayHeight;
 
     const colorAttachment = t.createTextureTracked({
       format: kFormat,
-      size: { width: kWidth, height: kHeight, depthOrArrayLayers: 1 },
+      size: { width: displayWidth, height: displayHeight, depthOrArrayLayers: 1 },
       usage: GPUTextureUsage.COPY_SRC | GPUTextureUsage.RENDER_ATTACHMENT,
     });
 
@@ -496,54 +557,69 @@ using the available codec and color space assets: VP9/H.264 and bt.601/bt.709.
     passEncoder.end();
     t.device.queue.submit([commandEncoder.finish()]);
 
-    // Build expected sampled colors by drawing the same source frame to a 2D canvas.
-    // This makes the check robust across codecs/container metadata while still validating
-    // that importExternalTexture sampling matches browser video rendering behavior.
-    const canvas = createCanvas(t, 'onscreen', kWidth, kHeight);
+    // Build expected sampled colors by drawing the same source frame to a 2D canvas at display size.
+    // This reference ensures importExternalTexture honors display dimensions (not coded dimensions)
+    // and produces results consistent with the browser's standard video rendering path,
+    // making the validation robust across different codecs and container metadata.
+    const canvas = createCanvas(t, 'onscreen', displayWidth, displayHeight);
     const canvasContext = canvas.getContext('2d', { colorSpace: 'srgb' });
     if (canvasContext === null) {
       frame.close();
-      t.skip(' onscreen canvas 2d context not available');
+      t.skip('onscreen canvas 2d context not available');
     }
     const ctx = canvasContext as CanvasRenderingContext2D;
-    ctx.drawImage(frame, 0, 0, kWidth, kHeight);
-    const imageData = ctx.getImageData(0, 0, kWidth, kHeight, { colorSpace: 'srgb' });
+    ctx.drawImage(frame, 0, 0, displayWidth, displayHeight);
+    const imageData = ctx.getImageData(0, 0, displayWidth, displayHeight, { colorSpace: 'srgb' });
     const bytes = imageData.data;
     const sample = (x: number, y: number): Uint8Array => {
       const xi = Math.floor(x);
       const yi = Math.floor(y);
-      const i = (yi * kWidth + xi) * 4;
+      const i = (yi * displayWidth + xi) * 4;
       return new Uint8Array([bytes[i + 0], bytes[i + 1], bytes[i + 2], bytes[i + 3]]);
     };
     const expected = {
-      topLeft: sample(kWidth * 0.25, kHeight * 0.25),
-      topRight: sample(kWidth * 0.75, kHeight * 0.25),
-      bottomLeft: sample(kWidth * 0.25, kHeight * 0.75),
-      bottomRight: sample(kWidth * 0.75, kHeight * 0.75),
+      topLeft: sample(displayWidth * 0.25, displayHeight * 0.25),
+      topRight: sample(displayWidth * 0.75, displayHeight * 0.25),
+      bottomLeft: sample(displayWidth * 0.25, displayHeight * 0.75),
+      bottomRight: sample(displayWidth * 0.75, displayHeight * 0.75),
     };
 
-    ttu.expectSinglePixelComparisonsAreOkInTexture(t, { texture: colorAttachment }, [
-      // Top-left.
-      {
-        coord: { x: kWidth * 0.25, y: kHeight * 0.25 },
-        exp: expected.topLeft,
-      },
-      // Top-right.
-      {
-        coord: { x: kWidth * 0.75, y: kHeight * 0.25 },
-        exp: expected.topRight,
-      },
-      // Bottom-left.
-      {
-        coord: { x: kWidth * 0.25, y: kHeight * 0.75 },
-        exp: expected.bottomLeft,
-      },
-      // Bottom-right.
-      {
-        coord: { x: kWidth * 0.75, y: kHeight * 0.75 },
-        exp: expected.bottomRight,
-      },
-    ]);
+    // Tolerance: 'video' actual (importExternalTexture) and expected (2D-canvas drawImage) each do
+    // YUV->RGB conversion independently, so a single channel can diverge by ~0.25 (hardware/decoder
+    // dependent, e.g. green quadrant reads R~0.25 on some Nvidia GPUs). Use maxFractionalDiff 0.3 to
+    // absorb this. The four quadrant colors differ pairwise by >= 1.0 in some channel, so a real
+    // display-scaling bug (wrong quadrant) still gives a ~1.0 diff and is caught. 'canvas' sources
+    // are exact sRGB RGBA (no YUV), so leave undefined to use the tight default.
+    const comparisonOptions =
+      sourceType === 'video' ? { maxFractionalDiff: 0.3 } : undefined;
+
+    ttu.expectSinglePixelComparisonsAreOkInTexture(
+      t,
+      { texture: colorAttachment },
+      [
+        // Top-left.
+        {
+          coord: { x: displayWidth * 0.25, y: displayHeight * 0.25 },
+          exp: expected.topLeft,
+        },
+        // Top-right.
+        {
+          coord: { x: displayWidth * 0.75, y: displayHeight * 0.25 },
+          exp: expected.topRight,
+        },
+        // Bottom-left.
+        {
+          coord: { x: displayWidth * 0.25, y: displayHeight * 0.75 },
+          exp: expected.bottomLeft,
+        },
+        // Bottom-right.
+        {
+          coord: { x: displayWidth * 0.75, y: displayHeight * 0.75 },
+          exp: expected.bottomRight,
+        },
+      ],
+      comparisonOptions
+    );
 
     frame.close();
   });
@@ -551,25 +627,36 @@ using the available codec and color space assets: VP9/H.264 and bt.601/bt.709.
 g.test('importExternalTexture,video_frame_display_size_from_textureDimensions')
   .desc(
     `
-Tests that textureDimensions() for texture_external matches VideoFrame display size.
+Tests that textureDimensions() builtin on texture_external returns the VideoFrame's display
+dimensions (displayWidth/displayHeight), not its coded dimensions (codedWidth/codedHeight).
 
-For the importExternalTexture path with scaled video frame display size, we validate scaling
-using the available codec and color space assets: VP9/H.264 and bt.601/bt.709.
+This is critical for shaders that need to compute texture coordinates or sample offsets,
+as they must use the presentation size that matches what textureSampleBaseClampToEdge and
+textureLoad operate on.
+
+Validates using:
+- VideoFrames with various display scales: smaller (0.5x), same (1x), larger (2x)
+- Multiple sources: decoded video files (H.264, VP9) and buffer-backed VideoFrames
+- Different video color spaces: bt.601, bt.709
 `
   )
   .params(u =>
     u //
-      .combine('videoName', kDisplayScaleVideoNames)
-      .combine('displayScale', kDisplayScales)
+      .combineWithParams(kDisplaySizeSourceParams)
+      .combine('displayScale', ['smaller', 'same', 'larger'] as const)
   )
   .fn(async t => {
-    const { videoName, displayScale } = t.params;
+    const { sourceType, displayScale } = t.params;
+    const videoName =
+      'videoName' in t.params
+        ? (t.params.videoName as (typeof kDisplayScaleVideoNames)[number])
+        : undefined;
 
     if (typeof VideoFrame === 'undefined') {
       t.skip('WebCodec is not supported');
     }
 
-    const frame = await createVideoFrameWithDisplayScale(t, videoName, displayScale);
+    const frame = await createVideoFrameWithDisplayScale(t, sourceType, videoName, displayScale);
 
     const externalTexture = t.device.importExternalTexture({
       source: frame,


### PR DESCRIPTION
For display‑size scale tests, a VideoFrame created from a video file is the right source to validate importExternalTexture because it exercises the real decode, color conversion, and display‑size metadata path. A canvas ImageData frame bypasses the video decode path, so it’s removed.

Added a focused video list to validate scaling across codec and color‑space variation, covering both codecs (VP9, H.264) and both color spaces (bt.601, bt.709).

Issue: #4605


<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) are accurate and complete.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Tests avoid [over-parameterization](https://github.com/gpuweb/cts/blob/main/docs/organization.md#parameterization) (see case count report).

When landing this PR, be sure to make any necessary issue status updates.
