### PR TITLE
Fix: Allow creating view with usage=0 from transient texture

### DIFF
--- a/src/webgpu/api/validation/createView.spec.ts
+++ b/src/webgpu/api/validation/createView.spec.ts
@@ -419,7 +419,7 @@ g.test('texture_view_usage_of_multiple_usages')
 
     let isValid = true;
     if (usage & GPUTextureUsage.TRANSIENT_ATTACHMENT) {
-      isValid &&= viewUsage === usage;
+      isValid &&= viewUsage === 0 || viewUsage === usage;
     }
 
     const texture = t.createTextureTracked({ format: 'rgba8unorm', size: [1, 1], usage });


### PR DESCRIPTION
Found in https://github.com/gfx-rs/wgpu/pull/9568. `webgpu:api,validation,createView:texture_view_usage_of_multiple_usages:usage1=16;usage2=32` fails when `viewUsage` is 0 because `isValid` is false, but this should be valid because `viewUsage=0` means full set of usage, because the view `description.usage` is resolved to `texture.usage` (https://gpuweb.github.io/gpuweb/#abstract-opdef-resolving-gputextureviewdescriptor-defaults).

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [ ] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) are accurate and complete.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Tests avoid [over-parameterization](https://github.com/gpuweb/cts/blob/main/docs/organization.md#parameterization) (see case count report).

When landing this PR, be sure to make any necessary issue status updates.
