### PR TITLE
Correct swizzle assignment on pointer tests

### DIFF
--- a/src/webgpu/shader/execution/statement/swizzle_assignment.spec.ts
+++ b/src/webgpu/shader/execution/statement/swizzle_assignment.spec.ts
@@ -265,6 +265,9 @@ g.test('swizzle_assignment_vars')
       kSwizzleAssignmentCases[t.params.case];
 
     t.skipIf(t.params.address_space === 'storage' && elemType === 'bool');
+    if (t.params.memory_view === 'ptr') {
+      t.skipIfLanguageFeatureNotSupported('pointer_composite_access');
+    }
 
     const vecType = `vec${vecSize}<${elemType}>`;
     const initialValues =
@@ -282,6 +285,7 @@ g.test('swizzle_assignment_vars')
 
     const wgsl = `
 requires swizzle_assignment;
+${t.params.memory_view === 'ptr' ? 'requires pointer_composite_access;' : ''}
 ${elemType === 'f16' ? 'enable f16;' : ''}
 
 struct Outputs {
@@ -380,6 +384,10 @@ g.test('swizzle_compound_assignment')
     const { elemType, vecSize, initial, swizzle, op, rhs, expected } =
       kSwizzleCompoundAssignmentCases[t.params.case];
 
+    if (t.params.memory_view === 'ptr') {
+      t.skipIfLanguageFeatureNotSupported('pointer_composite_access');
+    }
+
     const vecType = `vec${vecSize}<${elemType}>`;
     const initialValues = initial.join(', ');
 
@@ -392,6 +400,7 @@ g.test('swizzle_compound_assignment')
 
     const wgsl = `
 requires swizzle_assignment;
+${t.params.memory_view === 'ptr' ? 'requires pointer_composite_access;' : ''}
 ${elemType === 'f16' ? 'enable f16;' : ''}
 
 struct Outputs {

--- a/src/webgpu/shader/validation/statement/swizzle_assignment.spec.ts
+++ b/src/webgpu/shader/validation/statement/swizzle_assignment.spec.ts
@@ -144,3 +144,38 @@ fn main() {
 `;
     t.expectCompileResult(false, code);
   });
+
+g.test('pointer_swizzle_assignment')
+  .desc('Validate swizzle assignments on pointers')
+  .params(u =>
+    u
+      .combine('use_pointer', [true, false] as const)
+      .combine('requires_pointer_composite_access', [true, false] as const)
+      .combine('use_compound', [true, false] as const)
+  )
+  .fn(t => {
+    t.skipIfLanguageFeatureNotSupported('swizzle_assignment');
+    const { use_pointer, requires_pointer_composite_access, use_compound } = t.params;
+
+    const requires_directive = requires_pointer_composite_access
+      ? 'requires pointer_composite_access;'
+      : '';
+
+    const lhs = use_pointer ? 'p.xy' : '(*p).xy';
+    const op = use_compound ? '+=' : '=';
+
+    const code = `
+${requires_directive}
+@fragment
+fn main() {
+  var v = vec4f();
+  let p = &v;
+  ${lhs} ${op} vec2f(1.0);
+}
+`;
+
+    const has_feature = t.hasLanguageFeature('pointer_composite_access');
+    const expected = !use_pointer || has_feature;
+
+    t.expectCompileResult(expected, code);
+  });


### PR DESCRIPTION
The swizzle assignment spec was updated so that creating a SwizzleView from pointer requires support for pointer_composite_access, so CTS tests here are updated to correctly handle the interaction between swizzle_assignment and pointer_composite_access. Execution tests for swizzle assignment via pointer are now skipped if the pointer_composite_access language feature is not available, and validation tests are added to validate both cases.

Bug: crbug.com/534329233

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) are accurate and complete.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Tests avoid [over-parameterization](https://github.com/gpuweb/cts/blob/main/docs/organization.md#parameterization) (see case count report).

When landing this PR, be sure to make any necessary issue status updates.
