### PR TITLE
Add vec function var uniformity cases

### DIFF
--- a/src/webgpu/shader/validation/uniformity/uniformity.spec.ts
+++ b/src/webgpu/shader/validation/uniformity/uniformity.spec.ts
@@ -3,6 +3,7 @@ export const description = `Validation tests for uniformity analysis`;
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { keysOf } from '../../../../common/util/data_tables.js';
 import { unreachable } from '../../../../common/util/util.js';
+import { WGSLLanguageFeature } from '../../../capability_info.js';
 import { ShaderValidationTest } from '../shader_validation_test.js';
 
 import { Snippet, LoopCase, compileShouldSucceed } from './snippet.js';
@@ -1333,7 +1334,16 @@ function expectedUniformity(uniform: string, init: string): boolean {
   return false;
 }
 
-const kFuncVarCases = {
+interface FuncVarCase {
+  typename: string;
+  typedecl: string;
+  assignment: string;
+  cond: string;
+  uniform: string;
+  requires?: WGSLLanguageFeature;
+}
+
+const kFuncVarCases: Record<string, FuncVarCase> = {
   no_assign: {
     typename: `u32`,
     typedecl: ``,
@@ -2146,6 +2156,124 @@ const kFuncVarCases = {
     cond: `x.x > 0`,
     uniform: `never`,
   },
+  full_assignment_vec_uniform: {
+    typename: `vec3u`,
+    typedecl: ``,
+    assignment: `x = uniform_value[0];`,
+    cond: `x.x > 0`,
+    uniform: `always`,
+  },
+  full_assignment_vec_nonuniform: {
+    typename: `vec3u`,
+    typedecl: ``,
+    assignment: `x = nonuniform_value[0];`,
+    cond: `x.x > 0`,
+    uniform: `never`,
+  },
+  partial_assignment_vec_uniform: {
+    typename: `vec3u`,
+    typedecl: ``,
+    assignment: `x.x = uniform_value[0].x;`,
+    cond: `x.x > 0`,
+    uniform: `init`,
+  },
+  partial_assignment_vec_nonuniform: {
+    typename: `vec3u`,
+    typedecl: ``,
+    assignment: `x.x = nonuniform_value[0].x;`,
+    cond: `x.x > 0`,
+    uniform: `never`,
+  },
+  partial_assignment_vec_all_components_uniform: {
+    typename: `vec3u`,
+    typedecl: ``,
+    assignment: `x.x = uniform_value[0].x;
+    x.y = uniform_value[0].y;
+    x.z = uniform_value[0].z;`,
+    cond: `x.x > 0`,
+    uniform: `init`,
+  },
+  partial_assignment_vec_all_components_nonuniform: {
+    typename: `vec3u`,
+    typedecl: ``,
+    assignment: `x.x = nonuniform_value[0].x;
+    x.y = uniform_value[0].y;
+    x.z = uniform_value[0].z;`,
+    cond: `x.x > 0`,
+    uniform: `never`,
+  },
+  full_swizzle_assignment_uniform: {
+    requires: 'swizzle_assignment',
+    typename: `vec3u`,
+    typedecl: ``,
+    assignment: `x.xyz = uniform_value[0].xyz;`,
+    cond: `x.x > 0`,
+    uniform: `always`,
+  },
+  full_swizzle_assignment_nonuniform: {
+    typename: `vec3u`,
+    typedecl: ``,
+    assignment: `x.xyz = nonuniform_value[0].xyz;`,
+    cond: `x.x > 0`,
+    uniform: `never`,
+    requires: 'swizzle_assignment',
+  },
+  full_swizzle_assignment_permutation_uniform: {
+    requires: 'swizzle_assignment',
+    typename: `vec3u`,
+    typedecl: ``,
+    assignment: `x.zyx = uniform_value[0].xyz;`,
+    cond: `x.x > 0`,
+    uniform: `always`,
+  },
+  full_swizzle_assignment_permutation_nonuniform: {
+    requires: 'swizzle_assignment',
+    typename: `vec3u`,
+    typedecl: ``,
+    assignment: `x.zyx = nonuniform_value[0].xyz;`,
+    cond: `x.x > 0`,
+    uniform: `never`,
+  },
+  partial_swizzle_assignment_uniform: {
+    requires: 'swizzle_assignment',
+    typename: `vec3u`,
+    typedecl: ``,
+    assignment: `x.xy = uniform_value[0].xy;`,
+    cond: `x.x > 0`,
+    uniform: `init`,
+  },
+  partial_swizzle_assignment_nonuniform: {
+    requires: 'swizzle_assignment',
+    typename: `vec3u`,
+    typedecl: ``,
+    assignment: `x.xy = nonuniform_value[0].xy;`,
+    cond: `x.x > 0`,
+    uniform: `never`,
+  },
+  chained_full_swizzle_assignment_uniform: {
+    requires: 'swizzle_assignment',
+    typename: `vec3u`,
+    typedecl: ``,
+    assignment: `x.xyz.zyx = uniform_value[0].xyz;`,
+    cond: `x.x > 0`,
+    uniform: `always`,
+  },
+  chained_partial_swizzle_assignment_uniform: {
+    requires: 'swizzle_assignment',
+    typename: `vec3u`,
+    typedecl: ``,
+    assignment: `x.xyz.xy = uniform_value[0].xy;`,
+    cond: `x.x > 0`,
+    uniform: `init`,
+  },
+  chained_full_swizzle_assignment_nonuniform: {
+    requires: 'swizzle_assignment',
+    typename: `vec3u`,
+    typedecl: ``,
+    assignment: `x.xyz.zyx = nonuniform_value[0].xyz;`,
+    cond: `x.x > 0`,
+    uniform: `never`,
+  },
 };
 
 const kVarInit = {
@@ -2159,6 +2287,9 @@ g.test('function_variables')
   .params(u => u.combine('case', keysOf(kFuncVarCases)).combine('init', keysOf(kVarInit)))
   .fn(t => {
     const func_case = kFuncVarCases[t.params.case];
+    if (func_case.requires) {
+      t.skipIfLanguageFeatureNotSupported(func_case.requires);
+    }
     const code = `
 ${func_case.typedecl}
 


### PR DESCRIPTION
Add cases to the uniformity tests for vector function variables, including cases to test the uniformity rules for swizzle assignment as specified in: https://github.com/gpuweb/gpuweb/pull/5268

All tests pass in Tint following this fix:
https://dawn-review.googlesource.com/c/dawn/+/304176

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) are accurate and complete.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Tests avoid [over-parameterization](https://github.com/gpuweb/cts/blob/main/docs/organization.md#parameterization) (see case count report).

When landing this PR, be sure to make any necessary issue status updates.
