### PR TITLE
Fix pipeline_immediate:required_slots

### DIFF
--- a/src/webgpu/api/validation/encoding/programmable/pipeline_immediate.spec.ts
+++ b/src/webgpu/api/validation/encoding/programmable/pipeline_immediate.spec.ts
@@ -67,7 +67,7 @@ g.test('required_slots_set')
         When a struct variable is statically used, all non-padding bytes of the entire struct must be set,
         even if only one member is accessed. In this test, data.b.v is accessed, but both data.a and data.b
         must be set (excluding padding).
-      - dynamic_indexing: Array with dynamic indexing.
+      - dynamic_indexing: Vector with dynamic indexing.
     - Usage:
       - full: Set all declared bytes.
       - split: Set all declared bytes in multiple calls.
@@ -84,7 +84,6 @@ g.test('required_slots_set')
         'scalar',
         'vector',
         'struct_padding',
-        'dynamic_indexing',
         'mixed_types',
         'multiple_variables',
       ] as const)
@@ -156,7 +155,7 @@ g.test('required_slots_set')
         break;
       case 'dynamic_indexing':
         layoutImmediateSize = 16;
-        declarations = 'var<immediate> data: array<u32, 4>;';
+        declarations = 'var<immediate> data: vec4u;';
         helpers = 'fn use_data(i: u32) { _ = data[i]; }';
         computeArgs = '@builtin(local_invocation_index) i: u32';
         callCompute = 'use_data(i);';

--- a/src/webgpu/api/validation/encoding/programmable/pipeline_immediate.spec.ts
+++ b/src/webgpu/api/validation/encoding/programmable/pipeline_immediate.spec.ts
@@ -84,6 +84,7 @@ g.test('required_slots_set')
         'scalar',
         'vector',
         'struct_padding',
+        'dynamic_indexing',
         'mixed_types',
         'multiple_variables',
       ] as const)


### PR DESCRIPTION
* Arrays cannot be used in immediate variables so switch to dynamic indexing of a vector




Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) are accurate and complete.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Tests avoid [over-parameterization](https://github.com/gpuweb/cts/blob/main/docs/organization.md#parameterization) (see case count report).

When landing this PR, be sure to make any necessary issue status updates.
