### PR TITLE
Correct MAINTENANCE_TODO about TRANSIENT_ATTACHMENT

### DIFF
--- a/src/webgpu/api/operation/render_pass/resolve.spec.ts
+++ b/src/webgpu/api/operation/render_pass/resolve.spec.ts
@@ -59,7 +59,7 @@ Test basic render pass resolve behavior for combinations of:
     const { colorFormat } = t.params;
     t.skipIfTextureFormatNotSupported(colorFormat);
     t.skipIfTextureFormatNotResolvable(colorFormat);
-    // MAINTENANCE_TODO(#4509): Remove this when TRANSIENT_ATTACHMENT is added to the WebGPU spec.
+    // MAINTENANCE_TODO(#4509): Remove this after all implementations have TRANSIENT_ATTACHMENT.
     if (t.params.transientColorAttachment || t.params.transientDepthStencilAttachment) {
       t.skipIfTransientAttachmentNotSupported();
     }

--- a/src/webgpu/api/operation/render_pass/transient_attachment.spec.ts
+++ b/src/webgpu/api/operation/render_pass/transient_attachment.spec.ts
@@ -14,7 +14,7 @@ g.test('increasing_attachments_count')
   `
   )
   .fn(t => {
-    // MAINTENANCE_TODO(#4509): Remove this when TRANSIENT_ATTACHMENT is added to the WebGPU spec.
+    // MAINTENANCE_TODO(#4509): Remove this after all implementations have TRANSIENT_ATTACHMENT.
     t.skipIfTransientAttachmentNotSupported();
 
     const maxAttachments = t.device.limits.maxColorAttachments;
@@ -58,7 +58,7 @@ g.test('overlapping_transient_attachments')
   `
   )
   .fn(t => {
-    // MAINTENANCE_TODO(#4509): Remove this when TRANSIENT_ATTACHMENT is added to the WebGPU spec.
+    // MAINTENANCE_TODO(#4509): Remove this after all implementations have TRANSIENT_ATTACHMENT.
     t.skipIfTransientAttachmentNotSupported();
 
     const encoder = t.device.createCommandEncoder();

--- a/src/webgpu/api/validation/createBindGroup.spec.ts
+++ b/src/webgpu/api/validation/createBindGroup.spec.ts
@@ -220,7 +220,7 @@ g.test('texture_binding_must_have_correct_usage')
       "The test requires 'r32float' multisampled support which compat mode doesn't guarantee."
     );
 
-    // MAINTENANCE_TODO(#4509): Remove this when TRANSIENT_ATTACHMENT is added to the WebGPU spec.
+    // MAINTENANCE_TODO(#4509): Remove this after all implementations have TRANSIENT_ATTACHMENT.
     if ((usage & GPUConst.TextureUsage.TRANSIENT_ATTACHMENT) !== 0) {
       t.skipIfTransientAttachmentNotSupported();
     }
@@ -803,7 +803,7 @@ g.test('storage_texture,usage')
 
     const usage = usage0 | usage1;
 
-    // MAINTENANCE_TODO(#4509): Remove this when TRANSIENT_ATTACHMENT is added to the WebGPU spec.
+    // MAINTENANCE_TODO(#4509): Remove this after all implementations have TRANSIENT_ATTACHMENT.
     if ((usage & GPUConst.TextureUsage.TRANSIENT_ATTACHMENT) !== 0) {
       t.skipIfTransientAttachmentNotSupported();
     }
@@ -1242,7 +1242,7 @@ g.test('external_texture,texture_view,usage')
 
     const usage = usage0 | usage1;
 
-    // MAINTENANCE_TODO(#4509): Remove this when TRANSIENT_ATTACHMENT is added to the WebGPU spec.
+    // MAINTENANCE_TODO(#4509): Remove this after all implementations have TRANSIENT_ATTACHMENT.
     if ((usage & GPUConst.TextureUsage.TRANSIENT_ATTACHMENT) !== 0) {
       t.skipIfTransientAttachmentNotSupported();
     }

--- a/src/webgpu/api/validation/createTexture.spec.ts
+++ b/src/webgpu/api/validation/createTexture.spec.ts
@@ -358,7 +358,7 @@ g.test('sampleCount,valid_sampleCount_with_other_parameter_varies')
     if ((usage & GPUConst.TextureUsage.RENDER_ATTACHMENT) !== 0) {
       t.skipIfTextureFormatNotUsableAsRenderAttachment(format);
     }
-    // MAINTENANCE_TODO(#4509): Remove this when TRANSIENT_ATTACHMENT is added to the WebGPU spec.
+    // MAINTENANCE_TODO(#4509): Remove this after all implementations have TRANSIENT_ATTACHMENT.
     if ((usage & GPUConst.TextureUsage.TRANSIENT_ATTACHMENT) !== 0) {
       t.skipIfTransientAttachmentNotSupported();
     }
@@ -1035,7 +1035,7 @@ g.test('texture_usage')
       usage,
     };
 
-    // MAINTENANCE_TODO(#4509): Remove this when TRANSIENT_ATTACHMENT is added to the WebGPU spec.
+    // MAINTENANCE_TODO(#4509): Remove this after all implementations have TRANSIENT_ATTACHMENT.
     if ((usage & GPUConst.TextureUsage.TRANSIENT_ATTACHMENT) !== 0) {
       t.skipIfTransientAttachmentNotSupported();
     }
@@ -1075,7 +1075,7 @@ g.test('depthOrArrayLayers_and_mipLevelCount_for_transient_attachments')
       .combine('mipLevelCount', [1, 2])
   )
   .fn(t => {
-    // MAINTENANCE_TODO(#4509): Remove this when TRANSIENT_ATTACHMENT is added to the WebGPU spec.
+    // MAINTENANCE_TODO(#4509): Remove this after all implementations have TRANSIENT_ATTACHMENT.
     t.skipIfTransientAttachmentNotSupported();
 
     const { format, depthOrArrayLayers, mipLevelCount } = t.params;

--- a/src/webgpu/api/validation/render_pass/render_pass_descriptor.spec.ts
+++ b/src/webgpu/api/validation/render_pass/render_pass_descriptor.spec.ts
@@ -741,7 +741,7 @@ g.test('color_attachments,loadOp_storeOp')
     t.skipIfTextureFormatNotSupported(format);
     t.skipIfTextureFormatNotUsableAsRenderAttachment(format);
 
-    // MAINTENANCE_TODO(#4509): Remove this when TRANSIENT_ATTACHMENT is added to the WebGPU spec.
+    // MAINTENANCE_TODO(#4509): Remove this after all implementations have TRANSIENT_ATTACHMENT.
     if (transientTexture) {
       t.skipIfTransientAttachmentNotSupported();
     }
@@ -1129,7 +1129,7 @@ g.test('depth_stencil_attachment,loadOp_storeOp_match_depthReadOnly_stencilReadO
 
     t.skipIfTextureFormatNotSupported(format);
 
-    // MAINTENANCE_TODO(#4509): Remove this when TRANSIENT_ATTACHMENT is added to the WebGPU spec.
+    // MAINTENANCE_TODO(#4509): Remove this after all implementations have TRANSIENT_ATTACHMENT.
     if (transientTexture) {
       t.skipIfTransientAttachmentNotSupported();
     }

--- a/src/webgpu/api/validation/texture/bgra8unorm_storage.spec.ts
+++ b/src/webgpu/api/validation/texture/bgra8unorm_storage.spec.ts
@@ -106,7 +106,7 @@ Test that it is invalid to configure a GPUCanvasContext to 'GPUStorageBinding' u
   .fn(t => {
     const { canvasType, usage } = t.params;
 
-    // MAINTENANCE_TODO(#4509): Remove this when TRANSIENT_ATTACHMENT is added to the WebGPU spec.
+    // MAINTENANCE_TODO(#4509): Remove this after all implementations have TRANSIENT_ATTACHMENT.
     if ((usage & GPUConst.TextureUsage.TRANSIENT_ATTACHMENT) !== 0) {
       t.skipIfTransientAttachmentNotSupported();
     }
@@ -155,7 +155,7 @@ with 'bgra8unorm-storage' enabled.
   .fn(t => {
     const { canvasType, usage } = t.params;
 
-    // MAINTENANCE_TODO(#4509): Remove this when TRANSIENT_ATTACHMENT is added to the WebGPU spec.
+    // MAINTENANCE_TODO(#4509): Remove this after all implementations have TRANSIENT_ATTACHMENT.
     if ((usage & GPUConst.TextureUsage.TRANSIENT_ATTACHMENT) !== 0) {
       t.skipIfTransientAttachmentNotSupported();
     }

--- a/src/webgpu/gpu_test.ts
+++ b/src/webgpu/gpu_test.ts
@@ -675,7 +675,7 @@ export class GPUTestBase extends Fixture<GPUTestSubcaseBatchState> {
   }
 
   /** Skips this test case if the GPUTextureUsage `TRANSIENT_ATTACHMENT` is *not* supported. */
-  // MAINTENANCE_TODO(#4509): Remove this when TRANSIENT_ATTACHMENT is added to the WebGPU spec.
+  // MAINTENANCE_TODO(#4509): Remove this after all implementations have TRANSIENT_ATTACHMENT.
   skipIfTransientAttachmentNotSupported() {
     const isTransientAttachmentSupported = 'TRANSIENT_ATTACHMENT' in GPUTextureUsage;
     this.skipIf(

--- a/src/webgpu/idl/constants/flags.spec.ts
+++ b/src/webgpu/idl/constants/flags.spec.ts
@@ -46,7 +46,7 @@ const kTextureUsageExp: {
   TRANSIENT_ATTACHMENT: 0x20,
 };
 g.test('TextureUsage,count').fn(t => {
-  // MAINTENANCE_TODO(#4509): Remove this when TRANSIENT_ATTACHMENT is added to the WebGPU spec.
+  // MAINTENANCE_TODO(#4509): Remove this after all implementations have TRANSIENT_ATTACHMENT.
   if (!('TRANSIENT_ATTACHMENT' in GPUTextureUsage)) {
     delete kTextureUsageExp.TRANSIENT_ATTACHMENT;
   }
@@ -57,7 +57,7 @@ g.test('TextureUsage,values')
   .fn(t => {
     const { key } = t.params;
 
-    // MAINTENANCE_TODO(#4509): Remove this when TRANSIENT_ATTACHMENT is added to the WebGPU spec.
+    // MAINTENANCE_TODO(#4509): Remove this after all implementations have TRANSIENT_ATTACHMENT.
     t.skipIf(key === 'TRANSIENT_ATTACHMENT' && !('TRANSIENT_ATTACHMENT' in GPUTextureUsage));
 
     t.assertMember(GPUTextureUsage, kTextureUsageExp, key);

--- a/src/webgpu/web_platform/canvas/configure.spec.ts
+++ b/src/webgpu/web_platform/canvas/configure.spec.ts
@@ -220,7 +220,7 @@ g.test('usage')
   .fn(t => {
     const { canvasType, usage } = t.params;
 
-    // MAINTENANCE_TODO(#4509): Remove this when TRANSIENT_ATTACHMENT is added to the WebGPU spec.
+    // MAINTENANCE_TODO(#4509): Remove this after all implementations have TRANSIENT_ATTACHMENT.
     if ((usage & GPUConst.TextureUsage.TRANSIENT_ATTACHMENT) !== 0) {
       t.skipIfTransientAttachmentNotSupported();
     }
@@ -355,7 +355,7 @@ g.test('invalid_usage')
   .fn(t => {
     const { canvasType, format, usage } = t.params;
 
-    // MAINTENANCE_TODO(#4509): Remove this when TRANSIENT_ATTACHMENT is added to the WebGPU spec.
+    // MAINTENANCE_TODO(#4509): Remove this after all implementations have TRANSIENT_ATTACHMENT.
     if ((usage & GPUConst.TextureUsage.TRANSIENT_ATTACHMENT) !== 0) {
       t.skipIfTransientAttachmentNotSupported();
     }


### PR DESCRIPTION
This has been added to the spec but we can't remove it yet because it would cause tests to fail on Firefox/Safari. Update the TODO to indicate this.

Issue: #4509