### PR TITLE
Add a test that requires all known WGSL language features to be supported

### DIFF
--- a/src/webgpu/shader/validation/parse/requires.spec.ts
+++ b/src/webgpu/shader/validation/parse/requires.spec.ts
@@ -2,6 +2,7 @@ export const description = `Parser validation tests for requires`;
 
 import { makeTestGroup } from '../../../../common/framework/test_group.js';
 import { keysOf } from '../../../../common/util/data_tables.js';
+import { assert } from '../../../../common/util/util.js';
 import { kKnownWGSLLanguageFeatures } from '../../../capability_info.js';
 import { ShaderValidationTest } from '../shader_validation_test.js';
 
@@ -95,4 +96,18 @@ g.test('wgsl_matches_api')
   .fn(t => {
     const code = `requires ${t.params.feature};`;
     t.expectCompileResult(t.hasLanguageFeature(t.params.feature), code);
+  });
+
+g.test('have_all_language_features')
+  .desc(
+    `The spec technically requires support for all WGSL language features listed in the spec.
+    This test enforces that. It should be the ONLY test that fails when a new feature is
+    unavailable - others should skip themselves.`
+  )
+  .params(u => u.combine('feature', kKnownWGSLLanguageFeatures))
+  .fn(t => {
+    // First check that the API exposes the feature.
+    assert(t.hasLanguageFeature(t.params.feature));
+    // If it does, then also check that WGSL allows it.
+    t.expectCompileResult(true, `requires ${t.params.feature};`);
   });


### PR DESCRIPTION
See test description.

Tested in Chrome Stable and Canary, got expected results.

Issue: https://crbug.com/557328524

<hr>

**Requirements for PR author:**

- [x] All missing test coverage is tracked with "TODO" or `.unimplemented()`.
- [x] New helpers are `/** documented */` and new helper files are found in `helper_index.txt`.
- [x] Test behaves as expected in a WebGPU implementation. (If not passing, explain above.)
- [x] Test have be tested with compatibility mode validation enabled and behave as expected. (If not passing, explain above.)

**Requirements for [reviewer sign-off](https://github.com/gpuweb/cts/blob/main/docs/reviews.md):**

- [ ] Tests are properly located.
- [ ] [Test descriptions](https://github.com/gpuweb/cts/blob/main/docs/intro/plans.md) are accurate and complete.
- [ ] Tests provide complete coverage (including validation control cases). **Missing coverage MUST be covered by TODOs.**
- [ ] Tests avoid [over-parameterization](https://github.com/gpuweb/cts/blob/main/docs/organization.md#parameterization) (see case count report).

When landing this PR, be sure to make any necessary issue status updates.
