### PR TITLE
Handle setImmediates command in encoder open-state tests

### DIFF
--- a/src/webgpu/api/validation/encoding/encoder_open_state.spec.ts
+++ b/src/webgpu/api/validation/encoding/encoder_open_state.spec.ts
@@ -401,6 +401,11 @@ g.test('render_pass_commands')
             renderPass.setStencilReference(0);
           }
           break;
+        case 'setImmediates':
+          {
+            renderPass.setImmediates!(0, new Uint32Array(1));
+          }
+          break;
         case 'beginOcclusionQuery':
           {
             renderPass.beginOcclusionQuery(0);
@@ -525,6 +530,11 @@ g.test('render_bundle_commands')
             bundleEncoder.setVertexBuffer(1, buffer);
           }
           break;
+        case 'setImmediates':
+          {
+            bundleEncoder.setImmediates!(0, new Uint32Array(1));
+          }
+          break;
         case 'pushDebugGroup':
           {
             bundleEncoder.pushDebugGroup('group');
@@ -612,6 +622,11 @@ g.test('compute_pass_commands')
         case 'dispatchWorkgroupsIndirect':
           {
             computePass.dispatchWorkgroupsIndirect(indirectBuffer, 0);
+          }
+          break;
+        case 'setImmediates':
+          {
+            computePass.setImmediates!(0, new Uint32Array(1));
           }
           break;
         case 'pushDebugGroup':


### PR DESCRIPTION
The render pass, render bundle, and compute pass command switches listed setImmediates as a parameter but had no matching case. Once an implementation exposes setImmediates, the feature-presence guard no longer skips and the command falls through to unreachable().

Add a setImmediates case to each switch that issues a minimal valid call, keeping the existing feature-presence guards so the cases still skip when the feature is unavailable.

Issue: #4669

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) are accurate and complete.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Tests avoid [over-parameterization](https://github.com/gpuweb/cts/blob/main/docs/organization.md#parameterization) (see case count report).

When landing this PR, be sure to make any necessary issue status updates.
