### PR TITLE
Add frag_depth validation tests.

### DIFF
--- a/src/webgpu/capability_info.ts
+++ b/src/webgpu/capability_info.ts
@@ -990,6 +990,7 @@ export const kKnownWGSLLanguageFeatures = [
   'linear_indexing',
   'texture_formats_tier1',
   'immediate_address_space',
+  'fragment_depth',
 ] as const;
 
 export type WGSLLanguageFeature = (typeof kKnownWGSLLanguageFeatures)[number];

--- a/src/webgpu/listing_meta.json
+++ b/src/webgpu/listing_meta.json
@@ -2913,7 +2913,6 @@
   "webgpu:shader,validation,shader_io,builtins:duplicates:*": { "subcaseMS": 1.913 },
   "webgpu:shader,validation,shader_io,builtins:missing_vertex_position:*": { "subcaseMS": 0.975 },
   "webgpu:shader,validation,shader_io,builtins:nesting:*": { "subcaseMS": 2.700 },
-  "webgpu:shader,validation,shader_io,builtins:parse:*": { "subcaseMS": 10.114 },
   "webgpu:shader,validation,shader_io,builtins:placement:*": { "subcaseMS": 10.371 },
   "webgpu:shader,validation,shader_io,builtins:reuse_builtin_name:*": { "subcaseMS": 1.202 },
   "webgpu:shader,validation,shader_io,builtins:stage_inout:*": { "subcaseMS": 1.231 },

--- a/src/webgpu/shader/validation/shader_io/builtins.spec.ts
+++ b/src/webgpu/shader/validation/shader_io/builtins.spec.ts
@@ -437,7 +437,7 @@ g.test('reuse_builtin_name')
     t.expectCompileResult(true, code);
   });
 
-const kTests = {
+const kBuiltinTests = {
   pos: {
     src: `@builtin(position)`,
     pass: true,
@@ -496,17 +496,17 @@ const kTests = {
   },
 };
 
-g.test('parse')
+g.test('parse_builtin')
   .desc(`Test that @builtin is parsed correctly.`)
-  .params(u => u.combine('builtin', keysOf(kTests)))
+  .params(u => u.combine('builtin', keysOf(kBuiltinTests)))
   .fn(t => {
-    const src = kTests[t.params.builtin].src;
+    const src = kBuiltinTests[t.params.builtin].src;
     const code = `
 @vertex
 fn main() -> ${src} vec4<f32> {
   return vec4<f32>(.4, .2, .3, .1);
 }`;
-    t.expectCompileResult(kTests[t.params.builtin].pass, code);
+    t.expectCompileResult(kBuiltinTests[t.params.builtin].pass, code);
   });
 
 g.test('placement')
@@ -577,3 +577,60 @@ g.test('placement')
 
     t.expectCompileResult(scope === undefined || t.params.attribute[scope], code);
   });
+
+const kFragDepthTests = {
+  unset: {
+    src: `@builtin(frag_depth)`,
+    pass: true,
+    requires_feature: false,
+  },
+  less: {
+    src: `@builtin(frag_depth, less)`,
+    pass: true,
+    requires_feature: true,
+  },
+  greater: {
+    src: `@builtin(frag_depth, greater)`,
+    pass: true,
+    requires_feature: true,
+  },
+  trailing_comma: {
+    src: `@builtin(frag_depth, less,)`,
+    pass: true,
+    requires_feature: true,
+  },
+  missing_enum: {
+    src: `@builtin(frag_depth,)`,
+    pass: true,
+    requires_feature: false,
+  },
+  invalid_enum: {
+    src: `@builtin(frag_depth, any)`,
+    pass: false,
+    requires_feature: false,
+  },
+  missing_comma: {
+    src: `@builtin(frag_depth greater)`,
+    pass: false,
+    requires_feature: false,
+  },
+};
+
+g.test('parse_frag_depth')
+  .desc(`Test that @builtin is parsed correctly.`)
+  .params(u => u.combine('builtin', keysOf(kFragDepthTests)))
+  .fn(t => {
+    let data = kFragDepthTests[t.params.builtin];
+
+    if (data.requires_feature) {
+      t.skipIfLanguageFeatureNotSupported('fragment_depth');
+    }
+
+    const code = `
+@fragment
+fn main() -> ${data.src} f32 {
+  return .5;
+}`;
+    t.expectCompileResult(data.pass, code);
+  });
+


### PR DESCRIPTION
Add validation tests for the `fragment_depth` extension.

Issue: https://github.com/gpuweb/gpuweb/issues/5342

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) are accurate and complete.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Tests avoid [over-parameterization](https://github.com/gpuweb/cts/blob/main/docs/organization.md#parameterization) (see case count report).

When landing this PR, be sure to make any necessary issue status updates.
