### PR TITLE
Bump @webgpu/types to 0.1.71

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@types/w3c-image-capture": "^1.0.10",
         "@typescript-eslint/eslint-plugin": "^6.9.1",
         "@typescript-eslint/parser": "^6.9.1",
-        "@webgpu/types": "^0.1.68",
+        "@webgpu/types": "^0.1.71",
         "ansi-colors": "4.1.3",
         "babel-plugin-add-header-comment": "^1.0.3",
         "babel-plugin-const-enum": "^1.2.0",
@@ -148,6 +148,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.2.tgz",
       "integrity": "sha512-n7s51eWdaWZ3vGT2tD4T7J6eJs3QoBXydv7vkUM06Bf1cbVD2Kc2UrkzhiQwobfV7NwOnQXYL7UBJ5VPU+RGoQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.22.13",
@@ -1041,6 +1042,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.10.tgz",
       "integrity": "sha512-TlgT8JntpcbmKUFzjhsyhGfP2fsiz1Mv56im6enJ905xG1DAYesxJaeSbGqQmAw8OWPdhyJGhGSQGKRNJ45u9w==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -1216,6 +1218,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.9.1.tgz",
       "integrity": "sha512-C7AK2wn43GSaCUZ9do6Ksgi2g3mwFkMO3Cis96kzmgudoVaKyt62yNzJOktP0HDLb/iO2O0n2lBOzJgr6Q/cyg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "6.9.1",
         "@typescript-eslint/types": "6.9.1",
@@ -1539,9 +1542,9 @@
       "dev": true
     },
     "node_modules/@webgpu/types": {
-      "version": "0.1.68",
-      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.68.tgz",
-      "integrity": "sha512-3ab1B59Ojb6RwjOspYLsTpCzbNB3ZaamIAxBMmvnNkiDoLTZUOBXZ9p5nAYVEkQlDdf6qAZWi1pqj9+ypiqznA==",
+      "version": "0.1.71",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.71.tgz",
+      "integrity": "sha512-mMy8/ODcKhab808co15eW+yN+HgXoQxRQHTiBV9Mrvl1r0ufnid7YOcI+gi4eUWSWl9ezD6TW2KXccrL8HCh2A==",
       "dev": true,
       "license": "BSD-3-Clause"
     },
@@ -1569,6 +1572,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.2.tgz",
       "integrity": "sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==",
       "dev": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2038,6 +2042,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001541",
         "electron-to-chromium": "^1.4.535",
@@ -2898,6 +2903,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.52.0.tgz",
       "integrity": "sha512-zh/JHnaixqHZsolRB/w9/02akBk9EPrOs9JwcTP2ek7yL5bVvXuRariiaAjjoJ5DvuwQ1WAE/HsMz+w17YgBCg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -4350,6 +4356,7 @@
       "resolved": "https://registry.npmjs.org/grunt/-/grunt-1.6.1.tgz",
       "integrity": "sha512-/ABUy3gYWu5iBmrUSRBP97JLpQUm0GgVveDCp6t3yRNIoltIYw7rEj3g5y1o2PGPR2vfTRGa7WC/LZHLTXnEzA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "dateformat": "~4.6.2",
         "eventemitter2": "~0.4.13",
@@ -4827,6 +4834,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.62.0.tgz",
       "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.62.0",
         "@typescript-eslint/types": "5.62.0",
@@ -5034,6 +5042,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.50.0.tgz",
       "integrity": "sha512-FOnOGSuFuFLv/Sa+FDVRZl4GGVAAFFi8LecRsI5a1tMO5HIE8nCm4ivAlzt4dT3ol/PaaGC0rJEEXQmHJBGoOg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -7211,6 +7220,7 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.3.tgz",
       "integrity": "sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==",
       "dev": true,
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -8635,6 +8645,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
       "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "dev": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9043,6 +9054,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.2.tgz",
       "integrity": "sha512-n7s51eWdaWZ3vGT2tD4T7J6eJs3QoBXydv7vkUM06Bf1cbVD2Kc2UrkzhiQwobfV7NwOnQXYL7UBJ5VPU+RGoQ==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.22.13",
@@ -9748,6 +9760,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.10.tgz",
       "integrity": "sha512-TlgT8JntpcbmKUFzjhsyhGfP2fsiz1Mv56im6enJ905xG1DAYesxJaeSbGqQmAw8OWPdhyJGhGSQGKRNJ45u9w==",
       "dev": true,
+      "peer": true,
       "requires": {
         "undici-types": "~5.26.4"
       }
@@ -9888,6 +9901,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.9.1.tgz",
       "integrity": "sha512-C7AK2wn43GSaCUZ9do6Ksgi2g3mwFkMO3Cis96kzmgudoVaKyt62yNzJOktP0HDLb/iO2O0n2lBOzJgr6Q/cyg==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@typescript-eslint/scope-manager": "6.9.1",
         "@typescript-eslint/types": "6.9.1",
@@ -10077,9 +10091,9 @@
       "dev": true
     },
     "@webgpu/types": {
-      "version": "0.1.68",
-      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.68.tgz",
-      "integrity": "sha512-3ab1B59Ojb6RwjOspYLsTpCzbNB3ZaamIAxBMmvnNkiDoLTZUOBXZ9p5nAYVEkQlDdf6qAZWi1pqj9+ypiqznA==",
+      "version": "0.1.71",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.71.tgz",
+      "integrity": "sha512-mMy8/ODcKhab808co15eW+yN+HgXoQxRQHTiBV9Mrvl1r0ufnid7YOcI+gi4eUWSWl9ezD6TW2KXccrL8HCh2A==",
       "dev": true
     },
     "abbrev": {
@@ -10102,7 +10116,8 @@
       "version": "8.11.2",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.2.tgz",
       "integrity": "sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "acorn-jsx": {
       "version": "5.3.2",
@@ -10448,6 +10463,7 @@
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.1.tgz",
       "integrity": "sha512-FEVc202+2iuClEhZhrWy6ZiAcRLvNMyYcxZ8raemul1DYVOVdFsbqckWLdsixQZCpJlwe77Z3UTalE7jsjnKfQ==",
       "dev": true,
+      "peer": true,
       "requires": {
         "caniuse-lite": "^1.0.30001541",
         "electron-to-chromium": "^1.4.535",
@@ -11076,6 +11092,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.52.0.tgz",
       "integrity": "sha512-zh/JHnaixqHZsolRB/w9/02akBk9EPrOs9JwcTP2ek7yL5bVvXuRariiaAjjoJ5DvuwQ1WAE/HsMz+w17YgBCg==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -12143,6 +12160,7 @@
       "resolved": "https://registry.npmjs.org/grunt/-/grunt-1.6.1.tgz",
       "integrity": "sha512-/ABUy3gYWu5iBmrUSRBP97JLpQUm0GgVveDCp6t3yRNIoltIYw7rEj3g5y1o2PGPR2vfTRGa7WC/LZHLTXnEzA==",
       "dev": true,
+      "peer": true,
       "requires": {
         "dateformat": "~4.6.2",
         "eventemitter2": "~0.4.13",
@@ -12495,6 +12513,7 @@
           "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.62.0.tgz",
           "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
           "dev": true,
+          "peer": true,
           "requires": {
             "@typescript-eslint/scope-manager": "5.62.0",
             "@typescript-eslint/types": "5.62.0",
@@ -12622,6 +12641,7 @@
           "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.50.0.tgz",
           "integrity": "sha512-FOnOGSuFuFLv/Sa+FDVRZl4GGVAAFFi8LecRsI5a1tMO5HIE8nCm4ivAlzt4dT3ol/PaaGC0rJEEXQmHJBGoOg==",
           "dev": true,
+          "peer": true,
           "requires": {
             "@eslint-community/eslint-utils": "^4.2.0",
             "@eslint-community/regexpp": "^4.6.1",
@@ -14210,7 +14230,8 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.3.tgz",
       "integrity": "sha512-L/4pUDMxcNa8R/EthV08Zt42WBO4h1rarVtK0K+QJG0X187OLo7l699jWw0GKuwzkPQ//jMFA/8Xm6Fh3J/DAg==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "prettier-linter-helpers": {
       "version": "1.0.0",
@@ -15286,7 +15307,8 @@
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
       "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "unbox-primitive": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@types/w3c-image-capture": "^1.0.10",
     "@typescript-eslint/eslint-plugin": "^6.9.1",
     "@typescript-eslint/parser": "^6.9.1",
-    "@webgpu/types": "^0.1.68",
+    "@webgpu/types": "^0.1.71",
     "ansi-colors": "4.1.3",
     "babel-plugin-add-header-comment": "^1.0.3",
     "babel-plugin-const-enum": "^1.2.0",

--- a/src/webgpu/api/operation/command_buffer/programmable/immediate.spec.ts
+++ b/src/webgpu/api/operation/command_buffer/programmable/immediate.spec.ts
@@ -488,7 +488,7 @@ g.test('basic_execution')
       encoderType,
       pipeline,
       encoder => {
-        encoder.setImmediates!(0, inputData);
+        encoder.setImmediates(0, inputData);
       },
       expected
     );
@@ -525,17 +525,17 @@ g.test('update_data')
       encodeFn: (enc, bindGroup) => {
         // Step 1: Full set [1, 2, 3, 4]
         enc.setBindGroup(0, bindGroup, [0]);
-        enc.setImmediates!(0, new Uint32Array([1, 2, 3, 4]));
+        enc.setImmediates(0, new Uint32Array([1, 2, 3, 4]));
         dispatchOrDraw(encoderType, enc);
 
         // Step 2: Full update [5, 6, 7, 8]
         enc.setBindGroup(0, bindGroup, [256]);
-        enc.setImmediates!(0, new Uint32Array([5, 6, 7, 8]));
+        enc.setImmediates(0, new Uint32Array([5, 6, 7, 8]));
         dispatchOrDraw(encoderType, enc);
 
         // Step 3: Partial update offset 4 bytes (index 1) with [9, 10] -> [5, 9, 10, 8]
         enc.setBindGroup(0, bindGroup, [512]);
-        enc.setImmediates!(4, new Uint32Array([9, 10]));
+        enc.setImmediates(4, new Uint32Array([9, 10]));
         dispatchOrDraw(encoderType, enc);
       },
     });
@@ -666,11 +666,11 @@ g.test('pipeline_switch')
         // Only set bind group once between bind group compatible pipelines.
         setPipeline(encoderType, enc, pipelineA);
         enc.setBindGroup(0, bindGroup, [0]);
-        enc.setImmediates!(0, new Uint32Array([1, 2, 3, 4]));
+        enc.setImmediates(0, new Uint32Array([1, 2, 3, 4]));
 
         // Switch to Pipeline B without re-setting the bind group.
         setPipeline(encoderType, enc, pipelineB);
-        enc.setImmediates!(0, immDataB, undefined, immDataSizeB);
+        enc.setImmediates(0, immDataB, undefined, immDataSizeB);
         dispatchOrDraw(encoderType, enc);
       });
 
@@ -686,11 +686,11 @@ g.test('pipeline_switch')
       const renderTarget = encodeForPassType(t, encoderType, commandEncoder, enc => {
         setPipeline(encoderType, enc, pipelineA);
         enc.setBindGroup(0, bindGroup, [0]);
-        enc.setImmediates!(0, new Uint32Array([1, 2, 3, 4]));
+        enc.setImmediates(0, new Uint32Array([1, 2, 3, 4]));
 
         // Switch to Pipeline B without re-setting the bind group.
         setPipeline(encoderType, enc, pipelineB);
-        enc.setImmediates!(0, immDataB, undefined, immDataSizeB);
+        enc.setImmediates(0, immDataB, undefined, immDataSizeB);
         dispatchOrDraw(encoderType, enc);
       })!;
 
@@ -759,7 +759,7 @@ g.test('use_max_immediate_size')
       encoderType,
       pipeline,
       encoder => {
-        encoder.setImmediates!(0, data);
+        encoder.setImmediates(0, data);
       },
       [0xdeadbeef, 0xcafebabe]
     );
@@ -891,10 +891,10 @@ g.test('typed_array_arguments')
         enc.setBindGroup(0, bindGroup, [0]);
 
         // Initialize immediates to the baseline clear pattern.
-        enc.setImmediates!(0, clearData);
+        enc.setImmediates(0, clearData);
 
         // Overwrite with typed array data using the parametrized offset/size.
-        enc.setImmediates!(0, arr, dataOffset, dataSize);
+        enc.setImmediates(0, arr, dataOffset, dataSize);
 
         if (encoderType === 'compute pass') {
           dispatchOrDraw(encoderType, enc);
@@ -929,11 +929,11 @@ g.test('multiple_updates_before_draw_or_dispatch')
       pipeline,
       encoder => {
         // 1. Set all to [1, 2, 3, 4]
-        encoder.setImmediates!(0, new Uint32Array([1, 2, 3, 4]));
+        encoder.setImmediates(0, new Uint32Array([1, 2, 3, 4]));
         // 2. Update middle two to [5, 6] -> [1, 5, 6, 4]
-        encoder.setImmediates!(4, new Uint32Array([5, 6]));
+        encoder.setImmediates(4, new Uint32Array([5, 6]));
         // 3. Update last to [7] -> [1, 5, 6, 7]
-        encoder.setImmediates!(12, new Uint32Array([7]));
+        encoder.setImmediates(12, new Uint32Array([7]));
       },
       [1, 5, 6, 7]
     );
@@ -969,7 +969,7 @@ g.test('render_pass_and_bundle_mix')
     });
     bundleEncoder.setPipeline(pipeline);
     bundleEncoder.setBindGroup(0, bindGroup, [0]);
-    bundleEncoder.setImmediates!(0, new Uint32Array([1, 10]));
+    bundleEncoder.setImmediates(0, new Uint32Array([1, 10]));
     bundleEncoder.draw(1);
     const bundle = bundleEncoder.finish();
 
@@ -996,7 +996,7 @@ g.test('render_pass_and_bundle_mix')
     // Pass: Set [2, 20], Draw (Index 1)
     pass.setPipeline(pipeline);
     pass.setBindGroup(0, bindGroup, [256]);
-    pass.setImmediates!(0, new Uint32Array([2, 20]));
+    pass.setImmediates(0, new Uint32Array([2, 20]));
     pass.draw(1);
 
     pass.end();
@@ -1061,7 +1061,7 @@ g.test('render_bundle_isolation')
     });
     bundleEncoderA.setPipeline(pipeline);
     bundleEncoderA.setBindGroup(0, bindGroup, [0]);
-    bundleEncoderA.setImmediates!(0, new Uint32Array([1, 2]));
+    bundleEncoderA.setImmediates(0, new Uint32Array([1, 2]));
     bundleEncoderA.draw(1);
     const bundleA = bundleEncoderA.finish();
 
@@ -1071,7 +1071,7 @@ g.test('render_bundle_isolation')
     });
     bundleEncoderB.setPipeline(pipeline);
     bundleEncoderB.setBindGroup(0, bindGroup, [256]);
-    bundleEncoderB.setImmediates!(0, new Uint32Array([3, 4]));
+    bundleEncoderB.setImmediates(0, new Uint32Array([3, 4]));
     bundleEncoderB.draw(1);
     const bundleB = bundleEncoderB.finish();
 

--- a/src/webgpu/api/validation/capability_checks/features/subgroup_size_control.spec.ts
+++ b/src/webgpu/api/validation/capability_checks/features/subgroup_size_control.spec.ts
@@ -16,7 +16,7 @@ g.test('enables_subgroups')
   Test that enabling the 'subgroup-size-control' feature also enables the 'subgroups' feature.
   `
   )
-  .beforeAllSubcases(t => t.selectDeviceOrSkipTestCase('subgroup-size-control' as GPUFeatureName))
+  .beforeAllSubcases(t => t.selectDeviceOrSkipTestCase('subgroup-size-control'))
   .fn(t => {
     t.expect(() => hasFeature(t.device.features, 'subgroups'));
   });

--- a/src/webgpu/api/validation/createPipelineLayout.spec.ts
+++ b/src/webgpu/api/validation/createPipelineLayout.spec.ts
@@ -535,7 +535,7 @@ g.test('immediate_data_size')
   .fn(t => {
     t.skipIf(!supportsImmediateData(getGPU(t.rec)), 'Immediate data not supported');
 
-    const maxImmediateSize = t.device.limits.maxImmediateSize!;
+    const maxImmediateSize = t.device.limits.maxImmediateSize;
 
     const { immediateSize: sizeVariant } = t.params;
     let size: number;

--- a/src/webgpu/api/validation/encoding/cmds/setImmediates.spec.ts
+++ b/src/webgpu/api/validation/encoding/cmds/setImmediates.spec.ts
@@ -61,7 +61,7 @@ g.test('alignment')
     const data = new arrayBufferType(elementCount);
 
     t.shouldThrow(isContentSizeAligned ? false : 'OperationError', () => {
-      encoder.setImmediates!(rangeOffset, data, 0, elementCount);
+      encoder.setImmediates(rangeOffset, data, 0, elementCount);
     });
 
     validateFinish(isRangeOffsetAligned);
@@ -120,7 +120,7 @@ g.test('overflow')
     const data = new arrayBufferType(elementCount);
 
     const doSetImmediates = () => {
-      encoder.setImmediates!(rangeOffset, data, dataOffset, elementCount);
+      encoder.setImmediates(rangeOffset, data, dataOffset, elementCount);
     };
 
     if (_expectedError === 'OperationError') {
@@ -157,7 +157,7 @@ g.test('out_of_bounds')
     const arrayBufferType = kTypedArrayBufferViews[arrayType];
     const elementSize = arrayBufferType.BYTES_PER_ELEMENT;
 
-    const maxImmediateSize = t.device.limits.maxImmediateSize!;
+    const maxImmediateSize = t.device.limits.maxImmediateSize;
     if (maxImmediateSize === undefined) {
       t.skip('maxImmediateSize not found');
     }
@@ -178,7 +178,7 @@ g.test('out_of_bounds')
     const dataOverLimit = elementCount > dataLength;
 
     t.shouldThrow(dataOverLimit ? 'OperationError' : false, () => {
-      encoder.setImmediates!(rangeOffset, data, 0, elementCount);
+      encoder.setImmediates(rangeOffset, data, 0, elementCount);
     });
 
     if (!dataOverLimit) {

--- a/src/webgpu/api/validation/encoding/encoder_open_state.spec.ts
+++ b/src/webgpu/api/validation/encoding/encoder_open_state.spec.ts
@@ -403,7 +403,7 @@ g.test('render_pass_commands')
           break;
         case 'setImmediates':
           {
-            renderPass.setImmediates!(0, new Uint32Array(1));
+            renderPass.setImmediates(0, new Uint32Array(1));
           }
           break;
         case 'beginOcclusionQuery':
@@ -532,7 +532,7 @@ g.test('render_bundle_commands')
           break;
         case 'setImmediates':
           {
-            bundleEncoder.setImmediates!(0, new Uint32Array(1));
+            bundleEncoder.setImmediates(0, new Uint32Array(1));
           }
           break;
         case 'pushDebugGroup':
@@ -626,7 +626,7 @@ g.test('compute_pass_commands')
           break;
         case 'setImmediates':
           {
-            computePass.setImmediates!(0, new Uint32Array(1));
+            computePass.setImmediates(0, new Uint32Array(1));
           }
           break;
         case 'pushDebugGroup':

--- a/src/webgpu/api/validation/encoding/programmable/pipeline_immediate.spec.ts
+++ b/src/webgpu/api/validation/encoding/programmable/pipeline_immediate.spec.ts
@@ -207,7 +207,7 @@ g.test('required_slots_set')
       usage === 'overprovision' && trailingPaddingBytes === 0
         ? layoutImmediateSize + 4
         : layoutImmediateSize;
-    if (layoutSize > t.device.limits.maxImmediateSize!) {
+    if (layoutSize > t.device.limits.maxImmediateSize) {
       t.skip('maxImmediateSize not large enough for overprovision test');
     }
 
@@ -215,7 +215,7 @@ g.test('required_slots_set')
 
     const setImmediates = (offset: number, size: number) => {
       const data = new Uint8Array(size);
-      encoder.setImmediates!(offset, data, 0, size);
+      encoder.setImmediates(offset, data, 0, size);
     };
 
     if (usage === 'overprovision') {
@@ -340,7 +340,7 @@ g.test('unused_variable')
 
     if (usage === 'partial_start') {
       const data = new Uint8Array(8);
-      encoder.setImmediates!(0, data, 0, 8);
+      encoder.setImmediates(0, data, 0, 8);
     }
 
     t.runPass(encoder, code, kImmediateSize);
@@ -379,7 +379,7 @@ g.test('overprovisioned_immediate_data')
     const kSetSize = scenario === 'larger_than_layout' ? kLayoutSize + 4 : kLayoutSize;
 
     const data = new Uint8Array(kSetSize);
-    encoder.setImmediates!(0, data, 0, kSetSize);
+    encoder.setImmediates(0, data, 0, kSetSize);
 
     t.runPass(encoder, code, kLayoutSize);
 
@@ -428,7 +428,7 @@ g.test('render_bundle_execution_state_invalidation')
     });
     bundleEncoder.setPipeline(pipeline);
     const immediateData = new Uint8Array(16);
-    bundleEncoder.setImmediates!(0, immediateData, 0, 16);
+    bundleEncoder.setImmediates(0, immediateData, 0, 16);
     bundleEncoder.draw(3);
     const bundle = bundleEncoder.finish();
 
@@ -437,7 +437,7 @@ g.test('render_bundle_execution_state_invalidation')
 
     // Initial setup
     pass.setPipeline(pipeline);
-    pass.setImmediates!(0, immediateData, 0, 16);
+    pass.setImmediates(0, immediateData, 0, 16);
 
     // Execute bundle - this should invalidate state
     pass.executeBundles([bundle]);
@@ -445,7 +445,7 @@ g.test('render_bundle_execution_state_invalidation')
     // Try to draw
     pass.setPipeline(pipeline);
     if (resetImmediates) {
-      pass.setImmediates!(0, immediateData, 0, 16);
+      pass.setImmediates(0, immediateData, 0, 16);
     }
     pass.draw(3);
 

--- a/src/webgpu/capability_info.ts
+++ b/src/webgpu/capability_info.ts
@@ -970,6 +970,7 @@ export const kFeatureNameInfo: {
   'texture-formats-tier2':              {},
   'primitive-index':                    {},
   'texture-component-swizzle':          {},
+  'subgroup-size-control':              {},
   ['atomic-vec2u-min-max' as GPUFeatureName]: {},
 };
 /** List of all GPUFeatureName values. */

--- a/src/webgpu/shader/execution/shader_io/compute_builtins.spec.ts
+++ b/src/webgpu/shader/execution/shader_io/compute_builtins.spec.ts
@@ -1179,7 +1179,7 @@ g.test('subgroup_size_attribute')
       .combine('numSubgroups', [1, 2, 4] as const)
   )
   .fn(async t => {
-    t.skipIfDeviceDoesNotHaveFeature('subgroup-size-control' as GPUFeatureName);
+    t.skipIfDeviceDoesNotHaveFeature('subgroup-size-control');
 
     const { subgroupSize, numWorkGroups, numSubgroups } = t.params;
 

--- a/src/webgpu/shader/validation/extension/subgroup_size_control.spec.ts
+++ b/src/webgpu/shader/validation/extension/subgroup_size_control.spec.ts
@@ -17,7 +17,7 @@ g.test('enable_subgroup_size_control_requires_subgroups')
   .params(u => u.combine('enableSubgroups', [false, true] as const))
   .beforeAllSubcases(t => {
     t.selectDeviceOrSkipTestCase({
-      requiredFeatures: ['subgroup-size-control' as GPUFeatureName],
+      requiredFeatures: ['subgroup-size-control'],
     });
   })
   .fn(t => {
@@ -43,7 +43,7 @@ g.test('use_subgroup_size_attribute_requires_subgroup_size_control_extension_ena
   .params(u => u.combine('enableExtension', [false, true] as const))
   .beforeAllSubcases(t => {
     t.selectDeviceOrSkipTestCase({
-      requiredFeatures: ['subgroup-size-control' as GPUFeatureName],
+      requiredFeatures: ['subgroup-size-control'],
     });
   })
   .fn(t => {
@@ -69,7 +69,7 @@ g.test('subgroup_size_attribute_only_valid_in_compute_stage')
   .params(u => u.combine('stage', ['compute', 'vertex', 'fragment'] as const))
   .beforeAllSubcases(t => {
     t.selectDeviceOrSkipTestCase({
-      requiredFeatures: ['subgroup-size-control' as GPUFeatureName],
+      requiredFeatures: ['subgroup-size-control'],
     });
   })
   .fn(t => {
@@ -133,7 +133,7 @@ g.test('subgroup_size_value_must_be_const_or_override_i32_u32')
   .params(u => u.combine('case', keysOf(kSubgroupSizeValueCases)))
   .beforeAllSubcases(t => {
     t.selectDeviceOrSkipTestCase({
-      requiredFeatures: ['subgroup-size-control' as GPUFeatureName],
+      requiredFeatures: ['subgroup-size-control'],
     });
   })
   .fn(t => {
@@ -161,7 +161,7 @@ g.test('subgroup_size_constant_value_must_be_power_of_2')
   )
   .beforeAllSubcases(t => {
     t.selectDeviceOrSkipTestCase({
-      requiredFeatures: ['subgroup-size-control' as GPUFeatureName],
+      requiredFeatures: ['subgroup-size-control'],
     });
   })
   .fn(t => {
@@ -186,7 +186,7 @@ g.test('subgroup_size_override_must_be_power_of_2_at_pipeline_creation')
   .params(u => u.combine('size', [3, 5, 7, 15, 31, 63, 127] as const))
   .beforeAllSubcases(t => {
     t.selectDeviceOrSkipTestCase({
-      requiredFeatures: ['subgroup-size-control' as GPUFeatureName],
+      requiredFeatures: ['subgroup-size-control'],
     });
   })
   .fn(t => {
@@ -246,7 +246,7 @@ g.test('subgroup_size_override_valid_values_no_error')
   )
   .beforeAllSubcases(t => {
     t.selectDeviceOrSkipTestCase({
-      requiredFeatures: ['subgroup-size-control' as GPUFeatureName],
+      requiredFeatures: ['subgroup-size-control'],
     });
   })
   .fn(async t => {
@@ -282,7 +282,7 @@ g.test('workgroup_size_x_must_be_multiple_of_subgroup_size_at_pipeline_creation'
   )
   .beforeAllSubcases(t => {
     t.selectDeviceOrSkipTestCase({
-      requiredFeatures: ['subgroup-size-control' as GPUFeatureName],
+      requiredFeatures: ['subgroup-size-control'],
     });
   })
   .fn(async t => {
@@ -328,7 +328,7 @@ g.test('subgroup_size_must_be_between_min_and_max_at_pipeline_creation')
   )
   .beforeAllSubcases(t => {
     t.selectDeviceOrSkipTestCase({
-      requiredFeatures: ['subgroup-size-control' as GPUFeatureName],
+      requiredFeatures: ['subgroup-size-control'],
     });
   })
   .fn(t => {


### PR DESCRIPTION
This patch bumps @webgpu/types to 0.1.71 with below changes:
- `setImmediates` is a required method.
- `maxImmediateSize` is a required property.
- `subgroup-size-control` is a valid `GPUFeatureName`.




Issue: #4640

<hr>

**Requirements for PR author:**

- [*] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [*] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [*] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [*] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) are accurate and complete.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Tests avoid [over-parameterization](https://github.com/gpuweb/cts/blob/main/docs/organization.md#parameterization) (see case count report).

When landing this PR, be sure to make any necessary issue status updates.
