### PR TITLE
Extra WGSL validation for @align

### DIFF
--- a/src/webgpu/shader/validation/shader_io/align.spec.ts
+++ b/src/webgpu/shader/validation/shader_io/align.spec.ts
@@ -14,9 +14,7 @@ const kTests = {
   one: {
     src: '@align(1)',
     pass: false,
-    // EXCEPTION: Error: Unexpected validation error occurred:
-    // Error while parsing WGSL: :6:10 error: alignment must be a
-    // multiple of '4' bytes for the 'uniform' address space @align(1) a: i32,
+    // EXCEPTION: If the type is valid for some address space, the align value must be a multiple of the type's alignment.
   },
   four_a: {
     src: '@align(4)',
@@ -49,10 +47,7 @@ const kTests = {
   const_expr: {
     src: '@align(i_val + 4 - 6)',
     pass: false,
-    // EXCEPTION: Error: Unexpected validation error occurred:
-    // Error while parsing WGSL: :6:10 error: alignment must be a
-    // multiple of '4' bytes for the 'uniform' address space
-    // @align(i_val + 4 - 6) a: i32
+    // EXCEPTION: If the type is valid for some address space, the align value must be a multiple of the type's alignment.
   },
   const_expr_2: {
     src: '@align(i_val + 8 - 4)',
@@ -148,14 +143,7 @@ const f_val: f32 = 4.2;
 struct B {
   ${src} a: i32,
 }
-
-@group(0) @binding(0)
-var<uniform> uniform_buffer: B;
-
-@fragment
-fn main() -> @location(0) vec4<f32> {
-  return vec4<f32>(.4, .2, .3, .1);
-}`;
+`;
     t.expectCompileResult(kTests[t.params.align].pass, code);
   });
 
@@ -163,9 +151,18 @@ g.test('required_alignment')
   .desc('Test that the align with an invalid size is an error')
   .params(u =>
     u
-      .combine('address_space', ['storage', 'uniform'])
+      .combine('decl', ['var', 'const', 'let'] as const)
+      .combine('address_space', [
+        'storage',
+        'uniform',
+        'workgroup',
+        'function',
+        'private',
+        'immediate',
+      ] as const)
       .combine('align', [1, 2, 'alignment', 32])
       .combine('type', [
+        // Storage is used for all non-uniform address spaces.
         { name: 'i32', storage: 4, uniform: 4 },
         { name: 'u32', storage: 4, uniform: 4 },
         { name: 'f32', storage: 4, uniform: 4 },
@@ -198,19 +195,46 @@ g.test('required_alignment')
         { name: 'array<vec2<i32>, 2>', storage: 8, uniform: 16 },
         { name: 'array<vec4<i32>, 2>', storage: 16, uniform: 16 },
         { name: 'S', storage: 8, uniform: 16 },
+        { name: 'array<u32>', storage: 4, uniform: 4 },
       ])
-      .beginSubcases()
+      .filter(t => {
+        if (t.decl === 'let' && t.address_space !== 'function') {
+          return false;
+        }
+        if (
+          t.decl === 'const' &&
+          !(t.address_space === 'private' || t.address_space === 'function')
+        ) {
+          // Private is used as placeholder for module-scope const and function as placeholder for function-scope const.
+          return false;
+        }
+        if (t.type.name.startsWith('atomic')) {
+          if (t.address_space !== 'storage' && t.address_space !== 'workgroup') {
+            return false;
+          }
+          if (t.decl !== 'var') {
+            return false;
+          }
+        }
+        if (t.type.name === 'array<u32>' && t.address_space !== 'storage') {
+          return false;
+        }
+        if (t.type.name.indexOf('f16') !== -1 && t.address_space === 'immediate') {
+          // Remove this filter when f16 properly supported.
+          return false;
+        }
+        return true;
+      })
   )
   .fn(t => {
+    t.skipIf(
+      t.params.address_space === 'immediate' && !t.hasLanguageFeature('immediate_address_space'),
+      'Immediate address space not supported'
+    );
+
     // If the `uniform_buffer_standard_layout` feature is supported, the `uniform` address space has
     // the same layout constraints as `storage`.
     const has_ubo_std_layout = t.hasLanguageFeature('uniform_buffer_standard_layout');
-
-    // While this would fail validation, it doesn't fail for any reasons related to alignment.
-    // Atomics are not allowed in uniform address space as they have to be read_write.
-    if (t.params.address_space === 'uniform' && t.params.type.name.startsWith('atomic')) {
-      t.skip('No atomics in uniform address space');
-    }
 
     let code = '';
     if (t.params.type.name.includes('f16')) {
@@ -222,7 +246,7 @@ g.test('required_alignment')
       code += `struct S {
         a: mat4x2<f32>,          // Align 8
         b: array<vec${
-          t.params.address_space === 'storage' || has_ubo_std_layout ? 2 : 4
+          t.params.address_space !== 'uniform' || has_ubo_std_layout ? 2 : 4
         }<i32>, 2>,  // Storage align 8, uniform 16
       }
       `;
@@ -230,28 +254,44 @@ g.test('required_alignment')
 
     // Alignment value listed in the spec
     const min_align =
-      t.params.address_space === 'storage' || has_ubo_std_layout
+      t.params.address_space !== 'uniform' || has_ubo_std_layout
         ? `${t.params.type.storage}`
         : `${t.params.type.uniform}`;
     const align = t.params.align === 'alignment' ? min_align : t.params.align;
 
-    let address_space = 'uniform';
+    let address_space: string = t.params.address_space;
     if (t.params.address_space === 'storage') {
       // atomics require read_write, not just the default of read
       address_space = 'storage, read_write';
     }
+    let decl: string = t.params.decl;
+    if (decl === 'var') {
+      decl = `var<${address_space}>`;
+    }
+    const init = t.params.decl === 'let' || t.params.decl === 'const' ? ' = MyStruct()' : '';
+
+    const module_decl =
+      t.params.address_space === 'function'
+        ? ''
+        : `${
+            t.params.decl === 'var' &&
+            (t.params.address_space === 'uniform' || t.params.address_space === 'storage')
+              ? '@group(0) @binding(0)'
+              : ''
+          }
+    ${decl} a : MyStruct${init};`;
+
+    const func_decl = t.params.address_space === 'function' ? `${decl} a : MyStruct${init};` : '';
 
     code += `struct MyStruct {
       @align(${align}) a: ${t.params.type.name},
     }
 
-    @group(0) @binding(0)
-    var<${address_space}> a : MyStruct;`;
+    ${module_decl}`;
 
     code += `
-    @fragment
-    fn main() -> @location(0) vec4<f32> {
-      return vec4<f32>(.4, .2, .3, .1);
+    fn foo() {
+      ${func_decl}
     }`;
 
     let fails = align < min_align;

--- a/src/webgpu/shader/validation/shader_io/align.spec.ts
+++ b/src/webgpu/shader/validation/shader_io/align.spec.ts
@@ -220,10 +220,6 @@ g.test('required_alignment')
         if (t.type.name === 'array<u32>' && t.address_space !== 'storage') {
           return false;
         }
-        if (t.type.name.indexOf('f16') !== -1 && t.address_space === 'immediate') {
-          // Remove this filter when f16 properly supported.
-          return false;
-        }
         return true;
       })
   )

--- a/src/webgpu/shader/validation/shader_io/align.spec.ts
+++ b/src/webgpu/shader/validation/shader_io/align.spec.ts
@@ -161,6 +161,7 @@ g.test('required_alignment')
         'immediate',
       ] as const)
       .combine('align', [1, 2, 'alignment', 32])
+      .beginSubcases()
       .combine('type', [
         // Storage is used for all non-uniform address spaces.
         { name: 'i32', storage: 4, uniform: 4 },


### PR DESCRIPTION
* Cover no value decl usage
* Cover more address spaces
* Cover other types of decls




Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [ ] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [ ] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [ ] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) are accurate and complete.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Tests avoid [over-parameterization](https://github.com/gpuweb/cts/blob/main/docs/organization.md#parameterization) (see case count report).

When landing this PR, be sure to make any necessary issue status updates.
