### PR TITLE
Ensure WorkgroupSizeX never exceeds the maximum in subgroup size control tests

### DIFF
--- a/src/webgpu/shader/execution/shader_io/compute_builtins.spec.ts
+++ b/src/webgpu/shader/execution/shader_io/compute_builtins.spec.ts
@@ -1193,6 +1193,9 @@ g.test('subgroup_size_attribute')
 
     for (let subgroupSize = subgroupMinSize; subgroupSize <= subgroupMaxSize; subgroupSize *= 2) {
       const wgx = subgroupSize * numSubgroups;
+      if (wgx > t.device.limits.maxComputeWorkgroupSizeX) {
+        continue;
+      }
 
       const wgsl = `
 enable subgroups;

--- a/src/webgpu/shader/validation/extension/subgroup_size_control.spec.ts
+++ b/src/webgpu/shader/validation/extension/subgroup_size_control.spec.ts
@@ -214,9 +214,11 @@ async function getValidSubgroupSizes(device: GPUDevice): Promise<number[]> {
     subgroupMaxSize: number;
   }
   const { subgroupMinSize, subgroupMaxSize } = device.adapterInfo as SubgroupProperties;
+  const maxWorkgroupSizeX = device.limits.maxComputeWorkgroupSizeX;
 
   const sizes: number[] = [];
   for (let subgroupSize = subgroupMinSize; subgroupSize <= subgroupMaxSize; subgroupSize *= 2) {
+    if (subgroupSize > maxWorkgroupSizeX) break;
     const wgsl = `
 enable subgroups;
 enable subgroup_size_control;
@@ -294,6 +296,7 @@ g.test('workgroup_size_x_must_be_multiple_of_subgroup_size_at_pipeline_creation'
     for (const subgroupSize of validSubgroupSizes) {
       const workgroupSizeX = subgroupSize * multiplier + offset;
       if (workgroupSizeX <= 0) continue;
+      if (workgroupSizeX > t.device.limits.maxComputeWorkgroupSizeX) continue;
 
       const isMultiple = workgroupSizeX % subgroupSize === 0;
 


### PR DESCRIPTION


Issue: #4640

<hr>

**Requirements for PR author:**

- [*] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [*] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [*] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [*] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) are accurate and complete.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Tests avoid [over-parameterization](https://github.com/gpuweb/cts/blob/main/docs/organization.md#parameterization) (see case count report).

When landing this PR, be sure to make any necessary issue status updates.
