### PR TITLE
Check that an unused, destroyed occlusion query causes submit to fail

### DIFF
--- a/src/webgpu/api/validation/queue/destroyed/query_set.spec.ts
+++ b/src/webgpu/api/validation/queue/destroyed/query_set.spec.ts
@@ -25,6 +25,21 @@ Tests that use a destroyed query set in occlusion query on render pass encoder.
     encoder.validateFinishAndSubmitGivenState(t.params.querySetState);
   });
 
+g.test('unusedOcclusionQuery')
+  .desc(
+    `
+Tests that use a destroyed query set in occlusion query on render pass encoder, even if no beginOcclusionQuery calls are done.
+- x= {destroyed, not destroyed (control case)}
+  `
+  )
+  .paramsSubcasesOnly(u => u.combine('querySetState', ['valid', 'destroyed'] as const))
+  .fn(t => {
+    const occlusionQuerySet = vtu.createQuerySetWithState(t, t.params.querySetState);
+
+    const encoder = t.createEncoder('render pass', { occlusionQuerySet });
+    encoder.validateFinishAndSubmitGivenState(t.params.querySetState);
+  });
+
 g.test('timestamps')
   .desc(
     `

--- a/src/webgpu/listing_meta.json
+++ b/src/webgpu/listing_meta.json
@@ -734,6 +734,7 @@
   "webgpu:api,validation,queue,destroyed,query_set:beginOcclusionQuery:*": { "subcaseMS": 17.401 },
   "webgpu:api,validation,queue,destroyed,query_set:resolveQuerySet:*": { "subcaseMS": 16.401 },
   "webgpu:api,validation,queue,destroyed,query_set:timestamps:*": { "subcaseMS": 0.901 },
+  "webgpu:api,validation,queue,destroyed,query_set:unusedOcclusionQuery:*": { "subcaseMS": 8.855 },
   "webgpu:api,validation,queue,destroyed,texture:beginRenderPass:*": { "subcaseMS": 0.350 },
   "webgpu:api,validation,queue,destroyed,texture:copyBufferToTexture:*": { "subcaseMS": 16.550 },
   "webgpu:api,validation,queue,destroyed,texture:copyTextureToBuffer:*": { "subcaseMS": 15.900 },


### PR DESCRIPTION
See https://github.com/gpuweb/gpuweb/issues/6247




Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [X] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [X] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [X] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [X] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) are accurate and complete.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Tests avoid [over-parameterization](https://github.com/gpuweb/cts/blob/main/docs/organization.md#parameterization) (see case count report).

When landing this PR, be sure to make any necessary issue status updates.
