### PR TITLE
Test uninitialized queries in unsubmitted command buffers

### DIFF
--- a/src/webgpu/api/operation/command_buffer/queries/occlusionQuery.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/queries/occlusionQuery.spec.ts
@@ -520,6 +520,49 @@ g.test('occlusion_query,initial')
     );
   });
 
+g.test('occlusion_query,unsubmitted_render_pass')
+  .desc(
+    `
+Test getting contents of QuerySet without any queries with an unsubmitted render pass that uses them.
+This is a regression test for a bug in Dawn where encoding the pass marked the slots as ok to read
+when they should not have been marked as okay to read until the command buffer was submitted.
+`
+  )
+  .fn(async t => {
+    const kNumQueries = kMaxQueryCount;
+    const resources = t.setup({ numQueries: kNumQueries });
+
+    // Encode a render pass that uses the QuerySet but don't submit it.
+    {
+      const encoder = t.device.createCommandEncoder();
+      const pass = encoder.beginRenderPass({
+        colorAttachments: [
+          {
+            view: resources.renderTargetTexture.createView(),
+            loadOp: 'clear',
+            storeOp: 'store',
+          },
+        ],
+        occlusionQuerySet: resources.occlusionQuerySet,
+      });
+      for (let i = 0; i < resources.occlusionQuerySet.count; i += 2) {
+        pass.beginOcclusionQuery(i);
+        pass.endOcclusionQuery();
+      }
+      pass.end();
+      encoder.finish();
+    }
+
+    await t.runQueryTest(
+      resources,
+      null,
+      () => {},
+      (passed: boolean) => {
+        t.expect(!passed);
+      }
+    );
+  });
+
 g.test('occlusion_query,basic')
   .desc('Test all queries pass')
   .params(kQueryTestBaseParams)

--- a/src/webgpu/api/operation/command_buffer/queries/timestampQuery.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/queries/timestampQuery.spec.ts
@@ -8,10 +8,12 @@ there is not much we can test except that there are no errors.
   - compute pass
   - render pass
   - 64k query objects
+  - resolving unused slots
 `;
 
 import { makeTestGroup } from '../../../../../common/framework/test_group.js';
-import { AllFeaturesMaxLimitsGPUTest } from '../../../../gpu_test.js';
+import { range } from '../../../../../common/util/util.js';
+import { AllFeaturesMaxLimitsGPUTest, GPUTest } from '../../../../gpu_test.js';
 
 export const g = makeTestGroup(AllFeaturesMaxLimitsGPUTest);
 
@@ -95,6 +97,63 @@ and prevent pages from running.
     }
   });
 
+function encoderQueryUsage(
+  t: GPUTest,
+  stage: 'compute' | 'render',
+  numQuerySets: number,
+  numSlots: number
+) {
+  const encoder = t.device.createCommandEncoder();
+
+  const view = t
+    .createTextureTracked({
+      size: [1, 1, 1],
+      format: 'rgba8unorm',
+      usage: GPUTextureUsage.RENDER_ATTACHMENT,
+    })
+    .createView();
+
+  const querySets = range(numQuerySets, _ => {
+    const querySet = t.createQuerySetTracked({
+      type: 'timestamp',
+      count: numSlots,
+    });
+
+    switch (stage) {
+      case 'compute': {
+        for (let slot = 0; slot < numSlots; slot += 2) {
+          const pass = encoder.beginComputePass({
+            timestampWrites: {
+              querySet,
+              beginningOfPassWriteIndex: slot,
+              endOfPassWriteIndex: slot + 1,
+            },
+          });
+          pass.end();
+        }
+        break;
+      }
+      case 'render': {
+        for (let slot = 0; slot < numSlots; slot += 2) {
+          const pass = encoder.beginRenderPass({
+            colorAttachments: [{ view, loadOp: 'load', storeOp: 'store' }],
+            timestampWrites: {
+              querySet,
+              beginningOfPassWriteIndex: slot,
+              endOfPassWriteIndex: slot + 1,
+            },
+          });
+          pass.end();
+        }
+        break;
+      }
+    }
+
+    return querySet;
+  });
+  return { encoder, querySets };
+}
+
 g.test('many_slots')
   .desc(
     `
@@ -112,52 +171,50 @@ So, test we can use 4k slots across a few QuerySets
     const kNumSlots = 4096;
     const kNumQuerySets = 4;
 
-    const view = t
-      .createTextureTracked({
-        size: [1, 1, 1],
-        format: 'rgba8unorm',
-        usage: GPUTextureUsage.RENDER_ATTACHMENT,
-      })
-      .createView();
-    const encoder = t.device.createCommandEncoder();
-
-    for (let i = 0; i < kNumQuerySets; ++i) {
-      const querySet = t.createQuerySetTracked({
-        type: 'timestamp',
-        count: kNumSlots,
-      });
-
-      switch (stage) {
-        case 'compute': {
-          for (let slot = 0; slot < kNumSlots; slot += 2) {
-            const pass = encoder.beginComputePass({
-              timestampWrites: {
-                querySet,
-                beginningOfPassWriteIndex: slot,
-                endOfPassWriteIndex: slot + 1,
-              },
-            });
-            pass.end();
-          }
-          break;
-        }
-        case 'render': {
-          for (let slot = 0; slot < kNumSlots; slot += 2) {
-            const pass = encoder.beginRenderPass({
-              colorAttachments: [{ view, loadOp: 'load', storeOp: 'store' }],
-              timestampWrites: {
-                querySet,
-                beginningOfPassWriteIndex: slot,
-                endOfPassWriteIndex: slot + 1,
-              },
-            });
-            pass.end();
-          }
-          break;
-        }
-      }
-    }
-
+    const { encoder } = encoderQueryUsage(t, stage, kNumQuerySets, kNumSlots);
     const shouldError = false; // just expect no error
     t.expectValidationError(() => t.device.queue.submit([encoder.finish()]), shouldError);
+  });
+
+g.test('resolve_unused_slots')
+  .desc(
+    `
+Test resolving query sets with unused slots.
+
+We create a command buffer that uses the slots but don't actually submit it
+to make sure the implementation doesn't mistakenly mark them as used.
+    `
+  )
+  .params(u => u.combine('stage', ['compute', 'render'] as const))
+  .fn(t => {
+    const { stage } = t.params;
+
+    t.skipIfDeviceDoesNotHaveFeature('timestamp-query');
+
+    const kNumSlots = 4096;
+    const kNumQuerySets = 2;
+
+    // Create a encoder and encode usage of every query and slot but do not submit it.
+    const querySets = (() => {
+      const { encoder, querySets } = encoderQueryUsage(t, stage, kNumQuerySets, kNumSlots);
+      encoder.finish();
+      return querySets;
+    })();
+
+    // Read the slots, they should all be zero.
+    const encoder = t.device.createCommandEncoder();
+    const buffers = querySets.map((querySet, i) => {
+      const resolveBuffer = t.createBufferTracked({
+        size: kNumSlots * 8,
+        usage: GPUBufferUsage.COPY_SRC | GPUBufferUsage.QUERY_RESOLVE,
+      });
+      encoder.resolveQuerySet(querySet, 0, kNumSlots, resolveBuffer, 0);
+      return resolveBuffer;
+    });
+    t.device.queue.submit([encoder.finish()]);
+
+    for (const buffer of buffers) {
+      const expected = new Uint8Array(buffer.size);
+      t.expectGPUBufferValuesEqual(buffer, expected);
+    }
   });

--- a/src/webgpu/api/operation/command_buffer/queries/timestampQuery.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/queries/timestampQuery.spec.ts
@@ -172,8 +172,7 @@ So, test we can use 4k slots across a few QuerySets
     const kNumQuerySets = 4;
 
     const { encoder } = encoderQueryUsage(t, stage, kNumQuerySets, kNumSlots);
-    const shouldError = false; // just expect no error
-    t.expectValidationError(() => t.device.queue.submit([encoder.finish()]), shouldError);
+    t.device.queue.submit([encoder.finish()]);
   });
 
 g.test('resolve_unused_slots')


### PR DESCRIPTION
Query slots that have never been used at required to resolve to zero. Some implementations might wrongly mark them as used at encoding time instead of submit time.

These pass on some implementations but it could be by luck of the just happen to be zero

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [X] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) are accurate and complete.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Tests avoid [over-parameterization](https://github.com/gpuweb/cts/blob/main/docs/organization.md#parameterization) (see case count report).

When landing this PR, be sure to make any necessary issue status updates.
