### PR TITLE
Test that createBuffer/createTexture only allows exposed usages

### DIFF
--- a/src/webgpu/api/validation/buffer/create.spec.ts
+++ b/src/webgpu/api/validation/buffer/create.spec.ts
@@ -61,6 +61,7 @@ g.test('usage')
     u
       .combine('usage1', [0, ...kBufferUsages, kInvalidUsage])
       .combine('usage2', [0, ...kBufferUsages, kInvalidUsage])
+      .filter(p => p.usage1 <= p.usage2)
       .beginSubcases()
       .combine('mappedAtCreation', [false, true])
   )
@@ -80,6 +81,32 @@ g.test('usage')
       'validation',
       () => t.createBufferTracked({ size: kBufferSizeAlignment * 2, usage, mappedAtCreation }),
       !isValid
+    );
+  });
+
+g.test('new_usages')
+  .desc(`Valid sages not present in GPUBufferUsage shouldn't be accepted by createBuffer().`)
+  .params(u =>
+    u //
+      .beginSubcases()
+      .combine('usage', kBufferUsages)
+  )
+  .fn(t => {
+    const { usage } = t.params;
+
+    let exposedUsages = 0;
+    for (const v of Object.values(GPUBufferUsage)) {
+      exposedUsages |= v;
+    }
+
+    const success = (usage & exposedUsages) === usage;
+
+    t.expectGPUError(
+      'validation',
+      () => {
+        t.createBufferTracked({ size: 16, usage });
+      },
+      !success
     );
   });
 

--- a/src/webgpu/api/validation/buffer/create.spec.ts
+++ b/src/webgpu/api/validation/buffer/create.spec.ts
@@ -85,7 +85,7 @@ g.test('usage')
   });
 
 g.test('new_usages')
-  .desc(`Valid sages not present in GPUBufferUsage shouldn't be accepted by createBuffer().`)
+  .desc(`Valid usages not present in GPUBufferUsage shouldn't be accepted by createBuffer().`)
   .params(u =>
     u //
       .beginSubcases()

--- a/src/webgpu/api/validation/createTexture.spec.ts
+++ b/src/webgpu/api/validation/createTexture.spec.ts
@@ -1098,6 +1098,35 @@ g.test('depthOrArrayLayers_and_mipLevelCount_for_transient_attachments')
     }, !success);
   });
 
+g.test('new_usages')
+  .desc(`Valid sages not present in GPUTextureUsage shouldn't be accepted by createTexture().`)
+  .params(u =>
+    u
+      .combine('usage', [
+        ...kTextureUsages,
+        GPUConst.TextureUsage.RENDER_ATTACHMENT | GPUConst.TextureUsage.TRANSIENT_ATTACHMENT,
+      ])
+      .filter(p => isValidTextureUsageCombination(p.usage))
+  )
+  .fn(t => {
+    const { usage } = t.params;
+
+    let exposedUsages = 0;
+    for (const v of Object.values(GPUTextureUsage)) {
+      exposedUsages |= v;
+    }
+
+    const success = (usage & exposedUsages) === usage;
+
+    t.expectGPUError(
+      'validation',
+      () => {
+        t.createTextureTracked({ format: 'rgba8unorm', size: [1, 1], usage });
+      },
+      !success
+    );
+  });
+
 g.test('viewFormats')
   .desc(
     `Test creating a texture with viewFormats list for all {texture format}x{view format}. Only compatible view formats should be valid.`

--- a/src/webgpu/api/validation/createTexture.spec.ts
+++ b/src/webgpu/api/validation/createTexture.spec.ts
@@ -1099,7 +1099,7 @@ g.test('depthOrArrayLayers_and_mipLevelCount_for_transient_attachments')
   });
 
 g.test('new_usages')
-  .desc(`Valid sages not present in GPUTextureUsage shouldn't be accepted by createTexture().`)
+  .desc(`Valid usages not present in GPUTextureUsage shouldn't be accepted by createTexture().`)
   .params(u =>
     u
       .combine('usage', [


### PR DESCRIPTION
For any buffer/texture usages known by the CTS, check that the browser only accepts it if it also exposes it.

Currently the buffer test passes in all browsers - there haven't been any new usages in a long time. But next time we add a usage, this makes sure that when they start accepting the usage, they also start exposing it.

The texture test fails in Safari because it's missing validation of unknown texture usages (this is also caught by #4636 that tests an invalid usage). Passes in Chrome/Firefox.

Unrelated cleanup: filter out redundant cases in createBuffer usage tests.

Issue: none filed

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [-] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) are accurate and complete.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Tests avoid [over-parameterization](https://github.com/gpuweb/cts/blob/main/docs/organization.md#parameterization) (see case count report).

When landing this PR, be sure to make any necessary issue status updates.
