### PR TITLE
Change subcases to cases in api,validation,buffer,create:limit

### DIFF
--- a/src/webgpu/api/validation/buffer/create.spec.ts
+++ b/src/webgpu/api/validation/buffer/create.spec.ts
@@ -44,7 +44,8 @@ g.test('size')
 
 g.test('limit')
   .desc('Test buffer size is validated against maxBufferSize.')
-  .params(u => u.beginSubcases().combine('sizeAddition', [-1, 0, +1]))
+  // Note: Avoid using subcases here so we don't allocate the buffers for multiple subcases at once.
+  .params(u => u.combine('sizeAddition', [-1, 0, +1]))
   .fn(t => {
     const { sizeAddition } = t.params;
     const size = t.makeLimitVariant('maxBufferSize', { mult: 1, add: sizeAddition });


### PR DESCRIPTION
See comment

Issue: fixes #4627

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) are accurate and complete.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Tests avoid [over-parameterization](https://github.com/gpuweb/cts/blob/main/docs/organization.md#parameterization) (see case count report).

When landing this PR, be sure to make any necessary issue status updates.
