### PR TITLE
Add declaration tests for WGSL immediate variables

### DIFF
--- a/src/webgpu/capability_info.ts
+++ b/src/webgpu/capability_info.ts
@@ -987,6 +987,7 @@ export const kKnownWGSLLanguageFeatures = [
   'swizzle_assignment',
   'linear_indexing',
   'texture_formats_tier1',
+  'immediate_address_space',
 ] as const;
 
 export type WGSLLanguageFeature = (typeof kKnownWGSLLanguageFeatures)[number];

--- a/src/webgpu/shader/types.ts
+++ b/src/webgpu/shader/types.ts
@@ -1,5 +1,6 @@
 import { keysOf } from '../../common/util/data_tables.js';
 import { assert } from '../../common/util/util.js';
+import type { WGSLLanguageFeature } from '../capability_info.js';
 import { align } from '../util/math.js';
 
 const kDefaultArrayLength = 3;
@@ -102,7 +103,14 @@ export const kMatrixContainerTypeLayoutInfo =
   }
 } as const;
 
-export type AddressSpace = 'storage' | 'uniform' | 'private' | 'function' | 'workgroup' | 'handle';
+export type AddressSpace =
+  | 'storage'
+  | 'uniform'
+  | 'private'
+  | 'function'
+  | 'workgroup'
+  | 'immediate'
+  | 'handle';
 export type AccessMode = 'read' | 'write' | 'read_write';
 export type Scope = 'module' | 'function';
 
@@ -133,9 +141,12 @@ export type AddressSpaceInfo = {
   //   in the storage address space, must not be specified in the WGSL source.
   //   See §13.3 Address Spaces.
   spellAccessMode: Requirement;
+
+  // WGSL language feature required to use this address space, if any.
+  wgslLanguageFeature?: WGSLLanguageFeature;
 };
 
-export const kAddressSpaceInfo: Record<string, AddressSpaceInfo> = {
+export const kAddressSpaceInfo: Record<AddressSpace, AddressSpaceInfo> = {
   storage: {
     scope: 'module',
     binding: true,
@@ -170,6 +181,14 @@ export const kAddressSpaceInfo: Record<string, AddressSpaceInfo> = {
     spell: 'may',
     accessModes: ['read_write'],
     spellAccessMode: 'never',
+  },
+  immediate: {
+    scope: 'module',
+    binding: false,
+    spell: 'must',
+    accessModes: ['read'],
+    spellAccessMode: 'never',
+    wgslLanguageFeature: 'immediate_address_space',
   },
   handle: {
     scope: 'module',
@@ -237,8 +256,10 @@ export function* generateTypes({
   }
   const scalarType = isAtomic ? `atomic<${baseType}>` : baseType;
 
-  // Storage and uniform require host-sharable types.
-  if (addressSpace === 'storage' || addressSpace === 'uniform') {
+  // Storage, uniform, and immediate require host-shareable types.
+  const requiresHostShareable =
+    addressSpace === 'storage' || addressSpace === 'uniform' || addressSpace === 'immediate';
+  if (requiresHostShareable) {
     assert(isHostSharable(baseType), 'type ' + baseType.toString() + ' is not host sharable');
   }
 
@@ -289,6 +310,9 @@ export function* generateTypes({
 
   // Array types
   if (containerType === 'array') {
+    if (addressSpace === 'immediate') {
+      return;
+    }
     let arrayElemType: string = scalarType;
     let arrayElementCount: number = kDefaultArrayLength;
     let supportsAtomics = scalarInfo.supportsAtomics;
@@ -382,8 +406,11 @@ export function* supportedScalarTypes(p: { isAtomic: boolean; addressSpace: stri
     // Test atomics only on supported scalar types.
     if (p.isAtomic && !info.supportsAtomics) continue;
 
-    // Storage and uniform require host-sharable types.
-    const isHostShared = p.addressSpace === 'storage' || p.addressSpace === 'uniform';
+    // Storage, uniform, and immediate require host-shareable types.
+    const isHostShared =
+      p.addressSpace === 'storage' ||
+      p.addressSpace === 'uniform' ||
+      p.addressSpace === 'immediate';
     if (isHostShared && info.layout === undefined) continue;
 
     yield scalarType;

--- a/src/webgpu/shader/validation/decl/context_dependent_resolution.spec.ts
+++ b/src/webgpu/shader/validation/decl/context_dependent_resolution.spec.ts
@@ -230,6 +230,7 @@ const kLanguageCases = {
   packed_4x8_integer_dot_product: `requires packed_4x8_integer_dot_product;`,
   unrestricted_pointer_parameters: `requires unrestricted_pointer_parameters;`,
   pointer_composite_access: `requires pointer_composite_access;`,
+  immediate_address_space: `requires immediate_address_space;`,
 };
 
 g.test('language_names')

--- a/src/webgpu/shader/validation/decl/immediate.spec.ts
+++ b/src/webgpu/shader/validation/decl/immediate.spec.ts
@@ -1,0 +1,301 @@
+export const description = `
+Validation tests for the WGSL immediate address space.
+`;
+
+import { makeTestGroup } from '../../../../common/framework/test_group.js';
+import { keysOf } from '../../../../common/util/data_tables.js';
+import { ShaderValidationTest } from '../shader_validation_test.js';
+
+import { skipIfImmediateDataNotSupported } from './util.js';
+
+export const g = makeTestGroup(ShaderValidationTest);
+
+const kImmediateFeature = 'immediate_address_space' as const;
+const kImmediateHeader = `requires ${kImmediateFeature};`;
+
+const kValidStoreTypes = {
+  u32: `u32`,
+  i32: `i32`,
+  f32: `f32`,
+  vec2u: `vec2u`,
+  vec3i: `vec3i`,
+  vec4f: `vec4f`,
+  mat2x2f: `mat2x2f`,
+  struct_numeric: `S`,
+} as const;
+
+const kInvalidStoreTypes = {
+  bool: { enable: ``, prelude: ``, type: `bool` },
+  vec2_bool: { enable: ``, prelude: ``, type: `vec2<bool>` },
+  atomic_u32: { enable: ``, prelude: ``, type: `atomic<u32>` },
+  ptr_function_u32: { enable: ``, prelude: ``, type: `ptr<function, u32>` },
+  sampler: { enable: ``, prelude: ``, type: `sampler` },
+  sampler_comparison: { enable: ``, prelude: ``, type: `sampler_comparison` },
+  texture_2d: { enable: ``, prelude: ``, type: `texture_2d<f32>` },
+  runtime_array: { enable: ``, prelude: ``, type: `array<u32>` },
+  fixed_array: { enable: ``, prelude: ``, type: `array<u32, 4>` },
+  struct_runtime_array: { enable: ``, prelude: `struct S { data : array<u32> }`, type: `S` },
+  struct_fixed_array: {
+    enable: ``,
+    prelude: `struct S { data : array<vec4u, 4> }`,
+    type: `S`,
+  },
+  f16: { enable: `enable f16;`, prelude: ``, type: `f16` },
+  vec3h: { enable: `enable f16;`, prelude: ``, type: `vec3h` },
+} as const;
+
+g.test('store_type,valid')
+  .desc('Validates immediate store types supported by the current WGSL immediate implementation.')
+  .params(u => u.combine('type', keysOf(kValidStoreTypes)))
+  .fn(t => {
+    skipIfImmediateDataNotSupported(t);
+    const prelude = t.params.type === 'struct_numeric' ? 'struct S { a : u32, b : vec4f }' : '';
+    const wgsl = `
+${kImmediateHeader}
+${prelude}
+var<immediate> data : ${kValidStoreTypes[t.params.type]};
+@compute @workgroup_size(1)
+fn main() {
+  _ = data;
+}`;
+    t.expectCompileResult(true, wgsl);
+  });
+
+g.test('store_type,invalid')
+  .desc('Validates types that cannot be used for immediate variables.')
+  .params(u => u.combine('type', keysOf(kInvalidStoreTypes)))
+  .fn(t => {
+    skipIfImmediateDataNotSupported(t);
+    const testcase = kInvalidStoreTypes[t.params.type];
+    if (testcase.enable.includes('f16')) {
+      t.skipIfDeviceDoesNotHaveFeature('shader-f16');
+    }
+    const wgsl = `
+${kImmediateHeader}
+${testcase.enable}
+${testcase.prelude}
+var<immediate> data : ${testcase.type};
+@compute @workgroup_size(1)
+fn main() {
+  _ = data;
+}`;
+    t.expectCompileResult(false, wgsl);
+  });
+
+g.test('scope')
+  .desc('Validates that immediate variables are module-scope only.')
+  .params(u => u.combine('scope', ['module', 'function'] as const))
+  .fn(t => {
+    skipIfImmediateDataNotSupported(t);
+    const wgsl =
+      t.params.scope === 'module'
+        ? `
+${kImmediateHeader}
+var<immediate> data : u32;
+@compute @workgroup_size(1)
+fn main() {
+  _ = data;
+}`
+        : `
+${kImmediateHeader}
+@compute @workgroup_size(1)
+fn main() {
+  var<immediate> data : u32;
+  _ = data;
+}`;
+    t.expectCompileResult(t.params.scope === 'module', wgsl);
+  });
+
+g.test('binding_attributes')
+  .desc('Validates that @group and @binding are not allowed on immediate variables.')
+  .params(u =>
+    u.combine('group', ['', '@group(0)'] as const).combine('binding', ['', '@binding(0)'] as const)
+  )
+  .fn(t => {
+    skipIfImmediateDataNotSupported(t);
+    const wgsl = `
+${kImmediateHeader}
+${t.params.group} ${t.params.binding} var<immediate> data : u32;
+@compute @workgroup_size(1)
+fn main() {
+  _ = data;
+}`;
+    t.expectCompileResult(t.params.group === '' && t.params.binding === '', wgsl);
+  });
+
+g.test('access_mode')
+  .desc('Validates that immediate variables cannot spell an access mode.')
+  .params(u => u.combine('accessMode', ['', 'read', 'write', 'read_write'] as const))
+  .fn(t => {
+    skipIfImmediateDataNotSupported(t);
+    const suffix = t.params.accessMode === '' ? '' : `, ${t.params.accessMode}`;
+    const wgsl = `
+${kImmediateHeader}
+var<immediate${suffix}> data : u32;
+@compute @workgroup_size(1)
+fn main() {
+  _ = data;
+}`;
+    t.expectCompileResult(t.params.accessMode === '', wgsl);
+  });
+
+const kEntryPointCases = {
+  one_used: {
+    valid: true,
+    body: `
+var<immediate> a : u32;
+@compute @workgroup_size(1)
+fn main() {
+  _ = a;
+}`,
+  },
+  two_declared_one_used: {
+    valid: true,
+    body: `
+var<immediate> a : u32;
+var<immediate> b : u32;
+@compute @workgroup_size(1)
+fn main() {
+  _ = a;
+}`,
+  },
+  two_entry_points_one_each: {
+    valid: true,
+    body: `
+var<immediate> a : u32;
+var<immediate> b : u32;
+@compute @workgroup_size(1)
+fn main_a() {
+  _ = a;
+}
+@compute @workgroup_size(1)
+fn main_b() {
+  _ = b;
+}`,
+  },
+  one_entry_point_uses_two_directly: {
+    valid: false,
+    body: `
+var<immediate> a : u32;
+var<immediate> b : u32;
+@compute @workgroup_size(1)
+fn main() {
+  _ = a + b;
+}`,
+  },
+  one_entry_point_uses_two_through_helper: {
+    valid: false,
+    body: `
+var<immediate> a : u32;
+var<immediate> b : u32;
+fn read_b() -> u32 {
+  return b;
+}
+@compute @workgroup_size(1)
+fn main() {
+  _ = a + read_b();
+}`,
+  },
+} as const;
+
+g.test('entry_point_interface')
+  .desc('Validates one statically used immediate variable per entry point.')
+  .params(u => u.combine('case', keysOf(kEntryPointCases)))
+  .fn(t => {
+    skipIfImmediateDataNotSupported(t);
+    const testcase = kEntryPointCases[t.params.case];
+    t.expectCompileResult(testcase.valid, `${kImmediateHeader}\n${testcase.body}`);
+  });
+
+const kPointerCases = {
+  alias_module_scope: {
+    valid: true,
+    needsUnrestrictedPointerParameters: false,
+    body: `
+alias P = ptr<immediate, u32>;
+var<immediate> data : u32;
+@compute @workgroup_size(1)
+fn main() {
+  let p : P = &data;
+  _ = *p;
+}`,
+  },
+  let_inside_function: {
+    valid: true,
+    needsUnrestrictedPointerParameters: false,
+    body: `
+var<immediate> data : u32;
+@compute @workgroup_size(1)
+fn main() {
+  let p : ptr<immediate, u32> = &data;
+  _ = *p;
+}`,
+  },
+  write_through_pointer: {
+    valid: false,
+    needsUnrestrictedPointerParameters: false,
+    body: `
+var<immediate> data : u32;
+@compute @workgroup_size(1)
+fn main() {
+  let p : ptr<immediate, u32> = &data;
+  *p = 1u;
+}`,
+  },
+  pointer_parameter: {
+    valid: true,
+    needsUnrestrictedPointerParameters: true,
+    body: `
+var<immediate> data : u32;
+fn read_data(p : ptr<immediate, u32>) -> u32 {
+  return *p;
+}
+@compute @workgroup_size(1)
+fn main() {
+  _ = read_data(&data);
+}`,
+  },
+  explicit_read_access: {
+    valid: false,
+    needsUnrestrictedPointerParameters: false,
+    body: `
+alias P = ptr<immediate, u32, read>;`,
+  },
+  explicit_write_access: {
+    valid: false,
+    needsUnrestrictedPointerParameters: false,
+    body: `
+alias P = ptr<immediate, u32, write>;`,
+  },
+  explicit_read_write_access: {
+    valid: false,
+    needsUnrestrictedPointerParameters: false,
+    body: `
+alias P = ptr<immediate, u32, read_write>;`,
+  },
+  missing_store_type: {
+    valid: false,
+    needsUnrestrictedPointerParameters: false,
+    body: `
+alias P = ptr<immediate>;`,
+  },
+} as const;
+
+g.test('pointers')
+  .desc('Validates ptr<immediate> type creation, use, access modes, and function parameters.')
+  .params(u => u.combine('case', keysOf(kPointerCases)))
+  .fn(t => {
+    skipIfImmediateDataNotSupported(t);
+    const testcase = kPointerCases[t.params.case];
+    const unrestrictedHeader =
+      testcase.needsUnrestrictedPointerParameters &&
+      t.hasLanguageFeature('unrestricted_pointer_parameters')
+        ? 'requires unrestricted_pointer_parameters;\n'
+        : '';
+    const expected =
+      testcase.valid &&
+      (!testcase.needsUnrestrictedPointerParameters ||
+        t.hasLanguageFeature('unrestricted_pointer_parameters'));
+    const wgsl = `${kImmediateHeader}\n${unrestrictedHeader}${testcase.body}`;
+    t.expectCompileResult(expected, wgsl);
+  });

--- a/src/webgpu/shader/validation/decl/util.ts
+++ b/src/webgpu/shader/validation/decl/util.ts
@@ -1,3 +1,5 @@
+import { getGPU } from '../../../../common/util/navigator_gpu.js';
+import { supportsImmediateData } from '../../../../common/util/util.js';
 import {
   AccessMode,
   AddressSpace,
@@ -11,6 +13,40 @@ export type ShaderStage = 'vertex' | 'fragment' | 'compute';
 
 /** The list of all shader stages */
 export const kShaderStages = ['vertex', 'fragment', 'compute'] as const;
+
+export function requiredLanguageFeatureHeader(addressSpace: AddressSpace): string {
+  const feature = kAddressSpaceInfo[addressSpace].wgslLanguageFeature;
+  return feature === undefined ? '' : `requires ${feature};\n`;
+}
+
+type AddressSpaceSupportTest = {
+  readonly rec: Parameters<typeof getGPU>[0];
+  skip(message: string): never;
+  skipIfLanguageFeatureNotSupported(
+    langFeature: NonNullable<AddressSpaceInfo['wgslLanguageFeature']>
+  ): void;
+};
+
+export function skipIfImmediateDataNotSupported(t: AddressSpaceSupportTest): void {
+  if (!supportsImmediateData(getGPU(t.rec))) {
+    t.skip('Immediate data not supported');
+  }
+}
+
+export function skipIfAddressSpaceNotSupported(
+  t: AddressSpaceSupportTest,
+  addressSpace: AddressSpace
+): void {
+  if (addressSpace === 'immediate') {
+    skipIfImmediateDataNotSupported(t);
+    return;
+  }
+
+  const feature = kAddressSpaceInfo[addressSpace].wgslLanguageFeature;
+  if (feature !== undefined) {
+    t.skipIfLanguageFeatureNotSupported(feature);
+  }
+}
 
 /**
  * declareEntrypoint emits the WGSL to declare an entry point with the name, stage and body.
@@ -107,15 +143,16 @@ export function getVarDeclShader(
     p.explicitSpace ? p.addressSpace : '',
     p.explicitAccess ? p.accessMode : ''
   );
+  const header = requiredLanguageFeatureHeader(p.addressSpace);
 
   additionalBody = additionalBody ?? '';
 
   switch (info.scope) {
     case 'module':
-      return decl + '\n' + declareEntryPoint({ stage: p.stage, body: additionalBody });
+      return header + decl + '\n' + declareEntryPoint({ stage: p.stage, body: additionalBody });
 
     case 'function':
-      return declareEntryPoint({ stage: p.stage, body: decl + '\n' + additionalBody });
+      return header + declareEntryPoint({ stage: p.stage, body: decl + '\n' + additionalBody });
   }
 }
 

--- a/src/webgpu/shader/validation/decl/var.spec.ts
+++ b/src/webgpu/shader/validation/decl/var.spec.ts
@@ -4,7 +4,7 @@ Validation tests for host-shareable types.
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { keysOf } from '../../../../common/util/data_tables.js';
-import { AddressSpace, kAccessModeInfo, kAddressSpaceInfo } from '../../types.js';
+import { kAccessModeInfo, kAddressSpaceInfo } from '../../types.js';
 import { ShaderValidationTest } from '../shader_validation_test.js';
 
 import {
@@ -582,9 +582,7 @@ g.test('address_space_access_mode')
   });
 
 // Address spaces that can hold an i32 variable.
-const kNonHandleAddressSpaces = keysOf(kAddressSpaceInfo).filter(
-  as => as !== 'handle'
-) as AddressSpace[];
+const kNonHandleAddressSpaces = keysOf(kAddressSpaceInfo).filter(as => as !== 'handle');
 
 g.test('explicit_access_mode')
   .desc('Validate uses of an explicit access mode on a var declaration')

--- a/src/webgpu/shader/validation/decl/var.spec.ts
+++ b/src/webgpu/shader/validation/decl/var.spec.ts
@@ -14,6 +14,9 @@ import {
   supportsRead,
   supportsWrite,
   ShaderStage,
+  requiredLanguageFeatureHeader,
+  skipIfAddressSpaceNotSupported,
+  skipIfImmediateDataNotSupported,
 } from './util.js';
 
 export const g = makeTestGroup(ShaderValidationTest);
@@ -209,6 +212,31 @@ const kTypes = {
   },
 };
 
+const kImmediateTypesWithArray = new Set<string>([
+  'array<vec4<bool>>',
+  'array<vec4<bool>, 4>',
+  'array<vec4u>',
+  'array<vec4u, 4>',
+  'array<vec4u, array_size_const>',
+  'array<vec4u, array_size_override>',
+  'S_array_vec4u',
+  'S_array_vec4u_4',
+  'S_array_bool_4',
+] as const);
+
+const kImmediateUnsupportedF16Types = new Set<string>(['f16', 'vec3h', 'mat3x4h'] as const);
+
+function isImmediateStoreType(typeName: keyof typeof kTypes): boolean {
+  const type = kTypes[typeName];
+  return (
+    type.isHostShareable &&
+    type.isConstructible &&
+    type.isFixedFootprint &&
+    !kImmediateTypesWithArray.has(typeName) &&
+    !kImmediateUnsupportedF16Types.has(typeName)
+  );
+}
+
 g.test('module_scope_types')
   .desc('Test that only types that are allowed for a given address space are accepted.')
   .params(u =>
@@ -222,10 +250,14 @@ g.test('module_scope_types')
         'storage_rw',
         'uniform',
         'workgroup',
+        'immediate',
       ])
       .combine('via_alias', [false, true])
   )
   .fn(t => {
+    if (t.params.kind === 'immediate') {
+      skipIfImmediateDataNotSupported(t);
+    }
     if (kTypes[t.params.type].requiresF16) {
       t.skipIfDeviceDoesNotHaveFeature('shader-f16');
     }
@@ -265,9 +297,16 @@ g.test('module_scope_types')
         decl = 'var<workgroup> foo : ';
         shouldPass = type.isFixedFootprint;
         break;
+      case 'immediate':
+        decl = 'var<immediate> foo : ';
+        shouldPass = isImmediateStoreType(t.params.type);
+        break;
     }
 
-    const wgsl = `${type.requiresF16 ? 'enable f16;' : ''}
+    const featureHeader =
+      t.params.kind === 'immediate' ? requiredLanguageFeatureHeader('immediate') : '';
+
+    const wgsl = `${featureHeader}${type.requiresF16 ? 'enable f16;' : ''}
     const array_size_const = 4;
     override array_size_override = 4;
 
@@ -461,13 +500,18 @@ g.test('binding_point_on_non_resources')
   .desc('Test that non-resource variables cannot have either @group or @binding attributes.')
   .params(u =>
     u
-      .combine('addrspace', ['private', 'workgroup'])
+      .combine('addrspace', ['private', 'workgroup', 'immediate'] as const)
       .combine('group', ['', '@group(0)'])
       .combine('binding', ['', '@binding(0)'])
   )
   .fn(t => {
+    if (t.params.addrspace === 'immediate') {
+      skipIfImmediateDataNotSupported(t);
+    }
     const shouldPass = t.params.group === '' && t.params.binding === '';
-    const wgsl = `${t.params.group} ${t.params.binding} var<${t.params.addrspace}> foo : i32;`;
+    const header =
+      t.params.addrspace === 'immediate' ? requiredLanguageFeatureHeader('immediate') : '';
+    const wgsl = `${header}${t.params.group} ${t.params.binding} var<${t.params.addrspace}> foo : i32;`;
     t.expectCompileResult(shouldPass, wgsl);
   });
 
@@ -538,13 +582,24 @@ g.test('address_space_access_mode')
   .desc('Test that only storage accepts an access mode')
   .params(u =>
     u
-      .combine('address_space', ['private', 'storage', 'uniform', 'function', 'workgroup'] as const)
+      .combine('address_space', [
+        'private',
+        'storage',
+        'uniform',
+        'function',
+        'workgroup',
+        'immediate',
+      ] as const)
       .combine('access_mode', ['', 'read', 'write', 'read_write'] as const)
       .combine('trailing_comma', [true, false] as const)
   )
   .fn(t => {
+    if (t.params.address_space === 'immediate') {
+      skipIfImmediateDataNotSupported(t);
+    }
     let fdecl = ``;
     let mdecl = ``;
+    let header = ``;
     // Most address spaces do not accept an access mode, but should accept no
     // template argument or a trailing comma.
     let shouldPass = t.params.access_mode === '';
@@ -573,8 +628,12 @@ g.test('address_space_access_mode')
       case 'function':
         fdecl = `var<function${suffix}> x : u32;`;
         break;
+      case 'immediate':
+        header = requiredLanguageFeatureHeader('immediate');
+        mdecl = `var<immediate${suffix}> x : u32;`;
+        break;
     }
-    const code = `${mdecl}
+    const code = `${header}${mdecl}
     fn foo() {
       ${fdecl}
     }`;
@@ -601,6 +660,7 @@ g.test('explicit_access_mode')
         .combine('stage', ['compute' as ShaderStage]) // Only need to check compute shaders
   )
   .fn(t => {
+    skipIfAddressSpaceNotSupported(t, t.params.addressSpace);
     const prog = getVarDeclShader(t.params);
     const info = kAddressSpaceInfo[t.params.addressSpace];
 
@@ -628,6 +688,7 @@ g.test('implicit_access_mode')
         .combine('stage', ['compute' as ShaderStage]) // Only need to check compute shaders
   )
   .fn(t => {
+    skipIfAddressSpaceNotSupported(t, t.params.addressSpace);
     const prog = getVarDeclShader(t.params);
 
     // 7.3 var Declarations
@@ -650,6 +711,7 @@ g.test('read_access')
         .combine('stage', ['compute' as ShaderStage]) // Only need to check compute shaders
   )
   .fn(t => {
+    skipIfAddressSpaceNotSupported(t, t.params.addressSpace);
     const prog = getVarDeclShader(t.params, 'let copy = x;');
     const ok = supportsRead(t.params);
     t.expectCompileResult(ok, prog);
@@ -668,6 +730,7 @@ g.test('write_access')
         .combine('stage', ['compute' as ShaderStage]) // Only need to check compute shaders
   )
   .fn(t => {
+    skipIfAddressSpaceNotSupported(t, t.params.addressSpace);
     const prog = getVarDeclShader(t.params, 'x = 0;');
     const ok = supportsWrite(t.params);
     t.expectCompileResult(ok, prog);

--- a/src/webgpu/shader/validation/types/pointer.spec.ts
+++ b/src/webgpu/shader/validation/types/pointer.spec.ts
@@ -2,7 +2,7 @@ export const description = 'Test pointer type validation';
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { keysOf } from '../../../../common/util/data_tables.js';
-import { AddressSpace, kAccessModeInfo, kAddressSpaceInfo } from '../../types.js';
+import { kAccessModeInfo, kAddressSpaceInfo } from '../../types.js';
 import {
   pointerType,
   explicitSpaceExpander,
@@ -140,9 +140,7 @@ g.test('type')
   });
 
 // Address spaces that can hold an i32 variable.
-const kNonHandleAddressSpaces = keysOf(kAddressSpaceInfo).filter(
-  as => as !== 'handle'
-) as AddressSpace[];
+const kNonHandleAddressSpaces = keysOf(kAddressSpaceInfo).filter(as => as !== 'handle');
 
 g.test('let_ptr_explicit_type_matches_var')
   .desc(


### PR DESCRIPTION
This PR adds the first WGSL `immediate` address space validation
coverage.

It includes the shared CTS plumbing required by the tests:

- adds `immediate_address_space` to the known WGSL language features
- models `immediate` in the shared address space metadata
- emits required WGSL feature headers from declaration helpers
- skips immediate validation tests when immediate data support is not exposed

It then adds declaration validation coverage for `var<immediate>`:

- accepted scalar, vector, matrix, and struct store types
- rejected store types, including arrays and f16 cases
- module-scope-only declarations
- rejection of binding attributes
- rejection of explicit access modes
- one statically used immediate variable per entry point
- basic `ptr<immediate>` declaration behavior

Follow-up PRs will add type, expression, function, and uniformity
coverage one suite at a time after this lands.

Testing:

- `npm.cmd run typecheck`
- `npm.cmd run lint`
