### PR TITLE
Access subgroupMinSize/subgroupMaxSize directly on GPUAdapterInfo

### DIFF
--- a/src/webgpu/shader/execution/expression/call/builtin/subgroupAdd.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/subgroupAdd.spec.ts
@@ -482,10 +482,7 @@ g.test('fragment')
   )
   .fn(async t => {
     t.skipIfDeviceDoesNotHaveFeature('subgroups' as GPUFeatureName);
-    interface SubgroupProperties extends GPUAdapterInfo {
-      subgroupMinSize: number;
-    }
-    const { subgroupMinSize } = t.device.adapterInfo as SubgroupProperties;
+    const subgroupMinSize = t.device.adapterInfo.subgroupMinSize!;
     const innerTexels = (t.params.size[0] - 1) * (t.params.size[1] - 1);
     t.skipIf(innerTexels < subgroupMinSize, 'Too few texels to be reliable');
 

--- a/src/webgpu/shader/execution/expression/call/builtin/subgroupBitwise.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/subgroupBitwise.spec.ts
@@ -538,10 +538,7 @@ g.test('fragment,all_active')
     t.skipIfDeviceDoesNotHaveFeature('subgroups' as GPUFeatureName);
     const numInputs = t.params.size[0] * t.params.size[1];
 
-    interface SubgroupProperties extends GPUAdapterInfo {
-      subgroupMinSize: number;
-    }
-    const { subgroupMinSize } = t.device.adapterInfo as SubgroupProperties;
+    const subgroupMinSize = t.device.adapterInfo.subgroupMinSize!;
     const innerTexels = (t.params.size[0] - 1) * (t.params.size[1] - 1);
     t.skipIf(innerTexels < subgroupMinSize, 'Too few texels to be reliable');
 

--- a/src/webgpu/shader/execution/expression/call/builtin/subgroupBroadcast.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/subgroupBroadcast.spec.ts
@@ -463,11 +463,8 @@ g.test('compute,split')
     const testcase = kPredicateCases[t.params.predicate];
     const wgThreads = t.params.wgSize[0] * t.params.wgSize[1] * t.params.wgSize[2];
 
-    interface SubgroupProperties extends GPUAdapterInfo {
-      subgroupMinSize: number;
-      subgroupMaxSize: number;
-    }
-    const { subgroupMinSize, subgroupMaxSize } = t.device.adapterInfo as SubgroupProperties;
+    const subgroupMinSize = t.device.adapterInfo.subgroupMinSize!;
+    const subgroupMaxSize = t.device.adapterInfo.subgroupMaxSize!;
     for (let size = subgroupMinSize; size <= subgroupMaxSize; size *= 2) {
       t.skipIf(!testcase.filter(t.params.id, size), 'Skipping potential undefined behavior');
     }
@@ -696,10 +693,7 @@ g.test('fragment')
   .fn(async t => {
     t.skipIfDeviceDoesNotHaveFeature('subgroups' as GPUFeatureName);
     const innerTexels = (t.params.size[0] - 1) * (t.params.size[1] - 1);
-    interface SubgroupProperties extends GPUAdapterInfo {
-      subgroupMaxSize: number;
-    }
-    const { subgroupMaxSize } = t.device.adapterInfo as SubgroupProperties;
+    const subgroupMaxSize = t.device.adapterInfo.subgroupMaxSize!;
     t.skipIf(innerTexels < subgroupMaxSize, 'Too few texels to be reliable');
 
     const broadcast =

--- a/src/webgpu/shader/execution/expression/call/builtin/subgroupElect.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/subgroupElect.spec.ts
@@ -186,10 +186,7 @@ g.test('compute,each_invocation')
     t.skipIfDeviceDoesNotHaveFeature('subgroups' as GPUFeatureName);
     const wgThreads = t.params.wgSize[0] * t.params.wgSize[1] * t.params.wgSize[2];
 
-    interface SubgroupProperties extends GPUAdapterInfo {
-      subgroupMaxSize: number;
-    }
-    const { subgroupMaxSize } = t.device.adapterInfo as SubgroupProperties;
+    const subgroupMaxSize = t.device.adapterInfo.subgroupMaxSize!;
     t.skipIf(subgroupMaxSize <= t.params.id, 'No invocation selected');
 
     const wgsl = `
@@ -332,10 +329,7 @@ g.test('fragment')
   )
   .fn(async t => {
     t.skipIfDeviceDoesNotHaveFeature('subgroups' as GPUFeatureName);
-    interface SubgroupProperties extends GPUAdapterInfo {
-      subgroupMinSize: number;
-    }
-    const { subgroupMinSize } = t.device.adapterInfo as SubgroupProperties;
+    const subgroupMinSize = t.device.adapterInfo.subgroupMinSize!;
     const innerTexels = (t.params.size[0] - 1) * (t.params.size[1] - 1);
     t.skipIf(innerTexels < subgroupMinSize, 'Too few texels to be reliable');
 

--- a/src/webgpu/shader/execution/expression/call/builtin/subgroupMinMax.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/subgroupMinMax.spec.ts
@@ -573,10 +573,7 @@ g.test('fragment')
     t.skipIfDeviceDoesNotHaveFeature('subgroups' as GPUFeatureName);
     const numInputs = t.params.size[0] * t.params.size[1];
 
-    interface SubgroupProperties extends GPUAdapterInfo {
-      subgroupMinSize: number;
-    }
-    const { subgroupMinSize } = t.device.adapterInfo as SubgroupProperties;
+    const subgroupMinSize = t.device.adapterInfo.subgroupMinSize!;
     const innerTexels = (t.params.size[0] - 1) * (t.params.size[1] - 1);
     t.skipIf(innerTexels < subgroupMinSize, 'Too few texels to be reliable');
 

--- a/src/webgpu/shader/execution/expression/call/builtin/subgroupMul.spec.ts
+++ b/src/webgpu/shader/execution/expression/call/builtin/subgroupMul.spec.ts
@@ -512,11 +512,8 @@ g.test('fragment')
   )
   .fn(async t => {
     t.skipIfDeviceDoesNotHaveFeature('subgroups' as GPUFeatureName);
-    interface SubgroupProperties extends GPUAdapterInfo {
-      subgroupMinSize: number;
-      subgroupMaxSize: number;
-    }
-    const { subgroupMinSize, subgroupMaxSize } = t.device.adapterInfo as SubgroupProperties;
+    const subgroupMinSize = t.device.adapterInfo.subgroupMinSize!;
+    const subgroupMaxSize = t.device.adapterInfo.subgroupMaxSize!;
     const innerTexels = (t.params.size[0] - 1) * (t.params.size[1] - 1);
     t.skipIf(innerTexels < subgroupMinSize, 'Too few texels to be reliable');
     t.skipIf(subgroupMaxSize === 4 && t.params.quadIndex !== 0, 'Duplicate test');

--- a/src/webgpu/shader/execution/shader_io/compute_builtins.spec.ts
+++ b/src/webgpu/shader/execution/shader_io/compute_builtins.spec.ts
@@ -447,11 +447,8 @@ g.test('subgroup_size')
   )
   .fn(async t => {
     t.skipIfDeviceDoesNotHaveFeature('subgroups' as GPUFeatureName);
-    interface SubgroupProperties extends GPUAdapterInfo {
-      subgroupMinSize: number;
-      subgroupMaxSize: number;
-    }
-    const { subgroupMinSize, subgroupMaxSize } = t.device.adapterInfo as SubgroupProperties;
+    const subgroupMinSize = t.device.adapterInfo.subgroupMinSize!;
+    const subgroupMaxSize = t.device.adapterInfo.subgroupMaxSize!;
 
     const wgx = t.params.sizes[0];
     const wgy = t.params.sizes[1];
@@ -1183,11 +1180,8 @@ g.test('subgroup_size_attribute')
 
     const { numWorkGroups, numSubgroups } = t.params;
 
-    interface SubgroupProperties extends GPUAdapterInfo {
-      subgroupMinSize: number;
-      subgroupMaxSize: number;
-    }
-    const { subgroupMinSize, subgroupMaxSize } = t.device.adapterInfo as SubgroupProperties;
+    const subgroupMinSize = t.device.adapterInfo.subgroupMinSize!;
+    const subgroupMaxSize = t.device.adapterInfo.subgroupMaxSize!;
 
     let atLeastOneSucceeded = false;
 

--- a/src/webgpu/shader/execution/shader_io/fragment_builtins.spec.ts
+++ b/src/webgpu/shader/execution/shader_io/fragment_builtins.spec.ts
@@ -1693,11 +1693,8 @@ g.test('subgroup_size')
   )
   .fn(async t => {
     t.skipIfDeviceDoesNotHaveFeature('subgroups' as GPUFeatureName);
-    interface SubgroupProperties extends GPUAdapterInfo {
-      subgroupMinSize: number;
-      subgroupMaxSize: number;
-    }
-    const { subgroupMinSize, subgroupMaxSize } = t.device.adapterInfo as SubgroupProperties;
+    const subgroupMinSize = t.device.adapterInfo.subgroupMinSize!;
+    const subgroupMaxSize = t.device.adapterInfo.subgroupMaxSize!;
 
     const fsShader = `
 enable subgroups;

--- a/src/webgpu/shader/validation/extension/subgroup_size_control.spec.ts
+++ b/src/webgpu/shader/validation/extension/subgroup_size_control.spec.ts
@@ -209,11 +209,8 @@ g.test('subgroup_size_override_must_be_power_of_2_at_pipeline_creation')
  * between subgroupMinSize and subgroupMaxSize inclusive.
  */
 async function getValidSubgroupSizes(device: GPUDevice): Promise<number[]> {
-  interface SubgroupProperties extends GPUAdapterInfo {
-    subgroupMinSize: number;
-    subgroupMaxSize: number;
-  }
-  const { subgroupMinSize, subgroupMaxSize } = device.adapterInfo as SubgroupProperties;
+  const subgroupMinSize = device.adapterInfo.subgroupMinSize!;
+  const subgroupMaxSize = device.adapterInfo.subgroupMaxSize!;
   const maxWorkgroupSizeX = device.limits.maxComputeWorkgroupSizeX;
 
   const sizes: number[] = [];


### PR DESCRIPTION
These properties are now exposed on GPUAdapterInfo, so the local `SubgroupProperties` interface and the `adapterInfo as SubgroupProperties` casts are no longer needed. Read them directly via `adapterInfo.subgroupMinSize` / `adapterInfo.subgroupMaxSize`.

They are still declared optional in @webgpu/types (number | undefined), so a non-null assertion (!) is used at these call sites, which are all gated on the `subgroups` (or `subgroup-size-control`) feature where the values are guaranteed to be present.

<hr>

**Requirements for PR author:**

- [ ] ~All missing test coverage is tracked with "TODO" or `.unimplemented()`.~
- [ ] ~New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.~
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [ ] ~Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)~

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [x] Tests are properly located.
- [x] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) are accurate and complete.
- [x] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [x] Tests avoid [over-parameterization](https://github.com/gpuweb/cts/blob/main/docs/organization.md#parameterization) (see case count report).

When landing this PR, be sure to make any necessary issue status updates.
