### PR TITLE
Test truncation of subnormals

### DIFF
--- a/src/webgpu/listing_meta.json
+++ b/src/webgpu/listing_meta.json
@@ -1780,6 +1780,7 @@
   "webgpu:shader,execution,expression,call,builtin,trunc:abstract_float:*": { "subcaseMS": 12197.517 },
   "webgpu:shader,execution,expression,call,builtin,trunc:f16:*": { "subcaseMS": 120.204 },
   "webgpu:shader,execution,expression,call,builtin,trunc:f32:*": { "subcaseMS": 48.544 },
+  "webgpu:shader,execution,expression,call,builtin,trunc:subnormal_division:*": { "subcaseMS": 103.258 },
   "webgpu:shader,execution,expression,call,builtin,unpack2x16float:unpack:*": { "subcaseMS": 11.651 },
   "webgpu:shader,execution,expression,call,builtin,unpack2x16snorm:unpack:*": { "subcaseMS": 9.275 },
   "webgpu:shader,execution,expression,call,builtin,unpack2x16unorm:unpack:*": { "subcaseMS": 8.701 },

--- a/src/webgpu/shader/execution/expression/call/builtin/trunc.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/trunc.spec.ts
@@ -10,8 +10,15 @@ Component-wise when T is a vector.
 
 import { makeTestGroup } from '../../../../../../common/framework/test_group.js';
 import { AllFeaturesMaxLimitsGPUTest } from '../../../../../gpu_test.js';
-import { Type } from '../../../../../util/conversion.js';
-import { allInputSources, onlyConstInputSource, run } from '../../expression.js';
+import { kValue } from '../../../../../util/constants.js';
+import { Type, f32, f16 } from '../../../../../util/conversion.js';
+import { FP } from '../../../../../util/floating_point.js';
+import {
+  allInputSources,
+  onlyConstInputSource,
+  run,
+  basicExpressionBuilder,
+} from '../../expression.js';
 
 import { abstractFloatBuiltin, builtin } from './builtin.js';
 import { d } from './trunc.cache.js';
@@ -59,4 +66,40 @@ g.test('f16')
     t.skipIfDeviceDoesNotHaveFeature('shader-f16');
     const cases = await d.get('f16');
     await run(t, builtin('trunc'), [Type.f16], Type.f16, t.params, cases);
+  });
+
+g.test('subnormal_division')
+  .specURL('https://www.w3.org/TR/WGSL/#float-builtin-functions')
+  .desc(`truncate subnormals made even smaller to zero`)
+  .params(u => u.combine('inputSource', allInputSources).combine('type', ['f32', 'f16'] as const))
+  .fn(async t => {
+    const type = t.params.type;
+    if (type === 'f16') {
+      t.skipIfDeviceDoesNotHaveFeature('shader-f16');
+    }
+
+    const trait = FP[type as 'f32' | 'f16'];
+    const scalarBuilder = type === 'f32' ? f32 : f16;
+    const constant = kValue[type as 'f32' | 'f16'];
+    const cases = [
+      // Smallest subnormals (closest to zero)
+      {
+        input: [scalarBuilder(constant.negative.subnormal.max)],
+        expected: trait.toInterval(constant.negative.zero),
+      },
+      {
+        input: [scalarBuilder(constant.positive.subnormal.min)],
+        expected: trait.toInterval(constant.positive.zero),
+      },
+    ];
+
+    await run(
+      t,
+      // Divided by 10.0 to make subnormal even smaller and unrepresentable as subnormal, should truncate to zero
+      basicExpressionBuilder(values => `trunc(${values[0]} / 10.0)`),
+      [Type[type as 'f32' | 'f16']],
+      Type[type as 'f32' | 'f16'],
+      t.params,
+      cases
+    );
   });


### PR DESCRIPTION
Add a test that specifically captures the result of trunc() on a subnormal value which has been operated on to make it even smaller and no longer representable as subnormal. Whether the result of that operation is flushed to zero or not, the result of trunc() should still be zero.

Before https://dawn-review.googlesource.com/c/dawn/+/302655 was landed in Tint, this CTS test would fail on a Windows 11 device with an Intel driver (the result would be 1.0). Now it should pass on all known devices.

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) are accurate and complete.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Tests avoid [over-parameterization](https://github.com/gpuweb/cts/blob/main/docs/organization.md#parameterization) (see case count report).

When landing this PR, be sure to make any necessary issue status updates.
