### PR TITLE
Fix buffer_view validation tests

### DIFF
--- a/src/webgpu/shader/validation/expression/call/builtin/bufferArrayView.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/bufferArrayView.spec.ts
@@ -135,11 +135,9 @@ g.test('offset_type')
   .desc('Validates the offset parameter type')
   .params(u => u.combine('type', keysOf(kTypes)))
   .fn(t => {
+    t.skipIfLanguageFeatureNotSupported('buffer_view');
     const type = kTypes[t.params.type];
-    let enables = `enable subgroups;\n`;
-    if (type.requiresF16()) {
-      enables += `enable f16;`;
-    }
+    const enables = type.requiresF16() ? 'enable f16;' : '';
     const wgsl = `
 ${enables}
 @group(0) @binding(0) var<storage> v : buffer;
@@ -158,11 +156,9 @@ g.test('size_type')
   .desc('Validates the offset parameter type')
   .params(u => u.combine('type', keysOf(kTypes)))
   .fn(t => {
+    t.skipIfLanguageFeatureNotSupported('buffer_view');
     const type = kTypes[t.params.type];
-    let enables = `enable subgroups;\n`;
-    if (type.requiresF16()) {
-      enables += `enable f16;`;
-    }
+    const enables = type.requiresF16() ? 'enable f16;' : '';
     const wgsl = `
 ${enables}
 @group(0) @binding(0) var<storage> v : buffer;

--- a/src/webgpu/shader/validation/expression/call/builtin/bufferView.spec.ts
+++ b/src/webgpu/shader/validation/expression/call/builtin/bufferView.spec.ts
@@ -129,11 +129,9 @@ g.test('offset_type')
   .desc('Validates the offset parameter type')
   .params(u => u.combine('type', keysOf(kTypes)))
   .fn(t => {
+    t.skipIfLanguageFeatureNotSupported('buffer_view');
     const type = kTypes[t.params.type];
-    let enables = `enable subgroups;\n`;
-    if (type.requiresF16()) {
-      enables += `enable f16;`;
-    }
+    const enables = type.requiresF16() ? 'enable f16;' : '';
     const wgsl = `
 ${enables}
 @group(0) @binding(0) var<storage> v : buffer;


### PR DESCRIPTION
* bufferView and bufferArrayView tests had invalid checks for the parameter type tests (copypasta)




Issue: #<!-- Fill in the issue number here. See docs/intro/life_of.md -->

<hr>

**Requirements for PR author:**

- [ ] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [ ] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [ ] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [ ] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) are accurate and complete.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Tests avoid [over-parameterization](https://github.com/gpuweb/cts/blob/main/docs/organization.md#parameterization) (see case count report).

When landing this PR, be sure to make any necessary issue status updates.
