### PR TITLE
Test createTexture() with invalid usages or combinations of usages

### DIFF
--- a/src/webgpu/api/validation/buffer/create.spec.ts
+++ b/src/webgpu/api/validation/buffer/create.spec.ts
@@ -8,6 +8,7 @@ import {
   kAllBufferUsageBits,
   kBufferSizeAlignment,
   kBufferUsages,
+  kSomeBogusBufferUsage,
 } from '../../../capability_info.js';
 import { GPUConst } from '../../../constants.js';
 import { AllFeaturesMaxLimitsGPUTest } from '../../../gpu_test.js';
@@ -53,14 +54,12 @@ g.test('limit')
     t.expectGPUError('validation', () => t.createBufferTracked({ size, usage }), !isValid);
   });
 
-const kInvalidUsage = 0x8000;
-assert((kInvalidUsage & kAllBufferUsageBits) === 0);
 g.test('usage')
   .desc('Test combinations of zero to two usage flags are validated to be valid.')
   .params(u =>
     u
-      .combine('usage1', [0, ...kBufferUsages, kInvalidUsage])
-      .combine('usage2', [0, ...kBufferUsages, kInvalidUsage])
+      .combine('usage1', [0, ...kBufferUsages, kSomeBogusBufferUsage])
+      .combine('usage2', [0, ...kBufferUsages, kSomeBogusBufferUsage])
       .beginSubcases()
       .combine('mappedAtCreation', [false, true])
   )

--- a/src/webgpu/api/validation/createTexture.spec.ts
+++ b/src/webgpu/api/validation/createTexture.spec.ts
@@ -8,6 +8,7 @@ import {
   kTextureUsages,
   isValidTextureUsageCombination,
   kValidCombinationsOfOneOrTwoTextureUsages,
+  kAllTextureUsages,
 } from '../../capability_info.js';
 import { GPUConst } from '../../constants.js';
 import {
@@ -1096,6 +1097,40 @@ g.test('depthOrArrayLayers_and_mipLevelCount_for_transient_attachments')
     t.expectValidationError(() => {
       t.createTextureTracked(descriptor);
     }, !success);
+  });
+
+const kInvalidUsage = 0x8000;
+assert((kInvalidUsage & kAllTextureUsages) === 0);
+g.test('usage')
+  .desc('Test combinations of zero to two usage flags are validated to be valid.')
+  .params(u =>
+    u
+      .combine('usage1', [0, ...kTextureUsages, kInvalidUsage])
+      .combine('usage2', [0, ...kTextureUsages, kInvalidUsage])
+      .filter(p => p.usage1 <= p.usage2)
+  )
+  .fn(t => {
+    const { usage1, usage2 } = t.params;
+    const usage = usage1 | usage2;
+
+    // MAINTENANCE_TODO(#4509): Remove this after all implementations have TRANSIENT_ATTACHMENT.
+    if ((usage & GPUConst.TextureUsage.TRANSIENT_ATTACHMENT) !== 0) {
+      t.skipIfTransientAttachmentNotSupported();
+    }
+
+    const isValid =
+      usage !== 0 &&
+      (usage & ~kAllTextureUsages) === 0 &&
+      ((usage & GPUTextureUsage.TRANSIENT_ATTACHMENT) === 0 ||
+        usage === (GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.TRANSIENT_ATTACHMENT));
+
+    t.expectGPUError(
+      'validation',
+      () => {
+        t.createTextureTracked({ format: 'rgba8unorm', size: [1, 1], usage });
+      },
+      !isValid
+    );
   });
 
 g.test('viewFormats')

--- a/src/webgpu/api/validation/createTexture.spec.ts
+++ b/src/webgpu/api/validation/createTexture.spec.ts
@@ -9,6 +9,7 @@ import {
   isValidTextureUsageCombination,
   kValidCombinationsOfOneOrTwoTextureUsages,
   kAllTextureUsages,
+  kSomeBogusTextureUsage,
 } from '../../capability_info.js';
 import { GPUConst } from '../../constants.js';
 import {
@@ -1099,14 +1100,12 @@ g.test('depthOrArrayLayers_and_mipLevelCount_for_transient_attachments')
     }, !success);
   });
 
-const kInvalidUsage = 0x8000;
-assert((kInvalidUsage & kAllTextureUsages) === 0);
 g.test('usage')
   .desc('Test combinations of zero to two usage flags are validated to be valid.')
   .params(u =>
     u
-      .combine('usage1', [0, ...kTextureUsages, kInvalidUsage])
-      .combine('usage2', [0, ...kTextureUsages, kInvalidUsage])
+      .combine('usage1', [0, ...kTextureUsages, kSomeBogusTextureUsage])
+      .combine('usage2', [0, ...kTextureUsages, kSomeBogusTextureUsage])
       .filter(p => p.usage1 <= p.usage2)
   )
   .fn(t => {

--- a/src/webgpu/capability_info.ts
+++ b/src/webgpu/capability_info.ts
@@ -77,6 +77,10 @@ export const kAllBufferUsageBits = kBufferUsages.reduce(
   0
 );
 
+/** An arbitrary invalid buffer usage bit. */
+export const kSomeBogusBufferUsage: GPUBufferUsageFlags = 0x4000_0000;
+assert((kSomeBogusBufferUsage & kAllBufferUsageBits) === 0);
+
 // Errors
 
 /** Per-GPUErrorFilter info. */

--- a/src/webgpu/capability_info.ts
+++ b/src/webgpu/capability_info.ts
@@ -225,7 +225,7 @@ const kTextureUsageInfo: {
 /** List of all GPUTextureUsage values. */
 export const kTextureUsages = numericKeysOf(kTextureUsageInfo);
 /** Bitmask of all known texture usages. */
-const kAllTextureUsages = kTextureUsages.reduce((acc, usage) => acc | usage, 0);
+export const kAllTextureUsages = kTextureUsages.reduce((acc, usage) => acc | usage, 0);
 
 /** An arbitrary invalid texture usage bit. */
 export const kSomeBogusTextureUsage: GPUTextureUsageFlags = 0x4000_0000;


### PR DESCRIPTION
Missing test coverage for transient attachments.

Issue: #4509 

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [-] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) are accurate and complete.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Tests avoid [over-parameterization](https://github.com/gpuweb/cts/blob/main/docs/organization.md#parameterization) (see case count report).

When landing this PR, be sure to make any necessary issue status updates.
