### PR TITLE
Test using 0 as the override value of `@subgroup_size`

### DIFF
--- a/src/webgpu/shader/validation/extension/subgroup_size_control.spec.ts
+++ b/src/webgpu/shader/validation/extension/subgroup_size_control.spec.ts
@@ -183,7 +183,7 @@ g.test('subgroup_size_override_must_be_power_of_2_at_pipeline_creation')
     `Checks that when @subgroup_size is an override expression, it is a pipeline creation error
      if the override value resolves to a value that is not a power of 2.`
   )
-  .params(u => u.combine('size', [3, 5, 7, 15, 31, 63, 127] as const))
+  .params(u => u.combine('size', [0, 3, 5, 7, 15, 31, 63, 127] as const))
   .beforeAllSubcases(t => {
     t.selectDeviceOrSkipTestCase({
       requiredFeatures: ['subgroup-size-control'],


### PR DESCRIPTION
This patch adds a regression test that uses 0 as the override value of `@subgroup_size` for Dawn.




Issue: #4640

<hr>

**Requirements for PR author:**

- [*] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [*] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [*] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [*] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) are accurate and complete.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Tests avoid [over-parameterization](https://github.com/gpuweb/cts/blob/main/docs/organization.md#parameterization) (see case count report).

When landing this PR, be sure to make any necessary issue status updates.
