### PR TITLE
Test viewFormats with TRANSIENT_ATTACHMENT

### DIFF
--- a/src/webgpu/api/validation/createTexture.spec.ts
+++ b/src/webgpu/api/validation/createTexture.spec.ts
@@ -1227,24 +1227,24 @@ g.test('transient_viewFormats')
       .beginSubcases()
       .expandWithParams(({ format, _otherFormat }) => [
         // Control cases
-        { useTransient: true, viewFormats: undefined },
-        { useTransient: false, viewFormats: [format] },
-        { useTransient: false, viewFormats: [_otherFormat] },
+        { useTransient: true, viewFormat: undefined },
+        { useTransient: false, viewFormat: format },
+        { useTransient: false, viewFormat: _otherFormat },
         // Invalid cases
-        { useTransient: true, viewFormats: [format] },
-        { useTransient: true, viewFormats: [_otherFormat] },
-        { useTransient: true, viewFormats: [format, _otherFormat] },
+        { useTransient: true, viewFormat: format },
+        { useTransient: true, viewFormat: _otherFormat },
       ])
   )
   .fn(t => {
-    const { format, viewFormats, useTransient } = t.params;
+    const { format, viewFormat, useTransient } = t.params;
     t.skipIfTextureFormatNotSupported(format);
 
     const { blockWidth, blockHeight } = getBlockInfoForTextureFormat(format);
 
-    const invalid = useTransient && viewFormats !== undefined;
+    const invalid = useTransient && viewFormat !== undefined;
+    let tex: GPUTexture;
     t.expectValidationError(() => {
-      t.createTextureTracked({
+      tex = t.createTextureTracked({
         format,
         size: [blockWidth, blockHeight],
         usage:
@@ -1252,7 +1252,16 @@ g.test('transient_viewFormats')
           (useTransient ? GPUConst.TextureUsage.TRANSIENT_ATTACHMENT : 0),
         // Doesn't matter what formats we request, TRANSIENT_ATTACHMENT doesn't allow it.
         // So we use [format] since that's otherwise ALWAYS valid regardless of format.
-        viewFormats,
+        viewFormats: viewFormat ? [viewFormat] : undefined,
       });
     }, invalid);
+
+    if (invalid) {
+      // When we reach here the texture should be invalid, so creating a view should be invalid.
+      // But try it anyway just to see what happens - if the browser had a bug above, this could
+      // issue a bad command to the backend API.
+      t.expectValidationError(() => {
+        tex.createView({ format: viewFormat });
+      }, true);
+    }
   });

--- a/src/webgpu/api/validation/createTexture.spec.ts
+++ b/src/webgpu/api/validation/createTexture.spec.ts
@@ -1214,3 +1214,45 @@ g.test('viewFormats')
       });
     }, !compatible);
   });
+
+g.test('transient_viewFormats')
+  .desc(`Test that viewFormats is not allowed with TRANSIENT_ATTACHMENT textures.`)
+  .params(u =>
+    u
+      // Just test rgba8unorm formats as this check doesn't care about what the format is.
+      .combineWithParams([
+        { format: 'rgba8unorm', _otherFormat: 'rgba8unorm-srgb' },
+        { format: 'rgba8unorm-srgb', _otherFormat: 'rgba8unorm' },
+      ] as const)
+      .beginSubcases()
+      .expandWithParams(({ format, _otherFormat }) => [
+        // Control cases
+        { useTransient: true, viewFormats: undefined },
+        { useTransient: false, viewFormats: [format] },
+        { useTransient: false, viewFormats: [_otherFormat] },
+        // Invalid cases
+        { useTransient: true, viewFormats: [format] },
+        { useTransient: true, viewFormats: [_otherFormat] },
+        { useTransient: true, viewFormats: [format, _otherFormat] },
+      ])
+  )
+  .fn(t => {
+    const { format, viewFormats, useTransient } = t.params;
+    t.skipIfTextureFormatNotSupported(format);
+
+    const { blockWidth, blockHeight } = getBlockInfoForTextureFormat(format);
+
+    const invalid = useTransient && viewFormats !== undefined;
+    t.expectValidationError(() => {
+      t.createTextureTracked({
+        format,
+        size: [blockWidth, blockHeight],
+        usage:
+          GPUConst.TextureUsage.RENDER_ATTACHMENT |
+          (useTransient ? GPUConst.TextureUsage.TRANSIENT_ATTACHMENT : 0),
+        // Doesn't matter what formats we request, TRANSIENT_ATTACHMENT doesn't allow it.
+        // So we use [format] since that's otherwise ALWAYS valid regardless of format.
+        viewFormats,
+      });
+    }, invalid);
+  });

--- a/src/webgpu/api/validation/createTexture.spec.ts
+++ b/src/webgpu/api/validation/createTexture.spec.ts
@@ -1237,7 +1237,9 @@ g.test('transient_viewFormats')
   )
   .fn(t => {
     const { format, viewFormat, useTransient } = t.params;
-    t.skipIfTextureFormatNotSupported(format);
+    if (viewFormat && !textureFormatsAreViewCompatible(t.device.features, format, viewFormat)) {
+      t.skip(`"${format}" and "${viewFormat}" are not view-compatible`);
+    }
 
     const { blockWidth, blockHeight } = getBlockInfoForTextureFormat(format);
 


### PR DESCRIPTION
This should not be allowed.

Passes in Chromium with this patch: https://dawn-review.googlesource.com/c/dawn/+/310035

Issue: https://github.com/gpuweb/gpuweb/issues/6263
Spec change: https://github.com/gpuweb/gpuweb/pull/6267

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) are accurate and complete.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Tests avoid [over-parameterization](https://github.com/gpuweb/cts/blob/main/docs/organization.md#parameterization) (see case count report).

When landing this PR, be sure to make any necessary issue status updates.
