### PR TITLE
Fixup pointer tests after buffer_view landed

### DIFF
--- a/src/webgpu/shader/validation/types/pointer.spec.ts
+++ b/src/webgpu/shader/validation/types/pointer.spec.ts
@@ -97,6 +97,7 @@ interface TypeCase {
   storable: boolean;
   f16?: boolean;
   aspace?: string;
+  buffer_view?: boolean;
 }
 
 const kTypeCases: Record<string, TypeCase> = {
@@ -150,6 +151,20 @@ const kTypeCases: Record<string, TypeCase> = {
 
   // Reference
   reference: { type: `ref<function, u32>`, storable: false, aspace: 'function' },
+
+  // Runtime arrays (allowed by buffer_view).
+  uniform_runtime_array: {
+    type: 'array<u32>',
+    storable: true,
+    aspace: 'uniform',
+    buffer_view: true,
+  },
+  workgroup_runtime_array: {
+    type: 'array<u32>',
+    storable: true,
+    aspace: 'workgroup',
+    buffer_view: true,
+  },
 };
 
 g.test('type')
@@ -157,6 +172,10 @@ g.test('type')
   .params(u => u.combine('case', keysOf(kTypeCases)))
   .fn(t => {
     const testcase = kTypeCases[t.params.case];
+    let expect = testcase.storable;
+    if (testcase.buffer_view === true) {
+      expect &&= t.hasLanguageFeature('buffer_view');
+    }
     const aspace = testcase.aspace ?? 'storage';
     const access = testcase.type.includes('atomic') ? ', read_write' : '';
     const code = `${testcase.f16 ? 'enable f16;' : ''}
@@ -165,7 +184,7 @@ g.test('type')
     struct T { s : array<S> }
     alias u32_alias = u32;
     alias Type = ptr<${aspace}, ${testcase.type}${access}>;`;
-    t.expectCompileResult(testcase.storable, code);
+    t.expectCompileResult(expect, code);
   });
 
 // Address spaces that can hold an i32 variable.
@@ -269,8 +288,6 @@ const kStoreTypeNotInstantiable: Record<string, string> = {
   privateAtomic: 'alias p = ptr<private,atomic<u32>>;',
   functionAtomic: 'alias p = ptr<function,atomic<u32>>;',
   uniformAtomic: 'alias p = ptr<uniform,atomic<u32>>;',
-  workgroupRTArray: 'alias p = ptr<workgroup,array<i32>>;',
-  uniformRTArray: 'alias p = ptr<uniform,array<i32>>;',
   privateRTArray: 'alias p = ptr<private,array<i32>>;',
   functionRTArray: 'alias p = ptr<function,array<i32>>;',
   RTArrayNotLast: 'struct S { a: array<i32>, b: i32 } alias p = ptr<storage,S>;',


### PR DESCRIPTION
* Pointers to runtime arrays can be declared in workgroup and uniform storage classes with the buffer_view language feature




Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [ ] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [ ] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [ ] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) are accurate and complete.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Tests avoid [over-parameterization](https://github.com/gpuweb/cts/blob/main/docs/organization.md#parameterization) (see case count report).

When landing this PR, be sure to make any necessary issue status updates.
